### PR TITLE
[NMI-829] Restoring in-progress/created CrowdNode account

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		117ED4A128EC86E0006E3EE4 /* TransactionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117ED4A028EC86E0006E3EE4 /* TransactionObserver.swift */; };
 		117ED4A828ED66F9006E3EE4 /* TransactionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117ED4A728ED66F9006E3EE4 /* TransactionFilter.swift */; };
 		117ED4AA28ED6766006E3EE4 /* SpendableTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117ED4A928ED6765006E3EE4 /* SpendableTransaction.swift */; };
+		119E8D0429051F9900D406C1 /* CrowdNodeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D0329051F9900D406C1 /* CrowdNodeRequest.swift */; };
+		119E8D062905200300D406C1 /* CoinsToAddressTxFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D052905200300D406C1 /* CoinsToAddressTxFilter.swift */; };
+		119E8D082905409300D406C1 /* FullCrowdNodeSignUpTxSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D072905409300D406C1 /* FullCrowdNodeSignUpTxSet.swift */; };
+		119E8D0A2905413F00D406C1 /* TransactionWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D092905413F00D406C1 /* TransactionWrapper.swift */; };
+		119E8D0C2907C61400D406C1 /* CrowdNodeTopUpTx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D0B2907C61400D406C1 /* CrowdNodeTopUpTx.swift */; };
+		119E8D10290949B900D406C1 /* CrowdNodeErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D0F290949B900D406C1 /* CrowdNodeErrorResponse.swift */; };
+		119E8D122909513F00D406C1 /* CrowdNodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119E8D112909513F00D406C1 /* CrowdNodeError.swift */; };
 		11B8449428F27C470082770C /* ApiCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B8449328F27C460082770C /* ApiCode.swift */; };
 		11B8449628F5B9F80082770C /* CrowdNodeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B8449528F5B9F80082770C /* CrowdNodeResponse.swift */; };
 		11B8449A28F6D5480082770C /* SingleInputAddressSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B8449928F6D5480082770C /* SingleInputAddressSelector.swift */; };
@@ -650,6 +657,13 @@
 		117ED4A028EC86E0006E3EE4 /* TransactionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionObserver.swift; sourceTree = "<group>"; };
 		117ED4A728ED66F9006E3EE4 /* TransactionFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionFilter.swift; sourceTree = "<group>"; };
 		117ED4A928ED6765006E3EE4 /* SpendableTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpendableTransaction.swift; sourceTree = "<group>"; };
+		119E8D0329051F9900D406C1 /* CrowdNodeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeRequest.swift; sourceTree = "<group>"; };
+		119E8D052905200300D406C1 /* CoinsToAddressTxFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinsToAddressTxFilter.swift; sourceTree = "<group>"; };
+		119E8D072905409300D406C1 /* FullCrowdNodeSignUpTxSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullCrowdNodeSignUpTxSet.swift; sourceTree = "<group>"; };
+		119E8D092905413F00D406C1 /* TransactionWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionWrapper.swift; sourceTree = "<group>"; };
+		119E8D0B2907C61400D406C1 /* CrowdNodeTopUpTx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeTopUpTx.swift; sourceTree = "<group>"; };
+		119E8D0F290949B900D406C1 /* CrowdNodeErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeErrorResponse.swift; sourceTree = "<group>"; };
+		119E8D112909513F00D406C1 /* CrowdNodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeError.swift; sourceTree = "<group>"; };
 		11B8449328F27C460082770C /* ApiCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCode.swift; sourceTree = "<group>"; };
 		11B8449528F5B9F80082770C /* CrowdNodeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeResponse.swift; sourceTree = "<group>"; };
 		11B8449928F6D5480082770C /* SingleInputAddressSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleInputAddressSelector.swift; sourceTree = "<group>"; };
@@ -1819,10 +1833,16 @@
 		117ED4A628ED66A2006E3EE4 /* TxFilters */ = {
 			isa = PBXGroup;
 			children = (
-				117ED4A728ED66F9006E3EE4 /* TransactionFilter.swift */,
-				117ED4A928ED6765006E3EE4 /* SpendableTransaction.swift */,
+				119E8D052905200300D406C1 /* CoinsToAddressTxFilter.swift */,
+				119E8D0F290949B900D406C1 /* CrowdNodeErrorResponse.swift */,
+				119E8D0329051F9900D406C1 /* CrowdNodeRequest.swift */,
 				11B8449528F5B9F80082770C /* CrowdNodeResponse.swift */,
+				119E8D0B2907C61400D406C1 /* CrowdNodeTopUpTx.swift */,
+				119E8D072905409300D406C1 /* FullCrowdNodeSignUpTxSet.swift */,
 				11B8449928F6D5480082770C /* SingleInputAddressSelector.swift */,
+				117ED4A928ED6765006E3EE4 /* SpendableTransaction.swift */,
+				117ED4A728ED66F9006E3EE4 /* TransactionFilter.swift */,
+				119E8D092905413F00D406C1 /* TransactionWrapper.swift */,
 			);
 			path = TxFilters;
 			sourceTree = "<group>";
@@ -1831,6 +1851,7 @@
 			isa = PBXGroup;
 			children = (
 				11B8449328F27C460082770C /* ApiCode.swift */,
+				119E8D112909513F00D406C1 /* CrowdNodeError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -5268,6 +5289,7 @@
 				2A913E8923A30DA8006A2A59 /* DWBalanceDisplayOptionsStub.m in Sources */,
 				2A0C69CD23142F90001B8C90 /* DWModalPresentationAnimation.m in Sources */,
 				2A8B9E7A2302E67400FF8653 /* DWReceiveModel.m in Sources */,
+				119E8D0A2905413F00D406C1 /* TransactionWrapper.swift in Sources */,
 				2A74EFFB2305464C00C475EB /* DWRecoverTextView.m in Sources */,
 				4709C315287EA11900B4BD48 /* TxUserInfo.swift in Sources */,
 				2A7AF3182480E35A001D74F9 /* DWContactsFetchedDataSource.m in Sources */,
@@ -5277,6 +5299,7 @@
 				2A858A11237EE89C0097A7B5 /* DWPhoneWCSessionManager.m in Sources */,
 				2A4431E622D73617009BAF7F /* DWSeedPhraseTitledView.m in Sources */,
 				2A7AF38924829AF2001D74F9 /* UICollectionView+DWDPItemDequeue.m in Sources */,
+				119E8D0C2907C61400D406C1 /* CrowdNodeTopUpTx.swift in Sources */,
 				C3DAD2D52476886D0001624F /* DWContactsSearchInfoHeaderView.m in Sources */,
 				2A0C69B02312DD67001B8C90 /* DWSpecifyAmountViewController.m in Sources */,
 				2A4E534422F02BC300E5168A /* UIView+DWReuseHelper.m in Sources */,
@@ -5311,6 +5334,7 @@
 				2AB3416F23A8DCFB004E37A7 /* DWOnboardingModel.m in Sources */,
 				2A9FFE882230FF4700956D5F /* DWPlaceholderFormCellModel.m in Sources */,
 				2A8B9E4F22FED47E00FF8653 /* DWOverlapControl.m in Sources */,
+				119E8D062905200300D406C1 /* CoinsToAddressTxFilter.swift in Sources */,
 				2AB3417323A926C9004E37A7 /* DWDemoAppRootViewController.m in Sources */,
 				2AD7BCBE2673BDE9008FF133 /* DWSyncingHeaderView.m in Sources */,
 				2A9FFE9B2230FF4700956D5F /* DWUpholdLogoutTutorialViewController.m in Sources */,
@@ -5375,6 +5399,7 @@
 				117ED4AA28ED6766006E3EE4 /* SpendableTransaction.swift in Sources */,
 				2AFCB9B723BDFF3600FF59A6 /* DWUpholdTransferViewController.m in Sources */,
 				2A827B7224B5CA1800A42042 /* DWListCollectionLayout.m in Sources */,
+				119E8D0429051F9900D406C1 /* CrowdNodeRequest.swift in Sources */,
 				2A6688FD24BCB739008E10F0 /* DWDPTxItemView.m in Sources */,
 				2A0C69EF2316B7F5001B8C90 /* DWConfirmPaymentContentView.m in Sources */,
 				2A9FFE032230FF2B00956D5F /* DWUpholdTransactionObject.m in Sources */,
@@ -5459,6 +5484,7 @@
 				47AE8BA528BFADD900490F5E /* MerchantDAO.swift in Sources */,
 				47AE8BAA28BFAE5800490F5E /* ExploreDatabaseSyncManager.swift in Sources */,
 				2AB3416923A8C479004E37A7 /* DWOnboardingCollectionViewCell.m in Sources */,
+				119E8D10290949B900D406C1 /* CrowdNodeErrorResponse.swift in Sources */,
 				2A74F0012305C40F00C475EB /* DWHomeViewController+DWShortcuts.m in Sources */,
 				2A913E8223A30623006A2A59 /* DWHomeModelStub.m in Sources */,
 				2AFCB9BA23BDFF5E00FF59A6 /* DWUpholdAmountModel.m in Sources */,
@@ -5587,6 +5613,7 @@
 				2A0C69D323143568001B8C90 /* DWModalTransition.m in Sources */,
 				2A9FFE9F2230FF4700956D5F /* DWUpholdMainModel.m in Sources */,
 				47AE8BF928C1306000490F5E /* MerchantsDataProvider.swift in Sources */,
+				119E8D082905409300D406C1 /* FullCrowdNodeSignUpTxSet.swift in Sources */,
 				2A4431E922D738C0009BAF7F /* DWSeedPhraseModel.m in Sources */,
 				2A9FFE852230FF4700956D5F /* DWBaseFormCellModel.m in Sources */,
 				47AE8BFB28C1306000490F5E /* ExploreMapAnnotationView.swift in Sources */,
@@ -5610,6 +5637,7 @@
 				2A58815921A5906C00FD4D2C /* DWBaseLegacyViewController.m in Sources */,
 				C3CA2030247E54C400158074 /* DWNoNotificationsCell.m in Sources */,
 				2A4E534022F025FE00E5168A /* DWTxListEmptyTableViewCell.m in Sources */,
+				119E8D122909513F00D406C1 /* CrowdNodeError.swift in Sources */,
 				2A8B9E6522FFE43500FF8653 /* DWPayModel.m in Sources */,
 				2A1B7DB423244CD700BA8C6A /* NSAttributedString+DWBuilder.m in Sources */,
 				2A885FC82449B66500B9F679 /* DWSearchStateViewController.m in Sources */,

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -27,16 +27,16 @@ public class CrowdNode {
         // Link Existing Account
         case linkedOnline
     }
-    
+
     private let sendCoinsService = SendCoinsService()
     private let txObserver = TransactionObserver()
-    
+
     @Published private(set) var signUpState = SignUpState.notStarted
     private(set) var accountAddress: String = ""
-    private(set) var apiError: Error? = nil
-    
-    public static let shared: CrowdNode = CrowdNode()
-    
+    private(set) var apiError: Error?
+
+    public static let shared: CrowdNode = .init()
+
     init() {
         restoreState()
     }
@@ -44,36 +44,36 @@ public class CrowdNode {
 
 extension CrowdNode {
     private func restoreState() {
-        if (signUpState != SignUpState.notStarted) {
+        if signUpState != SignUpState.notStarted {
             // Already started/restored
             return
         }
-        
+
         print("restoring CrowdNode status")
         let fullSet = FullCrowdNodeSignUpTxSet()
         let wallet = DWEnvironment.sharedInstance().currentWallet
         wallet.allTransactions.forEach { transaction in
             fullSet.tryInclude(tx: transaction)
         }
-        
+
         if let welcomeResponse = fullSet.welcomeToApiResponse {
             precondition(welcomeResponse.toAddress != nil)
             setFinished(address: welcomeResponse.toAddress!)
             return
         }
-        
+
         if let acceptTermsResponse = fullSet.acceptTermsResponse {
             precondition(acceptTermsResponse.toAddress != nil)
             setAcceptingTerms(address: acceptTermsResponse.toAddress!)
             return
         }
-        
+
         if let signUpRequest = fullSet.signUpRequest {
             precondition(signUpRequest.fromAddresses.first != nil)
             setSigningUp(address: signUpRequest.fromAddresses.first!)
         }
     }
-    
+
     private func setFinished(address: String) {
         accountAddress = address
         print("found finished sign up, account: \(address)")
@@ -81,13 +81,13 @@ extension CrowdNode {
         // TODO: refreshBalance()
         // TODO: tax category
     }
-    
+
     private func setAcceptingTerms(address: String) {
         accountAddress = address
         print("found accept terms response, account: \(address)")
         signUpState = SignUpState.acceptingTerms
     }
-    
+
     private func setSigningUp(address: String) {
         accountAddress = address
         print("found signUp request, account: \(address)")
@@ -98,26 +98,27 @@ extension CrowdNode {
 extension CrowdNode {
     func signUp(accountAddress: String) async {
         self.accountAddress = accountAddress
-        
+
         do {
-            if (signUpState < SignUpState.signingUp) {
+            if signUpState < SignUpState.signingUp {
                 signUpState = SignUpState.fundingWallet
                 let topUpTx = try await topUpAccount(accountAddress)
                 print("CrowdNode TopUp tx hash: \(topUpTx.txHashHexString)")
-                
+
                 signUpState = SignUpState.signingUp
                 let (signUpTx, acceptTermsResponse) = try await makeSignUpRequest(accountAddress, [topUpTx])
                 print("CrowdNode SignUp tx hash: \(signUpTx.txHashHexString)")
                 print("CrowdNode AcceptTerms response tx hash: \(acceptTermsResponse.txHashHexString)")
-                
+
                 signUpState = SignUpState.acceptingTerms
                 let (termsAcceptedTx, welcomeResponse) = try await acceptTerms(accountAddress, [signUpTx, acceptTermsResponse])
                 print("CrowdNode Terms Accepted tx hash: \(termsAcceptedTx.txHashHexString)")
                 print("CrowdNode Welcome response tx hash: \(welcomeResponse.txHashHexString)")
-                
+
                 signUpState = SignUpState.finished
             }
-        } catch {
+        }
+        catch {
             signUpState = SignUpState.error
             apiError = error
         }
@@ -130,14 +131,14 @@ extension CrowdNode {
         )
         return await txObserver.first(filters: SpendableTransaction(txHashData: topUpTx.txHashData))
     }
-    
+
     private func makeSignUpRequest(_ accountAddress: String, _ inputs: [DSTransaction]) async throws -> (req: DSTransaction, resp: DSTransaction) {
         let signUpTx = try await sendCoinsService.sendCoins(
             address: CrowdNodeConstants.crowdNodeAddress,
             amount: CrowdNodeConstants.apiOffset + ApiCode.signUp.rawValue,
             inputSelector: SingleInputAddressSelector(candidates: inputs, address: accountAddress)
         )
-        
+
         let successResponse = CrowdNodeResponse(
             responseCode: ApiCode.pleaseAcceptTerms,
             accountAddress: accountAddress
@@ -146,23 +147,23 @@ extension CrowdNode {
             errorValue: CrowdNodeConstants.apiOffset + ApiCode.welcomeToApi.rawValue,
             accountAddress: accountAddress
         )
-        
+
         let responseTx = await txObserver.first(filters: errorResponse, successResponse)
-        
+
         if errorResponse.matches(tx: responseTx) {
             throw CrowdNodeError.signUp
         }
-        
+
         return (req: signUpTx, resp: responseTx)
     }
-    
+
     private func acceptTerms(_ accountAddress: String, _ inputs: [DSTransaction]) async throws -> (req: DSTransaction, resp: DSTransaction) {
         let termsAcceptedTx = try await sendCoinsService.sendCoins(
             address: CrowdNodeConstants.crowdNodeAddress,
             amount: CrowdNodeConstants.apiOffset + ApiCode.acceptTerms.rawValue,
             inputSelector: SingleInputAddressSelector(candidates: inputs, address: accountAddress)
         )
-        
+
         let successResponse = CrowdNodeResponse(
             responseCode: ApiCode.welcomeToApi,
             accountAddress: accountAddress
@@ -171,13 +172,13 @@ extension CrowdNode {
             errorValue: successResponse.coins,
             accountAddress: accountAddress
         )
-        
+
         let responseTx = await txObserver.first(filters: errorResponse, successResponse)
-        
+
         if errorResponse.matches(tx: responseTx) {
             throw CrowdNodeError.signUp
         }
-        
+
         return (req: termsAcceptedTx, resp: responseTx)
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNodeConstants.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNodeConstants.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -15,21 +15,20 @@
 //  limitations under the License.
 //
 
-struct CrowdNodeConstants {
+enum CrowdNodeConstants {
     private static let crowdNodeTestNetAddress = "yMY5bqWcknGy5xYBHSsh2xvHZiJsRucjuy"
     private static let crowdNodeMainNetAddress = "XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2"
-    
+
     static var crowdNodeAddress: String {
-        get {
-            if (DWEnvironment.sharedInstance().currentChain.isMainnet()) {
-                return crowdNodeMainNetAddress
-            } else {
-                return crowdNodeTestNetAddress
-            }
+        if DWEnvironment.sharedInstance().currentChain.isMainnet() {
+            return crowdNodeMainNetAddress
+        }
+        else {
+            return crowdNodeTestNetAddress
         }
     }
-    
-    static var minimumRequiredDash = UInt64(1000000)
-    static var requiredForSignup = minimumRequiredDash -  UInt64(100000)
+
+    static var minimumRequiredDash = UInt64(1_000_000)
+    static var requiredForSignup = minimumRequiredDash - UInt64(100_000)
     static var apiOffset = UInt64(20000)
 }

--- a/DashWallet/Sources/Models/CrowdNode/Model/ApiCode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Model/ApiCode.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -22,9 +22,9 @@ enum ApiCode: UInt64 {
     case withdrawalQueue = 16
     case withdrawalDenied = 32
     case withdrawAll = 1000
-    case signUp = 131072
+    case signUp = 131_072
     case acceptTerms = 65536
-    
+
     func maxCode() -> ApiCode {
         return ApiCode.signUp
     }

--- a/DashWallet/Sources/Models/CrowdNode/Model/CrowdNodeError.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Model/CrowdNodeError.swift
@@ -15,18 +15,19 @@
 //  limitations under the License.
 //
 
-public class CrowdNodeResponse: CoinsToAddressTxFilter {
-    let responseCode: ApiCode
+enum CrowdNodeError: Error {
+    case signUp
+    case deposit
+    case withdraw
     
-    init(responseCode: ApiCode, accountAddress: String?) {
-        self.responseCode = responseCode
-        let accountAddress = accountAddress
-        let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
-        
-        super.init(coins: responseAmount, address: accountAddress)
-    }
-    
-    override func matches(tx: DSTransaction) -> Bool {
-        return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
+    public var description: String {
+        switch self {
+        case .signUp:
+            return NSLocalizedString("We couldn’t create your CrowdNode account.", comment: "")
+        case .deposit:
+            return NSLocalizedString("We couldn’t make a deposit to your CrowdNode account.", comment: "")
+        case .withdraw:
+            return NSLocalizedString("We couldn’t withdraw from your CrowdNode account.", comment: "")
+        }
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/Model/CrowdNodeError.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Model/CrowdNodeError.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -19,7 +19,7 @@ enum CrowdNodeError: Error {
     case signUp
     case deposit
     case withdraw
-    
+
     public var description: String {
         switch self {
         case .signUp:

--- a/DashWallet/Sources/Models/CrowdNode/Services/SendCoinsService.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/SendCoinsService.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -19,18 +19,19 @@ import Combine
 
 public class SendCoinsService {
     private let transactionManager: DSTransactionManager = DWEnvironment.sharedInstance().currentChainManager.transactionManager
-    
+
     func sendCoins(address: String, amount: UInt64, inputSelector: SingleInputAddressSelector? = nil) async throws -> DSTransaction {
         let amount = UInt64(amount)
         let chain = DWEnvironment.sharedInstance().currentChain
         let account = DWEnvironment.sharedInstance().currentAccount
-        let transaction = DSTransaction.init(on: chain)
-        
-        if (inputSelector == nil) {
+        let transaction = DSTransaction(on: chain)
+
+        if inputSelector == nil {
             // Forming transaction normally
             let script = NSData.scriptPubKey(forAddress: address, for: chain)
             account.update(transaction, forAmounts: [amount], toOutputScripts: [script], withFee: true)
-        } else {
+        }
+        else {
             // Selecting proper inputs
             let balance = inputSelector!.selectFor(tx: transaction)
             transaction.addOutputAddress(address, amount: amount)
@@ -41,11 +42,11 @@ public class SendCoinsService {
             transaction.addOutputAddress(changeAddress, amount: change)
             transaction.sortOutputsAccordingToBIP69()
         }
-        
+
         await account.sign(transaction, withPrompt: nil)
         account.register(transaction, saveImmediately: false)
         try await transactionManager.publishTransaction(transaction)
-    
+
         return transaction
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -18,29 +18,28 @@
 import Combine
 
 public class TransactionObserver {
-    
     /// Observes status changes for transactions that match `filter`
     func observe(filters: [TransactionFilter]) -> AnyPublisher<DSTransaction, Never> {
         return NotificationCenter.default.publisher(for: NSNotification.Name.DSTransactionManagerTransactionStatusDidChange)
             .compactMap { notification in
                 let txKey = DSTransactionManagerNotificationTransactionKey
-                
+
                 if let info = notification.userInfo {
                     if let tx = info[txKey] as? DSTransaction {
                         return tx
                     }
                 }
-                
+
                 return nil
             }
             .filter { tx in filters.contains { $0.matches(tx: tx) } }
             .eraseToAnyPublisher()
     }
-    
+
     /// Waits for the first status change that matches `filter`
     func first(filters: TransactionFilter...) async -> DSTransaction {
         return await withCheckedContinuation { continuation in
-            var cancellable: AnyCancellable? = nil
+            var cancellable: AnyCancellable?
             cancellable = observe(filters: filters).first().sink(receiveValue: { tx in
                 cancellable?.cancel()
                 continuation.resume(returning: tx)

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CoinsToAddressTxFilter.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CoinsToAddressTxFilter.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -19,25 +19,25 @@ public class CoinsToAddressTxFilter: TransactionFilter {
     private let matchingAddress: String?
     private let withFee: Bool
     private(set) var coins: UInt64
-    private(set) var toAddress: String? = nil
+    private(set) var toAddress: String?
     private(set) var fromAddresses = Set<String>()
-    
+
     init(coins: UInt64, address: String?, withFee: Bool = false) {
-        self.matchingAddress = address
+        matchingAddress = address
         self.coins = coins
         self.withFee = withFee
     }
-    
+
     func matches(tx: DSTransaction) -> Bool {
         fromAddresses.removeAll()
         tx.inputAddresses.forEach { fromAddresses.insert($0 as! String) }
-        
+
         let output = tx.outputs.first(where: { output in
             let amountToMatch = withFee ? output.amount + tx.feeUsed : output.amount
             return amountToMatch == coins &&
                 (matchingAddress == nil || output.address == matchingAddress)
         })
-        
+
         toAddress = output?.address ?? toAddress
         return output != nil
     }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CoinsToAddressTxFilter.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CoinsToAddressTxFilter.swift
@@ -1,0 +1,44 @@
+//  
+//  Created by Andrei Ashikhmin
+//  Copyright © 2022 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+public class CoinsToAddressTxFilter: TransactionFilter {
+    private let matchingAddress: String?
+    private let withFee: Bool
+    private(set) var coins: UInt64
+    private(set) var toAddress: String? = nil
+    private(set) var fromAddresses = Set<String>()
+    
+    init(coins: UInt64, address: String?, withFee: Bool = false) {
+        self.matchingAddress = address
+        self.coins = coins
+        self.withFee = withFee
+    }
+    
+    func matches(tx: DSTransaction) -> Bool {
+        fromAddresses.removeAll()
+        tx.inputAddresses.forEach { fromAddresses.insert($0 as! String) }
+        
+        let output = tx.outputs.first(where: { output in
+            let amountToMatch = withFee ? output.amount + tx.feeUsed : output.amount
+            return amountToMatch == coins &&
+                (matchingAddress == nil || output.address == matchingAddress)
+        })
+        
+        toAddress = output?.address ?? toAddress
+        return output != nil
+    }
+}

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeErrorResponse.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeErrorResponse.swift
@@ -21,7 +21,7 @@ public class CrowdNodeErrorResponse: CoinsToAddressTxFilter {
         let accountAddress = accountAddress
         super.init(coins: errorValue, address: accountAddress, withFee: true)
     }
-    
+
     override func matches(tx: DSTransaction) -> Bool {
         return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
     }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeErrorResponse.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeErrorResponse.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -15,15 +15,11 @@
 //  limitations under the License.
 //
 
-public class CrowdNodeResponse: CoinsToAddressTxFilter {
-    let responseCode: ApiCode
-    
-    init(responseCode: ApiCode, accountAddress: String?) {
-        self.responseCode = responseCode
+/// CrowdNode returns the sent amount - fee as the indication of an error
+public class CrowdNodeErrorResponse: CoinsToAddressTxFilter {
+    init(errorValue: UInt64, accountAddress: String?) {
         let accountAddress = accountAddress
-        let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
-        
-        super.init(coins: responseAmount, address: accountAddress)
+        super.init(coins: errorValue, address: accountAddress, withFee: true)
     }
     
     override func matches(tx: DSTransaction) -> Bool {

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeRequest.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeRequest.swift
@@ -17,15 +17,15 @@
 
 public class CrowdNodeRequest: CoinsToAddressTxFilter {
     let requestCode: ApiCode
-    
+
     init(requestCode: ApiCode) {
         self.requestCode = requestCode
-        
+
         let address = CrowdNodeConstants.crowdNodeAddress
         let amount = CrowdNodeConstants.apiOffset + requestCode.rawValue
         super.init(coins: amount, address: address)
     }
-    
+
     override func matches(tx: DSTransaction) -> Bool {
         return super.matches(tx: tx) && fromAddresses.count == 1
     }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeRequest.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeRequest.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -15,18 +15,18 @@
 //  limitations under the License.
 //
 
-public class CrowdNodeResponse: CoinsToAddressTxFilter {
-    let responseCode: ApiCode
+public class CrowdNodeRequest: CoinsToAddressTxFilter {
+    let requestCode: ApiCode
     
-    init(responseCode: ApiCode, accountAddress: String?) {
-        self.responseCode = responseCode
-        let accountAddress = accountAddress
-        let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
+    init(requestCode: ApiCode) {
+        self.requestCode = requestCode
         
-        super.init(coins: responseAmount, address: accountAddress)
+        let address = CrowdNodeConstants.crowdNodeAddress
+        let amount = CrowdNodeConstants.apiOffset + requestCode.rawValue
+        super.init(coins: amount, address: address)
     }
     
     override func matches(tx: DSTransaction) -> Bool {
-        return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
+        return super.matches(tx: tx) && fromAddresses.count == 1
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeResponse.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeResponse.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -17,15 +17,15 @@
 
 public class CrowdNodeResponse: CoinsToAddressTxFilter {
     let responseCode: ApiCode
-    
+
     init(responseCode: ApiCode, accountAddress: String?) {
         self.responseCode = responseCode
         let accountAddress = accountAddress
         let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
-        
+
         super.init(coins: responseAmount, address: accountAddress)
     }
-    
+
     override func matches(tx: DSTransaction) -> Bool {
         return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
     }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -19,7 +19,7 @@ public class CrowdNodeTopUpTx: CoinsToAddressTxFilter {
     init(address: String) {
         super.init(coins: CrowdNodeConstants.requiredForSignup, address: address)
     }
-    
+
     override func matches(tx: DSTransaction) -> Bool {
         return tx.direction() == DSTransactionDirection.moved && super.matches(tx: tx)
     }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
@@ -15,18 +15,12 @@
 //  limitations under the License.
 //
 
-public class CrowdNodeResponse: CoinsToAddressTxFilter {
-    let responseCode: ApiCode
-    
-    init(responseCode: ApiCode, accountAddress: String?) {
-        self.responseCode = responseCode
-        let accountAddress = accountAddress
-        let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
-        
-        super.init(coins: responseAmount, address: accountAddress)
+public class CrowdNodeTopUpTx: CoinsToAddressTxFilter {
+    init(address: String) {
+        super.init(coins: CrowdNodeConstants.requiredForSignup, address: address)
     }
     
     override func matches(tx: DSTransaction) -> Bool {
-        return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
+        return tx.direction() == DSTransactionDirection.moved && super.matches(tx: tx)
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
@@ -1,0 +1,80 @@
+//  
+//  Created by Andrei Ashikhmin
+//  Copyright © 2022 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+class FullCrowdNodeSignUpTxSet: TransactionWrapper {
+    private let signUpRequestFilter = CrowdNodeRequest(requestCode: ApiCode.signUp)
+    private let crowdNodeTxFilters = [
+        CrowdNodeResponse(responseCode: ApiCode.welcomeToApi, accountAddress: nil),
+        CrowdNodeRequest(requestCode: ApiCode.acceptTerms),
+        CrowdNodeResponse(responseCode: ApiCode.pleaseAcceptTerms, accountAddress: nil)
+    ]
+    private var matchedFilters: [CoinsToAddressTxFilter] = []
+
+    var transactions: [Data: DSTransaction] = [:]
+    
+    var welcomeToApiResponse: CoinsToAddressTxFilter? {
+        matchedFilters.first { filter in
+            (filter as? CrowdNodeResponse)?.responseCode == ApiCode.welcomeToApi
+        }
+    }
+    
+    var acceptTermsRequest: CoinsToAddressTxFilter? {
+        matchedFilters.first { filter in
+            (filter as? CrowdNodeRequest)?.requestCode == ApiCode.acceptTerms
+        }
+    }
+    
+    var acceptTermsResponse: CoinsToAddressTxFilter? {
+        matchedFilters.first { filter in
+            (filter as? CrowdNodeResponse)?.responseCode == ApiCode.pleaseAcceptTerms
+        }
+    }
+    
+    var signUpRequest: CoinsToAddressTxFilter? {
+        matchedFilters.first { filter in
+            (filter as? CrowdNodeRequest)?.requestCode == ApiCode.signUp
+        }
+    }
+    
+    func tryInclude(tx: DSTransaction) {
+        if transactions[tx.txHashData] != nil {
+            // Already included
+            return
+        }
+
+        if signUpRequestFilter.matches(tx: tx) {
+            let chain = DWEnvironment.sharedInstance().currentChain
+            guard let possibleTopUpTx = chain.transaction(forHash: tx.inputs.first!.inputHash) else { return }
+            // TopUp transaction can only be matched if we know the account address
+            let topUpFilter = CrowdNodeTopUpTx(address: signUpRequestFilter.fromAddresses.first!)
+            
+            if topUpFilter.matches(tx: possibleTopUpTx) {
+                transactions[possibleTopUpTx.txHashData] = possibleTopUpTx
+                transactions[tx.txHashData] = tx
+                matchedFilters.append(topUpFilter)
+                matchedFilters.append(signUpRequestFilter)
+            }
+            
+            return
+        }
+        
+        if let matchedFilter = crowdNodeTxFilters.first(where: { $0.matches(tx: tx) }) {
+            transactions[tx.txHashData] = tx
+            matchedFilters.append(matchedFilter)
+        }
+    }
+}

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -20,36 +20,36 @@ class FullCrowdNodeSignUpTxSet: TransactionWrapper {
     private let crowdNodeTxFilters = [
         CrowdNodeResponse(responseCode: ApiCode.welcomeToApi, accountAddress: nil),
         CrowdNodeRequest(requestCode: ApiCode.acceptTerms),
-        CrowdNodeResponse(responseCode: ApiCode.pleaseAcceptTerms, accountAddress: nil)
+        CrowdNodeResponse(responseCode: ApiCode.pleaseAcceptTerms, accountAddress: nil),
     ]
     private var matchedFilters: [CoinsToAddressTxFilter] = []
 
     var transactions: [Data: DSTransaction] = [:]
-    
+
     var welcomeToApiResponse: CoinsToAddressTxFilter? {
         matchedFilters.first { filter in
             (filter as? CrowdNodeResponse)?.responseCode == ApiCode.welcomeToApi
         }
     }
-    
+
     var acceptTermsRequest: CoinsToAddressTxFilter? {
         matchedFilters.first { filter in
             (filter as? CrowdNodeRequest)?.requestCode == ApiCode.acceptTerms
         }
     }
-    
+
     var acceptTermsResponse: CoinsToAddressTxFilter? {
         matchedFilters.first { filter in
             (filter as? CrowdNodeResponse)?.responseCode == ApiCode.pleaseAcceptTerms
         }
     }
-    
+
     var signUpRequest: CoinsToAddressTxFilter? {
         matchedFilters.first { filter in
             (filter as? CrowdNodeRequest)?.requestCode == ApiCode.signUp
         }
     }
-    
+
     func tryInclude(tx: DSTransaction) {
         if transactions[tx.txHashData] != nil {
             // Already included
@@ -61,17 +61,17 @@ class FullCrowdNodeSignUpTxSet: TransactionWrapper {
             guard let possibleTopUpTx = chain.transaction(forHash: tx.inputs.first!.inputHash) else { return }
             // TopUp transaction can only be matched if we know the account address
             let topUpFilter = CrowdNodeTopUpTx(address: signUpRequestFilter.fromAddresses.first!)
-            
+
             if topUpFilter.matches(tx: possibleTopUpTx) {
                 transactions[possibleTopUpTx.txHashData] = possibleTopUpTx
                 transactions[tx.txHashData] = tx
                 matchedFilters.append(topUpFilter)
                 matchedFilters.append(signUpRequestFilter)
             }
-            
+
             return
         }
-        
+
         if let matchedFilter = crowdNodeTxFilters.first(where: { $0.matches(tx: tx) }) {
             transactions[tx.txHashData] = tx
             matchedFilters.append(matchedFilter)

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/SingleInputAddressSelector.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/SingleInputAddressSelector.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -19,26 +19,26 @@ public class SingleInputAddressSelector {
     let candidates: [DSTransaction]
     let address: String
     private let account = DWEnvironment.sharedInstance().currentAccount
-    
+
     init(candidates: [DSTransaction], address: String) {
         self.candidates = candidates
         self.address = address
     }
-    
+
     func selectFor(tx: DSTransaction) -> UInt64 {
         var balance: UInt64 = 0
-        
+
         candidates
             .filter { candidate in !account.transactionOutputsAreLocked(tx) }
             .forEach { candidate in
                 for (i, output) in candidate.outputs.enumerated() {
-                    if (output.address == self.address) {
+                    if output.address == self.address {
                         tx.addInputHash(candidate.txHash, index: UInt(i), script: output.outScript)
                         balance += output.amount
                     }
                 }
             }
-        
+
         return balance
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/SpendableTransaction.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/SpendableTransaction.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -18,11 +18,11 @@
 public class SpendableTransaction: TransactionFilter {
     private let txHashData: Data
     private let account = DWEnvironment.sharedInstance().currentAccount
-    
-    init (txHashData: Data) {
+
+    init(txHashData: Data) {
         self.txHashData = txHashData
     }
-    
+
     func matches(tx: DSTransaction) -> Bool {
         return tx.txHashData == txHashData &&
             !account.transactionOutputsAreLocked(tx)

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionWrapper.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionWrapper.swift
@@ -15,18 +15,7 @@
 //  limitations under the License.
 //
 
-public class CrowdNodeResponse: CoinsToAddressTxFilter {
-    let responseCode: ApiCode
-    
-    init(responseCode: ApiCode, accountAddress: String?) {
-        self.responseCode = responseCode
-        let accountAddress = accountAddress
-        let responseAmount = CrowdNodeConstants.apiOffset + responseCode.rawValue
-        
-        super.init(coins: responseAmount, address: accountAddress)
-    }
-    
-    override func matches(tx: DSTransaction) -> Bool {
-        return super.matches(tx: tx) && fromAddresses.first == CrowdNodeConstants.crowdNodeAddress
-    }
+protocol TransactionWrapper {
+    var transactions: [Data: DSTransaction] { get }
+    func tryInclude(tx: DSTransaction)
 }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionWrapper.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionWrapper.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //

--- a/DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard
@@ -18,7 +18,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lbk-ty-UO1">
-                                <rect key="frame" x="16" y="367" width="358" height="91"/>
+                                <rect key="frame" x="16" y="367" width="358" height="72"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ely-BQ-7hu" userLabel="Address Label">
+                                <rect key="frame" x="16" y="447" width="358" height="48"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <nil key="textColor"/>
@@ -38,7 +45,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </activityIndicatorView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sg3-mL-EdP">
-                                <rect key="frame" x="163" y="466" width="64" height="35"/>
+                                <rect key="frame" x="163" y="503" width="64" height="35"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Copy"/>
@@ -52,6 +59,7 @@
                     </view>
                     <connections>
                         <outlet property="actionButton" destination="FnW-zm-pFT" id="moS-Vv-9JP"/>
+                        <outlet property="addressLabel" destination="Ely-BQ-7hu" id="BII-eq-X5T"/>
                         <outlet property="animationView" destination="l8C-lh-lKO" id="to5-ct-SH2"/>
                         <outlet property="copyButton" destination="Sg3-mL-EdP" id="kdv-Hp-c2M"/>
                         <outlet property="outputLabel" destination="lbk-ty-UO1" id="e3W-Xh-bed"/>

--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -15,32 +15,67 @@
 //  limitations under the License.
 //
 
+import Combine
+
 class CrowdNodeModel {
-    private let crowdNode = CrowdNode()
+    private var cancellableBag = Set<AnyCancellable>()
+    private let crowdNode = CrowdNode.shared
+    
     @Published var outputMessage: String = ""
+    @Published var accountAddress: String = ""
     @Published var isLoading: Bool = false
+    @Published var signUpEnabled: Bool = false
+    
+    
+    init() {
+        self.accountAddress = crowdNode.accountAddress
+        
+        crowdNode.$signUpState
+            .sink { [weak self] state in
+                self?.signUpEnabled = false
+                self?.isLoading = false
+                
+                switch state {
+                case .notStarted:
+                    self?.signUpEnabled = true
+                    self?.outputMessage = NSLocalizedString("Sign up to CrowdNode", comment: "")
+                    
+                case .fundingWallet, .signingUp:
+                    self?.isLoading = true
+                    self?.outputMessage = NSLocalizedString("Your CrowdNode account is creating…", comment: "")
+                    
+                case .acceptingTerms:
+                    self?.isLoading = true
+                    self?.outputMessage = NSLocalizedString("Accepting terms of use…", comment: "")
+                    
+                case .finished:
+                    self?.outputMessage = NSLocalizedString("Your CrowdNode account is set up and ready to use!", comment: "")
+                    
+                case .error:
+                    self?.signUpEnabled = true
+                    self?.outputMessage = NSLocalizedString("We couldn’t create your CrowdNode account.", comment: "") + " \(String(describing: self?.crowdNode.apiError?.localizedDescription))"
+                    
+                case .linkedOnline:
+                    break
+                }
+            }
+            .store(in: &cancellableBag)
+    }
     
     @MainActor
     func signUp() {
         Task.init {
-            defer { isLoading = false }
-            
             if let accountAddress = DWEnvironment.sharedInstance().currentAccount.receiveAddress {
                 print("CrowdNode account address: \(accountAddress)")
-                outputMessage = accountAddress
+                self.accountAddress = accountAddress
                 
-                do {
-                    let success = await DSAuthenticationManager.sharedInstance().authenticate(
-                        withPrompt: NSLocalizedString("Sign up to CrowdNode", comment: ""),
-                        usingBiometricAuthentication: false, alertIfLockout: false
-                    ).0
+                let success = await DSAuthenticationManager.sharedInstance().authenticate(
+                    withPrompt: NSLocalizedString("Sign up to CrowdNode", comment: ""),
+                    usingBiometricAuthentication: false, alertIfLockout: false
+                ).0
             
-                    if (success) {
-                        isLoading = true
-                        try await crowdNode.signUp(accountAddress: accountAddress)
-                    }
-                } catch {
-                    outputMessage = error.localizedDescription
+                if (success) {
+                    await crowdNode.signUp(accountAddress: accountAddress)
                 }
             }
         }

--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -20,61 +20,60 @@ import Combine
 class CrowdNodeModel {
     private var cancellableBag = Set<AnyCancellable>()
     private let crowdNode = CrowdNode.shared
-    
+
     @Published var outputMessage: String = ""
     @Published var accountAddress: String = ""
     @Published var isLoading: Bool = false
     @Published var signUpEnabled: Bool = false
-    
-    
+
     init() {
-        self.accountAddress = crowdNode.accountAddress
-        
+        accountAddress = crowdNode.accountAddress
+
         crowdNode.$signUpState
             .sink { [weak self] state in
                 self?.signUpEnabled = false
                 self?.isLoading = false
-                
+
                 switch state {
                 case .notStarted:
                     self?.signUpEnabled = true
                     self?.outputMessage = NSLocalizedString("Sign up to CrowdNode", comment: "")
-                    
+
                 case .fundingWallet, .signingUp:
                     self?.isLoading = true
                     self?.outputMessage = NSLocalizedString("Your CrowdNode account is creating…", comment: "")
-                    
+
                 case .acceptingTerms:
                     self?.isLoading = true
                     self?.outputMessage = NSLocalizedString("Accepting terms of use…", comment: "")
-                    
+
                 case .finished:
                     self?.outputMessage = NSLocalizedString("Your CrowdNode account is set up and ready to use!", comment: "")
-                    
+
                 case .error:
                     self?.signUpEnabled = true
                     self?.outputMessage = NSLocalizedString("We couldn’t create your CrowdNode account.", comment: "") + " \(String(describing: self?.crowdNode.apiError?.localizedDescription))"
-                    
+
                 case .linkedOnline:
                     break
                 }
             }
             .store(in: &cancellableBag)
     }
-    
+
     @MainActor
     func signUp() {
         Task.init {
             if let accountAddress = DWEnvironment.sharedInstance().currentAccount.receiveAddress {
                 print("CrowdNode account address: \(accountAddress)")
                 self.accountAddress = accountAddress
-                
+
                 let success = await DSAuthenticationManager.sharedInstance().authenticate(
                     withPrompt: NSLocalizedString("Sign up to CrowdNode", comment: ""),
                     usingBiometricAuthentication: false, alertIfLockout: false
                 ).0
-            
-                if (success) {
+
+                if success {
                     await crowdNode.signUp(accountAddress: accountAddress)
                 }
             }

--- a/DashWallet/Sources/UI/CrowdNode/New Account/NewAccountViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/New Account/NewAccountViewController.swift
@@ -1,4 +1,4 @@
-//  
+//
 //  Created by Andrei Ashikhmin
 //  Copyright © 2022 Dash Core Group. All rights reserved.
 //
@@ -15,41 +15,40 @@
 //  limitations under the License.
 //
 
-import UIKit
 import Combine
-
+import UIKit
 
 class NewAccountViewController: UIViewController {
     private let viewModel = CrowdNodeModel()
     private var cancellableBag = Set<AnyCancellable>()
-    
+
     @IBOutlet var actionButton: UIButton!
     @IBOutlet var outputLabel: UILabel!
     @IBOutlet var addressLabel: UILabel!
     @IBOutlet var copyButton: UIButton!
     @IBOutlet var animationView: UIActivityIndicatorView!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configureHierarchy()
         configureObservers()
     }
-    
+
     @objc static func controller() -> NewAccountViewController {
         let storyboard = UIStoryboard(name: "CrowdNode", bundle: nil)
         let vc = storyboard.instantiateViewController(withIdentifier: "NewAccountViewController") as! NewAccountViewController
         return vc
     }
-    
+
     @IBAction func createAccountAction() {
         viewModel.signUp()
     }
-    
+
     @IBAction func copyOutput() {
         UIPasteboard.general.string = addressLabel.text
     }
-    
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         cancellableBag.removeAll()
@@ -58,18 +57,17 @@ class NewAccountViewController: UIViewController {
 
 extension NewAccountViewController {
     private func configureHierarchy() {
-        self.definesPresentationContext = true
-        self.view.backgroundColor = UIColor.dw_secondaryBackground()
+        definesPresentationContext = true
+        view.backgroundColor = UIColor.dw_secondaryBackground()
         actionButton.setTitle(NSLocalizedString("Sign up to CrowdNode", comment: ""), for: .normal)
     }
 
-    
     private func configureObservers() {
         viewModel.$signUpEnabled
             .receive(on: DispatchQueue.main)
             .assign(to: \.isEnabled, on: actionButton)
             .store(in: &cancellableBag)
-        
+
         viewModel.$accountAddress
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] address in
@@ -77,18 +75,19 @@ extension NewAccountViewController {
                 self?.copyButton.isEnabled = !address.isEmpty
             })
             .store(in: &cancellableBag)
-        
+
         viewModel.$outputMessage
             .receive(on: DispatchQueue.main)
             .assign(to: \.text!, on: outputLabel)
             .store(in: &cancellableBag)
-        
+
         viewModel.$isLoading
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] isLoading in
-                if (isLoading) {
+                if isLoading {
                     self?.animationView.startAnimating()
-                } else {
+                }
+                else {
                     self?.animationView.stopAnimating()
                 }
             })


### PR DESCRIPTION
## Issue being fixed or feature implemented
When CrowdNode is re-initialized (e.g. due to the app being restarted) we want to restore the current sign-up state.

## What was done?
- Going through the wallet transactions and detecting all that belong to the sign-up process.
- Setting the current CrowdNode sign-up state depending on the available transactions.
- Restoring the account address that was used for sign-up.

Additionally, `swiftformat` was applied to the CrowdNode folders.

## How Has This Been Tested?
manually

## Breaking Changes
n/a


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone