### PR TITLE
chore(coinbase): migrate Buy endpoints from v2 to v3

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -631,6 +631,8 @@
 		752772122AAA1CE30066557E /* Coinbase-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 752772112AAA1CE30066557E /* Coinbase-Info.plist */; };
 		754119E01CDA93FF0042DC51 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAE12BE61B2DEE7F00895CC5 /* NotificationCenter.framework */; };
 		757E09991ADB8EEB006FD352 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 757E09971ADB8EEB006FD352 /* Localizable.strings */; };
+		75CED09E2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CED09D2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift */; };
+		75CED0A02ACFED200095F10C /* CoinbaseDepositResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CED09F2ACFED200095F10C /* CoinbaseDepositResponse.swift */; };
 		75D5F3CE191EC270004AB296 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 75D5F3CD191EC270004AB296 /* main.m */; };
 		75E2F3C82AA4CF1900C3B458 /* Topper-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 75E2F3C72AA4CF1900C3B458 /* Topper-Info.plist */; };
 		75E2F3CA2AA4D1B900C3B458 /* Topper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E2F3C92AA4D1B900C3B458 /* Topper.swift */; };
@@ -1826,6 +1828,8 @@
 		759816E619357D6F005060EA /* BRBubbleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BRBubbleView.m; sourceTree = "<group>"; };
 		75CE194E1B9642EB000778E4 /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		75CE50B51B5216F100DBC18C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = DashWalletTests/Info.plist; sourceTree = SOURCE_ROOT; };
+		75CED09D2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseDepositRequest.swift; sourceTree = "<group>"; };
+		75CED09F2ACFED200095F10C /* CoinbaseDepositResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseDepositResponse.swift; sourceTree = "<group>"; };
 		75D5F3BE191EC270004AB296 /* dashwallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dashwallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		75D5F3C9191EC270004AB296 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		75D5F3CD191EC270004AB296 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -4903,6 +4907,7 @@
 		47A2A2E3293DF63F00938DB7 /* DTOs */ = {
 			isa = PBXGroup;
 			children = (
+				75CED09C2ACFD0E00095F10C /* Deposit */,
 				0F6EDFB028C896BC000427E7 /* Base */,
 				4751CACB2970004500F63AC4 /* Account */,
 				4751CACA2970003D00F63AC4 /* Exchange Rates */,
@@ -5385,6 +5390,15 @@
 				47FA3B0129364991008D58DC /* HTTPClient.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		75CED09C2ACFD0E00095F10C /* Deposit */ = {
+			isa = PBXGroup;
+			children = (
+				75CED09D2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift */,
+				75CED09F2ACFED200095F10C /* CoinbaseDepositResponse.swift */,
+			);
+			path = Deposit;
 			sourceTree = "<group>";
 		};
 		75D5F3B5191EC270004AB296 = {
@@ -6688,6 +6702,7 @@
 				2A913E8223A30623006A2A59 /* DWHomeModelStub.m in Sources */,
 				2ADC9D1C24603C4F001D7C0D /* UISearchBar+DWAdditions.m in Sources */,
 				2A74F0042305C59700C475EB /* UIViewController+DWTxFilter.m in Sources */,
+				75CED0A02ACFED200095F10C /* CoinbaseDepositResponse.swift in Sources */,
 				2ACCA3AD24BE117300DB32DE /* DWProfileTxsFetchedDataSource.m in Sources */,
 				117ED4A828ED66F9006E3EE4 /* TransactionFilter.swift in Sources */,
 				C3DAD2C024747F580001624F /* DWSearchViewController.m in Sources */,
@@ -6821,6 +6836,7 @@
 				C94F5E8C29D3FEC10034FD57 /* ShortcutsModel.swift in Sources */,
 				2A6300452328D07500827825 /* DWLockPinInputView.m in Sources */,
 				2A0C69AC23125074001B8C90 /* UIView+DWHUD.m in Sources */,
+				75CED09E2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift in Sources */,
 				C94D98212A4CC78F00F3BEE1 /* DashInputField.swift in Sources */,
 				2A8B9E6822FFE4CC00FF8653 /* DWPayOptionModel.m in Sources */,
 				2A7AF36924826681001D74F9 /* DWDPRespondedIncomingRequestObject.m in Sources */,

--- a/DashWallet/Sources/Models/Coinbase/Accounts/Account/CBAccount.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/Account/CBAccount.swift
@@ -132,7 +132,7 @@ extension CBAccount {
 
             let result: BaseDataResponse<CoinbaseTransaction> = try await httpClient
                 .request(.sendCoinsToWallet(accountId: accountId, verificationCode: verificationCode, dto: dto))
-            try? await refreshAccount() // Ignore if fails
+            let _ = try? await refreshAccount() // Ignore if fails
 
             return result.data
         } catch HTTPClientError.statusCode(let r) where r.statusCode == 402 {
@@ -164,46 +164,30 @@ extension CBAccount {
 
 // MARK: Buy
 extension CBAccount {
-    public func placeCoinbaseBuyOrder(amount: UInt64, paymentMethod: CoinbasePaymentMethod) async throws -> CoinbasePlaceBuyOrder {
-        let fiatCurrency = Coinbase.sendLimitCurrency
-        if let localNumber = try? Coinbase.shared.currencyExchanger.convertDash(amount: amount.dashAmount, to: fiatCurrency) {
-            if localNumber < kMinUSDAmountOrder {
-                let min = NSDecimalNumber(decimal: kMinUSDAmountOrder)
-                let localFormatter = NumberFormatter.fiatFormatter(currencyCode: fiatCurrency)
-                let str = localFormatter.string(from: min) ?? "$1.99"
-                throw Coinbase.Error.transactionFailed(.enteredAmountTooLow(minimumAmount: str))
-            } else if localNumber > Coinbase.shared.sendLimit {
-                throw Coinbase.Error.transactionFailed(.limitExceded)
-            }
+    public func placeCoinbaseBuyOrder(amount: UInt64) async throws -> CoinbasePlaceBuyOrder {
+        let fiatCurrency = Coinbase.defaultFiat
+        
+        guard let localNumber = try? Coinbase.shared.currencyExchanger.convertDash(amount: amount.dashAmount, to: fiatCurrency) else {
+            throw Coinbase.Error.general(.rateNotFound)
+        }
+        
+        if localNumber < kMinUSDAmountOrder {
+            let min = NSDecimalNumber(decimal: kMinUSDAmountOrder)
+            let localFormatter = NumberFormatter.fiatFormatter(currencyCode: fiatCurrency)
+            let str = localFormatter.string(from: min) ?? "$1.99"
+            throw Coinbase.Error.transactionFailed(.enteredAmountTooLow(minimumAmount: str))
+        } else if localNumber > Coinbase.shared.sendLimit {
+            throw Coinbase.Error.transactionFailed(.limitExceded)
         }
 
-        // NOTE: Make sure we format the amount back into coinbase format (en_US)
-        let amount = amount.formattedDashAmountWithoutCurrencySymbol.coinbaseAmount()
-
-        let request = CoinbasePlaceBuyOrderRequest(amount: amount, currency: kDashCurrency, paymentMethod: paymentMethod.id, commit: false, quote: nil)
+        let formatter = NumberFormatter.decimalFormatter
+        formatter.maximumFractionDigits = 2
+        let amountStr = formatter.string(from: NSDecimalNumber(decimal: localNumber))!.coinbaseAmount()
+        let request = CoinbasePlaceBuyOrderRequest(clientOrderId: UUID(), productId: Coinbase.dashUSDPair, side: Coinbase.transactionTypeBuy, orderConfiguration: OrderConfiguration(marketMarketIoc: MarketMarketIoc(quoteSize: amountStr)))
 
         do {
             try await authInterop.refreshTokenIfNeeded()
-            let result: BaseDataResponse<CoinbasePlaceBuyOrder> = try await httpClient.request(.placeBuyOrder(accountId, request))
-            return result.data
-        } catch HTTPClientError.statusCode(let r) {
-            if let error = r.error?.errors.first {
-                throw Coinbase.Error.transactionFailed(.message(error.message))
-            }
-
-            throw Coinbase.Error.unknownError
-        } catch {
-            throw error
-        }
-    }
-
-    public func commitCoinbaseBuyOrder(orderID: String) async throws -> CoinbasePlaceBuyOrder {
-        do {
-            try await authInterop.refreshTokenIfNeeded()
-            let result: BaseDataResponse<CoinbasePlaceBuyOrder> = try await httpClient.request(.commitBuyOrder(accountId, orderID))
-            try? await refreshAccount() // Ignore if fails
-
-            return result.data
+            return try await httpClient.request<CoinbasePlaceBuyOrder>(.placeBuyOrder(request))
         } catch HTTPClientError.statusCode(let r) {
             if let error = r.error?.errors.first {
                 throw Coinbase.Error.transactionFailed(.message(error.message))
@@ -265,7 +249,7 @@ extension CBAccount {
         do {
             try await authInterop.refreshTokenIfNeeded()
             let result: BaseDataResponse<CoinbaseSwapeTrade> = try await httpClient.request(.swapTradeCommit(orderID))
-            try? await refreshAccount() // Ignore if fails
+            let _ = try? await refreshAccount() // Ignore if fails
 
             return result.data
         } catch HTTPClientError.statusCode(let r) {

--- a/DashWallet/Sources/Models/Coinbase/Accounts/AccountRepository.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/AccountRepository.swift
@@ -26,6 +26,10 @@ class AccountRepository {
     var dashAccount: CBAccount? {
         cachedAccounts[kDashAccount]
     }
+    
+    var usdAccount: CBAccount? {
+        cachedAccounts[Coinbase.dashUSDPair]
+    }
 
     init(authInterop: CBAuthInterop) {
         self.authInterop = authInterop

--- a/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
@@ -58,16 +58,9 @@ class AccountService {
         return tx
     }
 
-    public func placeBuyOrder(for accountName: String, amount: UInt64, paymentMethod: CoinbasePaymentMethod) async throws -> CoinbasePlaceBuyOrder {
+    public func placeBuyOrder(for accountName: String, amount: UInt64) async throws -> CoinbasePlaceBuyOrder {
         let account = try await account(by: accountName)
-        return try await account.placeCoinbaseBuyOrder(amount: amount, paymentMethod: paymentMethod)
-    }
-
-    public func commitBuyOrder(accountName: String, orderID: String) async throws -> CoinbasePlaceBuyOrder {
-        let account = try await account(by: accountName)
-
-        let order = try await account.commitCoinbaseBuyOrder(orderID: orderID)
-        return order
+        return try await account.placeCoinbaseBuyOrder(amount: amount)
     }
 
     func placeTradeOrder(from origin: CBAccount, to destination: CBAccount, amount: String) async throws -> CoinbaseSwapeTrade {

--- a/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
@@ -62,6 +62,15 @@ class AccountService {
         let account = try await account(by: accountName)
         return try await account.placeCoinbaseBuyOrder(amount: amount)
     }
+    
+    public func deposit(to accountName: String, from paymentMethodId: String, amount: UInt64) async throws {
+        let account = try await account(by: accountName)
+        let result = try await account.deposit(from: paymentMethodId, amount: amount)
+        
+        if result.status != "created" {
+            throw Coinbase.Error.general(.depositFailed)
+        }
+    }
 
     func placeTradeOrder(from origin: CBAccount, to destination: CBAccount, amount: String) async throws -> CoinbaseSwapeTrade {
         try await origin.convert(amount: amount, to: destination)

--- a/DashWallet/Sources/Models/Coinbase/Auth/CBAuth.swift
+++ b/DashWallet/Sources/Models/Coinbase/Auth/CBAuth.swift
@@ -151,9 +151,7 @@ extension CBAuth {
             URLQueryItem(name: "account", value: Coinbase.account),
         ]
 
-        if let clientID = Coinbase.clientID as? String {
-            queryItems.append(URLQueryItem(name: "client_id", value: clientID))
-        }
+        queryItems.append(URLQueryItem(name: "client_id", value: Coinbase.clientID))
 
         var urlComponents = URLComponents()
         urlComponents.scheme = "https"

--- a/DashWallet/Sources/Models/Coinbase/Coinbase+Constants.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase+Constants.swift
@@ -24,7 +24,7 @@ extension Coinbase {
     static let grantType = "authorization_code"
     static let responseType = "code"
     static let scope =
-        "wallet:accounts:read,wallet:user:read,wallet:payment-methods:read,wallet:buys:read,wallet:buys:create,wallet:transactions:transfer,wallet:transactions:request,wallet:transactions:read,wallet:supported-assets:read,wallet:sells:create,wallet:sells:read,wallet:transactions:send,wallet:addresses:read,wallet:addresses:create,wallet:trades:create,wallet:accounts:create"
+        "wallet:accounts:read,wallet:user:read,wallet:payment-methods:read,wallet:buys:read,wallet:buys:create,wallet:transactions:transfer,wallet:transactions:request,wallet:transactions:read,wallet:supported-assets:read,wallet:sells:create,wallet:sells:read,wallet:transactions:send,wallet:addresses:read,wallet:addresses:create,wallet:trades:create,wallet:accounts:create,wallet:deposits:create"
     static let defaultFiat = "USD"
     static let sendLimitCurrency = defaultFiat
     static let sendLimitAmount: Decimal = 1.0

--- a/DashWallet/Sources/Models/Coinbase/Coinbase+Constants.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase+Constants.swift
@@ -25,10 +25,14 @@ extension Coinbase {
     static let responseType = "code"
     static let scope =
         "wallet:accounts:read,wallet:user:read,wallet:payment-methods:read,wallet:buys:read,wallet:buys:create,wallet:transactions:transfer,wallet:transactions:request,wallet:transactions:read,wallet:supported-assets:read,wallet:sells:create,wallet:sells:read,wallet:transactions:send,wallet:addresses:read,wallet:addresses:create,wallet:trades:create,wallet:accounts:create"
-    static let sendLimitCurrency = "USD"
+    static let defaultFiat = "USD"
+    static let sendLimitCurrency = defaultFiat
     static let sendLimitAmount: Decimal = 1.0
     static let sendLimitPeriod = "month"
     static let account = "all"
+    static let buyFee = 0.006
+    static let dashUSDPair = "DASH-USD"
+    static let transactionTypeBuy = "BUY"
     
     static let clientSecret: String = {
         if let path = Bundle.main.path(forResource: "Coinbase-Info", ofType: "plist"),

--- a/DashWallet/Sources/Models/Coinbase/Coinbase+Error.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase+Error.swift
@@ -27,6 +27,8 @@ extension Coinbase {
             case noActiveUser
             case revokedToken
             case noPaymentMethods
+            case noCashAccount
+            case rateNotFound
 
             var errorDescription: String? {
                 switch self {
@@ -36,6 +38,10 @@ extension Coinbase {
                     return NSLocalizedString("For your security, you have been signed out.", comment: "Coinbase")
                 case .noPaymentMethods:
                     return NSLocalizedString("Please add a payment method on Coinbase", comment: "Coinbase/Buy Dash")
+                case .noCashAccount:
+                    return NSLocalizedString("No cash account found", comment: "Coinbase")
+                case .rateNotFound:
+                    return NSLocalizedString("Could not find exchange rate.", comment: "")
                 }
             }
             

--- a/DashWallet/Sources/Models/Coinbase/Coinbase+Error.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase+Error.swift
@@ -29,6 +29,7 @@ extension Coinbase {
             case noPaymentMethods
             case noCashAccount
             case rateNotFound
+            case depositFailed
 
             var errorDescription: String? {
                 switch self {
@@ -42,6 +43,8 @@ extension Coinbase {
                     return NSLocalizedString("No cash account found", comment: "Coinbase")
                 case .rateNotFound:
                     return NSLocalizedString("Could not find exchange rate.", comment: "")
+                case .depositFailed:
+                    return NSLocalizedString("Failed to make a deposit.", comment: "Coinbase")
                 }
             }
             

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -109,6 +109,14 @@ extension Coinbase {
     var dashAccount: CBAccount? {
         accountService.dashAccount
     }
+    
+    public func getUsdAccount() async -> CBAccount? {
+        do {
+            return try await accountService.account(by: Coinbase.defaultFiat)
+        } catch {
+            return nil
+        }
+    }
 }
 
 extension Coinbase {
@@ -168,30 +176,9 @@ extension Coinbase {
     ///
     /// - Throws: Coinbase.Error
     ///
-    func placeCoinbaseBuyOrder(amount: UInt64,
-                               paymentMethod: CoinbasePaymentMethod) async throws -> CoinbasePlaceBuyOrder {
+    func placeCoinbaseBuyOrder(amount: UInt64) async throws -> CoinbasePlaceBuyOrder {
         do {
-            return try await accountService.placeBuyOrder(for: kDashAccount, amount: amount, paymentMethod: paymentMethod)
-        } catch Coinbase.Error.userSessionRevoked {
-            try await auth.signOut()
-            throw Coinbase.Error.userSessionRevoked
-        } catch {
-            throw error
-        }
-    }
-
-    /// Commit Buy Order
-    ///
-    /// - Parameters:
-    ///   - orderID: Order id from `CoinbasePlaceBuyOrder` you receive by calling `placeCoinbaseBuyOrder`
-    ///
-    /// - Returns: CoinbasePlaceBuyOrder
-    ///
-    /// - Throws: Coinbase.Error
-    ///
-    func commitCoinbaseBuyOrder(orderID: String) async throws -> CoinbasePlaceBuyOrder {
-        do {
-            return try await accountService.commitBuyOrder(accountName: kDashAccount, orderID: orderID)
+            return try await accountService.placeBuyOrder(for: kDashAccount, amount: amount)
         } catch Coinbase.Error.userSessionRevoked {
             try await auth.signOut()
             throw Coinbase.Error.userSessionRevoked

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -182,8 +182,23 @@ extension Coinbase {
         } catch Coinbase.Error.userSessionRevoked {
             try await auth.signOut()
             throw Coinbase.Error.userSessionRevoked
-        } catch {
-            throw error
+        }
+    }
+    
+    /// Deposit to the fiat account
+    ///
+    /// - Parameters:
+    ///   - paymentMethodId: Id of the payment method with which to make the deposit
+    ///   - amount: Plain amount in Dash
+    ///
+    /// - Throws: Coinbase.Error
+    ///
+    func depositToFiatAccount(from paymentMethodId: String, amount: UInt64) async throws {
+        do {
+            try await accountService.deposit(to: Coinbase.defaultFiat, from: paymentMethodId, amount: amount)
+        } catch Coinbase.Error.userSessionRevoked {
+            try await auth.signOut()
+            throw Coinbase.Error.userSessionRevoked
         }
     }
 

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/CoinbaseAPIEndpoint.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/CoinbaseAPIEndpoint.swift
@@ -133,6 +133,7 @@ struct CoinbaseAPIError: Decodable {
 public enum CoinbaseEndpoint {
     case account(String)
     case accounts
+    case deposit(accountId: String, dto: CoinbaseDepositRequest)
     case userAuthInformation
     case exchangeRates(String)
     case activePaymentMethods
@@ -176,6 +177,7 @@ extension CoinbaseEndpoint: TargetType, AccessTokenAuthorizable {
         switch self {
         case .account(let name): return "/v2/accounts/\(name)"
         case .accounts: return "/v2/accounts"
+        case .deposit(let accountId, _): return "v2/accounts/\(accountId)/deposits"
         case .userAuthInformation: return "/v2/user/auth"
         case .exchangeRates: return "/v2/exchange-rates"
         case .activePaymentMethods: return "/v2/payment-methods"
@@ -196,7 +198,7 @@ extension CoinbaseEndpoint: TargetType, AccessTokenAuthorizable {
 
     public var method: Moya.Method {
         switch self {
-        case .getToken, .placeBuyOrder, .sendCoinsToWallet, .swapTrade, .swapTradeCommit, .createCoinbaseAccountAddress, .refreshToken, .revokeToken:
+        case .getToken, .placeBuyOrder, .sendCoinsToWallet, .swapTrade, .swapTradeCommit, .createCoinbaseAccountAddress, .refreshToken, .revokeToken, .deposit:
             return .post
         default:
             return .get
@@ -234,6 +236,8 @@ extension CoinbaseEndpoint: TargetType, AccessTokenAuthorizable {
         case .swapTrade(let dto):
             return .requestJSONEncodable(dto)
         case .placeBuyOrder(let dto):
+            return .requestJSONEncodable(dto)
+        case .deposit(_, let dto):
             return .requestJSONEncodable(dto)
         case .accounts:
             return .requestParameters(parameters: ["limit": 300, "order": "asc"], encoding: URLEncoding.default)

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Deposit/CoinbaseDepositRequest.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Deposit/CoinbaseDepositRequest.swift
@@ -1,0 +1,30 @@
+//  
+//  Created by Andrei Ashikhmin
+//  Copyright © 2023 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+public struct CoinbaseDepositRequest: Codable {
+    let amount: String
+    let currency: String
+    let paymentMethod: String
+
+    enum CodingKeys: String, CodingKey {
+        case amount
+        case currency
+        case paymentMethod = "payment_method"
+    }
+}

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Deposit/CoinbaseDepositResponse.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Deposit/CoinbaseDepositResponse.swift
@@ -1,0 +1,37 @@
+//  
+//  Created by Andrei Ashikhmin
+//  Copyright © 2023 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+struct CoinbaseDepositResponse: Codable {
+    let id: String
+    let status: String
+    let createdAt: String
+    let updatedAt: String
+    let resource: String
+    let resourcePath: String
+    let committed: Bool
+    let payoutAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, status, resource, committed
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case resourcePath = "resource_path"
+        case payoutAt = "payout_at"
+    }
+}

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Payment Methods/CoinbasePaymentMethodsResponse.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Payment Methods/CoinbasePaymentMethodsResponse.swift
@@ -133,3 +133,16 @@ public enum PaymentMethodType: String, Codable {
         }
     }
 }
+
+extension PaymentMethodType {
+    var isBankAccount: Bool {
+        get {
+            switch self {
+            case .achBankAccount, .sepaBankAccount, .idealBankAccount, .eftBankAccount:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+}

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Place Buy Order/CoinbasePlaceBuyOrderRequest.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Place Buy Order/CoinbasePlaceBuyOrderRequest.swift
@@ -7,18 +7,34 @@
 
 import Foundation
 
-// MARK: - CoinBasePlaceBuyOrderRequest
-public struct CoinbasePlaceBuyOrderRequest: Codable {
-    let amount: String
-    let currency: String
-    let paymentMethod: String
-    let commit: Bool?
-    let quote: Bool?
+// MARK: - CoinbasePlaceOrderParams
 
+public struct CoinbasePlaceBuyOrderRequest: Codable {
+    var clientOrderId: UUID
+    var productId: String
+    var side: String
+    var orderConfiguration: OrderConfiguration
+    
     enum CodingKeys: String, CodingKey {
-        case amount
-        case currency
-        case paymentMethod = "payment_method"
-        case commit, quote
+        case clientOrderId = "client_order_id"
+        case productId = "product_id"
+        case side
+        case orderConfiguration = "order_configuration"
+    }
+}
+
+public struct OrderConfiguration: Codable {
+    var marketMarketIoc: MarketMarketIoc
+    
+    enum CodingKeys: String, CodingKey {
+        case marketMarketIoc = "market_market_ioc"
+    }
+}
+
+public struct MarketMarketIoc: Codable {
+    var quoteSize: String
+    
+    enum CodingKeys: String, CodingKey {
+        case quoteSize = "quote_size"
     }
 }

--- a/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Place Buy Order/CoinbasePlaceBuyOrderResponse.swift
+++ b/DashWallet/Sources/Models/Coinbase/Infrastructure/API/DTOs/Place Buy Order/CoinbasePlaceBuyOrderResponse.swift
@@ -10,59 +10,47 @@ import Foundation
 // MARK: - CoinbasePlaceBuyOrder
 
 struct CoinbasePlaceBuyOrder: Codable {
-    let id: String? // TODO: Use just String and handle error
-    let status: String?
-    let userReference, transaction, createdAt, updatedAt: String?
-    let resource: String?
-    let resourcePath: String?
-    let paymentMethod: PaymentMethod?
-    let holdUntil: String?
-    let holdDays: Int?
-    let isFirstBuy: Bool?
-    let fee: Amount
-    let amount: Amount
-    let total: Amount
-    let subtotal: Amount
-    let unitPrice: UnitPrice?
-    let requiresCompletionStep: Bool?
-    let committed: Bool?
-
+    let success: Bool
+    let failureReason: String
+    let orderId: String
+    let errorResponse: ErrorResponse?
+    let successResponse: SuccessResponse?
+    let orderConfiguration: OrderConfiguration?
+    
     enum CodingKeys: String, CodingKey {
-        case id
-        case fee
-        case status
-        case userReference = "user_reference"
-        case transaction
-        case createdAt = "created_at"
-        case updatedAt = "updated_at"
-        case resource
-        case resourcePath = "resource_path"
-        case paymentMethod = "payment_method"
-        case holdUntil = "hold_until"
-        case holdDays = "hold_days"
-        case isFirstBuy = "is_first_buy"
-        case amount, total, subtotal
-        case unitPrice = "unit_price"
-        case requiresCompletionStep = "requires_completion_step"
-        case committed
+        case success
+        case failureReason = "failure_reason"
+        case orderId = "order_id"
+        case errorResponse = "error_response"
+        case successResponse = "success_response"
+        case orderConfiguration = "order_configuration"
     }
 }
 
-// MARK: - PaymentMethod
-
-struct PaymentMethod: Codable {
-    let id, resource, resourcePath: String?
-
+struct SuccessResponse: Codable {
+    let orderId: String
+    let productId: String
+    let side: String
+    let clientOrderId: String
+    
     enum CodingKeys: String, CodingKey {
-        case id
-        case resource
-        case resourcePath = "resource_path"
+        case orderId = "order_id"
+        case productId = "product_id"
+        case side
+        case clientOrderId = "client_order_id"
     }
 }
 
-// MARK: - UnitPrice
-
-struct UnitPrice: Codable {
-    let amount, currency: String?
-    let scale: Int?
+struct ErrorResponse: Codable {
+    let error: String
+    let message: String
+    let errorDetails: String
+    let previewFailureReason: String
+    
+    enum CodingKeys: String, CodingKey {
+        case error
+        case message
+        case errorDetails = "error_details"
+        case previewFailureReason = "preview_failure_reason"
+    }
 }

--- a/DashWallet/Sources/UI/Coinbase/Base/UIViewController+Coinbase.swift
+++ b/DashWallet/Sources/UI/Coinbase/Base/UIViewController+Coinbase.swift
@@ -92,7 +92,7 @@ extension CoinbaseCodeConfirmationPreviewing where Self: BaseViewController {
 protocol CoinbaseTransactionHandling: CoinbaseCodeConfirmationPreviewing, CoinbaseTransactionDelegate, ErrorPresentable { }
 
 extension CoinbaseTransactionHandling where Self: BaseViewController {
-    func transferFromCoinbaseToWalletDidFail(with error: Coinbase.Error) {
+    func transferFromCoinbaseToWalletDidFail(with error: Error) {
         if case Coinbase.Error.transactionFailed(let r) = error {
             switch r {
             case .twoFactorRequired:

--- a/DashWallet/Sources/UI/Coinbase/Base/ViewModel+Coinbase.swift
+++ b/DashWallet/Sources/UI/Coinbase/Base/ViewModel+Coinbase.swift
@@ -21,7 +21,7 @@ import Foundation
 
 protocol CoinbaseTransactionDelegate: AnyObject {
     func transferFromCoinbaseToWalletDidSucceed()
-    func transferFromCoinbaseToWalletDidFail(with error: Coinbase.Error)
+    func transferFromCoinbaseToWalletDidFail(with error: Error)
     func transferFromCoinbaseToWalletDidCancel()
 }
 

--- a/DashWallet/Sources/UI/Coinbase/Buy Dash/Confirm Transaction Controller/ConfirmOrderController.swift
+++ b/DashWallet/Sources/UI/Coinbase/Buy Dash/Confirm Transaction Controller/ConfirmOrderController.swift
@@ -96,10 +96,10 @@ final class ConfirmOrderController: OrderPreviewViewController {
         model as! ConfirmOrderModel
     }
 
-    init(order: CoinbasePlaceBuyOrder, paymentMethod: CoinbasePaymentMethod, plainAmount: UInt64) {
+    init(paymentMethod: CoinbasePaymentMethod, plainAmount: UInt64) {
         super.init(nibName: nil, bundle: nil)
 
-        model = ConfirmOrderModel(order: order, paymentMethod: paymentMethod, plainAmount: plainAmount)
+        model = ConfirmOrderModel(paymentMethod: paymentMethod, plainAmount: plainAmount)
         model.transactionDelegate = self
         configureModel()
     }

--- a/DashWallet/Sources/UI/Coinbase/Buy Dash/Confirm Transaction Controller/Model/ConfirmOrderModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Buy Dash/Confirm Transaction Controller/Model/ConfirmOrderModel.swift
@@ -52,6 +52,10 @@ final class ConfirmOrderModel: OrderPreviewModel {
     }
     
     func placeOrder() async throws {
+        if paymentMethod.type.isBankAccount {
+            try await Coinbase.shared.depositToFiatAccount(from: paymentMethod.id, amount: amountToTransfer)
+        }
+        
         let result = try await Coinbase.shared.placeCoinbaseBuyOrder(amount: amountToTransfer)
         
         if !result.success {

--- a/DashWallet/Sources/UI/Coinbase/Buy Dash/Model/BuyDashModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Buy Dash/Model/BuyDashModel.swift
@@ -94,12 +94,6 @@ final class BuyDashModel: CoinbaseAmountModel {
                 return Coinbase.Error.general(.noPaymentMethods)
             }
             
-            // TODO
-//            coinBaseRepository.depositToFiatAccount(
-//                            uiState.value.paymentMethod!!.paymentMethodId,
-//                            amountStr
-//                        )
-            
             select(paymentMethod: method)
         } else {
             return Coinbase.Error.transactionFailed(.notEnoughFunds)

--- a/DashWallet/Sources/UI/Coinbase/Custodial Swaps/Order Preview/Model/ConvertCryptoOrderPreviewModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Custodial Swaps/Order Preview/Model/ConvertCryptoOrderPreviewModel.swift
@@ -27,6 +27,7 @@ final class ConvertCryptoOrderPreviewModel: OrderPreviewModel {
     var completionHandle: (() -> Void)?
     var failureHandle: ((ConfirmOrderError) -> Void)?
     var orderChangeHandle: (() -> Void)?
+    var showCountdown: Bool = true
 
     /// Selected account, origin
     let selectedAccount: CBAccount
@@ -46,7 +47,7 @@ final class ConvertCryptoOrderPreviewModel: OrderPreviewModel {
         amountToTransfer = order.outputAmount.amount.plainDashAmount()!
     }
 
-    func placeOrder() {
+    func placeOrder() async throws {
         guard let orderId = order.id else {
             failureHandle?(.error)
             return

--- a/DashWallet/Sources/UI/Coinbase/Order Preview/Model/OrderPreviewModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Order Preview/Model/OrderPreviewModel.swift
@@ -24,8 +24,9 @@ protocol OrderPreviewModel: CoinbaseTransactionSendable {
     var completionHandle: (() -> Void)? { set get }
     var failureHandle: ((ConfirmOrderError) -> Void)? { set get }
     var orderChangeHandle: (() -> Void)? { set get }
+    var showCountdown: Bool { get }
 
-    func placeOrder()
+    func placeOrder() async throws
     func retry()
 }
 

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/Model/TransferAmountModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/Model/TransferAmountModel.swift
@@ -103,7 +103,7 @@ final class TransferAmountModel: CoinbaseAmountModel, CoinbaseTransactionSendabl
 
         obtainNewAddress { [weak self] address in
             guard let address else {
-                self?.delegate?.transferFromCoinbaseToWalletDidFail(with: .transactionFailed(.failedToObtainNewAddress))
+                self?.delegate?.transferFromCoinbaseToWalletDidFail(with: Coinbase.Error.transactionFailed(.failedToObtainNewAddress))
                 return
             }
 

--- a/DashWallet/Sources/UI/Portal/IntegrationViewController.swift
+++ b/DashWallet/Sources/UI/Portal/IntegrationViewController.swift
@@ -217,10 +217,13 @@ extension IntegrationViewController {
         let title = error.failureReason
         let message = error.localizedDescription
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: error.recoverySuggestion, style: .default) { [weak self] _ in
-            self?.model.handle(error: error)
+        
+        if let action = error.recoverySuggestion {
+            let confirmAction = UIAlertAction(title: action, style: .default) { [weak self] _ in
+                self?.model.handle(error: error)
+            }
+            alert.addAction(confirmAction)
         }
-        alert.addAction(confirmAction)
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel)
         alert.addAction(cancelAction)

--- a/DashWallet/Sources/UI/Portal/IntegrationViewController.swift
+++ b/DashWallet/Sources/UI/Portal/IntegrationViewController.swift
@@ -62,8 +62,6 @@ final class IntegrationViewController: BaseViewController, NetworkReachabilityHa
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        configureModel()
         configureHierarchy()
 
         networkStatusDidChange = { [weak self] _ in
@@ -74,6 +72,7 @@ final class IntegrationViewController: BaseViewController, NetworkReachabilityHa
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        configureModel()
         model.refresh()
     }
     

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "طلب سحب";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "لقد تجاوزت حد التفويض على كوين بيس.";

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "محدد وجه التعريف";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Лимит на лицева идентификация";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Плащането не може да се изпълни";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Можете да се удостоверите с Touch ID за плащания по-долу";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Potvrdit a zaplatit";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Nelze se připojit k síti Dash, zkontrolujte prosím, zda jste připojeni k internetu.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Platbu nelze provést";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Pro placení se níže můžete ověřit přes Touch ID";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Bestätigen & Bezahlen";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Bestätigen(%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Bestätigen(%1$d %2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Verbindung zum Dash-Netzwerk konnte nicht hergestellt werden. Überprüfe bitte, ob du mit dem Internet verbunden bist.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Zahlung konnte nicht durchgeführt werden";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Kein aktiver Nutzer";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Keine Zahlungsmethode";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Auszahlen beantragt";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Ja";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Du die Zahlung weiter unten über Touch ID authentifizieren";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Du hast den Berechtigungsrahmen von Coinbase überschritten.";

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face-ID Limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Autorisierungssitzung konnte nicht gestartet werden.";
 
 /* Buy Sell Portal */

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "όριο Face ID ";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Αποτυχία εκκίνησης περιόδου λειτουργίας εξουσιοδότησης";
 
 /* Buy Sell Portal */

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Επιβεβαίωση και Πληρωμή";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Επιβεβαιώστε (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Επιβεβαιώστε (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Δεν ήταν δυνατή η σύνδεση στο δίκτυο Dash, ελέγξτε ότι είστε συνδεδεμένοι στο Διαδίκτυο.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Δεν ήταν δυνατή η πληρωμή";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Δεν υπάρχει ενεργός χρήστης";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Δεν υπάρχουν τρόποι πληρωμής";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Ζητήθηκε απόσυρση";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Ναι";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Μπορείτε να επαληθεύσετε το Touch ID για πληρωμές παρακάτω";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Υπερβήκατε το όριο εξουσιοδότησης στην Coinbase.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Límite de Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "No se pudo iniciar la sesión de autenticación";
 
 /* Buy Sell Portal */

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirmar y Pagar";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirmar (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirmar (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "No se pudo conectar a la red Dash, verifica que estés conectado a Internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "No se pudo realizar el pago";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Usuario inactivo";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Sin métodos de pago";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Retiro solicitado";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Si";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Puedes autenticar con Touch ID para pagos abajo de";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Excediste el límite de autorización en Coinbase.";

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limiit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "درخواست برداشت صورت گرفته است";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "از حد تعریف‌شده در کوین‌بیس فراتر رفتید.";

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Nabigong simulan ang auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Kumpirmahin & Magbayad";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Kumpirmahin (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Kumpirmahin (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Hindi makakonekta sa network ng Dash, mangyaring suriin kung nakakonekta ka sa internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Hindi makagawa ng ipambabayad";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Walang aktibong user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Walang paraan ng pagbabayad";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Hiniling ang withdrawal";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Oo";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Maaari kang magkumpirma gamit ang iyong Touch ID sa mga bayarin sa ibaba";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Lumampas ka sa limitasyon ng awtorisasyon sa Coinbase.";

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirmer & payer";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirmer (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirmer (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Connexion impossible au réseau Dash, veuillez vérifier votre connexion à Internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Impossible d'effectuer le paiement";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Aucun utilisateur actif";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Aucun mode de paiement";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Retrait demandé";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Oui";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Vous pouvez vous authentifier avec Touch ID pour les paiements ci-dessous";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Vous avez dépassé la limite d'autorisation sur Coinbase.";

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Limite pour Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Impossible de démarrer la session d'authentification";
 
 /* Buy Sell Portal */

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID összehatár";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "konfirmasi & bayar";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Konfirmasi (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "konfirmasi (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Tidak dapat terhubung ke jaringan Dash, harap periksa apakah Anda terhubung ke internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Tidak dapat melakukan pembayaran";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Tidak ada pengguna aktif";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Tidak ada metode pembayaran";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Penarikan diminta";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Ya";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Anda dapat mengautentikasi dengan Touch ID untuk pembayaran di bawah ini";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Anda melampaui batas otorisasi di Coinbase.";

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Identitas wajah terbatas";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Gagal memulai sesi autentikasi";
 
 /* Buy Sell Portal */

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Conferma e paga";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confermare (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confermare (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Impossibile connettersi alla rete Dash, controlla di essere connesso a Internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Impossibile effettuare il pagamento";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Nessun utente attivo";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Nessun metodo di pagamento";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Ritiro richiesto";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Si";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Puoi effettuare l'autenticazione con Touch ID per i pagamenti di seguito";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Hai superato il limite di autorizzazione su Coinbase.";

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Limite \"Face ID\"";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Impossibile avviare la sessione di autenticazione";
 
 /* Buy Sell Portal */

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "確認 & 支払い";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "確認する (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "確認する (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Dashのネットワークにつなげられませんでした。インターネットに接続されているか確認してください。";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "支払いを完了できませんでした";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "アクティブなユーザーがいません";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "支払い方法がありません";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "出金がリクエストされました";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "はい";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "以下の支払いにはTouch IDの指紋認証をご利用いただけます";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Coinbaseの認証制限を超えてしまいました。";

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face IDの送金可能額";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "認証セッションの開始に失敗しました";
 
 /* Buy Sell Portal */

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID 제한";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "승인 세션을 시작하는 데 실패하였습니다";
 
 /* Buy Sell Portal */

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "승인 & 지불";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "확인 (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "확인 (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "대시 네트워크에 연결할 수 없습니다. 인터넷 연결 상태를 확인하십시오.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "지불에 실패하였습니다";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "활동하지 않는 사용자";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "지불 방법 없음";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "출금이 요청됨";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "예";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "지불을 위해서는 터치 ID를 통해 아래에서 인증할 수 있습니다";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "코인베이스 인증 제한을 초과하였습니다.";

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limiet";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Kan authenticatiesessie niet starten";
 
 /* Buy Sell Portal */

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Bevestig en betaal";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Bevestig (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Bevestig (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Kon niet verbinden met Dash-netwerk, controleer of je verbonden bent met het internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Kon betaling niet maken";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Geen actieve gebruiker";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Geen betalingsmethodes";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Opname is aangevraagd";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Ja";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "U kunt authenticeren met vingerafdruk voor onderstaande betalingen";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Je hebt de autorisatielimiet op Coinbase overschreden.";

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Nie powiodło się rozpoczęcie sessji auth.";
 
 /* Buy Sell Portal */

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Potwierdź i Zapłać";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Potwierdź (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Potwierdź (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Niemożliwe jest połączenie z siecią Dash. Sprawdź swoje połączenie z internetem. ";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Nie można dokonać płatności";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Brak aktywnych użytkowników";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Brak metody płatności";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Żądanie wypłaty";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Tak";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Możesz dokonać uwierzytelnienia za pomocą Touch ID dla płatności poniżej";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Przekroczyłeś limit autoryzacji na Coinbase.";

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirme & Pague";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirmar (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirmar (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Não foi possível conectar à rede Dash, por favor verifique se você está conectado à internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Não foi possível fazer o pagamento";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Nenhum usuário ativo";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Sem métodos de pagamento";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Saque solicitado";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Sim";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Você pode autenticar com Touch ID para pagamentos abaixo de";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Você excedeu o limite de autorização na Coinbase.";

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Limite de ID de face";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Falha ao iniciar a sessão de autenticação";
 
 /* Buy Sell Portal */

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "limita Face ID-ului";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Plata nu a putut fi efectuată";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Подтвердить и оплатить";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Подтвердить (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Подтвердить (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Невозможно подключиться к сети Dash. Пожалуйста, проверьте подключены ли вы к Интернету. ";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Не удалось совершить платёж";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Отсутствует активный пользователь";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Отсутствуют способы оплаты";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Запрос на вывод средств отправлен";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Да";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "В дальнейшем Вам будут доступны платежи через Touch ID";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Превышен лимит авторизаций на Coinbase.";

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Лимит Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Не удалось запустить сеанс авторизации";
 
 /* Buy Sell Portal */

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Potvrdiť a zaplatiť";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Potvrďte (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Potvrďte (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Nepodarilo sa pripojiť k sieti Dash. Skontrolujte, či ste pripojení k internetu.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Platba sa nedá uskutočniť ";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Žiadny aktívny používateľ";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Žiadne spôsoby platby";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Žiadosť o výber podaná";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Áno";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Platby nižšie môžete overiť pomocou Touch ID";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Prekročili ste autorizačný limit na Coinbase.";

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Limit pre Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Nepodarilo sa spustiť autorizáciu";
 
 /* Buy Sell Portal */

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Limit u prepoznavanju lica";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limit";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "ยืนยันและชำระเงิน";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "ยืนยัน (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "ยืนยัน (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "ไม่สามารถเชื่อมต่อกับเครือข่าย DASH โปรดตรวจสอบว่าคุณเชื่อมต่อกับอินเทอร์เน็ต";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "ไม่สามารถชำระเงินได้";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "ไม่มีผู้ใช้ที่ใช้งานอยู่";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "ไม่มีวิธีการชำระเงิน";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "ขอถอนเงิน";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "ใช่";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "คุณสามารถตรวจสอบด้วย Touch ID สำหรับการชำระเงินด้านล่าง";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "คุณทำรายการเกินขีดจำกัดการอนุญาตของ Coinbase";

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "ขีดจำกัด Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "ไม่สามารถเริ่มเซสชันการรับรองความถูกต้องได้";
 
 /* Buy Sell Portal */

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID limiti";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Kimlik doğrulama oturumu başlatılamadı";
 
 /* Buy Sell Portal */

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Onayla ve Öde";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Onay (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Onay (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Dash ağına bağlanılmadı, lütfen internete bağlı olup olmadığınızı kontrol edin.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Ödeme yapılamadı";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Aktif kullanıcı yok";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Ödeme yöntemi yok";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Para çekme isteği gönderildi";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Evet";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Dokunmatik Kimlik doğrulaması ile aşağıdaki ödemeleri yapabilirsiniz";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Coinbase'deki yetki sınırını aştınız.";

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Ліміт Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Не вдалося розпочати сеанс авторизації";
 
 /* Buy Sell Portal */

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Підтвердити & сплатити";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Підтвердження (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Підтвердження (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Не вдалося підключитися до мережі Dash. Будь ласка, перевірте, чи ви підключені до Інтернету.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Не вдалося здійснити платіж";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "Немає активного користувача";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Немає способів оплати";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Запит на вивід коштів відправлено";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Так";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Ви можете пройти автентифікацію за допомогою Touch ID для платежів нижче";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Ви перевищили ліміт авторизації на Coinbase.";

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Xác nhận & Thanh toán";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Không thể thực hiện giao dịch";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "Bạn có thể xác thực với Touch ID cho giao dịch bên dưới";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Giới hạn Face ID";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "面容ID限制";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID 解鎖的限制";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "Failed to start auth session";
 
 /* Buy Sell Portal */

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "Confirm & Pay";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "Confirm (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "Confirm (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "Could not connect to the Dash network, please check that you are connected to the internet.";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "No active user";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "Yes";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "You can authenticate with Touch ID for payments below";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "确认并付款";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "确认 (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "确认 (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "无法连接到Dash网络，请检查您是否已连接到了互联网。";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "无法付款";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "没有活跃用户";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "没有支付方式";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "提款请求";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "是的";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "您可以使用指纹识别来认证下方交易";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "您超出了 Coinbase的授权限制.";

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "脸部识别限制";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "无法启动身份验证会话";
 
 /* Buy Sell Portal */

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -330,9 +330,6 @@
 "Confirm & Pay" = "確認並付款";
 
 /* Coinbase/Buy Dash/Confirm Order */
-"Confirm (%@)" = "確認 (%@)";
-
-/* Coinbase/Buy Dash/Confirm Order */
 "Confirm (%d%@)" = "確認 (%1$d%2$@)";
 
 /* No comment provided by engineer. */
@@ -393,6 +390,9 @@
 
 /* No comment provided by engineer. */
 "Could not connect to the Dash network, please check that you are connected to the internet." = "無法連接到達世幣網絡，請檢查您是否已連接到互聯";
+
+/* No comment provided by engineer. */
+"Could not find exchange rate." = "Could not find exchange rate.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "無法進行支付";
@@ -1009,6 +1009,9 @@
 
 /* Coinbase */
 "No active user" = "沒有活躍用戶";
+
+/* Coinbase */
+"No cash account found" = "No cash account found";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "沒有付款方式";
@@ -1821,6 +1824,9 @@
 /* CrowdNode */
 "Withdrawal requested" = "提款請求";
 
+/* Coinbase */
+"Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";
+
 /* No comment provided by engineer. */
 "Yes" = "是的";
 
@@ -1838,6 +1844,9 @@
 
 /* No comment provided by engineer. */
 "You can authenticate with Touch ID for payments below" = "您可以使用Touch ID進行以下付款的驗證";
+
+/* Coinbase */
+"You don’t have enough balance" = "You don’t have enough balance";
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "你超出了 Coinbase 的授權限制。";

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -593,6 +593,9 @@
 "Face ID limit" = "Face ID 解鎖的限制";
 
 /* Coinbase */
+"Failed to make a deposit." = "Failed to make a deposit.";
+
+/* Coinbase */
 "Failed to start auth session" = "無法啟動身份驗證會話";
 
 /* Buy Sell Portal */


### PR DESCRIPTION
## Issue being fixed or feature implemented
Coinbase is going to shut down some v2 API endpoints. We need to migrate, starting from the Buy feature


## What was done?
- Replace v2/accounts/{account_id}/buys with api/v3/brokerage/orders calls.
- Rearrange Buy flow: no need to create and commit an order as the /orders endpoint executes the order immediately.
- Improve HTTPClient errors.
- Fix the de-authentication button.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone