### PR TITLE
fix(ui): Use 'delete.left' icon when running on device with iOS < 15.0

### DIFF
--- a/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboardButton.swift
+++ b/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboardButton.swift
@@ -129,7 +129,13 @@ class NumberKeyboardButton: UIView {
             titleLabel.text = value.stringValue
         case .delete:
 
-            let image = UIImage(systemName: "delete.backward")!.withTintColor(Styles.textColor)
+            let image: UIImage
+
+            if #available(iOS 15.0, *) {
+                image = UIImage(systemName: "delete.backward")!.withTintColor(Styles.textColor)
+            } else {
+                image = UIImage(systemName: "delete.left")!.withTintColor(Styles.textColor)
+            }
 
             let textAttachment = NSTextAttachment()
             textAttachment.image = image


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When app is running on iOS 14 we get a crash due to missing system icon. The one we have been using is only available for iOS 15+.

## What was done?
<!--- Describe your changes in detail -->
- [x] Use 'delete.left' icon when running on device with iOS < 15.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone