### PR TITLE
fix: deeplink from camera & balance auth

### DIFF
--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -193,6 +193,7 @@ struct ProvideAmountIntro<Content: View>: View {
             destination: destination,
             dashBalance: CoinJoinService.shared.mixingState.isInProgress ? model.coinJoinBalance : model.walletBalance,
             balanceLabel: balanceLabel + ":",
+            authCallback: model.auth,
             avatarView: avatarView
         )
     }

--- a/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.m
+++ b/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.m
@@ -159,7 +159,7 @@ static NSString *sanitizeString(NSString *s) {
     self.paymentInput = paymentInput;
 
     if (paymentInput.request) {
-        if (paymentInput.source == DWPaymentInputSource_ScanQR && paymentInput.request.isValidAsNonDashpayPaymentRequest) {
+        if ((paymentInput.source == DWPaymentInputSource_ScanQR || paymentInput.source == DWPaymentInputSource_URL) && paymentInput.request.isValidAsNonDashpayPaymentRequest) {
             DSPaymentProtocolRequest *protocolRequest = [self protocolRequestFromPaymentRequest:self.paymentInput.request];
             [self txManagerRequestingAdditionalInfo:DSRequestingAdditionalInfo_Amount
                                     protocolRequest:protocolRequest];

--- a/DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift
@@ -24,6 +24,7 @@ struct SendIntro<Content: View>: View {
     var destination: String? = nil
     var dashBalance: UInt64? = nil
     var balanceLabel: String? = nil
+    var authCallback: ((@escaping (Bool) -> Void) -> Void)? = nil
     @ViewBuilder var avatarView: () -> Content
 
     var body: some View {
@@ -63,7 +64,7 @@ struct SendIntro<Content: View>: View {
                     }
                     
                     Button(action: {
-                        balanceHidden.toggle()
+                        toggleBalanceVisibility()
                     }) {
                         Image(systemName: balanceHidden ? "eye.slash.fill" : "eye.fill")
                             .resizable()
@@ -80,6 +81,18 @@ struct SendIntro<Content: View>: View {
                 .foregroundColor(.secondaryText)
             }
         }.frame(maxWidth: .infinity, alignment: .leading)
+    }
+    
+    private func toggleBalanceVisibility() {
+        if let authCallback = authCallback, balanceHidden {
+            authCallback { [self] isAuthenticated in
+                if isAuthenticated {
+                    balanceHidden.toggle()
+                }
+            }
+        } else {
+            balanceHidden.toggle()
+        }
     }
     
     @ViewBuilder

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -591,10 +591,11 @@ PODS:
     - "!ProtoCompiler-gRPCPlugin (~> 1.0)"
     - DAPI-GRPC/Messages
     - gRPC-ProtoRPC
-  - DashSharedCore (0.5.0)
+  - DashSharedCore (0.5.1)
   - DashSync (0.1.0):
     - CocoaLumberjack (= 3.7.2)
     - DAPI-GRPC (= 0.22.0-dev.8)
+    - DashSharedCore (= 0.5.1)
     - DSDynamicOptions (= 0.1.2)
     - DWAlertController (= 0.2.1)
     - TinyCborObjc (= 0.4.6)
@@ -736,7 +737,6 @@ PODS:
 DEPENDENCIES:
   - CloudInAppMessaging (= 0.1.0)
   - CocoaImageHashing (from `https://github.com/ameingast/cocoaimagehashing.git`, commit `ad01eee`)
-  - DashSharedCore (from `../dash-shared-core/`)
   - DashSync (from `../DashSync/`)
   - DSDynamicOptions (= 0.1.2)
   - Firebase/DynamicLinks
@@ -766,6 +766,7 @@ SPEC REPOS:
     - CloudInAppMessaging
     - CocoaLumberjack
     - DAPI-GRPC
+    - DashSharedCore
     - DSDynamicOptions
     - DWAlertController
     - Firebase
@@ -803,8 +804,6 @@ EXTERNAL SOURCES:
   CocoaImageHashing:
     :commit: ad01eee
     :git: https://github.com/ameingast/cocoaimagehashing.git
-  DashSharedCore:
-    :path: "../dash-shared-core/"
   DashSync:
     :path: "../DashSync/"
   MMSegmentSlider:
@@ -832,8 +831,8 @@ SPEC CHECKSUMS:
   CocoaImageHashing: 8656031d0899abe6c1c415827de43e9798189c53
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DAPI-GRPC: 138d62523bbfe7e88a39896f1053c0bc12390d9f
-  DashSharedCore: 18baa0f6c2bc2b4fc4628651d293f4fd6645025f
-  DashSync: 2438dbf626f13a8633ccc19c718c1c223c8ee831
+  DashSharedCore: b8481feb5f08acf162b548edbfc7a9b1ce491141
+  DashSync: 1f5741aad267dcc0cfc04b6903490d304232ddf2
   DSDynamicOptions: 347cc5d2c4e080eb3de6a86719ad3d861b82adfc
   DWAlertController: 5f4cd8adf90336331c054857f709f5f8d4b16a5b
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
@@ -868,6 +867,6 @@ SPEC CHECKSUMS:
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   UIViewController-KeyboardAdditions: a691dc7e63a49854d341455a778ee8497dfc4662
 
-PODFILE CHECKSUM: 1ec71e13430fe0345b364b97448746daa931e0b4
+PODFILE CHECKSUM: a5ef71862394897c78a0cc247502754372e88c07
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
## Issue being fixed or feature implemented
- When scanning a Dash QR code with the camera app, the result is immediate confirmation without ability to modify the amount and without the "Insufficient funds" error being displayed.
- When scanning Dash QR from the app's lockscreen, the full balance can be revealed without authenticating.

## What was done?
- Treat URL payment request the same as QR request, i.e., redirect user to "Send" screen.
- Request authentication for balance reveal


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone