### PR TITLE
fix(crowdnode): Validating preferences before restoring state

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -180,6 +180,7 @@ extension CrowdNode {
 
         DSLogger.log("restoring CrowdNode state")
         signUpState = SignUpState.notStarted
+        validatePrefs()
 
         if tryRestoreSignUp() {
             refreshWithdrawalLimits()
@@ -203,7 +204,7 @@ extension CrowdNode {
                 DSLogger.log("Failure while restoring linked CrowdNode account: \(error.localizedDescription)")
             }
         } else {
-            DSLogger.log("CrowdNode: online account address isn't found")
+            DSLogger.log("CrowdNode: account not found")
         }
     }
 
@@ -265,6 +266,17 @@ extension CrowdNode {
         prefs.accountAddress = address
         DSLogger.log("found signUp CrowdNode request, account: \(address)")
         signUpState = SignUpState.signingUp
+    }
+    
+    private func validatePrefs() {
+        if let accountAddress = prefs.accountAddress {
+            let wallet = DWEnvironment.sharedInstance().currentWallet
+            
+            if !wallet.containsAddress(accountAddress) {
+                DSLogger.log("Found alien address in CrowdNode prefs")
+                reset()
+            }
+        }
     }
 
     private func reset() {

--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -127,9 +127,11 @@ final class CrowdNodeModel {
     init() {
         signUpState = crowdNode.signUpState
         onlineAccountState = crowdNode.onlineAccountState
-        accountAddress = crowdNode.accountAddress
         observeState()
         observeBalances()
+        
+        crowdNode.restoreState()
+        accountAddress = crowdNode.accountAddress
     }
 
     func getAccountAddress() {
@@ -153,8 +155,6 @@ final class CrowdNodeModel {
             }
 
             if !accountAddress.isEmpty {
-                self.accountAddress = accountAddress
-
                 if await authenticate(message: promptMessage) {
                     signUpEnabled = false
                     await persistentSignUp(accountAddress: accountAddress)
@@ -238,8 +238,6 @@ final class CrowdNodeModel {
         crowdNode.$onlineAccountState
             .sink { [weak self] state in self?.onlineAccountState = state }
             .store(in: &cancellableBag)
-
-        crowdNode.restoreState()
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
In some cases, the wallet restores UserDefaults containing a saved address that doesn't belong to the current wallet.


## What was done?
- If prefs have an address, validate that it belongs to the wallet. Erase prefs if it isn't
- Restore CrowdNode state before assigning an address in the viewModel.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone