### PR TITLE
fix(dashspend): remove grouping by source

### DIFF
--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
@@ -141,9 +141,9 @@ class MerchantDAO: PointOfUseDAO {
                 let exp =
                     Expression<Bool>(literal: "(latitude - \(anchorLatitude))*(latitude - \(anchorLatitude)) + (longitude - \(anchorLongitude))*(longitude - \(anchorLongitude)) = MIN((latitude - \(anchorLatitude))*(latitude - \(anchorLatitude)) + (longitude - \(anchorLongitude))*(longitude - \(anchorLongitude)))")
 
-                query = query.group([ExplorePointOfUse.source, ExplorePointOfUse.merchantId], having: exp)
+                query = query.group([ExplorePointOfUse.merchantId], having: exp)
             } else {
-                query = query.group([ExplorePointOfUse.source, ExplorePointOfUse.merchantId])
+                query = query.group([ExplorePointOfUse.merchantId])
             }
 
             var distanceSorting = Expression<Bool>(value: true)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Currently, the search results are grouped by source and merchantId, but only grouping by merchantId is needed.


## What was done?
- Remove grouping by source


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how merchant results are grouped and aggregated, which may affect the way nearby merchants are displayed in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->