### PR TITLE
fix(coinbase): error and max button behavior

### DIFF
--- a/DashWallet/Sources/UI/Coinbase/Custodial Swaps/CustodialSwapsViewController.swift
+++ b/DashWallet/Sources/UI/Coinbase/Custodial Swaps/CustodialSwapsViewController.swift
@@ -126,6 +126,8 @@ extension CustodialSwapsViewController: ConverterViewDelegate {
             self.amountView.inputTypeSwitcher.reloadData()
             self.amountView.amountInputControl.reloadData()
             self.actionButton?.isEnabled = self.model.isAllowedToContinue
+            showErrorIfNeeded()
+            
             self.dismiss(animated: true)
         }
 

--- a/DashWallet/Sources/UI/Coinbase/Custodial Swaps/Model/CustodialSwapsModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Custodial Swaps/Model/CustodialSwapsModel.swift
@@ -110,11 +110,21 @@ class CustodialSwapsModel: CoinbaseAmountModel {
 
     override func selectAllFundsWithoutAuth() {
         guard let selectedAccount else { return }
-
-        let max = AmountObject(localAmountString: selectedAccount.info.balance.amount,
+        let max: AmountObject!
+        
+        if currentInputItem == .app {
+            max = AmountObject(plainAmount: selectedAccount.info.plainAmountInDash,
+                               fiatCurrencyCode: amount.fiatCurrencyCode,
+                               localFormatter: supplementaryNumberFormatter,
+                               currencyExchanger: currencyExchanger).localAmount
+            
+        } else {
+            max = AmountObject(localAmountString: selectedAccount.info.balance.amount,
                                fiatCurrencyCode: selectedAccount.info.balance.currency,
                                localFormatter: supplementaryNumberFormatter,
                                currencyExchanger: currencyExchanger)
+        }
+        
         supplementaryAmount = max
         mainAmount = supplementaryAmount.dashAmount
         amountDidChange()


### PR DESCRIPTION
## Issue being fixed or feature implemented
- The "Insufficient funds" error isn't recalculated when the source currency is switched.
- The local currency option shows the source currency value instead of the fiat value.


## What was done?
- Recheck if need to show an error after switching the currency
- Fix the AmountObject for the local currency 


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone