### PR TITLE
fix: Crash on backup reminder

### DIFF
--- a/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
@@ -145,11 +145,6 @@ final class BackupInfoViewController: BaseViewController {
         }
     }
 
-    @IBAction
-    func closeButtonAction() {
-        delegate?.secureWalletRoutineDidCanceled(self)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
@@ -123,10 +123,26 @@ final class BackupInfoViewController: BaseViewController {
 
     @IBAction
     func backupButtonAction() {
-        let controller = DWBackupSeedPhraseViewController(model: seedPhraseModel)
-        controller.shouldCreateNewWalletOnScreenshot = shouldCreateNewWalletOnScreenshot
-        controller.delegate = delegate
-        navigationController?.pushViewController(controller, animated: true)
+        if type == .setup {
+            showSeedPhraseViewController()
+        } else {
+            DSAuthenticationManager.sharedInstance()
+                .authenticate(withPrompt: nil,
+                              usingBiometricAuthentication: false,
+                              alertIfLockout: true) { [weak self] authenticated, _, _ in
+                    guard authenticated else {
+                        return
+                    }
+
+                    guard let self else {
+                        return
+                    }
+
+                    self.seedPhraseModel = DWPreviewSeedPhraseModel()
+                    self.seedPhraseModel.getOrCreateNewWallet()
+                    self.showSeedPhraseViewController()
+                }
+        }
     }
 
     @IBAction
@@ -180,6 +196,13 @@ extension BackupInfoViewController {
             showCloseButtonIfNeeded()
             bottomButtonStack.isHidden = false
         }
+    }
+
+    private func showSeedPhraseViewController() {
+        let controller = DWBackupSeedPhraseViewController(model: seedPhraseModel)
+        controller.shouldCreateNewWalletOnScreenshot = shouldCreateNewWalletOnScreenshot
+        controller.delegate = delegate
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     private func reloadCloseButton() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixed a crash that happens when user tries to backup the wallet from the reminder flow.

## What was done?
<!--- Describe your changes in detail -->
- [x] Initialize seed after auth and make it available for the seed view controller

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
QA/Manually 

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone