### PR TITLE
feat(wallet): multi-select transaction filter with Rewards and Shielded categories

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -889,6 +889,8 @@
 		A5D5DD000000000000000551 /* InternalTransferConfirmSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000552 /* InternalTransferConfirmSheet.swift */; };
 		A5D5DD000000000000000560 /* ShieldedTransferCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000562 /* ShieldedTransferCoordinator.swift */; };
 		A5D5DD000000000000000561 /* ShieldedTransferCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000562 /* ShieldedTransferCoordinator.swift */; };
+		A5D5DD000000000000000570 /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */; };
+		A5D5DD000000000000000571 /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */; };
 		A5D5DD000000000000001102 /* DWRegistrationPhaseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001001 /* DWRegistrationPhaseAdapter.swift */; };
 		A5D5DD000000000000001104 /* DWIdentityRegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001002 /* DWIdentityRegistrationController.swift */; };
 		A5D5DD000000000000001106 /* DWIdentityAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001003 /* DWIdentityAuthorizer.swift */; };
@@ -2702,6 +2704,7 @@
 		A5D5DD000000000000000532 /* InternalTransferHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalTransferHostingController.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000000552 /* InternalTransferConfirmSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalTransferConfirmSheet.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000000562 /* ShieldedTransferCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldedTransferCoordinator.swift; sourceTree = "<group>"; };
+		A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldedWithdrawalStore.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001001 /* DWRegistrationPhaseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWRegistrationPhaseAdapter.swift; path = Identity/DWRegistrationPhaseAdapter.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001002 /* DWIdentityRegistrationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWIdentityRegistrationController.swift; path = Identity/DWIdentityRegistrationController.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001003 /* DWIdentityAuthorizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWIdentityAuthorizer.swift; path = Identity/DWIdentityAuthorizer.swift; sourceTree = "<group>"; };
@@ -6461,6 +6464,7 @@
 				A5D5DD000000000000000532 /* InternalTransferHostingController.swift */,
 				A5D5DD000000000000000552 /* InternalTransferConfirmSheet.swift */,
 				A5D5DD000000000000000562 /* ShieldedTransferCoordinator.swift */,
+				A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */,
 			);
 			path = InternalTransfer;
 			sourceTree = "<group>";
@@ -8767,6 +8771,7 @@
 				A5D5DD000000000000000530 /* InternalTransferHostingController.swift in Sources */,
 				A5D5DD000000000000000550 /* InternalTransferConfirmSheet.swift in Sources */,
 				A5D5DD000000000000000560 /* ShieldedTransferCoordinator.swift in Sources */,
+				A5D5DD000000000000000570 /* ShieldedWithdrawalStore.swift in Sources */,
 				A5D5DD000000000000000249 /* PlatformSendExecutor.swift in Sources */,
 				A5D5DD000000000000000252 /* StorageExplorerView.swift in Sources */,
 				A5D5DD000000000000000255 /* StorageModelListViews.swift in Sources */,
@@ -9632,6 +9637,7 @@
 				A5D5DD000000000000000531 /* InternalTransferHostingController.swift in Sources */,
 				A5D5DD000000000000000551 /* InternalTransferConfirmSheet.swift in Sources */,
 				A5D5DD000000000000000561 /* ShieldedTransferCoordinator.swift in Sources */,
+				A5D5DD000000000000000571 /* ShieldedWithdrawalStore.swift in Sources */,
 				A5D5DD000000000000000250 /* PlatformSendExecutor.swift in Sources */,
 				A5D5DD000000000000000253 /* StorageExplorerView.swift in Sources */,
 				A5D5DD000000000000000256 /* StorageModelListViews.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -90,6 +90,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
         // background queue with no @MainActor hop (unlike deleteWalletsFromSDK).
         CoinJoinRecovery.shared.resetForWipe()
         CoinJoinWithdrawalStore.shared.resetForWipe()
+        ShieldedWithdrawalStore.shared.resetForWipe()
         // CrowdNode state is per-wallet-keyed; the wipe destroys every wallet, so
         // clear every wallet's keys (the CrowdNode singleton's own
         // `DWWillWipeWallet` observer only resets the ACTIVE wallet's keys). Also
@@ -203,5 +204,6 @@ final class SwiftDashSDKWalletWiper: NSObject {
         let walletIdHex = walletId.map { String(format: "%02x", $0) }.joined()
         CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
         CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
+        ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
     }
 }

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -226,6 +226,16 @@ class Transaction: TransactionDataItem, Identifiable {
     /// True when this is the funding tx of a "to Shielded" transfer.
     var isShieldedTransfer: Bool { shieldedLockInfo != nil }
 
+    /// True when this incoming tx is the L1 payout of a Shielded → Core
+    /// withdrawal the app performed — matched by destination address via
+    /// `ShieldedWithdrawalStore` (the SDK's opaque withdraw call returns no
+    /// txid, so the app tags the receive address it handed the withdraw).
+    /// Drives the "Shielded received" home filter category.
+    var isShieldedWithdrawalReceipt: Bool {
+        direction == .received
+            && snapshot.outputAddresses.contains { ShieldedWithdrawalStore.shared.contains($0) }
+    }
+
     /// True when the shielded transfer is still pending / stuck — its asset
     /// lock is broadcast/IS-locked/CL-locked (`statusRaw` 1…3) but the shield
     /// state transition hasn't consumed it yet (4 = consumed = success). Drives

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -459,6 +459,18 @@ extension Transaction {
 
     var txHashData: Data { snapshot.txid }
 
+    /// True for any masternode special transaction: provider registration
+    /// (proRegTx), update registrar/service, or revocation. Drives the
+    /// "Masternode" home filter category.
+    var isMasternodeTransaction: Bool {
+        switch transactionType {
+        case .masternodeRegistration, .masternodeUpdate, .masternodeRevoke:
+            return true
+        default:
+            return false
+        }
+    }
+
     var isCoinbaseTransaction: Bool {
         TransactionTypeKind(rawValue: snapshot.typeKind) == .coinbase
     }

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -295,11 +295,12 @@ struct HomeViewContent<Content: View>: View {
         .sheet(isPresented: $showFilterDialog) {
             let dialog = TransactionFilterDialog(
                 selectedFilters: $viewModel.selectedFilters,
-                showRewards: viewModel.hasRewardsHistory
+                showRewards: viewModel.hasRewardsHistory,
+                showMasternode: viewModel.hasMasternodeHistory
             )
 
             if #available(iOS 16.0, *) {
-                dialog.presentationDetents([.height(TransactionFilterDialog.height(showRewards: viewModel.hasRewardsHistory))])
+                dialog.presentationDetents([.height(TransactionFilterDialog.height(showRewards: viewModel.hasRewardsHistory, showMasternode: viewModel.hasMasternodeHistory))])
             } else {
                 dialog
             }

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -294,14 +294,12 @@ struct HomeViewContent<Content: View>: View {
         }
         .sheet(isPresented: $showFilterDialog) {
             let dialog = TransactionFilterDialog(
-                selectedFilter: viewModel.displayMode,
-                onFilterSelected: { mode in
-                    viewModel.displayMode = mode
-                }
+                selectedFilters: $viewModel.selectedFilters,
+                showRewards: viewModel.hasRewardsHistory
             )
-            
+
             if #available(iOS 16.0, *) {
-                dialog.presentationDetents([.height(350)])
+                dialog.presentationDetents([.height(TransactionFilterDialog.height(showRewards: viewModel.hasRewardsHistory))])
             } else {
                 dialog
             }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -24,13 +24,18 @@ private let kBaseBalanceHeaderHeight: CGFloat = 100
 private let kTimeskewTolerance: TimeInterval = 3600 // 1 hour
 private let maxShortcutsCount = 4
 
-@objc(DWHomeTxDisplayMode)
-public enum HomeTxDisplayMode: UInt {
-    case all = 0
-    case received
+/// One selectable category in the home screen's transaction filter. The
+/// filter is multi-select (checkboxes): a transaction shows when it belongs
+/// to ANY selected category, and a selection covering every offered category
+/// means "All" — which also shows transactions that fit no category (internal
+/// transfers, CoinJoin mixing groups).
+enum TransactionFilterCategory: CaseIterable {
     case sent
+    case received
     case rewards
     case giftCard
+    case shieldedSent
+    case shieldedReceived
 }
 
 class HomeViewModel: ObservableObject {
@@ -69,11 +74,19 @@ class HomeViewModel: ObservableObject {
     @Published var showCoinJoinSweepDialog: Bool = false
     @Published private(set) var timeSkew: TimeInterval = 0
     @Published private(set) var showJoinDashpay: Bool = true
-    @Published var displayMode: HomeTxDisplayMode = .all {
+    /// Selected filter categories (multi-select checkboxes). Defaults to every
+    /// category — i.e. "All". Never empty: the dialog blocks unchecking the
+    /// last box.
+    @Published var selectedFilters: Set<TransactionFilterCategory> = Set(TransactionFilterCategory.allCases) {
         didSet {
             reloadTxDataSource()
         }
     }
+
+    /// True when the wallet has ever received a masternode/mining reward
+    /// (any coinbase tx in history). Gates the "Rewards" filter row; computed
+    /// on each full reload.
+    @Published private(set) var hasRewardsHistory: Bool = false
 
     @Published private(set) var headerHeight: CGFloat = kBaseBalanceHeaderHeight // TDOO: move back to HomeView when fully transitioned to SwiftUI
     @Published private(set) var showReclassifyTransaction: Transaction? = nil
@@ -256,10 +269,14 @@ class HomeViewModel: ObservableObject {
             self.coinJoinTxSets = [:]
             self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
 
+            // Gates the "Rewards" filter row; computed from the unfiltered
+            // history so it doesn't flap with the current selection.
+            let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
+
             var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
                 Tx.shared.updateRateIfNeeded(for: wrappedTx)
 
-                if !self.passesFilter(transaction: wrappedTx, displayMode: self.displayMode) {
+                if !self.passesFilter(transaction: wrappedTx, selected: self.selectedFilters, hasRewards: hasRewards) {
                     return nil
                 }
 
@@ -332,6 +349,9 @@ class HomeViewModel: ObservableObject {
 
             DispatchQueue.main.async {
                 self.txItems = array
+                if self.hasRewardsHistory != hasRewards {
+                    self.hasRewardsHistory = hasRewards
+                }
             }
         }
     }
@@ -357,7 +377,15 @@ class HomeViewModel: ObservableObject {
                 return
             }
 
-            if !self.passesFilter(transaction: tx, displayMode: self.displayMode) {
+            // A coinbase tx arriving incrementally unlocks the Rewards row
+            // without waiting for the next full reload.
+            if tx.isCoinbaseTransaction && !self.hasRewardsHistory {
+                DispatchQueue.main.async {
+                    self.hasRewardsHistory = true
+                }
+            }
+
+            if !self.passesFilter(transaction: tx, selected: self.selectedFilters, hasRewards: self.hasRewardsHistory) {
                 return
             }
 
@@ -660,19 +688,51 @@ extension HomeViewModel {
         return finalMetadata
     }
     
-    private func passesFilter(transaction: Transaction, displayMode: HomeTxDisplayMode) -> Bool {
-        switch displayMode {
-        case .all:
-            return true
-        case .sent:
-            return transaction.direction == .sent
-        case .received:
-            return transaction.direction == .received && !transaction.isCoinbaseTransaction
-        case .rewards:
-            return transaction.isCoinbaseTransaction
-        case .giftCard:
-            return GiftCardMetadataProvider.shared.availableMetadata[transaction.txHashData] != nil
+    /// Union semantics: show the tx when it belongs to any selected category.
+    /// A selection covering every OFFERED category (rewards is offered only
+    /// when `hasRewards`) is "All" and also admits txs that fit no category
+    /// (internal transfers, CoinJoin mixing groups).
+    private func passesFilter(transaction: Transaction, selected: Set<TransactionFilterCategory>, hasRewards: Bool) -> Bool {
+        var offered = Set(TransactionFilterCategory.allCases)
+        if !hasRewards {
+            offered.remove(.rewards)
         }
+        if selected.isSuperset(of: offered) {
+            return true
+        }
+        return !selected.isDisjoint(with: categories(of: transaction))
+    }
+
+    /// Categories a transaction belongs to. Overlaps are allowed (a gift-card
+    /// purchase is also a sent tx); rewards and shielded receipts are carved
+    /// out of received, mirroring how the old single-select filter separated
+    /// rewards from receives.
+    private func categories(of transaction: Transaction) -> Set<TransactionFilterCategory> {
+        if transaction.isCoinbaseTransaction {
+            return [.rewards]
+        }
+        var categories: Set<TransactionFilterCategory> = []
+        if transaction.isShieldedTransfer {
+            categories.insert(.shieldedSent)
+        }
+        let isShieldedReceipt = transaction.isShieldedWithdrawalReceipt
+        if isShieldedReceipt {
+            categories.insert(.shieldedReceived)
+        }
+        if GiftCardMetadataProvider.shared.availableMetadata[transaction.txHashData] != nil {
+            categories.insert(.giftCard)
+        }
+        switch transaction.direction {
+        case .sent:
+            categories.insert(.sent)
+        case .received:
+            if !isShieldedReceipt {
+                categories.insert(.received)
+            }
+        default:
+            break
+        }
+        return categories
     }
 }
 

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -33,6 +33,7 @@ enum TransactionFilterCategory: CaseIterable {
     case sent
     case received
     case rewards
+    case masternode
     case giftCard
     case shieldedSent
     case shieldedReceived
@@ -92,6 +93,11 @@ class HomeViewModel: ObservableObject {
     /// (any coinbase tx in history). Gates the "Rewards" filter row; computed
     /// on each full reload.
     @Published private(set) var hasRewardsHistory: Bool = false
+
+    /// True when the wallet has ever had a masternode special transaction
+    /// (proRegTx / update / revocation). Gates the "Masternode" filter row;
+    /// computed on each full reload.
+    @Published private(set) var hasMasternodeHistory: Bool = false
 
     @Published private(set) var headerHeight: CGFloat = kBaseBalanceHeaderHeight // TDOO: move back to HomeView when fully transitioned to SwiftUI
     @Published private(set) var showReclassifyTransaction: Transaction? = nil
@@ -302,9 +308,10 @@ class HomeViewModel: ObservableObject {
             self.coinJoinTxSets = [:]
             self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
 
-            // Gates the "Rewards" filter row; computed from the unfiltered
-            // history so it doesn't flap with the current selection.
+            // Gate the "Rewards" / "Masternode" filter rows; computed from the
+            // unfiltered history so they don't flap with the current selection.
             let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
+            let hasMasternodes = transactions.contains { $0.isMasternodeTransaction }
 
             // Snapshot each provider's metadata once per reload —
             // `availableMetadata` copies the whole dictionary through the
@@ -316,7 +323,7 @@ class HomeViewModel: ObservableObject {
             var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
                 Tx.shared.updateRateIfNeeded(for: wrappedTx)
 
-                if !self.passesFilter(transaction: wrappedTx, selected: self.selectedFilters, hasRewards: hasRewards, giftCardTxIds: giftCardTxIds) {
+                if !self.passesFilter(transaction: wrappedTx, selected: self.selectedFilters, hasRewards: hasRewards, hasMasternodes: hasMasternodes, giftCardTxIds: giftCardTxIds) {
                     return nil
                 }
 
@@ -392,6 +399,9 @@ class HomeViewModel: ObservableObject {
                 if self.hasRewardsHistory != hasRewards {
                     self.hasRewardsHistory = hasRewards
                 }
+                if self.hasMasternodeHistory != hasMasternodes {
+                    self.hasMasternodeHistory = hasMasternodes
+                }
             }
         }
     }
@@ -417,15 +427,20 @@ class HomeViewModel: ObservableObject {
                 return
             }
 
-            // A coinbase tx arriving incrementally unlocks the Rewards row
-            // without waiting for the next full reload.
+            // A coinbase / masternode tx arriving incrementally unlocks its
+            // filter row without waiting for the next full reload.
             if tx.isCoinbaseTransaction && !self.hasRewardsHistory {
                 DispatchQueue.main.async {
                     self.hasRewardsHistory = true
                 }
             }
+            if tx.isMasternodeTransaction && !self.hasMasternodeHistory {
+                DispatchQueue.main.async {
+                    self.hasMasternodeHistory = true
+                }
+            }
 
-            if !self.passesFilter(transaction: tx, selected: self.selectedFilters, hasRewards: self.hasRewardsHistory) {
+            if !self.passesFilter(transaction: tx, selected: self.selectedFilters, hasRewards: self.hasRewardsHistory, hasMasternodes: self.hasMasternodeHistory) {
                 return
             }
 
@@ -735,17 +750,20 @@ extension HomeViewModel {
     }
     
     /// Union semantics: show the tx when it belongs to any selected category.
-    /// A selection covering every OFFERED category (rewards is offered only
-    /// when `hasRewards`) is "All" and also admits txs that fit no category
-    /// (internal transfers, CoinJoin mixing groups).
+    /// A selection covering every OFFERED category (rewards / masternode are
+    /// offered only when their history flags are set) is "All" and also admits
+    /// txs that fit no category (internal transfers, CoinJoin mixing groups).
     ///
     /// `giftCardTxIds` is an optional pre-snapshotted key set for the
     /// `.giftCard` category — full-reload loops pass it to avoid copying the
     /// provider's dictionary per transaction; single-tx callers omit it.
-    private func passesFilter(transaction: Transaction, selected: Set<TransactionFilterCategory>, hasRewards: Bool, giftCardTxIds: Set<Data>? = nil) -> Bool {
+    private func passesFilter(transaction: Transaction, selected: Set<TransactionFilterCategory>, hasRewards: Bool, hasMasternodes: Bool, giftCardTxIds: Set<Data>? = nil) -> Bool {
         var offered = Set(TransactionFilterCategory.allCases)
         if !hasRewards {
             offered.remove(.rewards)
+        }
+        if !hasMasternodes {
+            offered.remove(.masternode)
         }
         if selected.isSuperset(of: offered) {
             return true
@@ -760,6 +778,9 @@ extension HomeViewModel {
     private func categories(of transaction: Transaction, giftCardTxIds: Set<Data>? = nil) -> Set<TransactionFilterCategory> {
         if transaction.isCoinbaseTransaction {
             return [.rewards]
+        }
+        if transaction.isMasternodeTransaction {
+            return [.masternode]
         }
         var categories: Set<TransactionFilterCategory> = []
         if transaction.isShieldedTransfer {

--- a/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
+++ b/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
@@ -4,16 +4,18 @@ import SwiftUI
 /// shortcut per row, applied live through the binding (the sheet stays open
 /// while toggling). The "All" row checks every box; a fully checked selection
 /// means "show everything", including transactions that fit no category
-/// (internal transfers, CoinJoin mixing groups). The Rewards row is offered
-/// only when the wallet has ever earned a masternode/mining reward.
+/// (internal transfers, CoinJoin mixing groups). The Rewards and Masternode
+/// rows are offered only when the wallet has ever had a masternode/mining
+/// reward or a masternode special transaction, respectively.
 struct TransactionFilterDialog: View {
     @Binding var selectedFilters: Set<TransactionFilterCategory>
     let showRewards: Bool
+    let showMasternode: Bool
 
     /// Sheet detent height for the current row count (options + the All row),
     /// matching the BottomSheet's title + row + padding metrics.
-    static func height(showRewards: Bool) -> CGFloat {
-        let rows = showRewards ? 7 : 6
+    static func height(showRewards: Bool, showMasternode: Bool) -> CGFloat {
+        let rows = 6 + (showRewards ? 1 : 0) + (showMasternode ? 1 : 0)
         return CGFloat(134 + rows * 54)
     }
 
@@ -24,6 +26,9 @@ struct TransactionFilterDialog: View {
         ]
         if showRewards {
             options.append(FilterOption(category: .rewards, title: NSLocalizedString("Rewards", comment: "Transaction filter"), icon: .system("trophy")))
+        }
+        if showMasternode {
+            options.append(FilterOption(category: .masternode, title: NSLocalizedString("Masternode", comment: "Transaction filter"), icon: .system("server.rack")))
         }
         options.append(contentsOf: [
             FilterOption(category: .giftCard, title: NSLocalizedString("Gift card", comment: ""), icon: .custom("image.dashspend.giftcard")),

--- a/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
+++ b/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
@@ -1,47 +1,73 @@
 import SwiftUI
-import UIKit
 
-@objc
-class TransactionFilterDialogPresenter: NSObject {
-    @objc static func present(from viewController: UIViewController, selectedFilter: HomeTxDisplayMode, onFilterSelected: @escaping (HomeTxDisplayMode) -> Void) {
-        let dialog = TransactionFilterDialog(
-            selectedFilter: selectedFilter,
-            onFilterSelected: onFilterSelected
-        )
-        
-        let hostingController = UIHostingController(rootView: dialog)
-        hostingController.setDetent(350)
-        viewController.present(hostingController, animated: true)
-    }
-}
-
+/// Multi-select transaction filter: one checkbox per category plus an "Only"
+/// shortcut per row, applied live through the binding (the sheet stays open
+/// while toggling). The "All" row checks every box; a fully checked selection
+/// means "show everything", including transactions that fit no category
+/// (internal transfers, CoinJoin mixing groups). The Rewards row is offered
+/// only when the wallet has ever earned a masternode/mining reward.
 struct TransactionFilterDialog: View {
-    @Environment(\.presentationMode) private var presentationMode
-    let selectedFilter: HomeTxDisplayMode
-    var onFilterSelected: (HomeTxDisplayMode) -> Void
-    
-    private let filterOptions: [FilterOption] = [
-        FilterOption(mode: .all, title: NSLocalizedString("All", comment: ""), icon: .custom("image.filter.options")),
-        FilterOption(mode: .sent, title: NSLocalizedString("Sent", comment: ""), icon: .custom("tx.item.sent.icon")),
-        FilterOption(mode: .received, title: NSLocalizedString("Received", comment: ""), icon: .custom("tx.item.received.icon")),
-        FilterOption(mode: .giftCard, title: NSLocalizedString("Gift card", comment: ""), icon: .custom("image.dashspend.giftcard"))
-    ]
-    
+    @Binding var selectedFilters: Set<TransactionFilterCategory>
+    let showRewards: Bool
+
+    /// Sheet detent height for the current row count (options + the All row),
+    /// matching the BottomSheet's title + row + padding metrics.
+    static func height(showRewards: Bool) -> CGFloat {
+        let rows = showRewards ? 7 : 6
+        return CGFloat(134 + rows * 54)
+    }
+
+    private var filterOptions: [FilterOption] {
+        var options = [
+            FilterOption(category: .sent, title: NSLocalizedString("Sent", comment: ""), icon: .custom("tx.item.sent.icon")),
+            FilterOption(category: .received, title: NSLocalizedString("Received", comment: ""), icon: .custom("tx.item.received.icon"))
+        ]
+        if showRewards {
+            options.append(FilterOption(category: .rewards, title: NSLocalizedString("Rewards", comment: "Transaction filter"), icon: .system("trophy")))
+        }
+        options.append(contentsOf: [
+            FilterOption(category: .giftCard, title: NSLocalizedString("Gift card", comment: ""), icon: .custom("image.dashspend.giftcard")),
+            FilterOption(category: .shieldedSent, title: NSLocalizedString("Shielded sent", comment: "Transaction filter"), icon: .system("shield.fill")),
+            FilterOption(category: .shieldedReceived, title: NSLocalizedString("Shielded received", comment: "Transaction filter"), icon: .system("shield"))
+        ])
+        return options
+    }
+
+    private var offeredCategories: Set<TransactionFilterCategory> {
+        Set(filterOptions.map { $0.category })
+    }
+
+    private var allChecked: Bool {
+        selectedFilters.isSuperset(of: offeredCategories)
+    }
+
     var body: some View {
         BottomSheet(
             title: NSLocalizedString("Filter transactions", comment: ""),
             showBackButton: .constant(false)
         ) {
             VStack(spacing: 4) {
+                FilterCheckboxRow(
+                    title: NSLocalizedString("All", comment: ""),
+                    icon: .custom("image.filter.options"),
+                    isChecked: allChecked,
+                    onToggle: {
+                        selectedFilters = Set(TransactionFilterCategory.allCases)
+                    }
+                )
+
                 ForEach(filterOptions) { option in
-                    RadioButtonRow(
+                    FilterCheckboxRow(
                         title: option.title,
                         icon: option.icon,
-                        isSelected: option.mode == selectedFilter
-                    ) {
-                        onFilterSelected(option.mode)
-                        presentationMode.wrappedValue.dismiss()
-                    }
+                        isChecked: selectedFilters.contains(option.category),
+                        onOnly: {
+                            selectedFilters = [option.category]
+                        },
+                        onToggle: {
+                            toggle(option.category)
+                        }
+                    )
                 }
             }
             .padding(.vertical, 6)
@@ -52,12 +78,71 @@ struct TransactionFilterDialog: View {
         }
         .background(Color.primaryBackground)
     }
+
+    private func toggle(_ category: TransactionFilterCategory) {
+        var selection = selectedFilters
+        if selection.contains(category) {
+            selection.remove(category)
+            // Never allow an empty filter — the last checked box stays checked.
+            if selection.intersection(offeredCategories).isEmpty {
+                return
+            }
+        } else {
+            selection.insert(category)
+        }
+        selectedFilters = selection
+    }
 }
 
-struct FilterOption: Identifiable {
-    let id = UUID()
-    let mode: HomeTxDisplayMode
+private struct FilterCheckboxRow: View {
     let title: String
     let icon: IconName
+    let isChecked: Bool
+    var onOnly: (() -> Void)? = nil
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 16) {
+                Icon(name: icon)
+                    .frame(width: 30, height: 30)
+
+                Text(title)
+                    .font(.subhead)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primaryText)
+
+                Spacer()
+
+                if let onOnly = onOnly {
+                    Button(action: onOnly) {
+                        Text(NSLocalizedString("Only", comment: "Transaction filter"))
+                            .font(.subhead)
+                            .fontWeight(.medium)
+                            .foregroundColor(.dashBlue)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+
+                Image(isChecked ? "icon_checkbox_square_checked" : "icon_checkbox_square")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+            .padding(.horizontal, 16)
+            .contentShape(Rectangle())
+            .frame(minHeight: 54)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
 }
 
+private struct FilterOption: Identifiable {
+    let category: TransactionFilterCategory
+    let title: String
+    let icon: IconName
+
+    var id: TransactionFilterCategory { category }
+}

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -384,9 +384,20 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 toCoreAddress: coreAddress,
                 amount: amountCredits)
         } catch {
+            // shieldedSpendUnconfirmed means the spend may already be on
+            // chain (non-retryable), so its payout can still arrive — tag
+            // the destination so the incoming tx classifies as a shielded
+            // withdrawal either way.
+            if case PlatformWalletError.shieldedSpendUnconfirmed = error {
+                ShieldedWithdrawalStore.shared.record(address: coreAddress)
+            }
             handleSpendError(error, manager: env.manager)
             return
         }
+
+        // Tag the payout destination so the home list can classify the
+        // incoming L1 tx as "Shielded received" (the SDK call returns no txid).
+        ShieldedWithdrawalStore.shared.record(address: coreAddress)
 
         Self.logger.info("🛡️ SHIELD-TX :: withdraw route completed")
         phase = .broadcasting

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedWithdrawalStore.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedWithdrawalStore.swift
@@ -1,0 +1,108 @@
+//
+//  ShieldedWithdrawalStore.swift
+//  DashWallet
+//
+//  Persists the destination Core addresses of Shielded → Core withdrawals the
+//  app performed, so the home screen can classify the resulting incoming L1
+//  transaction as "Shielded received".
+//
+//  Address tagging (not txid tagging) is deliberate: the SDK's
+//  `shieldedWithdraw` is an opaque call that returns no txid, so the only
+//  app-side handle on the payout is the fresh receive address resolved right
+//  before the withdraw. Receive addresses are single-use in practice (the app
+//  always hands out the next unused one), so an incoming tx paying a recorded
+//  address is the withdrawal's payout.
+//
+//  Mirrors `CoinJoinWithdrawalStore`'s shape: per-wallet UserDefaults key,
+//  NSLock-guarded in-memory cache (readable from the home screen's background
+//  grouping queue), and the same wipe/remove lifecycle hooks in
+//  `SwiftDashSDKWalletWiper`. No legacy-key migration — the store postdates
+//  multi-wallet support.
+//
+
+import Foundation
+
+final class ShieldedWithdrawalStore {
+
+    static let shared = ShieldedWithdrawalStore()
+
+    private let defaults = UserDefaults.standard
+    private let lock = NSLock()
+    /// Per-wallet key prefix; the effective key is `<keyPrefix>_<walletIdHex>`
+    /// so an address recorded under wallet A isn't tagged as A's withdrawal
+    /// while wallet B is active. Falls back to the bare prefix when no wallet
+    /// is active. `WalletEnvironment.activeWalletIdHex` reads only
+    /// UserDefaults (safe from the background grouping queue).
+    private let keyPrefix = "shieldedWithdrawal.v1.addresses"
+    /// Cache keyed by the resolved (per-wallet) key, so a wallet switch
+    /// between accesses re-reads the new wallet's set instead of serving the
+    /// previous wallet's cached addresses.
+    private var cacheKey: String?
+    private var cache: Set<String>?
+
+    private init() {}
+
+    private func resolvedKey() -> String {
+        guard let walletIdHex = WalletEnvironment.activeWalletIdHex as String?,
+              !walletIdHex.isEmpty else {
+            return keyPrefix
+        }
+        return "\(keyPrefix)_\(walletIdHex)"
+    }
+
+    private func loaded() -> Set<String> {
+        let key = resolvedKey()
+        if cacheKey == key, let cache { return cache }
+        let stored = (defaults.array(forKey: key) as? [String]) ?? []
+        let set = Set(stored)
+        cacheKey = key
+        cache = set
+        return set
+    }
+
+    /// Record a withdrawal's destination Core address (Base58Check).
+    /// Idempotent and thread-safe.
+    func record(address: String) {
+        guard !address.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        var set = loaded()
+        guard !set.contains(address) else { return }
+        set.insert(address)
+        cache = set
+        defaults.set(Array(set), forKey: resolvedKey())
+    }
+
+    /// Whether `address` is a recorded shielded-withdrawal destination.
+    /// Thread-safe; cheap (in-memory `Set` lookup).
+    func contains(_ address: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return loaded().contains(address)
+    }
+
+    /// Clear a SINGLE wallet's recorded addresses (per-wallet Remove flow —
+    /// the removed wallet may not be the active one). Thread-safe.
+    func clearForWallet(walletIdHex: String) {
+        guard !walletIdHex.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        let key = "\(keyPrefix)_\(walletIdHex)"
+        defaults.removeObject(forKey: key)
+        if cacheKey == key {
+            cacheKey = nil
+            cache = nil
+        }
+    }
+
+    /// Clear ALL recorded addresses on a full wallet wipe (walletIds are gone
+    /// by wipe time, so enumerate by prefix). Also resets the in-memory cache
+    /// on the long-lived `shared` singleton. Thread-safe.
+    func resetForWipe() {
+        lock.lock(); defer { lock.unlock() }
+        for key in defaults.dictionaryRepresentation().keys {
+            if key == keyPrefix || key.hasPrefix("\(keyPrefix)_") {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        cacheKey = nil
+        cache = nil
+    }
+}

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1709,6 +1709,9 @@
 /* Online Merchant */
 "Online Merchant" = "Online Merchant";
 
+/* Transaction filter */
+"Only" = "Only";
+
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
@@ -2099,6 +2102,9 @@
 /* No comment provided by engineer. */
 "Reward" = "Reward";
 
+/* Transaction filter */
+"Rewards" = "Rewards";
+
 /* No comment provided by engineer. */
 "Save" = "Save";
 
@@ -2301,6 +2307,12 @@
 
 /* No comment provided by engineer. */
 "Setup Wallet" = "Setup Wallet";
+
+/* Transaction filter */
+"Shielded received" = "Shielded received";
+
+/* Transaction filter */
+"Shielded sent" = "Shielded sent";
 
 /* CrowdNode */
 "Share" = "Share";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1487,6 +1487,9 @@
 /* Map */
 "Map" = "Map";
 
+/* Transaction filter */
+"Masternode" = "Masternode";
+
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 


### PR DESCRIPTION
## What

Reworks the home-screen transaction filter (All / Sent / Received / Gift card) into **multi-select checkboxes**, and adds three new categories: **Rewards**, **Shielded sent**, and **Shielded received**.

Each row has a checkbox plus an **Only** button that narrows the selection to just that category. Tapping **All** checks every box. The sheet stays open while toggling and the list filters live; the last checked box can't be unchecked, so the filter never goes empty.

## Semantics

- Union filtering: a transaction shows when it matches **any** checked category.
- A fully checked selection means "All" and also shows transactions that fit no category (internal transfers, CoinJoin mixing groups) — same as the old All mode.
- Rewards (coinbase) are carved out of Received, as before; gift-card purchases still overlap with Sent.

## Rewards

The `.rewards` predicate existed in `HomeTxDisplayMode` but was never surfaced in the dialog. The row now appears **only when the wallet has ever had a masternode/mining reward**: each full reload scans the unfiltered history for a coinbase tx (`hasRewardsHistory`), and a coinbase arriving incrementally unlocks the row without waiting for a reload.

## Shielded categories

- **Shielded sent** — the existing `isShieldedTransfer` classification (L1 funding tx of a to-Shielded transfer).
- **Shielded received** — new `ShieldedWithdrawalStore`: the SDK's `shieldedWithdraw` is opaque (no txid returned), so `ShieldedTransferCoordinator.performWithdraw` records the destination Core address (on success and on the may-already-be-on-chain `shieldedSpendUnconfirmed` error), and an incoming tx paying a recorded address classifies as Shielded received. Receive addresses are single-use in practice, so address tagging is reliable. Store mirrors `CoinJoinWithdrawalStore` (per-wallet UserDefaults, NSLock cache) with the same remove/wipe hooks in `SwiftDashSDKWalletWiper`.

## Masternode category

A **Masternode** row matches any masternode special transaction (provider registration, update registrar/service, revocation) via the SDK's typed discriminant. Like Rewards, it appears only when the wallet has ever had such a transaction, and masternode txs are carved out of Sent/Received into their own exclusive category.

## Notes

- Withdrawals performed before this change have no recorded address and keep showing under plain Received.
- Filter selection still resets to All on relaunch (unchanged behavior).
- Removes the unused ObjC `TransactionFilterDialogPresenter` and the single-select `HomeTxDisplayMode`.
- New strings: "Rewards", "Shielded sent", "Shielded received", "Only".

## Verification

- Clean `dashpay` scheme build (`iphonesimulator`, `ARCHS=arm64`).
- Testnet smoke of the filter sheet still pending (no simulator session in this environment) — worth checking the Only buttons and sheet height with/without the Rewards row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

