### PR TITLE
feat(crowdnode): Tax category for CrowdNode and Coinbase

### DIFF
--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -106,7 +106,9 @@ extension Coinbase {
 
     public func createNewCoinbaseDashAddress() async throws -> String {
         do {
-            return try await accountService.retrieveAddress(for: kDashAccount)
+            let address = try await accountService.retrieveAddress(for: kDashAccount)
+            Taxes.shared.mark(address: address, with: .transferOut)
+            return address
         } catch Coinbase.Error.userSessionRevoked {
             try await auth.signOut()
             throw Coinbase.Error.userSessionRevoked
@@ -129,7 +131,12 @@ extension Coinbase {
     public func transferFromCoinbaseToDashWallet(verificationCode: String?,
                                                  amount: UInt64) async throws -> CoinbaseTransaction {
         do {
-            return try await accountService.send(from: kDashAccount, amount: amount, verificationCode: verificationCode)
+            let tx = try await accountService.send(from: kDashAccount, amount: amount, verificationCode: verificationCode)
+            
+            if let address = tx.to?.address {
+                Taxes.shared.mark(address: address, with: .transferIn)
+            }
+            return tx
         } catch Coinbase.Error.userSessionRevoked {
             try await auth.signOut()
             throw Coinbase.Error.userSessionRevoked

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -244,7 +244,7 @@ extension CrowdNode {
         DSLogger.log("found finished CrowdNode sign up, account: \(address)")
         signUpState = SignUpState.finished
         refreshBalance(retries: 1)
-        // TODO: tax category
+        setTaxCategories()
     }
 
     private func setAcceptingTerms(address: String) {
@@ -784,7 +784,7 @@ extension CrowdNode {
                     accountAddress = address
                     prefs.crowdNodeAccountAddress = address
                     prefs.crowdNodePrimaryAddress = result.primaryAddress
-                    // TODO: tax category
+                    setTaxCategories()
                     changeOnlineState(to: .validating)
                 }
             }
@@ -920,5 +920,12 @@ extension CrowdNode {
         default:
             break
         }
+    }
+}
+
+extension CrowdNode {
+    private func setTaxCategories() {
+        Taxes.shared.mark(address: accountAddress, with: .transferIn)
+        Taxes.shared.mark(address: CrowdNode.crowdNodeAddress, with: .transferOut)
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -87,7 +87,7 @@ public final class CrowdNode {
         case linking = 1
         case validating = 2
         case confirming = 3
-        case creating = 4 // TODO: NMI-917
+        case creating = 4
         case signingUp = 5
         case done = 6
 

--- a/DashWallet/Sources/Models/Taxes/Taxes.swift
+++ b/DashWallet/Sources/Models/Taxes/Taxes.swift
@@ -73,8 +73,10 @@ class Taxes: NSObject {
             if let address = outputAddress as? String, let txCategory = self.taxCategory(for: address) {
                 // Some transactions might have output that returns change
                 // to the input same address, so need to check that directions match.
-                if (tx.direction() == .sent && txCategory.isOutgoing) ||
-                    (tx.direction() == .received && txCategory.isIncoming) {
+                let txDirection = tx.direction
+                
+                if (txDirection == .sent && txCategory.isOutgoing) ||
+                    (txDirection == .received && txCategory.isIncoming) {
                     taxCategory = txCategory
                     break
                 }

--- a/DashWallet/Sources/Models/Taxes/Taxes.swift
+++ b/DashWallet/Sources/Models/Taxes/Taxes.swift
@@ -35,6 +35,14 @@ enum TxUserInfoTaxCategory: Int {
 
     /// Expense
     case expense
+    
+    var isIncoming: Bool  {
+        self == .income || self == .transferIn
+    }
+    
+    var isOutgoing: Bool  {
+        self == .expense || self == .transferOut
+    }
 }
 
 // MARK: - Taxes
@@ -61,8 +69,16 @@ class Taxes: NSObject {
     func taxCategory(for tx: DSTransaction) -> TxUserInfoTaxCategory {
         var taxCategory: TxUserInfoTaxCategory = tx.defaultTaxCategory()
 
-        if let inputAddress = tx.inputAddresses.first as? String, let txCategory = self.taxCategory(for: inputAddress) {
-            taxCategory = txCategory
+        for outputAddress in tx.outputAddresses {
+            if let address = outputAddress as? String, let txCategory = self.taxCategory(for: address) {
+                // Some transactions might have output that returns change
+                // to the input same address, so need to check that directions match.
+                if (tx.direction() == .sent && txCategory.isOutgoing) ||
+                    (tx.direction() == .received && txCategory.isIncoming) {
+                    taxCategory = txCategory
+                    break
+                }
+            }
         }
 
         taxCategory = txUserInfos.get(by: tx.txHashData)?.taxCategory ?? taxCategory

--- a/DashWallet/Sources/UI/CrowdNode/Online/CrowdNodeWebViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Online/CrowdNodeWebViewController.swift
@@ -84,7 +84,6 @@ class CrowdNodeWebViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 if state == .done {
-                    // TODO: check
                     self?.navigationController?.popViewController(animated: true)
                 }
             }
@@ -94,7 +93,6 @@ class CrowdNodeWebViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
                 if error != nil {
-                    // TODO: check
                     self?.navigationController?.popViewController(animated: true)
                 }
             }

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
@@ -283,7 +283,8 @@ extension CrowdNodeTransferController {
             if isOnlineAccountDone {
                 UIApplication.shared.open(URL(string: CrowdNode.withdrawalLimitsUrl)!)
             } else {
-                // TODO create online account
+                vc.dismiss(animated: true)
+                self.navigationController?.pushViewController(OnlineAccountEmailController.controller(), animated: true)
             }
         }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
We want to mark CrowdNode and Coinbase addresses with a tax category.


## What was done?
- `taxCategory` function is fixed to check the outputs of a transaction for an address.
- CrowdNode address and account address are marked with tax categories.
- Addresses from which transfers to and from Coinbase are made are marked with tax categories.
- Small fixed and cleanup for CrowdNode.


## How Has This Been Tested?
manually


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone