### PR TITLE
fix: allow to edit amount after quick scan

### DIFF
--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -33,11 +33,13 @@ final class ProvideAmountViewController: SendAmountViewController {
 
     private let address: String
     private let contact: DWDPBasicUserItem?
+    private var details: DSPaymentProtocolDetails?
     private var isBalanceHidden = true
 
-    init(address: String, contact: DWDPBasicUserItem?) {
+    init(address: String, details: DSPaymentProtocolDetails?, contact: DWDPBasicUserItem?) {
         self.address = address
         self.contact = contact
+        self.details = details
         super.init(model: SendAmountModel())
     }
 
@@ -263,6 +265,7 @@ final class ProvideAmountViewController: SendAmountViewController {
                                                name: .balanceChangeNotification, object: nil)
 
         updateBalance()
+        updateInitialAmount()
     }
 
     deinit {
@@ -290,6 +293,18 @@ extension ProvideAmountViewController {
             balanceLabel.text = String(repeating: "*", count: fullStr.count + 4)
         } else {
             balanceLabel.text = fullStr
+        }
+    }
+    
+    private func updateInitialAmount() {
+        if let details = details {
+            let totalAmount = details.outputAmounts.reduce(UInt64(0)) { sum, element in
+                if let number = element as? NSNumber {
+                    return sum + number.uint64Value
+                }
+                return sum
+            }
+            model.updateCurrentAmountObject(with: totalAmount)
         }
     }
 }

--- a/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
@@ -132,7 +132,7 @@ extension PaymentController: DWPaymentProcessorDelegate {
     }
 
     func paymentProcessor(_ processor: DWPaymentProcessor, requestAmountWithDestination sendingDestination: String, details: DSPaymentProtocolDetails?, contactItem: DWDPBasicUserItem?) {
-        let vc = ProvideAmountViewController(address: sendingDestination, contact: contactItem)
+        let vc = ProvideAmountViewController(address: sendingDestination, details: details, contact: contactItem)
         vc.locksBalance = locksBalance
         vc.delegate = self
         vc.hidesBottomBarWhenPushed = true


### PR DESCRIPTION
## Issue being fixed or feature implemented
If a QR code with an amount specified is scanned, the app shows the confirmation dialog immediately but it should redirect to the "enter amount" screen and allow to modify the amount.

## What was done?
- Redirect to the "enter amount" screen for QR scanned payment intents.
- Pre-set the initial amount on the "enter amount" screen.


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone