### PR TITLE
fix: crash in the Currency Picker on Close button tap

### DIFF
--- a/DashWallet/Sources/UI/Home/DWHomeViewController+DWShortcuts.m
+++ b/DashWallet/Sources/UI/Home/DWHomeViewController+DWShortcuts.m
@@ -156,6 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showLocalCurrencyAction {
     DWLocalCurrencyViewController *controller =
         [[DWLocalCurrencyViewController alloc] initWithNavigationAppearance:DWNavigationAppearance_White
+                                                           presentationMode:DWCurrencyPickerPresentationMode_Dialog
                                                                currencyCode:nil];
     controller.delegate = self;
     [self presentControllerModallyInNavigationController:controller];

--- a/DashWallet/Sources/UI/Menu/Settings/DWSettingsMenuViewController.m
+++ b/DashWallet/Sources/UI/Menu/Settings/DWSettingsMenuViewController.m
@@ -205,6 +205,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showCurrencySelector {
     DWLocalCurrencyViewController *controller =
         [[DWLocalCurrencyViewController alloc] initWithNavigationAppearance:DWNavigationAppearance_Default
+                                                           presentationMode:DWCurrencyPickerPresentationMode_Screen
                                                                currencyCode:nil];
     controller.delegate = self;
     [self.navigationController pushViewController:controller animated:YES];

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.h
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.h
@@ -21,6 +21,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, DWCurrencyPickerPresentationMode) {
+    DWCurrencyPickerPresentationMode_Dialog,
+    DWCurrencyPickerPresentationMode_Screen,
+};
+
 @class DWLocalCurrencyViewController;
 
 @protocol DWLocalCurrencyViewControllerDelegate <NSObject>
@@ -37,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isGlobal;
 
 - (instancetype)initWithNavigationAppearance:(DWNavigationAppearance)navigationAppearance
+                                presentationMode:(DWCurrencyPickerPresentationMode)mode
                                 currencyCode:(nullable NSString *)currencyCode;
 
 @end

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.m
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.m
@@ -33,6 +33,7 @@ static CGFloat const SECTION_SPACING = 10.0;
 @interface DWLocalCurrencyViewController () <UISearchBarDelegate, UISearchResultsUpdating>
 
 @property (nonatomic, assign) DWNavigationAppearance navigationAppearance;
+@property (nonatomic, assign) DWCurrencyPickerPresentationMode presentationMode;
 @property (nonatomic, strong) DWLocalCurrencyModel *model;
 @property (nonatomic, strong) UILabel *priceSourceLabel;
 
@@ -41,10 +42,12 @@ static CGFloat const SECTION_SPACING = 10.0;
 @implementation DWLocalCurrencyViewController
 
 - (instancetype)initWithNavigationAppearance:(DWNavigationAppearance)navigationAppearance
+                            presentationMode:(DWCurrencyPickerPresentationMode)mode
                                 currencyCode:(nullable NSString *)currencyCode {
     self = [super initWithStyle:UITableViewStylePlain];
     if (self) {
         self.navigationAppearance = navigationAppearance;
+        self.presentationMode = mode;
         if (navigationAppearance == DWNavigationAppearance_Default) {
             self.title = NSLocalizedString(@"Local Currency", nil);
         }
@@ -59,8 +62,10 @@ static CGFloat const SECTION_SPACING = 10.0;
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    UIBarButtonItem *barButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose target:self action:@selector(closeButtonAction)];
-    self.navigationItem.rightBarButtonItem = barButton;
+    if (self.presentationMode == DWCurrencyPickerPresentationMode_Dialog) {
+        UIBarButtonItem *barButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemClose target:self action:@selector(closeButtonAction)];
+        self.navigationItem.rightBarButtonItem = barButton;
+    }
 
     self.title = NSLocalizedString(@"Local Currency", nil);
 

--- a/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
@@ -115,6 +115,7 @@ class BaseAmountViewController: ActionButtonViewController, AmountProviding {
 
     internal func showCurrencyList() {
         let currencyController = DWLocalCurrencyViewController(navigationAppearance: .white,
+                                                               presentationMode: .dialog,
                                                                currencyCode: model.localCurrencyCode)
         currencyController.isGlobal = false
         currencyController.delegate = self


### PR DESCRIPTION
## Issue being fixed or feature implemented
If opened from Settings, the currency picker shows both the Back and the Close buttons and crashes when the Close button is pressed. The Close button is only intended to be shown for a popover mode and its behaviour isn't implemented in the screen mode.

## What was done?
- Make the currency picker aware of it's presentation mode.
- Don't show the close button for Screen presentation mode.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone