### PR TITLE
fix: Tapping share opens share dialog instead of closing the screen

### DIFF
--- a/DashWallet/Sources/UI/LockScreen/QuickReceive/DWQuickReceiveViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/QuickReceive/DWQuickReceiveViewController.m
@@ -88,10 +88,7 @@ static NSString *const DASH_WEBSITE = @"https://dash.org";
 - (void)setupView {
     self.titleLabel.text = NSLocalizedString(@"Scan this to Pay", @"A title of the quick receive screen");
 
-    // TODO: Implement quick receive
-
     DWReceiveViewController *receiveController = [[DWReceiveViewController alloc] initWithModel:self.receiveModel];
-    receiveController.viewType = DWReceiveViewType_QuickReceive;
     receiveController.delegate = self;
     receiveController.allowedToImportPrivateKey = NO;
 

--- a/DashWallet/Sources/UI/Payments/Receive/ReceiveViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/ReceiveViewController.swift
@@ -17,32 +17,11 @@
 
 import Foundation
 
-// MARK: - ReceiveViewType
-
-@objc(DWReceiveViewType)
-enum ReceiveViewType: Int {
-    @objc(DWReceiveViewType_Default)
-    case `default`
-
-    @objc(DWReceiveViewType_QuickReceive)
-    case quick
-}
-
-extension ReceiveViewType {
-    var secondButtonTitle: String {
-        if self == .default {
-            return NSLocalizedString("Share address", comment: "Receive screen")
-        } else {
-            return NSLocalizedString("Exit", comment: "Receive screen")
-        }
-    }
-}
 
 // MARK: - ReceiveViewControllerDelegate
 
 @objc(DWReceiveViewControllerDelegate)
 protocol ReceiveViewControllerDelegate: AnyObject {
-    func receiveViewControllerExitButtonAction(_ controller: ReceiveViewController)
     func importPrivateKeyButtonAction(_ controller: ReceiveViewController)
 }
 
@@ -51,9 +30,6 @@ protocol ReceiveViewControllerDelegate: AnyObject {
 @objc(DWReceiveViewController)
 class ReceiveViewController: BaseViewController {
     var model: DWReceiveModelProtocol!
-
-    @objc
-    var viewType: ReceiveViewType = .default
 
     @objc
     weak var delegate: ReceiveViewControllerDelegate?
@@ -98,7 +74,6 @@ extension ReceiveViewController {
         view.addSubview(mainStackView)
 
         let receiveContentView = ReceiveContentView.view(with: model)
-        receiveContentView.viewType = viewType
         receiveContentView.specifyAmountHandler = { [weak self] in
             guard let self else { return }
 
@@ -109,10 +84,6 @@ extension ReceiveViewController {
         receiveContentView.shareHandler = { [weak self] sender in
             guard let self else { return }
             self.dw_shareReceiveInfo(self.model, sender: sender)
-        }
-        receiveContentView.exitHandler = { [weak self] in
-            guard let self else { return }
-            self.delegate?.receiveViewControllerExitButtonAction(self)
         }
 
         receiveContentView.backgroundColor = .dw_background()

--- a/DashWallet/Sources/UI/Payments/Receive/RequestAmount/Views/DWRequestAmountContentView.m
+++ b/DashWallet/Sources/UI/Payments/Receive/RequestAmount/Views/DWRequestAmountContentView.m
@@ -49,7 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
 
         DWReceiveContentView *contentView = [DWReceiveContentView viewWith:model];
         contentView.translatesAutoresizingMaskIntoConstraints = NO;
-        contentView.viewType = DWReceiveViewType_Default;
         __weak typeof(self) weakSelf = self;
 
         contentView.shareHandler = ^(UIButton *sender) {

--- a/DashWallet/Sources/UI/Payments/Receive/Views/ReceiveContentView.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/Views/ReceiveContentView.swift
@@ -30,16 +30,10 @@ final class ReceiveContentView: UIView {
     private var model: DWReceiveModelProtocol!
     private var feedbackGenerator = UINotificationFeedbackGenerator()
 
-    @objc
-    public var viewType: ReceiveViewType = .default
-
     public var specifyAmountHandler: (() -> Void)?
 
     @objc
     public var shareHandler: ((UIButton) -> Void)?
-
-    @objc
-    public var exitHandler: (() -> Void)?
 
     @IBAction
     func addressButtonAction() {
@@ -60,11 +54,7 @@ final class ReceiveContentView: UIView {
 
     @IBAction
     func secondButtonAction() {
-        if viewType == .default {
-            shareHandler?(secondButton)
-        } else {
-            exitHandler?()
-        }
+        shareHandler?(secondButton)
     }
 
     @objc
@@ -94,7 +84,7 @@ final class ReceiveContentView: UIView {
 extension ReceiveContentView {
     private func configureHierarchy() {
         specifyAmountButton.setTitle(NSLocalizedString("Specify Amount", comment: "Receive screen"), for: .normal)
-        secondButton.setTitle(viewType.secondButtonTitle, for: .normal)
+        secondButton.setTitle(NSLocalizedString("Share address", comment: "Receive screen"), for: .normal)
     }
 
     private func reloadView() {
@@ -107,10 +97,7 @@ extension ReceiveContentView {
         qrCodeButton.isHidden = model.qrCodeImage == nil
 
         specifyAmountButton.isEnabled = hasValue
-
-        if viewType == .default {
-            secondButton.isEnabled = hasValue
-        }
+        secondButton.isEnabled = hasValue
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix an issue when tapping 'Share button' closes the screen.

## What was done?
<!--- Describe your changes in detail -->
- [x] Open share dialog when tapping 'Share' button on 'Quick Receive' screen

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, QA

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone