### PR TITLE
docs(dashsync): platform pin is plain v4.1-dev — integration branch retired

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -52,11 +52,12 @@ tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
 and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`
 integration branch is retired.
 
-One open nuance: the fee VALUE `send_payment` returns on plain `v4.1-dev` is
-still the builder's size-based estimate until
-[platform #4049](https://github.com/dashpay/platform/pull/4049) (rust-dashcore
-pin bump picking up dashpay/rust-dashcore#872) merges — a ≤546-duff display
-nuance on the pay-to-contact success screen, not a compile/behavior blocker.
+No open nuances: the verified tip `0bfdc5745c` IS the merge of
+[platform #4049](https://github.com/dashpay/platform/pull/4049), so
+`send_payment` returns the exact fee (Σinputs − Σoutputs via
+dashpay/rust-dashcore#872) and the faucet captcha's aggregate
+proof-of-work cap ([#4100](https://github.com/dashpay/platform/pull/4100))
+is included as well.
 
 After changing the platform checkout, rebuild both xcframework slices from
 `../platform/packages/swift-sdk`:

--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -44,15 +44,19 @@ included.
 
 ## Platform pin
 
-The app currently builds against sibling `../platform` branch
-`local/tx-decode-plus-v4.1-dev-dashwallet`, commit `3a51cbd198`. It contains the
-app-required tx decoding, DashPay fee threading, raw signer, testnet faucet,
-classified SPV peers, and filter-rescan surfaces.
+The app builds against sibling `../platform` on **`v4.1-dev`** (verified
+2026-07-12: dashpay arm64-sim build green at app tip `62a7eb40c` against
+`origin/v4.1-dev` tip `0bfdc5745c`). Every app-required surface is upstream:
+tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
+`RawKeySigner` (#4097), the testnet faucet client (#4098), classified SPV peers,
+and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`
+integration branch is retired.
 
-This branch is a temporary integration pin, not a release destination. Every
-app-required platform change must be upstreamed/reconciled onto `v4.1-dev`, and
-the final migration build must use `../platform` on `v4.1-dev`. DashSync removal
-is not complete while dashwallet-ios depends on the private integration branch.
+One open nuance: the fee VALUE `send_payment` returns on plain `v4.1-dev` is
+still the builder's size-based estimate until
+[platform #4049](https://github.com/dashpay/platform/pull/4049) (rust-dashcore
+pin bump picking up dashpay/rust-dashcore#872) merges — a ≤546-duff display
+nuance on the pay-to-contact success screen, not a compile/behavior blocker.
 
 After changing the platform checkout, rebuild both xcframework slices from
 `../platform/packages/swift-sdk`:


### PR DESCRIPTION
Every app-required platform surface has now merged to `v4.1-dev` (fee threading; RawKeySigner #4097; TestnetFaucet #4098; SPV filter-rescan #4099; TransactionDecoder via key-wallet-ffi; classified peers), and the app builds green against it — verified at app tip `62a7eb40c` vs `origin/v4.1-dev` tip `0bfdc5745c`, sim xcframework rebuilt from pure `v4.1-dev`, dashpay arm64-sim BUILD SUCCEEDED, installed and launched on the QA sim. The `local/tx-decode-plus-v4.1-dev-dashwallet` integration branch is retired.

Remaining nuance documented in the note: the exact-fee VALUE from `send_payment` lands with platform #4049 (rust-dashcore pin bump for dashpay/rust-dashcore#872) — display-only, ≤546 duffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)