### PR TITLE
fix(dashspend): robust Explore DB v3 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ TODO.md
 */Topper-Info.plist
 */Coinbase-Info.plist
 */ZenLedger-Info.plist
+CLAUDE.md

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -597,6 +597,8 @@
 		755049AA2C846299008FA7EB /* DWAboutViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 755049A72C846299008FA7EB /* DWAboutViewController.m */; };
 		755049AC2C846576008FA7EB /* MenuItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755049AB2C846576008FA7EB /* MenuItemModel.swift */; };
 		755049AD2C846576008FA7EB /* MenuItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755049AB2C846576008FA7EB /* MenuItemModel.swift */; };
+		7556EE412DF9876B004E8093 /* ExploreSyncBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7556EE402DF9876B004E8093 /* ExploreSyncBannerView.swift */; };
+		7556EE422DF9876B004E8093 /* ExploreSyncBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7556EE402DF9876B004E8093 /* ExploreSyncBannerView.swift */; };
 		755A22BD2B1385FD001F170D /* IconAttributedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755A22BC2B1385FD001F170D /* IconAttributedText.swift */; };
 		755B4B222B0C903500B844F0 /* DWDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755B4B212B0C903500B844F0 /* DWDateFormatter.swift */; };
 		755B4B232B0C903500B844F0 /* DWDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755B4B212B0C903500B844F0 /* DWDateFormatter.swift */; };
@@ -2491,6 +2493,7 @@
 		755049A72C846299008FA7EB /* DWAboutViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DWAboutViewController.m; sourceTree = "<group>"; };
 		755049A82C846299008FA7EB /* DWAboutViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DWAboutViewController.h; sourceTree = "<group>"; };
 		755049AB2C846576008FA7EB /* MenuItemModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemModel.swift; sourceTree = "<group>"; };
+		7556EE402DF9876B004E8093 /* ExploreSyncBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreSyncBannerView.swift; sourceTree = "<group>"; };
 		755A22BC2B1385FD001F170D /* IconAttributedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconAttributedText.swift; sourceTree = "<group>"; };
 		755B4B212B0C903500B844F0 /* DWDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DWDateFormatter.swift; sourceTree = "<group>"; };
 		755C32372C358FBD007DA721 /* BackupSeedPhraseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSeedPhraseViewController.swift; sourceTree = "<group>"; };
@@ -5771,6 +5774,7 @@
 				47AE8BD328C1305E00490F5E /* MerchantListViewController.swift */,
 				47AE8BDD28C1305E00490F5E /* AtmListViewController.swift */,
 				47AE8BB728C1305E00490F5E /* AllMerchantLocationsViewController.swift */,
+				7556EE402DF9876B004E8093 /* ExploreSyncBannerView.swift */,
 			);
 			path = List;
 			sourceTree = "<group>";
@@ -8811,6 +8815,7 @@
 				C9F4520B2A1209D100825057 /* HomeHeaderModel.swift in Sources */,
 				47C6E6E02919578C003FEDF2 /* TerritoryListModel.swift in Sources */,
 				2AFF01DB243F4559003718DC /* DWDPRegistrationStatus.m in Sources */,
+				7556EE412DF9876B004E8093 /* ExploreSyncBannerView.swift in Sources */,
 				472D13ED299E6579006903F1 /* CurrencyExchanger_Objc.m in Sources */,
 				471DD1B8290A92CD00E030C8 /* Tools.swift in Sources */,
 				478A2C7128DC554200AD1420 /* BuySellPortalModel.swift in Sources */,
@@ -9468,6 +9473,7 @@
 				C9D2C76C2A320AA000D15901 /* AccountListController.swift in Sources */,
 				753261B02CBC11BF003CDE00 /* WelcomeViewController.swift in Sources */,
 				C9D2C76D2A320AA000D15901 /* DWUpholdTransactionObject.m in Sources */,
+				7556EE422DF9876B004E8093 /* ExploreSyncBannerView.swift in Sources */,
 				754C27CD2CC3C15B00BA7B9F /* FeatureSingleItem.swift in Sources */,
 				C943B5052A40A54600AF23C5 /* DWDPIncomingRequestCell.m in Sources */,
 				C9D2C76E2A320AA000D15901 /* DWBaseSeedViewController.m in Sources */,

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
@@ -39,16 +39,42 @@ class ExploreDatabaseConnection {
             try? self?.connect()
         }
     }
+    
+    static func hasOldMerchantIdSchema(at url: URL) -> Bool {
+        do {
+            let db = try Connection(url.path)
+            // Query the sqlite_master table to get the schema
+            let query = "SELECT sql FROM sqlite_master WHERE type='table' AND name='merchant'"
+            
+            if let row = try db.prepare(query).makeIterator().next(),
+               let sql = row[0] as? String {
+                // Check if merchantId is defined as INTEGER (old schema)
+                // New schema should have it as TEXT
+                return sql.contains("merchantId` INTEGER") || sql.contains("merchantId INTEGER")
+            }
+        } catch {
+            // If we can't check, assume it might be old to be safe
+            return true
+        }
+        return false
+    }
 
     func connect() throws {
         db = nil
 
-        guard let dbPath = dbPath() else { throw ExploreDatabaseConnectionError.fileNotFound }
+        guard let dbPath = dbPath() else { 
+            // No database found - this is expected if we're waiting for v3 download
+            // Create an in-memory database to prevent crashes
+            db = try Connection(.inMemory)
+            return
+        }
 
         do {
-            db = try Connection(nil ?? dbPath)
+            db = try Connection(dbPath)
         } catch {
             print(error)
+            // Fallback to in-memory database if connection fails
+            db = try Connection(.inMemory)
         }
     }
 
@@ -59,18 +85,34 @@ class ExploreDatabaseConnection {
     }
 
     func execute<Item: RowDecodable>(query: QueryType) throws -> [Item] {
-        let items = try db.prepare(query)
+        guard db != nil else { return [] }
+        
+        do {
+            let items = try db.prepare(query)
 
-        var resultItems: [Item] = []
+            var resultItems: [Item] = []
 
-        for item in items {
-            resultItems.append(Item(row: item))
+            for item in items {
+                resultItems.append(Item(row: item))
+            }
+
+            return resultItems
+        } catch {
+            // If query fails (e.g., table doesn't exist in in-memory db), return empty array
+            print("Database query failed: \(error)")
+            return []
         }
-
-        return resultItems
     }
 
     func execute<Item: RowDecodable>(query: String) throws -> [Item] {
-        try db.prepareRowIterator(query).map { Item(row: $0) }
+        guard db != nil else { return [] }
+        
+        do {
+            return try db.prepareRowIterator(query).map { Item(row: $0) }
+        } catch {
+            // If query fails (e.g., table doesn't exist in in-memory db), return empty array
+            print("Database query failed: \(error)")
+            return []
+        }
     }
 }

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -135,16 +135,14 @@ extension ExploreDatabaseSyncManager {
     }
 
     private func unzipFile(at path: String, password: String) {
-        // DispatchQueue.global().asyncAfter(deadline: .now() + 10.0) {
-            var error: NSError?
-            let urlToUnzip = self.getDocumentsDirectory()
-            SSZipArchive.unzipFile(atPath: path, toDestination: urlToUnzip.path, preserveAttributes: true, overwrite: true,
-                                   nestedZipLevel: 0, password: password, error: &error, delegate: nil,
-                                   progressHandler: nil) { path, _, _ in
-                NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
-                try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
-            }
-        // }
+        var error: NSError?
+        let urlToUnzip = self.getDocumentsDirectory()
+        SSZipArchive.unzipFile(atPath: path, toDestination: urlToUnzip.path, preserveAttributes: true, overwrite: true,
+                                nestedZipLevel: 0, password: password, error: &error, delegate: nil,
+                                progressHandler: nil) { path, _, _ in
+            NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
+        }
     }
 
     private func getDocumentsDirectory() -> URL {

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -20,7 +20,7 @@ import Foundation
 import SSZipArchive
 
 // TODO: Move it to plist and note in release process
-let gsFilePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v2.db"
+let gsFilePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v3.db"
 
 private let fileName = "explore"
 
@@ -135,14 +135,16 @@ extension ExploreDatabaseSyncManager {
     }
 
     private func unzipFile(at path: String, password: String) {
-        var error: NSError?
-        let urlToUnzip = getDocumentsDirectory()
-        SSZipArchive.unzipFile(atPath: path, toDestination: urlToUnzip.path, preserveAttributes: true, overwrite: true,
-                               nestedZipLevel: 0, password: password, error: &error, delegate: nil,
-                               progressHandler: nil) { path, _, _ in
-            NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
-            try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
-        }
+        // DispatchQueue.global().asyncAfter(deadline: .now() + 10.0) {
+            var error: NSError?
+            let urlToUnzip = self.getDocumentsDirectory()
+            SSZipArchive.unzipFile(atPath: path, toDestination: urlToUnzip.path, preserveAttributes: true, overwrite: true,
+                                   nestedZipLevel: 0, password: password, error: &error, delegate: nil,
+                                   progressHandler: nil) { path, _, _ in
+                NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
+                try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
+            }
+        // }
     }
 
     private func getDocumentsDirectory() -> URL {

--- a/DashWallet/Sources/Models/Uphold/DWUpholdMainnetConstants.m
+++ b/DashWallet/Sources/Models/Uphold/DWUpholdMainnetConstants.m
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)logoutURLString {
     return @"https://uphold.com/";
+
 }
 
 @end

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -52,6 +52,8 @@ class ExplorePointOfUseListViewController: UIViewController {
     internal var radius = 20 // In miles //Move to model
     internal var mapView: ExploreMapView!
     internal var showMapButton: UIButton!
+    internal var syncBannerView: ExploreSyncBannerView?
+    internal var syncBannerHeightConstraint: NSLayoutConstraint?
 
     internal var contentViewTopLayoutConstraint: NSLayoutConstraint!
     internal var contentView: UIView!
@@ -136,6 +138,9 @@ class ExplorePointOfUseListViewController: UIViewController {
 
         showMapIfNeeded()
         DWLocationManager.shared.add(observer: self)
+        
+        // Check database sync status again in case it changed while navigating
+        checkDatabaseSyncStatus()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -144,6 +149,7 @@ class ExplorePointOfUseListViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         DWLocationManager.shared.remove(observer: self)
+        NotificationCenter.default.removeObserver(self, name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
     }
 
     override func viewDidLoad() {
@@ -184,12 +190,76 @@ class ExplorePointOfUseListViewController: UIViewController {
         }
 
         configureHierarchy()
+        
+        // Check database sync status
+        checkDatabaseSyncStatus()
+        
+        // Observe database sync notifications
+        NotificationCenter.default.addObserver(self, selector: #selector(databaseHasBeenUpdated), name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
     }
 }
 
 extension ExplorePointOfUseListViewController {
     @objc
     internal func configureModel() { }
+    
+    private func checkDatabaseSyncStatus() {
+        // Check if we need to show sync banner
+        // If database doesn't exist or has old schema, show banner
+        let documentsPath = FileManager.documentsDirectoryURL.appendingPathComponent(kExploreDashDatabaseName)
+        let fileExists = FileManager.default.fileExists(atPath: documentsPath.path)
+        
+        // If file doesn't exist or has old schema, show sync banner
+        if !fileExists || ExploreDatabaseConnection.hasOldMerchantIdSchema(at: documentsPath) {
+            showSyncBanner()
+        } else {
+            hideSyncBanner()
+        }
+    }
+    
+    private func showSyncBanner() {
+        guard syncBannerView?.isHidden == true else { return }
+        
+        syncBannerView?.isHidden = false
+        syncBannerHeightConstraint?.constant = 30
+        
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    private func hideSyncBanner() {
+        guard syncBannerView?.isHidden == false else { return }
+        
+        syncBannerHeightConstraint?.constant = 0
+        
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        } completion: { _ in
+            self.syncBannerView?.isHidden = true
+        }
+    }
+    
+    @objc private func databaseHasBeenUpdated() {
+        DispatchQueue.main.async { [weak self] in
+            // Database has been updated, hide the sync banner
+            self?.hideSyncBanner()
+            
+            // The database connection needs to be re-established after update
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                guard let self = self else { return }
+                
+                self.model.items = []
+                if let currentProvider = self.model.currentDataProvider {
+                    currentProvider.items = []
+                    currentProvider.currentPage = nil
+                }
+                
+                self.model.refreshItems()
+                self.tableView.reloadData()
+            }
+        }
+    }
 }
 
 // MARK: DWLocationObserver
@@ -306,6 +376,12 @@ extension ExplorePointOfUseListViewController {
         contentView.layer.cornerRadius = 20
         contentView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         view.addSubview(contentView)
+        
+        // Add sync banner attached to app bar but overlaying content
+        syncBannerView = ExploreSyncBannerView()
+        syncBannerView?.translatesAutoresizingMaskIntoConstraints = false
+        syncBannerView?.isHidden = true
+        view.addSubview(syncBannerView!)
 
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -364,6 +440,10 @@ extension ExplorePointOfUseListViewController {
 
         contentViewTopLayoutConstraint = contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
                                                                           constant: -handlerViewHeight)
+        
+        syncBannerHeightConstraint = syncBannerView!.heightAnchor.constraint(equalToConstant: 0)
+        // Set high z-position to overlay content
+        syncBannerView!.layer.zPosition = 100
 
         NSLayoutConstraint.activate([
             contentViewTopLayoutConstraint,
@@ -371,6 +451,12 @@ extension ExplorePointOfUseListViewController {
             contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            
+            // Sync banner constraints - attached to app bar, overlaying content
+            syncBannerView!.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            syncBannerView!.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            syncBannerView!.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            syncBannerHeightConstraint!,
 
             handlerView.heightAnchor.constraint(equalToConstant: handlerViewHeight),
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExploreSyncBannerView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExploreSyncBannerView.swift
@@ -1,0 +1,54 @@
+//
+//  Created by Andrei Ashikhmin
+//  Copyright © 2025 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+class ExploreSyncBannerView: UIView {
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = NSLocalizedString("Sync in progress… Results may not be complete.", comment: "Explore Dash")
+        label.textColor = .white
+        label.font = .dw_font(forTextStyle: .footnote)
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+    
+    private func setupView() {
+        backgroundColor = .dw_dashBlue()
+        
+        addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+        ])
+    }
+}

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Неуспешно синхронизиране";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Синхронизирай сега";
 

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Synchronizace selhala";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Synchronizovat";
 

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Synchronisierung fehlgeschlagen";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Jetzt synchronisieren";
 

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Ο Συγχρονισμός Απέτυχε!";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Συγχρονισμός Τώρα";
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Falla en la Sincronizacío";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sincronizar Ahora";
 

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Pumalya ang pag-sync";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "I-sync ngayon";
 

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Échec de synchronisation";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Synchroniser maintenant";
 

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sinkronisasi Gagal";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sinkronkan Sekarang";
 

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sincronizzazione Fallita";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sincronizza Ora";
 

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "同期に失敗しました";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "すぐに同期する";
 

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "동기화에 실패하였습니다";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "지금 동기화합니다";
 

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync mislukt";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Nu synchroniseren";
 

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Synchronizacja Zawiodła";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Synchronizuj Teraz";
 

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sicronização Falhou";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sincronizar Agora";
 

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Ошибка синхронизации";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Синхронизировать";
 

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Synchronizácia zlyhala";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Synchronizovať teraz";
 

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "ซิงค์ล้มเหลว";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "ซิงค์ตอนนี้";
 

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Senkronizasyon Başarısız";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Şimdi Senkronize Et";
 

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Помилка синхронізації";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Синхронізувати зараз";
 

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Đồng bộ không thành công";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Đồng bộ luôn";
 

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "Sync Failed";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "Sync Now";
 

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "同步失败";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "立刻同步";
 

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -2374,6 +2374,9 @@
 /* No comment provided by engineer. */
 "Sync Failed" = "同步失敗";
 
+/* Explore Dash */
+"Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Sync Now" = "立即同步";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
- If the app didn't update to v3 Explore database prior to the user opening the Explore feature, the app will crash due to a schema mismatch.

## What was done?
- Check the DB schema, don't connect if old
- Wait for new DB download
- Show "data is syncing" notification
- Reload search results once DB is ready


## How Has This Been Tested?
QA


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone