### PR TITLE
fix(wallet): adapt shielded spends to the SDK's per-operation resolver (latest v4.1-dev)

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -45,8 +45,10 @@ included.
 ## Platform pin
 
 The app builds against sibling `../platform` on **`v4.1-dev`** (verified
-2026-07-12: dashpay arm64-sim build green at app tip `62a7eb40c` against
-`origin/v4.1-dev` tip `0bfdc5745c`). Every app-required surface is upstream:
+2026-07-15: dashpay arm64-sim build green at app tip `62a7eb40c` against
+`origin/v4.1-dev` tip `88949b7144`; the seedless-shielded-bind API drift —
+`shieldedWithdraw`/`shieldedUnshield` gaining a per-operation
+`resolver:` — is adapted in `ShieldedTransferCoordinator`). Every app-required surface is upstream:
 tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
 `RawKeySigner` (#4097), the testnet faucet client (#4098), classified SPV peers,
 and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`

--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -54,8 +54,9 @@ tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
 and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`
 integration branch is retired.
 
-No open nuances: the verified tip `0bfdc5745c` IS the merge of
-[platform #4049](https://github.com/dashpay/platform/pull/4049), so
+No open nuances: the verified tip includes
+[platform #4049](https://github.com/dashpay/platform/pull/4049) (merged as
+`0bfdc5745c`), so
 `send_payment` returns the exact fee (Σinputs − Σoutputs via
 dashpay/rust-dashcore#872) and the faucet captcha's aggregate
 proof-of-work cap ([#4100](https://github.com/dashpay/platform/pull/4100))

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -380,6 +380,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
         do {
             try await env.manager.shieldedWithdraw(
                 walletId: env.walletId,
+                // Per-operation Orchard spend authority (seedless shielded
+                // bind, platform #4125/#4126); the SDK holds the resolver
+                // alive across the FFI call via withExtendedLifetime.
+                resolver: MnemonicResolver(),
                 account: 0,
                 toCoreAddress: coreAddress,
                 amount: amountCredits)
@@ -444,6 +448,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
         do {
             try await env.manager.shieldedUnshield(
                 walletId: env.walletId,
+                // Per-operation Orchard spend authority — see above.
+                resolver: MnemonicResolver(),
                 account: 0,
                 toPlatformAddress: platformAddress,
                 amount: amountCredits)


### PR DESCRIPTION
Follow-up to #796 (which merged as docs-only before these commits landed on its branch — recovered here).

The latest platform `v4.1-dev` tip (`88949b7144`) lands the seedless shielded bind (platform #4125/#4126): `shieldedWithdraw` / `shieldedUnshield` now take a per-operation `resolver: MnemonicResolver` supplying the Orchard spend authority. This adapts both `ShieldedTransferCoordinator` call sites — a per-call `MnemonicResolver()`, same shape as SwiftExampleApp; the SDK holds the resolver alive across the FFI call via `withExtendedLifetime`. Also refreshes the migration doc's pin note to the newly verified tip.

Verified: sim xcframework rebuilt from `88949b7144` (new FFI types confirmed present in the generated header), dashpay arm64-sim BUILD SUCCEEDED on the current `swift-sdk-integration` tip (`8db1d310d`), installed + launched on the QA sim. Without this, the app does not compile against the latest `v4.1-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)