### PR TITLE
feat(coinbase): Use UInt64 for coinbase balance instead of String

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -578,6 +578,7 @@
 		47C661B428FDCF7800028A8D /* ActionButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C661B328FDCF7800028A8D /* ActionButtonViewController.swift */; };
 		47C661B628FE75A700028A8D /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C661B528FE75A700028A8D /* BaseViewController.swift */; };
 		47C661B828FE907300028A8D /* AmountInputControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47C661B728FE907300028A8D /* AmountInputControl.swift */; };
+		47E4B7B7292F85E800CE0EB6 /* Numbers+Dash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E4B7B6292F85E800CE0EB6 /* Numbers+Dash.swift */; };
 		47E71F76286AEDE300CDF2BD /* DWCSVExporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 47E71F74286AED1900CDF2BD /* DWCSVExporter.m */; };
 		47F2C67D28602D4F00C2B774 /* BasePageSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2C67C28602D4F00C2B774 /* BasePageSheetViewController.swift */; };
 		47F2C6822860319400C2B774 /* TxReclassifyTransactionsInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F2C6812860319400C2B774 /* TxReclassifyTransactionsInfoViewController.swift */; };
@@ -1733,6 +1734,7 @@
 		47C661B328FDCF7800028A8D /* ActionButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButtonViewController.swift; sourceTree = "<group>"; };
 		47C661B528FE75A700028A8D /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		47C661B728FE907300028A8D /* AmountInputControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountInputControl.swift; sourceTree = "<group>"; };
+		47E4B7B6292F85E800CE0EB6 /* Numbers+Dash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Numbers+Dash.swift"; sourceTree = "<group>"; };
 		47E71F74286AED1900CDF2BD /* DWCSVExporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DWCSVExporter.m; sourceTree = "<group>"; };
 		47E71F75286AED1900CDF2BD /* DWCSVExporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWCSVExporter.h; sourceTree = "<group>"; };
 		47F2C67C28602D4F00C2B774 /* BasePageSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePageSheetViewController.swift; sourceTree = "<group>"; };
@@ -4067,6 +4069,7 @@
 				47B30D77290BFCA60080C326 /* NumberFormatter+DashWallet.swift */,
 				47B30D7B29100ABA0080C326 /* UIStackView+DashWallet.swift */,
 				47B30D812911259D0080C326 /* UIViewController+Payments.swift */,
+				47E4B7B6292F85E800CE0EB6 /* Numbers+Dash.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -5859,6 +5862,7 @@
 				2AD1CE8D22DCB3B600C99324 /* DWVerifySeedPhraseModel.m in Sources */,
 				2ADB396924223D9B00A6F898 /* DWDashPayAnimationView.m in Sources */,
 				2AEC5CBE24940EC200F4A689 /* DWDPOutgoingRequestNotificationObject.m in Sources */,
+				47E4B7B7292F85E800CE0EB6 /* Numbers+Dash.swift in Sources */,
 				47AE8C1328C5F0A700490F5E /* PointOfUseDetailsViewController.swift in Sources */,
 				47AE8C1C28C6AA2500490F5E /* PointOfUseLocationServicePopup.swift in Sources */,
 				47F2C6822860319400C2B774 /* TxReclassifyTransactionsInfoViewController.swift in Sources */,

--- a/DashWallet/Sources/Categories/Numbers+Dash.swift
+++ b/DashWallet/Sources/Categories/Numbers+Dash.swift
@@ -1,0 +1,31 @@
+//  
+//  Created by tkhp
+//  Copyright © 2022 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension UInt64 {
+    var formattedDashAmount: String {
+        let plainNumber = Decimal(self)
+        let duffsNumber = Decimal(DUFFS)
+        let dashNumber = plainNumber/duffsNumber
+        if #available(iOS 15.0, *) {
+            return dashNumber.formatted(.number)
+        } else {
+            return "\(dashNumber)"
+        }
+    }
+}

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -47,8 +47,14 @@ class Coinbase {
 }
 
 extension Coinbase {
-    var lastKnownBalance: String? {
-        getUserCoinbaseAccounts.lastKnownBalance
+    var lastKnownBalance: UInt64? {
+        guard let balance = getUserCoinbaseAccounts.lastKnownBalance, let dashNumber = Decimal(string: balance) else {
+            return nil
+        }
+        
+        let duffsNumber = Decimal(DUFFS)
+        let plainAmount = dashNumber * duffsNumber
+        return NSDecimalNumber(decimal: plainAmount).uint64Value
     }
 
     var hasLastKnownBalance: Bool {

--- a/DashWallet/Sources/Models/Coinbase/domain/Model/remote/CoinbaseUserAccountsResponse.swift
+++ b/DashWallet/Sources/Models/Coinbase/domain/Model/remote/CoinbaseUserAccountsResponse.swift
@@ -36,7 +36,18 @@ struct CoinbaseUserAccountData: Codable, Identifiable {
 
 // MARK: - Balance
 struct Balance: Codable {
-    let amount, currency: String
+    let amount: String
+    let currency: String
+    
+    var plainAmount: UInt64 {
+        guard let dashNumber = Decimal(string: amount) else {
+            return 0
+        }
+        
+        let duffsNumber = Decimal(DUFFS)
+        let plainAmount = dashNumber * duffsNumber
+        return NSDecimalNumber(decimal: plainAmount).uint64Value
+    }
 }
 
 // MARK: - Currency

--- a/DashWallet/Sources/UI/Coinbase/CoinbaseEntryPoint/Model/CoinbaseEntryPointModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/CoinbaseEntryPoint/Model/CoinbaseEntryPointModel.swift
@@ -78,7 +78,7 @@ final class CoinbaseEntryPointModel {
     var balance: UInt64 {
         guard let amount = Coinbase.shared.lastKnownBalance else { return 0 }
         
-        return UInt64(DSPriceManager.sharedInstance().amount(forDashString: amount))
+        return amount
     }
     
     private var reachability: DSReachabilityManager { return DSReachabilityManager.shared() }

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/Model/TransferAmountModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/Model/TransferAmountModel.swift
@@ -61,9 +61,8 @@ final class TransferAmountModel: SendAmountModel {
             super.selectAllFunds(preparationHandler)
         } else {
             guard let balance = Coinbase.shared.lastKnownBalance else { return }
-            
-            let maxAmount = AmountObject(dashAmountString: balance, fiatCurrencyCode: localCurrencyCode, localFormatter: localFormatter)
-            
+        
+            let maxAmount = AmountObject(plainAmount: Int64(balance), fiatCurrencyCode: localCurrencyCode, localFormatter: localFormatter)
             updateCurrentAmountObject(with: maxAmount)
         }
     }

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountViewController.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountViewController.swift
@@ -146,18 +146,15 @@ extension TransferAmountViewController: ConverterViewDelegate {
 //MARK: ConverterViewDataSource
 extension BaseAmountModel: ConverterViewDataSource {
     var coinbaseBalance: String {
-        return Coinbase.shared.lastKnownBalance ?? NSLocalizedString("Unknown Balance", comment: "Coinbase")
+        guard let balance = Coinbase.shared.lastKnownBalance else {
+            return NSLocalizedString("Unknown Balance", comment: "Coinbase")
+        }
+        
+        return balance.formattedDashAmount
     }
     
     var walletBalance: String {
-        let plainNumber = Decimal(DWEnvironment.sharedInstance().currentWallet.balance)
-        let duffsNumber = Decimal(DUFFS)
-        let dashNumber = plainNumber/duffsNumber
-        if #available(iOS 15.0, *) {
-            return dashNumber.formatted(.number)
-        } else {
-            return "\(dashNumber)"
-        }
+        DWEnvironment.sharedInstance().currentWallet.balance.formattedDashAmount
     }
 }
 

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/Views/ConverterView.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/Views/ConverterView.swift
@@ -121,6 +121,8 @@ extension ConverterView {
         leftContainer.translatesAutoresizingMaskIntoConstraints = false
         leftContainer.alignment = .center
         leftContainer.spacing = 22
+        leftContainer.isUserInteractionEnabled = true
+        leftContainer.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(swapAction)))
         addSubview(leftContainer)
         
         let fromLabel = UILabel()
@@ -132,7 +134,6 @@ extension ConverterView {
         
         swapImageView = UIImageView(image: UIImage(named: "coinbase.converter.switch"))
         swapImageView.isUserInteractionEnabled = true
-        swapImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(swapAction)))
         leftContainer.addArrangedSubview(swapImageView)
         
         let toLabel = UILabel()
@@ -222,17 +223,15 @@ private class SourceView: UIView {
         imageView.image = UIImage(named: source.imageName)
         titleLabel.text = source.title
         
-        if let balance = balance, let _ = Double(balance) {
+        if let balance = balance, let dashNumber = Decimal(string: balance, locale: .current) {
             walletBalanceStackView.isHidden = false
   
-            let dashNumber = Decimal(string: balance, locale: .current)!
             let duffsNumber = Decimal(DUFFS)
-            var plainAmount = dashNumber * duffsNumber
+            let plainAmount = dashNumber * duffsNumber
             
             let dashAmount = NSDecimalNumber(decimal: plainAmount).int64Value
             let fiatAmount = DSPriceManager.sharedInstance().localCurrencyString(forDashAmount: dashAmount) ?? "Fetching..."
             
-            var hasNetwork = true
             let lastKnownBalance = hasNetwork ? "" : NSLocalizedString("Last known balance", comment: "Buy Sell Portal") + ": "
             let dashStr = "\(balance) DASH"
             let fiatStr = " ≈ \(fiatAmount)"

--- a/DashWallet/Sources/UI/Portal/Model/ServiceDataSource.swift
+++ b/DashWallet/Sources/UI/Portal/Model/ServiceDataSource.swift
@@ -51,15 +51,13 @@ class UpholdDataSource: ServiceDataSource {
             self.item = ServiceItem(status: .syncing, service: .uphold)
             
             if let balance: NSDecimalNumber = DWUpholdClient.sharedInstance().lastKnownBalance {
-                let balance = balance.description(withLocale: NSLocale.current)
-                item = .init(status: .authorized, service: .uphold, dashBalance: balance)
+                item = .init(status: .authorized, service: .uphold, dashBalance: balance.uint64Value)
             } else {
                 DWUpholdClient.sharedInstance().getCards { [weak self] dashCard, fiatCards in
                     self?.dashCard = dashCard
                     
                     if let available: NSDecimalNumber = dashCard?.available {
-                        let balance = available.description(withLocale: NSLocale.current)
-                        self?.item = .init(status: .authorized, service: .uphold, dashBalance: balance)
+                        self?.item = .init(status: .authorized, service: .uphold, dashBalance: available.uint64Value)
                     } else {
                         self?.item = .init(status: .failed, service: .uphold)
                     }
@@ -99,7 +97,7 @@ class CoinbaseDataSource: ServiceDataSource {
                         case .finished: break
                         }
                     }, receiveValue: { [weak self] response in
-                        self?.item = .init(status: .authorized, service: .coinbase, dashBalance: response?.balance.amount)
+                        self?.item = .init(status: .authorized, service: .coinbase, dashBalance: response?.balance.plainAmount)
                     })
                     .store(in: &cancelables)
             }

--- a/DashWallet/Sources/UI/Portal/Model/VO/ServiceItem.swift
+++ b/DashWallet/Sources/UI/Portal/Model/VO/ServiceItem.swift
@@ -40,11 +40,7 @@ extension ServiceItem {
         guard let balance = dashBalance else { return nil }
         
         let priceManger = DSPriceManager.sharedInstance()
-        let dashAmount = DWAmountObject(dashAmountString: balance,
-                                        localFormatter: priceManger.localFormat,
-                                        currencyCode: priceManger.localCurrencyCode)
-        
-        return priceManger.localCurrencyString(forDashAmount: dashAmount.plainAmount)
+        return priceManger.localCurrencyString(forDashAmount: Int64(balance))
     }
 }
 
@@ -68,12 +64,12 @@ class ServiceItem: Hashable {
     var status: Status
     var service: Service
 
-    var dashBalance: String?
+    var dashBalance: UInt64?
     var usageCount: Int = 0
     
     var isInUse: Bool { return status == .syncing || status == .authorized }
     
-    init(status: Status, service: Service, dashBalance: String? = nil) {
+    init(status: Status, service: Service, dashBalance: UInt64? = nil) {
         self.status = status
         self.service = service
         self.dashBalance = dashBalance


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fetching user's balance from coinbase returns string value in us_US locale. If user has a different locale we can't parse the balance correctly.

## What was done?
<!--- Describe your changes in detail -->
- [x] Coinbase service returns balance as `UInt64`
- [x] Update UI to handle plain dash amount instead of string

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone