### PR TITLE
fix: compact UI for SE 1st gen

### DIFF
--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -69,7 +69,7 @@ final class ProvideAmountViewController: SendAmountViewController {
 
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 26
+        stackView.spacing = UIDevice.isIphone5OrLess ? 10 : 26
         stackView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(stackView)
         
@@ -107,10 +107,10 @@ final class ProvideAmountViewController: SendAmountViewController {
         stackView.addArrangedSubview(amountView)
 
         NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: UIDevice.isIphone5OrLess ? 0 : 10),
             stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
-            swiftUIController.view.heightAnchor.constraint(equalToConstant: 100)
+            swiftUIController.view.heightAnchor.constraint(equalToConstant: UIDevice.isIphone5OrLess ? 84 : 100)
         ])
     }
 

--- a/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboard.swift
+++ b/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboard.swift
@@ -170,7 +170,7 @@ extension NumberKeyboard {
 extension NumberKeyboard {
     enum Style {
         static let padding: CGFloat = 5
-        static let buttonHeight: CGFloat = 50
+        static let buttonHeight: CGFloat = UIDevice.isIphone5OrLess ? 45 : 50
         static let buttonMaxWidth: CGFloat = 115
         static let rowsCount: UInt = 4
         static let sectionsCount = 3


### PR DESCRIPTION
## Issue being fixed or feature implemented
iPhone SE 1st gen has UI overlapping issues on the Send screen.

## What was done?
Adjust sizes and margins for smaller screens to make UI more compact


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone