### PR TITLE
fix(crowdnode): crash on deposit tap

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -459,6 +459,11 @@ extension CrowdNode {
 
     func calculateWithdrawalPermil(forAmount: UInt64) -> UInt64 {
         let maxPermil = ApiCode.withdrawAll.rawValue
+        
+        if balance == 0 {
+            return maxPermil
+        }
+        
         let permil = UInt64(round(Double(forAmount * maxPermil) / Double(balance)))
         let requestPermil = min(permil, maxPermil)
 

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
@@ -63,16 +63,16 @@ final class CrowdNodeTransferController: SendAmountViewController, NetworkReacha
         }
         startNetworkMonitoring()
         configureObservers()
-
-        if mode == .deposit && viewModel.shouldShowWithdrawalLimitsDialog {
-            showWithdrawalLimitsInfo()
-            viewModel.shouldShowWithdrawalLimitsDialog = false
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         viewModel.showNotificationOnResult = false
+        
+        if mode == .deposit && viewModel.shouldShowWithdrawalLimitsDialog {
+            showWithdrawalLimitsInfo()
+            viewModel.shouldShowWithdrawalLimitsDialog = false
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
A user has an issue where tapping on Deposit in CrowdNode consistently causes a crash.

## What was done?
- `showWithdrawalLimitsInfo` moved to `viewDidAppear` as a potential fix.
- Check for 0 balance in `calculateWithdrawalPermil` just in case.

There aren't seem to be any other potential causes that I can detect right now. The crash happens immediately on navigation from Portal to Transfer screen, and not on actual deposit/withdrawal operation.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone