### PR TITLE
fix: Display 'Syncing...' message instead of crashing

### DIFF
--- a/DashWallet/Sources/Categories/DSTransaction+DashWallet.swift
+++ b/DashWallet/Sources/Categories/DSTransaction+DashWallet.swift
@@ -43,7 +43,16 @@ extension DSTransaction {
         case .moved:
             amount = account!.amountReceivedFromTransaction(onExternalAddresses: self)
         case .sent:
-            amount = chain.amountSent(by: self) - chain.amountReceived(from: self) - (feeUsed == UInt64.max ? 0 : feeUsed)
+            let amountSent = chain.amountSent(by: self)
+            let amountReceived = chain.amountReceived(from: self)
+
+            // NOTE: During the sync we may get an incorectly amount from DashSync.
+            if amountReceived > amountSent {
+                return UInt64.max
+            }
+
+            let fee = feeUsed == UInt64.max ? 0 : feeUsed
+            amount = amountSent - amountReceived - fee
         case .received:
             amount = account!.amountReceived(from: self)
         case .notAccountFunds:

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -273,7 +273,10 @@ extension TxDetailModel {
         guard hasFee else { return nil }
 
         let title = NSLocalizedString("Network fee", comment: "")
-        let feeValue = transaction.feeUsed
+
+        var feeValue = transaction.feeUsed
+        feeValue = feeValue == UInt64.max ? 0 : feeValue
+
         let detail = NSAttributedString.dashAttributedString(for: feeValue, tintColor: tintColor, font: font)
 
         return DWTitleDetailCellModel(style: .default, title: title, attributedDetail: detail)

--- a/DashWallet/Sources/UI/Views/Transitions/Item/Model/TransactionDataItem.swift
+++ b/DashWallet/Sources/UI/Views/Transitions/Item/Model/TransactionDataItem.swift
@@ -33,6 +33,10 @@ protocol TransactionDataItem {
 
 extension TransactionDataItem {
     var formattedDashAmountWithDirectionalSymbol: String {
+        guard dashAmount != UInt64.max else {
+            return NSLocalizedString("Syncing...", comment: "Transaction/Amount")
+        }
+
         let formatted = dashAmount.formattedDashAmount
 
         if formatted.isCurrencySymbolAtTheBeginning {
@@ -43,6 +47,10 @@ extension TransactionDataItem {
     }
 
     func attributedDashAmount(with font: UIFont, color: UIColor = .dw_label()) -> NSAttributedString {
+        guard dashAmount != UInt64.max else {
+            return NSAttributedString(string: NSLocalizedString("Syncing...", comment: "Transaction/Amount"))
+        }
+
         var formatted = formattedDashAmountWithDirectionalSymbol
         return formatted.attributedAmountStringWithDashSymbol(tintColor: color, dashSymbolColor: color, font: font)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Display 'Syncing...' message instead of crashing. 

The core issue is that when we sync the wallet for the first time (or do transaction re-sync) the app crashes, because DashSync returns invalid result for input/output amount. For example, when we are trying to retrieve input/output amount, for the first time, for a transaction that has 9 inputs and 9 outputs we only able to calculate amount for 4 inputs and 5 outputs, because we don’t have all addresses of all funding derivation paths at that moment.

The previous versions had not been crashing, but was showing the wrong amount for some time during the sync, because:

```
uint64_t amount = 1 - 2; // Legal operation in objc
let amount: UInt64 = 1 - 2 // Crash in swift, arithmetic overflow 
````

## What was done?
<!--- Describe your changes in detail -->
- [x] Return `UInt64.max` as transaction amount instead of crashing due to arithmetic overflow
- [x] Show 'Syncing...' message if amount is equal to `UInt64.max`
- [x] Show 0 fees instead of `UInt64.max` value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone