### PR TITLE
feat(dashpay): integrate DashPay UI into Send screen and Receive tab

### DIFF
--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -32,10 +32,12 @@ final class ProvideAmountViewController: SendAmountViewController {
     private var balanceLabel: UILabel!
 
     private let address: String
+    private let contact: DWDPBasicUserItem?
     private var isBalanceHidden = true
 
-    init(address: String) {
+    init(address: String, contact: DWDPBasicUserItem?) {
         self.address = address
+        self.contact = contact
         super.init(model: SendAmountModel())
     }
 
@@ -88,14 +90,32 @@ final class ProvideAmountViewController: SendAmountViewController {
         toLabel.textColor = .dw_label()
         toLabel.text = NSLocalizedString("to", comment: "Send Screen: to address")
         sendContainer.addSubview(toLabel)
+        
+        let destinationLabel = UILabel()
+        destinationLabel.translatesAutoresizingMaskIntoConstraints = false
+        destinationLabel.font = .dw_font(forTextStyle: .body)
+        destinationLabel.textColor = .dw_label()
+        destinationLabel.lineBreakMode = .byTruncatingMiddle
+        sendContainer.addSubview(destinationLabel)
 
-        let addressLabel = UILabel()
-        addressLabel.translatesAutoresizingMaskIntoConstraints = false
-        addressLabel.font = .dw_font(forTextStyle: .body)
-        addressLabel.textColor = .dw_label()
-        addressLabel.text = address
-        addressLabel.lineBreakMode = .byTruncatingMiddle
-        sendContainer.addSubview(addressLabel)
+    #if DASHPAY
+        let avatarView = DWDPAvatarView()
+        
+        if let contact = contact {
+            destinationLabel.text = contact.username
+            avatarView.blockchainIdentity = contact.blockchainIdentity
+            avatarView.translatesAutoresizingMaskIntoConstraints = false
+            avatarView.backgroundMode = .random
+            avatarView.isUserInteractionEnabled = false
+            avatarView.isSmall = true
+            sendContainer.addSubview(avatarView)
+        } else {
+            destinationLabel.text = address
+            avatarView.isHidden = true
+        }
+    #else
+        destinationLabel.text = address
+    #endif
 
         let balanceStackView = UIStackView()
         balanceStackView.axis = .horizontal
@@ -137,8 +157,12 @@ final class ProvideAmountViewController: SendAmountViewController {
 
         amountView.removeFromSuperview()
         stackView.addArrangedSubview(amountView)
-
-        NSLayoutConstraint.activate([
+        
+        titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        toLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        destinationLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        
+        var constraints = [
             stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
@@ -147,18 +171,44 @@ final class ProvideAmountViewController: SendAmountViewController {
             titleLabel.topAnchor.constraint(equalTo: sendContainer.topAnchor),
             titleLabel.bottomAnchor.constraint(equalTo: sendContainer.bottomAnchor),
 
-            toLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 2),
+            toLabel.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 8),
             toLabel.lastBaselineAnchor.constraint(equalTo: titleLabel.lastBaselineAnchor),
-
-            addressLabel.leadingAnchor.constraint(equalTo: toLabel.trailingAnchor, constant: 2),
-            addressLabel.lastBaselineAnchor.constraint(equalTo: titleLabel.lastBaselineAnchor),
-            addressLabel.trailingAnchor.constraint(equalTo: sendContainer.trailingAnchor),
-
+            
+            destinationLabel.lastBaselineAnchor.constraint(equalTo: titleLabel.lastBaselineAnchor),
+            
             spacer.widthAnchor.constraint(equalToConstant: 6),
 
             showHideBalanceButton.widthAnchor.constraint(equalToConstant: 24),
             showHideBalanceButton.heightAnchor.constraint(equalToConstant: 24),
+        ]
+        
+    #if DASHPAY
+        avatarView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        
+        if contact != nil {
+            constraints.append(contentsOf: [
+                avatarView.leadingAnchor.constraint(equalTo: toLabel.trailingAnchor, constant: 6),
+                avatarView.bottomAnchor.constraint(equalTo: sendContainer.bottomAnchor, constant: -2),
+                avatarView.widthAnchor.constraint(equalToConstant: 20),
+                avatarView.heightAnchor.constraint(equalToConstant: 20),
+                
+                destinationLabel.leadingAnchor.constraint(equalTo: avatarView.trailingAnchor, constant: 6),
+                destinationLabel.trailingAnchor.constraint(equalTo: sendContainer.trailingAnchor)
+            ])
+        } else {
+            constraints.append(contentsOf: [
+                destinationLabel.leadingAnchor.constraint(equalTo: toLabel.trailingAnchor, constant: 6),
+                destinationLabel.trailingAnchor.constraint(equalTo: sendContainer.trailingAnchor)
+            ])
+        }
+    #else
+        constraints.append(contentsOf: [
+            destinationLabel.leadingAnchor.constraint(equalTo: toLabel.trailingAnchor, constant: 2),
+            destinationLabel.trailingAnchor.constraint(equalTo: sendContainer.trailingAnchor)
         ])
+    #endif
+
+        NSLayoutConstraint.activate(constraints)
     }
 
     @objc

--- a/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
@@ -129,14 +129,12 @@ extension PaymentController: DWPaymentProcessorDelegate {
         }
     }
 
-    func paymentProcessor(_ processor: DWPaymentProcessor, requestAmountWithDestination sendingDestination: String,
-                          details: DSPaymentProtocolDetails?, contactItem: DWDPBasicUserItem) {
-        let vc = ProvideAmountViewController(address: sendingDestination)
+    func paymentProcessor(_ processor: DWPaymentProcessor, requestAmountWithDestination sendingDestination: String, details: DSPaymentProtocolDetails?, contactItem: DWDPBasicUserItem?) {
+        let vc = ProvideAmountViewController(address: sendingDestination, contact: contactItem)
         vc.locksBalance = locksBalance
         vc.delegate = self
         vc.hidesBottomBarWhenPushed = true
         vc.definesPresentationContext = true
-        // vc.contactItem = nil //TODO: pass contactItem
         // vc.demoMode = self.demoMode; //TODO: demoMode
         presentationAnchor!.navigationController?.pushViewController(vc, animated: true)
         provideAmountViewController = vc

--- a/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.h
+++ b/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)paymentProcessor:(DWPaymentProcessor *)processor
     requestAmountWithDestination:(NSString *)sendingDestination
                          details:(nullable DSPaymentProtocolDetails *)details
-                     contactItem:(id<DWDPBasicUserItem>)contactItem;
+                     contactItem:(nullable id<DWDPBasicUserItem>)contactItem;
 
 - (void)paymentProcessor:(DWPaymentProcessor *)processor
     requestUserActionTitle:(nullable NSString *)title

--- a/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModel.m
+++ b/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModel.m
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic, strong) UIImage *qrCodeImage;
 @property (nullable, nonatomic, copy) NSString *paymentAddress;
+#if DASHPAY
+@property (nullable, nonatomic, copy) NSString *username;
+#endif
 @property (nullable, nonatomic, strong) DSPaymentRequest *paymentRequest;
 @property (nonatomic, strong) dispatch_queue_t updateQueue;
 
@@ -76,6 +79,19 @@ NS_ASSUME_NONNULL_BEGIN
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
     pasteboard.string = paymentAddress;
 }
+
+#if DASHPAY
+- (void)copyUsernameToPasteboard {
+    NSString *username = self.paymentRequest.dashpayUsername;
+
+    if (!username) {
+        return;
+    }
+    
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    pasteboard.string = username;
+}
+#endif
 
 - (void)copyQRImageToPasteboard {
     UIImage *qrImage = self.qrCodeImage;
@@ -203,6 +219,9 @@ NS_ASSUME_NONNULL_BEGIN
             self.paymentRequest = paymentRequest;
             self.qrCodeImage = qrCodeImage;
             self.paymentAddress = paymentAddress;
+#if DASHPAY
+            self.username = paymentRequest.dashpayUsername;
+#endif
             [self.delegate receivingInfoDidUpdate];
         });
     });

--- a/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModelProtocol.h
+++ b/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModelProtocol.h
@@ -30,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, readonly, nonatomic, strong) UIImage *qrCodeImage;
 @property (nullable, readonly, nonatomic, copy) NSString *paymentAddress;
+#if DASHPAY
+@property (nullable, readonly, nonatomic, copy) NSString *username;
+#endif
 @property (readonly, nonatomic, assign) CGSize qrCodeSize;
 @property (readonly, nonatomic, assign) uint64_t amount;
 @property (nonatomic, weak) id<DWReceiveModelDelegate> delegate;
@@ -38,6 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)copyAddressToPasteboard;
 - (void)copyQRImageToPasteboard;
+#if DASHPAY
+- (void)copyUsernameToPasteboard;
+#endif
 
 - (nullable NSString *)requestAmountReceivedInfoIfReceived;
 

--- a/DashWallet/Sources/UI/Payments/Receive/ReceiveViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/ReceiveViewController.swift
@@ -105,15 +105,13 @@ extension ReceiveViewController {
         mainStackView.addArrangedSubview(importPrivateKeyButton)
 
         mainStackView.addArrangedSubview(EmptyView())
-
+        
         NSLayoutConstraint.activate([
             mainStackView.topAnchor.constraint(equalTo: view.topAnchor),
             mainStackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             mainStackView.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
             mainStackView.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-
-            receiveContentView.heightAnchor.constraint(equalToConstant: 373),
-            importPrivateKeyButton.heightAnchor.constraint(equalToConstant: 64),
+            importPrivateKeyButton.heightAnchor.constraint(equalToConstant: 64)
         ])
     }
 }

--- a/DashWallet/Sources/UI/Payments/Receive/Views/ReceiveContentView.xib
+++ b/DashWallet/Sources/UI/Payments/Receive/Views/ReceiveContentView.xib
@@ -3,7 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -12,22 +12,118 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReceiveContentView" customModule="dashwallet" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="393" height="429"/>
+        <stackView contentMode="scaleToFill" axis="vertical" id="iN0-l3-epB" customClass="ReceiveContentView" customModule="dashpay" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="876"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" placeholderIntrinsicWidth="244" placeholderIntrinsicHeight="244" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o9A-Nq-Am2" userLabel="QR Image Button">
-                    <rect key="frame" x="54" y="30" width="285" height="285"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iRW-QI-X6Y" userLabel="QRContainer">
+                    <rect key="frame" x="0.0" y="0.0" width="393" height="289"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" placeholderIntrinsicWidth="244" placeholderIntrinsicHeight="244" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o9A-Nq-Am2" userLabel="QR Image Button">
+                            <rect key="frame" x="72" y="25" width="249" height="249"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="o9A-Nq-Am2" secondAttribute="height" multiplier="1:1" id="bdd-pf-7Qi"/>
+                            </constraints>
+                            <connections>
+                                <action selector="qrButtonAction" destination="iN0-l3-epB" eventType="touchUpInside" id="fB9-hT-DuG"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
-                        <constraint firstAttribute="width" secondItem="o9A-Nq-Am2" secondAttribute="height" multiplier="1:1" id="ecn-15-zZJ"/>
+                        <constraint firstAttribute="height" constant="280" id="2np-sN-fAc"/>
+                        <constraint firstAttribute="bottom" secondItem="o9A-Nq-Am2" secondAttribute="bottom" constant="15" id="7qG-Yk-0Fz"/>
+                        <constraint firstItem="o9A-Nq-Am2" firstAttribute="centerX" secondItem="iRW-QI-X6Y" secondAttribute="centerX" id="EbK-YH-L0B"/>
+                        <constraint firstItem="o9A-Nq-Am2" firstAttribute="top" secondItem="iRW-QI-X6Y" secondAttribute="top" constant="25" id="sWf-6p-T8m"/>
                     </constraints>
+                </view>
+                <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xr5-Vn-acb">
+                    <rect key="frame" x="0.0" y="289" width="393" height="38"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="38" id="MvZ-tr-Kxr"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                    <color key="tintColor" name="Label"/>
+                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="-8" maxY="0.0"/>
+                    <state key="normal" title="Button" image="icon_copy_outline">
+                        <color key="titleColor" name="Label"/>
+                    </state>
                     <connections>
-                        <action selector="qrButtonAction" destination="iN0-l3-epB" eventType="touchUpInside" id="fB9-hT-DuG"/>
+                        <action selector="addressButtonAction" destination="iN0-l3-epB" eventType="touchUpInside" id="bbn-dg-vcc"/>
                     </connections>
                 </button>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RaT-Ej-cHE" userLabel="Address Container">
+                    <rect key="frame" x="0.0" y="327" width="393" height="78"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Dash address" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lWz-IE-Gom" userLabel="Label">
+                            <rect key="frame" x="15" y="9" width="88.333333333333329" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <color key="textColor" name="SecondaryTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="yfLBSjZxH9Ut2aVNHRy6xRm3CwynpU2GQw" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1CX-Au-x58" userLabel="Address">
+                            <rect key="frame" x="15" y="31" width="323" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_copy_outline" translatesAutoresizingMaskIntoConstraints="NO" id="zJP-Ue-yE7" userLabel="Copy">
+                            <rect key="frame" x="360" y="31.333333333333311" width="13" height="15.333333333333332"/>
+                            <color key="tintColor" systemColor="labelColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="13" id="3dM-xn-JW2"/>
+                            </constraints>
+                        </imageView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="zJP-Ue-yE7" secondAttribute="trailing" constant="20" id="2Yg-zH-82n"/>
+                        <constraint firstItem="lWz-IE-Gom" firstAttribute="top" secondItem="RaT-Ej-cHE" secondAttribute="top" constant="9" id="8Ps-il-gmz"/>
+                        <constraint firstItem="1CX-Au-x58" firstAttribute="top" secondItem="lWz-IE-Gom" secondAttribute="bottom" constant="5" id="W1c-BG-YmV"/>
+                        <constraint firstAttribute="height" constant="78" id="e9p-u5-hcJ"/>
+                        <constraint firstAttribute="trailing" secondItem="1CX-Au-x58" secondAttribute="trailing" constant="55" id="fNz-ep-ZgM"/>
+                        <constraint firstItem="lWz-IE-Gom" firstAttribute="leading" secondItem="RaT-Ej-cHE" secondAttribute="leading" constant="15" id="iee-NT-jN0"/>
+                        <constraint firstItem="1CX-Au-x58" firstAttribute="leading" secondItem="RaT-Ej-cHE" secondAttribute="leading" constant="15" id="nfu-6H-u1g"/>
+                        <constraint firstItem="zJP-Ue-yE7" firstAttribute="centerY" secondItem="RaT-Ej-cHE" secondAttribute="centerY" id="oYI-OA-yfo"/>
+                    </constraints>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9nj-2z-HcH" userLabel="Username Container">
+                    <rect key="frame" x="0.0" y="405" width="393" height="60"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Username" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="haT-7z-9eY" userLabel="Label">
+                            <rect key="frame" x="15" y="5" width="66" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <color key="textColor" name="SecondaryTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="johndoe" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tFL-6u-bUn" userLabel="Username">
+                            <rect key="frame" x="15" y="27" width="323" height="17"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon_copy_outline" translatesAutoresizingMaskIntoConstraints="NO" id="Hos-kN-lDx" userLabel="Copy">
+                            <rect key="frame" x="360" y="22.666666666666686" width="13" height="15"/>
+                            <color key="tintColor" systemColor="labelColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="15" id="JlF-R9-Ybp"/>
+                                <constraint firstAttribute="width" constant="13" id="f5J-0p-lSu"/>
+                            </constraints>
+                        </imageView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="Hos-kN-lDx" secondAttribute="trailing" constant="20" id="5OW-SA-IW8"/>
+                        <constraint firstAttribute="height" constant="60" id="8DH-hN-qaM"/>
+                        <constraint firstAttribute="trailing" secondItem="tFL-6u-bUn" secondAttribute="trailing" constant="55" id="AHU-c0-FWQ"/>
+                        <constraint firstItem="tFL-6u-bUn" firstAttribute="top" secondItem="haT-7z-9eY" secondAttribute="bottom" constant="5" id="X0n-6G-1mv"/>
+                        <constraint firstItem="haT-7z-9eY" firstAttribute="top" secondItem="9nj-2z-HcH" secondAttribute="top" constant="5" id="ZV9-uJ-u6b"/>
+                        <constraint firstItem="tFL-6u-bUn" firstAttribute="leading" secondItem="9nj-2z-HcH" secondAttribute="leading" constant="15" id="dUA-wZ-0xL"/>
+                        <constraint firstItem="Hos-kN-lDx" firstAttribute="centerY" secondItem="9nj-2z-HcH" secondAttribute="centerY" id="dqQ-Ck-lrj"/>
+                        <constraint firstItem="haT-7z-9eY" firstAttribute="leading" secondItem="9nj-2z-HcH" secondAttribute="leading" constant="15" id="veT-MU-MDj"/>
+                    </constraints>
+                </view>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="RfN-ty-gGi">
-                    <rect key="frame" x="0.0" y="369" width="393" height="60"/>
+                    <rect key="frame" x="0.0" y="465" width="393" height="60"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kht-g7-sDW">
                             <rect key="frame" x="0.0" y="0.0" width="196.66666666666666" height="60"/>
@@ -56,64 +152,43 @@
                         <constraint firstAttribute="height" constant="60" id="DtG-Si-RzG"/>
                     </constraints>
                 </stackView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pyX-0c-gLN" customClass="HairlineView" customModule="dashwallet" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="368" width="393" height="1"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="1" id="ZIz-ux-YId"/>
-                    </constraints>
-                </view>
-                <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xr5-Vn-acb">
-                    <rect key="frame" x="15" y="330" width="363" height="38"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="38" id="MvZ-tr-Kxr"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                    <color key="tintColor" name="Label"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="-8" maxY="0.0"/>
-                    <state key="normal" title="Button" image="icon_copy_outline">
-                        <color key="titleColor" name="Label"/>
-                    </state>
-                    <connections>
-                        <action selector="addressButtonAction" destination="iN0-l3-epB" eventType="touchUpInside" id="bbn-dg-vcc"/>
-                    </connections>
-                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-            <constraints>
-                <constraint firstAttribute="bottom" secondItem="RfN-ty-gGi" secondAttribute="bottom" id="FfV-8o-evC"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="pyX-0c-gLN" secondAttribute="trailing" id="XEL-9X-Vtq"/>
-                <constraint firstItem="RfN-ty-gGi" firstAttribute="top" secondItem="pyX-0c-gLN" secondAttribute="bottom" id="Xnl-mY-QGf"/>
-                <constraint firstItem="RfN-ty-gGi" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Zyp-Ei-DJq"/>
-                <constraint firstItem="pyX-0c-gLN" firstAttribute="top" secondItem="Xr5-Vn-acb" secondAttribute="bottom" id="bl7-c7-BWL"/>
-                <constraint firstItem="o9A-Nq-Am2" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="eBm-kC-ItE"/>
-                <constraint firstItem="Xr5-Vn-acb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="15" id="eZn-a7-jkI"/>
-                <constraint firstItem="RfN-ty-gGi" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="g8w-BX-PGX"/>
-                <constraint firstItem="o9A-Nq-Am2" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="30" id="gaq-LN-4aw"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Xr5-Vn-acb" secondAttribute="trailing" constant="15" id="qLV-YR-DTB"/>
-                <constraint firstItem="pyX-0c-gLN" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="v7j-k2-Yyj"/>
-                <constraint firstItem="Xr5-Vn-acb" firstAttribute="top" secondItem="o9A-Nq-Am2" secondAttribute="bottom" constant="15" id="voh-Re-aek"/>
-            </constraints>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="actionButtonsStackView" destination="RfN-ty-gGi" id="FCA-Dj-gZM"/>
                 <outlet property="addressButton" destination="Xr5-Vn-acb" id="weK-db-IjM"/>
+                <outlet property="addressContainer" destination="RaT-Ej-cHE" id="ib9-Di-Npr"/>
+                <outlet property="addressLabel" destination="1CX-Au-x58" id="IDw-B2-u0N"/>
                 <outlet property="qrCodeButton" destination="o9A-Nq-Am2" id="wLm-gF-nRf"/>
+                <outlet property="qrContainer" destination="iRW-QI-X6Y" id="POe-kl-Z7c"/>
                 <outlet property="secondButton" destination="Yxz-Ss-dgD" id="bYU-DO-qPJ"/>
                 <outlet property="specifyAmountButton" destination="Kht-g7-sDW" id="ffA-zq-bDb"/>
+                <outlet property="usernameContainer" destination="9nj-2z-HcH" id="35m-8d-ybE"/>
+                <outlet property="usernameLabel" destination="tFL-6u-bUn" id="CMJ-Lh-ueQ"/>
             </connections>
-            <point key="canvasLocation" x="67.938931297709928" y="-107.3943661971831"/>
-        </view>
+            <point key="canvasLocation" x="57.251908396946561" y="43.661971830985919"/>
+        </stackView>
+        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" id="jZO-WJ-wdZ">
+            <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <point key="canvasLocation" x="-81" y="-349"/>
+        </imageView>
     </objects>
     <resources>
-        <image name="icon_copy_outline" width="16" height="16"/>
+        <image name="icon_copy_outline" width="13" height="15.333333015441895"/>
         <namedColor name="DashBlueColor">
             <color red="0.0" green="0.55294117647058827" blue="0.8901960784313725" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Label">
             <color red="0.097999997437000275" green="0.10999999940395355" blue="0.12200000137090683" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <namedColor name="SecondaryTextColor">
+            <color red="0.32156862745098042" green="0.36078431372549019" blue="0.40000000000000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="labelColor">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
## Issue being fixed or feature implemented
In DashPay, the Send screen should have the contact userpic and username instead of the destination address. The Receive tab should have the username under the address.


## What was done?
- Changed `ProvideAmountViewController` UI to display contact info if not null.
- Changed `ReceiveContentView` UI to include the username.
- `ReceiveContentView` content is adjusted on small screens to fit into SE format.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone