### PR TITLE
feat(wallet): Switch Wallet home-screen shortcut

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -693,6 +693,8 @@
 		75AE5A7F2A87C363006CD4BA /* DWConfirmUsernameContentView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C943B5712A40ED4200AF23C5 /* DWConfirmUsernameContentView.xib */; };
 		75B3C1A22E36100100CAFE02 /* ShortcutSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */; };
 		75B3C1A32E36100100CAFE03 /* ShortcutSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */; };
+		75B3C1B22E36100100CAFE12 /* WalletSwitchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE11 /* WalletSwitchDialog.swift */; };
+		75B3C1B32E36100100CAFE13 /* WalletSwitchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE11 /* WalletSwitchDialog.swift */; };
 		75B3C1B22E36100100CAFE05 /* ShortcutCustomizeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */; };
 		75B3C1B32E36100100CAFE06 /* ShortcutCustomizeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */; };
 		75B4D7E52EEC100000A1B2C3 /* WalletSendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B4D7E42EEC100000A1B2C3 /* WalletSendService.swift */; };
@@ -2585,6 +2587,7 @@
 		75AA33D42BF9E1D400F12465 /* Font+DWStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+DWStyle.swift"; sourceTree = "<group>"; };
 		75AA33D72BFB4A5A00F12465 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSelectionView.swift; sourceTree = "<group>"; };
+		75B3C1B12E36100100CAFE11 /* WalletSwitchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSwitchDialog.swift; sourceTree = "<group>"; };
 		75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCustomizeBannerView.swift; sourceTree = "<group>"; };
 		75B4D7E42EEC100000A1B2C3 /* WalletSendService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletSendService.swift; sourceTree = "<group>"; };
 		75BDE7AB2BF3287400556791 /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
@@ -3738,6 +3741,7 @@
 				C94F5E8D29D404850034FD57 /* ShortcutCell.swift */,
 				75B3C1B12E36100100CAFE04 /* ShortcutCustomizeBannerView.swift */,
 				75B3C1A12E36100100CAFE01 /* ShortcutSelectionView.swift */,
+				75B3C1B12E36100100CAFE11 /* WalletSwitchDialog.swift */,
 				2A1AF6DC23C7681B00442AF5 /* DWShortcutCollectionViewCell~ipad.xib */,
 				2A1AF6DD23C7681B00442AF5 /* DWShortcutCollectionViewCell~iphone.xib */,
 				C94F5E8F29D4060A0034FD57 /* ShortcutsView.swift */,
@@ -8915,6 +8919,7 @@
 				C94F5E8E29D404850034FD57 /* ShortcutCell.swift in Sources */,
 				75B3C1B22E36100100CAFE05 /* ShortcutCustomizeBannerView.swift in Sources */,
 				75B3C1A22E36100100CAFE02 /* ShortcutSelectionView.swift in Sources */,
+				75B3C1B22E36100100CAFE12 /* WalletSwitchDialog.swift in Sources */,
 				2A44312122CCA2A0009BAF7F /* UIColor+DWStyle.m in Sources */,
 				FBEF3AF121823CD800917AB6 /* DWEnvironment.m in Sources */,
 				47AE8BF028C1306000490F5E /* AtmItemCell.swift in Sources */,
@@ -9768,6 +9773,7 @@
 				C9D2C84D2A320AA000D15901 /* ShortcutCell.swift in Sources */,
 				75B3C1B32E36100100CAFE06 /* ShortcutCustomizeBannerView.swift in Sources */,
 				75B3C1A32E36100100CAFE03 /* ShortcutSelectionView.swift in Sources */,
+				75B3C1B32E36100100CAFE13 /* WalletSwitchDialog.swift in Sources */,
 				C9D2C84F2A320AA000D15901 /* UIColor+DWStyle.m in Sources */,
 				C9D2C8502A320AA000D15901 /* DWEnvironment.m in Sources */,
 				C9D2C8512A320AA000D15901 /* AtmItemCell.swift in Sources */,

--- a/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
@@ -71,7 +71,60 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate, ExploreView
             showTopper()
         case .getTestDash:
             showTestnetFaucet()
+        case .switchWallet:
+            showSwitchWallet()
         }
+    }
+
+    // MARK: - Switch Wallet
+
+    /// Entry point of the Switch Wallet shortcut. Presentation scales with how
+    /// many OTHER wallets exist: one → confirmation alert directly; two to
+    /// five → bottom-sheet picker (then the same confirmation); more → the
+    /// full Wallets screen (which has its own switch confirmation). The
+    /// shortcut is hidden/degraded while only one wallet exists, so an empty
+    /// list here is just a defensive no-op.
+    private func showSwitchWallet() {
+        let walletsViewModel = WalletsViewModel()
+        walletsViewModel.reload()
+        let others = walletsViewModel.rows.filter { !$0.isActive }
+        guard !others.isEmpty else { return }
+
+        if others.count == 1 {
+            confirmWalletSwitch(to: others[0], viewModel: walletsViewModel)
+        } else if others.count <= 5 {
+            let dialog = WalletSwitchDialog(rows: others) { [weak self] row in
+                self?.dismiss(animated: true) {
+                    self?.confirmWalletSwitch(to: row, viewModel: walletsViewModel)
+                }
+            }
+            let hostingController = UIHostingController(rootView: dialog)
+            hostingController.setDetent(WalletSwitchDialog.height(rowCount: others.count))
+            present(hostingController, animated: true)
+        } else {
+            guard let navigationController else { return }
+            let controller = UIHostingController(rootView: WalletsScreen(vc: navigationController))
+            controller.hidesBottomBarWhenPushed = true
+            navigationController.pushViewController(controller, animated: true)
+        }
+    }
+
+    /// The always-shown switch confirmation. The switch itself runs through
+    /// `WalletsViewModel.switchWallet` (shared runtime call + error logging);
+    /// the home screen refreshes via the active-wallet-change notification.
+    /// `viewModel` is captured by the action so it outlives the alert.
+    private func confirmWalletSwitch(to row: WalletRow, viewModel: WalletsViewModel) {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Switch Wallet", comment: "Wallets"),
+            message: String(
+                format: NSLocalizedString("Would you like to switch to \"%@\"? You can always switch back later.", comment: "Wallets"),
+                row.displayName),
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Switch", comment: "Wallets"), style: .default) { _ in
+            viewModel.switchWallet(to: row.walletId)
+        })
+        present(alert, animated: true)
     }
 
     // MARK: - Private

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -832,29 +832,46 @@ extension HomeViewModel {
         let options = DWGlobalOptions.sharedInstance()
         let isTestnet = WalletEnvironment.isTestnet
 
-        // Check for custom configuration first
+        // Check for custom configuration first. Mapped on main: the Switch
+        // Wallet availability gate reads main-actor wallet state, and this
+        // reload can run off-main (the published write lands on main anyway).
         if let customShortcuts = options.shortcuts,
            customShortcuts.count == maxShortcutsCount {
-            let items = customShortcuts.compactMap { number -> ShortcutAction? in
-                guard var type = ShortcutActionType(rawValue: number.intValue) else { return nil }
-                // A faucet shortcut saved on testnet degrades to Spend
-                // after a switch to mainnet (no mainnet faucet exists);
-                // the saved config is untouched, so it comes back when
-                // the user returns to testnet.
-                if type == .getTestDash && !isTestnet {
-                    type = .spend
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                let canSwitchWallet = MainActor.assumeIsolated { WalletsViewModel.switchableWalletCount > 1 }
+                let items = customShortcuts.compactMap { number -> ShortcutAction? in
+                    guard var type = ShortcutActionType(rawValue: number.intValue) else { return nil }
+                    // A faucet shortcut saved on testnet degrades to Spend
+                    // after a switch to mainnet (no mainnet faucet exists);
+                    // the saved config is untouched, so it comes back when
+                    // the user returns to testnet.
+                    if type == .getTestDash && !isTestnet {
+                        type = .spend
+                    }
+                    // A Switch Wallet shortcut degrades to Receive while the
+                    // device is back to a single wallet; the saved config is
+                    // untouched, so it returns when another wallet is added.
+                    if type == .switchWallet && !canSwitchWallet {
+                        type = .receive
+                    }
+                    return ShortcutAction(type: type)
                 }
-                return ShortcutAction(type: type)
-            }
-            if items.count == maxShortcutsCount {
-                DispatchQueue.main.async {
+                if items.count == maxShortcutsCount {
                     self.shortcutItems = items
+                } else {
+                    self.applyDefaultShortcuts(options: options, isTestnet: isTestnet)
                 }
-                return
             }
+            return
         }
 
-        // Fall back to default state-based logic
+        applyDefaultShortcuts(options: options, isTestnet: isTestnet)
+    }
+
+    /// The default state-based bar (no custom configuration, or the saved one
+    /// no longer maps to a full set of actions).
+    private func applyDefaultShortcuts(options: DWGlobalOptions, isTestnet: Bool) {
         let walletNeedsBackup = options.walletNeedsBackup
         let userHasBalance = options.userHasBalance
         // On testnet the last default slot offers the faucet instead of

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
@@ -45,12 +45,15 @@ enum ShortcutActionType: Int {
     // Appended last: raw values persist in DWGlobalOptions.shortcuts,
     // so inserting mid-enum would silently remap saved configurations.
     case getTestDash
+    case switchWallet
 }
 
 extension ShortcutActionType {
     /// The features available for shortcut bar customization. Computed
-    /// (not stored) because the faucet entry follows the runtime
-    /// network — it appears only while the wallet is on testnet.
+    /// (not stored) because two entries follow runtime state: the faucet
+    /// appears only while the wallet is on testnet, and Switch Wallet only
+    /// while the current network has more than one wallet to switch among.
+    @MainActor
     static var customizableActions: [ShortcutActionType] {
         var actions: [ShortcutActionType] = [
             .buySellDash, .explore, .spend, .atm, .receive,
@@ -59,6 +62,9 @@ extension ShortcutActionType {
         ]
         if WalletEnvironment.isTestnet {
             actions.insert(.getTestDash, at: 0)
+        }
+        if WalletsViewModel.switchableWalletCount > 1 {
+            actions.append(.switchWallet)
         }
         return actions
     }
@@ -167,6 +173,13 @@ extension ShortcutActionType {
                 fatalError("Image not found for shortcut type: \(self)")
             }
             return image
+        case .switchWallet:
+            // Reuses the network-switch glyph (circular arrows) — same
+            // "switch" metaphor, no dedicated asset yet.
+            guard let image = UIImage(named: "shortcut_switchNetwork") else {
+                fatalError("Image not found for shortcut type: \(self)")
+            }
+            return image
         default:
             fatalError("Image not found for shortcut type: \(self)")
         }
@@ -228,6 +241,8 @@ extension ShortcutActionType {
             return NSLocalizedString("Topper", comment: "Translate it as short as possible! (24 symbols max)")
         case .getTestDash:
             return NSLocalizedString("1 tDash", comment: "Translate it as short as possible! (24 symbols max)")
+        case .switchWallet:
+            return NSLocalizedString("Switch Wallet", comment: "Translate it as short as possible! (24 symbols max)")
         }
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift
@@ -1,0 +1,72 @@
+//
+//  WalletSwitchDialog.swift
+//  DashWallet
+//
+//  Bottom-sheet picker for the Switch Wallet shortcut, shown when the device
+//  has two to five OTHER wallets. Rows render the wallet name plus username /
+//  balance when known. Selection only reports back to UIKit
+//  (`HomeViewController.showSwitchWallet`), which shows the always-required
+//  confirmation alert — the sheet never switches by itself.
+//
+
+import SwiftUI
+
+struct WalletSwitchDialog: View {
+    let rows: [WalletRow]
+    var onSelect: (WalletRow) -> Void
+
+    /// Sheet detent height for `rowCount` rows, matching the BottomSheet's
+    /// title + row + padding metrics (same scheme as TransactionFilterDialog).
+    static func height(rowCount: Int) -> CGFloat {
+        CGFloat(134 + rowCount * 60)
+    }
+
+    var body: some View {
+        BottomSheet(
+            title: NSLocalizedString("Switch Wallet", comment: "Wallets"),
+            showBackButton: .constant(false)
+        ) {
+            VStack(spacing: 4) {
+                ForEach(rows) { row in
+                    Button(action: { onSelect(row) }) {
+                        HStack(spacing: 12) {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(row.displayName)
+                                    .font(.subhead)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(.primaryText)
+                                    .lineLimit(1)
+                                if let username = row.username {
+                                    Text("@\(username)")
+                                        .font(.caption)
+                                        .foregroundColor(.dashBlue)
+                                        .lineLimit(1)
+                                }
+                                if let balance = row.balanceText {
+                                    Text(balance)
+                                        .font(.caption)
+                                        .foregroundColor(.secondaryText)
+                                        .lineLimit(1)
+                                }
+                            }
+                            Spacer(minLength: 8)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(.secondaryText)
+                        }
+                        .padding(.horizontal, 16)
+                        .contentShape(Rectangle())
+                        .frame(minHeight: 60)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .padding(.vertical, 6)
+            .background(Color.secondaryBackground)
+            .clipShape(RoundedShape(corners: .allCorners, radii: 12))
+            .padding(.horizontal, 20)
+            .padding(.top, 25)
+        }
+        .background(Color.primaryBackground)
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -82,17 +82,10 @@ final class WalletsViewModel: ObservableObject {
     /// scoped by walletId; the balance from the managed wallet.
     func reload() {
         let host = SwiftDashSDKHost.shared
-        guard let manager = host.manager else {
-            rows = []
-            return
-        }
-
-        let switchableIds = Set(SwiftDashSDKHost.persistedMnemonics().map { $0.walletId })
         let activeId = activeWalletId()
         let context = host.modelContainer?.mainContext
 
-        let built: [WalletRow] = manager.wallets.values
-            .filter { switchableIds.contains($0.walletId) }
+        let built: [WalletRow] = Self.switchableWallets()
             .map { wallet in
                 let walletId = wallet.walletId
                 let persisted = context.flatMap { Self.fetchPersistentWallet(walletId: walletId, in: $0) }
@@ -114,6 +107,19 @@ final class WalletsViewModel: ObservableObject {
 
         rows = built
     }
+
+    /// The wallets the current network can switch among: the running manager's
+    /// wallets intersected with the walletIds that have a persisted mnemonic
+    /// (a wallet without a mnemonic isn't switchable). Shared by `reload()`
+    /// and the Switch Wallet shortcut's visibility gate.
+    static func switchableWallets() -> [ManagedPlatformWallet] {
+        guard let manager = SwiftDashSDKHost.shared.manager else { return [] }
+        let switchableIds = Set(SwiftDashSDKHost.persistedMnemonics().map { $0.walletId })
+        return manager.wallets.values.filter { switchableIds.contains($0.walletId) }
+    }
+
+    /// Cheap visibility gate for the Switch Wallet shortcut (offered while > 1).
+    static var switchableWalletCount: Int { switchableWallets().count }
 
     var hasSingleWallet: Bool { rows.count <= 1 }
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2413,6 +2413,12 @@
 /* No comment provided by engineer. */
 "Swept!" = "Swept!";
 
+/* Wallets */
+"Switch" = "Switch";
+
+/* Translate it as short as possible! (24 symbols max) */
+"Switch Wallet" = "Switch Wallet";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Switch to Mainnet" = "Switch to Mainnet";
 
@@ -2952,6 +2958,9 @@
 
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
+
+/* Wallets */
+"Would you like to switch to \"%@\"? You can always switch back later." = "Would you like to switch to \"%@\"? You can always switch back later.";
 
 /* Coinbase */
 "Would you like to make a deposit for your purchase using a linked bank account?" = "Would you like to make a deposit for your purchase using a linked bank account?";


### PR DESCRIPTION
## What

A new **Switch Wallet** shortcut for the home screen's customizable shortcut bar.

## Visibility

- Appears in the shortcut customization picker **only while the current network has more than one switchable wallet** (`WalletsViewModel.switchableWalletCount`, the same manager-wallets ∩ persisted-mnemonics intersection the Wallets screen uses — now a shared helper).
- If the user placed it on the bar and the device later drops back to a single wallet, the saved slot **degrades to Receive** without touching the saved configuration (same pattern as the testnet faucet degrading to Spend on mainnet) — it returns as soon as another wallet exists.

## Tap behavior (confirmation in every path)

| Other wallets | Presentation |
|---|---|
| 1 | Confirmation alert directly: *“Would you like to switch to "\<Name\>"? You can always switch back later.”* |
| 2–5 | Bottom-sheet picker (`WalletSwitchDialog`, name/username/balance per row) → same confirmation alert |
| >5 | Pushes the full **Wallets** screen (which has its own switch confirmation) |

The switch itself runs through the existing `WalletsViewModel.switchWallet` → `SwiftDashSDKWalletRuntime.switchWallet` path; the home screen refreshes via the active-wallet-change notification.

## Notes

- Enum case appended last (`ShortcutActionType.switchWallet`) — raw values persist in `DWGlobalOptions.shortcuts`, so ordering is load-bearing.
- Icon reuses the `shortcut_switchNetwork` circular-arrows glyph; a dedicated asset can replace it later.
- `ShortcutActionType.customizableActions` became `@MainActor` (it now reads main-actor wallet state); its only consumer is the SwiftUI picker.
- New strings: "Switch Wallet", "Switch", and the confirmation message.

## Verification

- Clean `dashpay` scheme build (`iphonesimulator`, `ARCHS=arm64`).
- On-device flows pending a QA wallet unlock: worth checking the picker entry appears only with ≥2 wallets, the 1-other-wallet direct confirmation, and the 2–5 sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)