### PR TITLE
fix: report cached rates on init

### DIFF
--- a/DashWallet/Sources/Infrastructure/Currency Exchanger/Data Provider/RatesProvider.swift
+++ b/DashWallet/Sources/Infrastructure/Currency Exchanger/Data Provider/RatesProvider.swift
@@ -70,7 +70,14 @@ final class BaseRatesProvider: NSObject, RatesProvider {
     private let kRefreshTimeInterval: TimeInterval = 60
     private let kPriceByCodeKey = "DS_PRICEMANAGER_PRICESBYCODE"
 
-    var updateHandler: (([RateObject]) -> Void)?
+    var updateHandler: (([RateObject]) -> Void)? {
+        didSet {
+            let plainPricesByCode = UserDefaults.standard.object(forKey: kPriceByCodeKey) as! [String : NSNumber]
+            updateHandler?(plainPricesByCode.map { code, rate in
+                RateObject(code: code, name: currencyName(fromCode: code), price: rate.decimalValue)
+            })
+        }
+    }
 
     private var lastPriceSourceInfo: String!
 
@@ -78,7 +85,6 @@ final class BaseRatesProvider: NSObject, RatesProvider {
 
     override init() {
         operationQueue = DSOperationQueue()
-
         super.init()
     }
 
@@ -109,5 +115,12 @@ final class BaseRatesProvider: NSObject, RatesProvider {
         }
 
         operationQueue.addOperation(priceOperation)
+    }
+    
+    func currencyName(fromCode code: String) -> String {
+        let locale = Locale.current
+        let currencyName = locale.localizedString(forCurrencyCode: code)
+        
+        return currencyName ?? code
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Cached rates are not being used right now in the wallet UI

## What was done?
Emit cached rates in the RatesProvider ctor


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone