### PR TITLE
fix: PIN dialog being cut-off

### DIFF
--- a/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
@@ -105,8 +105,10 @@ extension PaymentController {
 
 extension PaymentController: ConfirmPaymentViewControllerDelegate {
     func confirmPaymentViewControllerDidConfirm(_ controller: ConfirmPaymentViewController) {
-        if let output = paymentOutput {
-            paymentProcessor.confirmPaymentOutput(output)
+        controller.dismiss(animated: true) { [weak self] in
+            if let output = self?.paymentOutput {
+                self?.paymentProcessor.confirmPaymentOutput(output)
+            }
         }
     }
 
@@ -180,6 +182,7 @@ extension PaymentController: DWPaymentProcessorDelegate {
 
     func paymentProcessorDidCancelTransactionSigning(_ processor: DWPaymentProcessor) {
         provideAmountViewController?.hideActivityIndicator()
+        delegate?.paymentControllerDidCancelTransaction(self)
         confirmViewController?.isSendingEnabled = true
     }
 

--- a/DashWallet/Sources/UI/Uphold/Transfer/Confirm/UpholdConfirmViewController.swift
+++ b/DashWallet/Sources/UI/Uphold/Transfer/Confirm/UpholdConfirmViewController.swift
@@ -90,7 +90,9 @@ extension UpholdConfirmViewController: ConfirmPaymentViewControllerDelegate {
     }
 
     func confirmPaymentViewControllerDidConfirm(_ controller: ConfirmPaymentViewController) {
-        upholdModel.confirm(withOTPToken: nil)
+        controller.dismiss(animated: true) { [weak self] in
+            self?.upholdModel.confirm(withOTPToken: nil)
+        }
     }
 }
 


### PR DESCRIPTION
Showing the PIN dialog in the `.pageSheet` context (iOS 15+) causes the PIN dialog to be cut-off at the edge of the sheet.

## What was done?
- Dismiss confirmation dialogs before requesting PIN.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone