### PR TITLE
fix(wallet): recovery phrase shows the active wallet; discoverable rename/remove on Wallets

### DIFF
--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
@@ -56,7 +56,13 @@ struct WalletsScreen: View {
                 ScrollView {
                     VStack(spacing: 0) {
                         ForEach(viewModel.rows) { row in
-                            WalletRowView(row: row)
+                            WalletRowView(
+                                row: row,
+                                onRename: {
+                                    renameText = row.displayName
+                                    renameTarget = row
+                                },
+                                onRemove: { beginRemove(row) })
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     if !row.isActive { pendingSwitch = row }
@@ -238,6 +244,8 @@ struct WalletsScreen: View {
 
 private struct WalletRowView: View {
     let row: WalletRow
+    let onRename: () -> Void
+    let onRemove: () -> Void
 
     var body: some View {
         HStack(spacing: 12) {
@@ -264,6 +272,26 @@ private struct WalletRowView: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.dashBlue)
+            }
+            // Visible entry point for rename/remove — the long-press context
+            // menu duplicates these but is undiscoverable on its own.
+            Menu {
+                Button {
+                    onRename()
+                } label: {
+                    Label(NSLocalizedString("Rename", comment: "Wallets"), systemImage: "pencil")
+                }
+                Button(role: .destructive) {
+                    onRemove()
+                } label: {
+                    Label(NSLocalizedString("Remove", comment: "Wallets"), systemImage: "trash")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.secondaryText)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
             }
         }
         .padding(.horizontal, 16)

--- a/DashWallet/Sources/UI/Setup/SecureWallet/Seed/DWPreviewSeedPhraseModel+Mnemonic.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/Seed/DWPreviewSeedPhraseModel+Mnemonic.swift
@@ -35,15 +35,29 @@ extension DWPreviewSeedPhraseModel {
         }
     }
 
-    /// Read the mnemonic of the first wallet known to SwiftDashSDK's
-    /// `WalletStorage`. Returns nil if no wallet has stored a mnemonic
-    /// yet (e.g. migration deferred, async creation still in flight).
+    /// Read the ACTIVE wallet's mnemonic from SwiftDashSDK's `WalletStorage`,
+    /// resolved via the per-network active-wallet registry
+    /// (`WalletEnvironment.activeWalletId`, seeded on wallet create/start/
+    /// switch). Falls back to the sole stored wallet on pre-registry installs.
+    /// Returns nil if no mnemonic is stored yet (migration deferred, async
+    /// creation in flight) — or if several wallets exist and none matches the
+    /// registry: showing ANOTHER wallet's phrase would have the user back up
+    /// the wrong words, so an empty screen is the safer failure.
     @objc(readStoredMnemonic)
     func readStoredMnemonic() -> String? {
         do {
             let storage = WalletStorage()
             let walletIds = try storage.listWalletIdsWithMnemonic()
-            guard let walletId = walletIds.first else { return nil }
+            let activeId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind)
+            let walletId: Data
+            if let activeId, walletIds.contains(activeId) {
+                walletId = activeId
+            } else if walletIds.count == 1, let only = walletIds.first {
+                walletId = only
+            } else {
+                Self.mnemonicLogger.error("readStoredMnemonic: active wallet not resolvable among \(walletIds.count, privacy: .public) stored mnemonic(s)")
+                return nil
+            }
             return try storage.retrieveMnemonic(for: walletId)
         } catch {
             Self.mnemonicLogger.error("readStoredMnemonic failed: \(String(describing: error), privacy: .public)")


### PR DESCRIPTION
## Recovery phrase bug (the dangerous one)

Settings → **View Recovery Phrase** read the mnemonic of whatever wallet `WalletStorage.listWalletIdsWithMnemonic()` happened to enumerate first (`DWPreviewSeedPhraseModel+Mnemonic.swift`). With more than one wallet on device, it could show a *different wallet's* recovery phrase — a user diligently backing up those words would be backing up the wrong wallet.

Fix: resolve the **active** wallet through the per-network registry (`WalletEnvironment.activeWalletId(for:)`, which is seeded on wallet create, host start, and runtime switch), with a fallback to the sole stored wallet for pre-registry installs. If several wallets exist and none matches the registry, the reader returns nil (empty screen) — deliberately safer than guessing, since showing a plausible-but-wrong phrase is the worst outcome. The verify-seed onboarding flow was unaffected (it checks the in-hand phrase, not storage).

## Wallets: visible rename and remove

Rename and per-wallet Remove were already implemented on the Wallets screen — but **only reachable via long-press context menu**, so in practice invisible. Each wallet row now has a visible **⋯ menu** with:

- **Rename** — existing alert flow; stores the name in `PersistentWallet.name`, empty resets to the default "Wallet abcd1234…" label.
- **Remove** — existing safety flow: warning copy, requires typing that wallet's own recovery phrase (verified by deriving its walletId), destructive confirm; the last remaining wallet still routes to the full reset flow. If the removed wallet is active, the app switches to another wallet first.

The long-press context menu is kept as a secondary path.

## Verification

- Clean `dashpay` scheme build (`iphonesimulator`, `ARCHS=arm64`).
- On-device check on the QA simulator pending (wallet is PIN-locked in this environment). Suggested manual test: with 2+ wallets, switch to the second wallet and open View Recovery Phrase — before this fix it could show wallet #1's words; after, it must show the active wallet's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)