### PR TITLE
fix: overflow crash

### DIFF
--- a/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertContentView.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertContentView.swift
@@ -113,7 +113,14 @@ final class SyncingAlertContentView: UIView {
             let atTheEndOfSyncBlocksAndSyncingMasternodeList = chain.lastSyncBlockHeight >= chain.estimatedBlockHeight - 6 && chainManager.masternodeManager
                 .masternodeListRetrievalQueueCount > 0 && chainManager.syncPhase == .synced
             if atTheEndOfInitialTerminalBlocksAndSyncingMasternodeList || atTheEndOfSyncBlocksAndSyncingMasternodeList {
-                let remaining = max(0, chainManager.masternodeManager.masternodeListRetrievalQueueMaxAmount - chainManager.masternodeManager.masternodeListRetrievalQueueCount)
+                var remaining: UInt = 0
+                
+                if chainManager.masternodeManager.masternodeListRetrievalQueueCount > chainManager.masternodeManager.masternodeListRetrievalQueueMaxAmount {
+                    remaining = 0
+                } else {
+                    remaining = chainManager.masternodeManager.masternodeListRetrievalQueueMaxAmount - chainManager.masternodeManager.masternodeListRetrievalQueueCount
+                }
+
                 subtitleLabel.text = String(format: NSLocalizedString("masternode list #%d of %d", comment: ""), remaining, chainManager.masternodeManager.masternodeListRetrievalQueueMaxAmount)
             } else {
                 if chainManager.syncPhase == .initialTerminalBlocks {


### PR DESCRIPTION
## Issue being fixed or feature implemented
There is an overflow crash caused by the wrong NSUInteger handling.

## What was done?
- Check if substruction will cause overflow


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone