### PR TITLE
fix: change rate "syncing" label

### DIFF
--- a/DashWallet/Sources/Infrastructure/Currency Exchanger/CurrencyExchanger.swift
+++ b/DashWallet/Sources/Infrastructure/Currency Exchanger/CurrencyExchanger.swift
@@ -269,9 +269,9 @@ extension CurrencyExchanger {
             let amount = try convertDash(amount: dashAmount, to: currency)
             return amount.formattedFiatAmount
         } catch CurrencyExchanger.Error.ratesAreFetching {
-            return NSLocalizedString("Syncing...", comment: "Balance")
+            return NSLocalizedString("Fetching rates…", comment: "Balance")
         } catch CurrencyExchanger.Error.ratesNotAvailable {
-            return NSLocalizedString("Syncing...", comment: "Balance")
+            return NSLocalizedString("Fetching rates…", comment: "Balance")
         } catch {
             return NSLocalizedString("Invalid amount", comment: "Balance")
         }

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Informationen abrufen";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Konto";
 

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Λήψη πληροφοριών";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Λογαριασμός χρημάτων";
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Obteniendo información";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Cuenta fiduciaria";
 

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Kinukuha ang Impormasyon";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Récupération des infos";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Compte fiduciaire";
 

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Mengambil info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Akun Fiat";
 

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Informazioni sul recupero";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Conto Fiat";
 

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "情報の取得";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "フィアットアカウント";
 

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "정보 가져오는 중";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "법정 화폐 계좌";
 

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Info ophalen";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat rekening";
 

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Pobieranie informacji";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Konto Walutowe";
 

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Buscando informação";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Conta Fiat";
 

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Получение данных";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Фиатный счёт";
 

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Načítavanie informácií";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Hotovostný účet";
 

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "การดึงข้อมูล";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "บัญชีเงินสด";
 

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Bilgi Alınıyor";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Hesabı";
 

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Отримання інформації";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Фіатний рахунок";
 

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "Fetching Info";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "正在获取信息";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "法币账户";
 

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -799,6 +799,9 @@
 /* Explore Dash */
 "Fetching Info" = "正在獲取信息";
 
+/* Balance */
+"Fetching rates…" = "Fetching rates…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "法幣賬戶";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
While rates are fetching, the fiat value says "syncing" which is confusing for users who are thinking the chain is syncing.

## What was done?
Replace "syncing" with "fetching rates"


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone