### PR TITLE
fix(crowdnode): authenticate the user before deposit

### DIFF
--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -296,7 +296,11 @@ extension CrowdNodeModel {
 extension CrowdNodeModel {
     func deposit(amount: Int64) async throws {
         guard amount > 0 else { return }
-        try await crowdNode.deposit(amount: UInt64(amount))
+        
+        let usingBiometric = DSAuthenticationManager.sharedInstance().canUseBiometricAuthentication(forAmount: UInt64(amount))
+        if await authenticate(allowBiometric: usingBiometric) {
+            try await crowdNode.deposit(amount: UInt64(amount))
+        }
     }
 
     func withdraw(permil: UInt) async throws {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
To avoid crashes due to authorization being forcefully invoked in non-UI thread, we need to manually authorize the user in UI thread before the deposit is made.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone