### PR TITLE
feat: Lock balance on 'ProvideAmountController' when sending from quick scan

### DIFF
--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -102,6 +102,10 @@ static CGFloat ActionButtonsHeight(void) {
     return controller;
 }
 
+- (BOOL)locksBalance {
+    return YES;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -28,6 +28,7 @@ protocol ProvideAmountViewControllerDelegate: AnyObject {
 final class ProvideAmountViewController: SendAmountViewController {
     weak var delegate: ProvideAmountViewControllerDelegate?
 
+    public var locksBalance = false
     private var balanceLabel: UILabel!
 
     private let address: String
@@ -166,8 +167,22 @@ final class ProvideAmountViewController: SendAmountViewController {
 
     @objc
     func toggleBalanceVisibilityAction() {
-        isBalanceHidden.toggle()
-        updateBalance()
+        let toggleBalance = { [weak self] in
+            guard let self else { return }
+
+            self.isBalanceHidden.toggle()
+            self.updateBalance()
+        }
+
+        if locksBalance && isBalanceHidden {
+            DSAuthenticationManager.sharedInstance().authenticate(withPrompt: nil, usingBiometricAuthentication: false, alertIfLockout: true) { authenticatedOrSuccess, _, _ in
+
+                guard authenticatedOrSuccess else { return }
+                toggleBalance()
+            }
+        } else {
+            toggleBalance()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
@@ -50,6 +50,7 @@ final class PaymentController: NSObject {
     @objc weak var presentationContextProvider: PaymentControllerPresentationContextProviding?
 
     @objc public var contactItem: DWDPBasicUserItem?
+    @objc public var locksBalance = false
 
     private var paymentProcessor: DWPaymentProcessor
     private weak var confirmViewController: DWConfirmSendPaymentViewController?
@@ -129,6 +130,7 @@ extension PaymentController: DWPaymentProcessorDelegate {
     func paymentProcessor(_ processor: DWPaymentProcessor, requestAmountWithDestination sendingDestination: String,
                           details: DSPaymentProtocolDetails?, contactItem: DWDPBasicUserItem) {
         let vc = ProvideAmountViewController(address: sendingDestination)
+        vc.locksBalance = locksBalance
         vc.delegate = self
         vc.hidesBottomBarWhenPushed = true
         // vc.contactItem = nil //TODO: pass contactItem

--- a/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.h
+++ b/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL demoMode;
 @property (nullable, nonatomic, weak) id<DWDemoDelegate> demoDelegate;
 
+@property (nonatomic, assign) BOOL locksBalance;
+
 - (void)performScanQRCodeAction;
 /// Check pasteboard and pay
 - (void)payToAddressAction;

--- a/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.m
+++ b/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.m
@@ -51,6 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.paymentController = [[PaymentController alloc] init];
     _paymentController.delegate = self;
+    _paymentController.locksBalance = self.locksBalance;
     _paymentController.presentationContextProvider = self;
     _paymentController.contactItem = [self contactItem];
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->


## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lock balance on 'ProvideAmountController' when sending from quick scan

## What was done?
<!--- Describe your changes in detail -->
- [x] Make it possible to lock balance and request auth before trying to show
- [x] Pass the `locksBalance` flag when sending from quick scan

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone