### PR TITLE
feat(dashpay): join DashPay from the Shielded balance with readiness UX

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -45,10 +45,13 @@ included.
 ## Platform pin
 
 The app builds against sibling `../platform` on **`v4.1-dev`** (verified
-2026-07-15: dashpay arm64-sim build green at app tip `62a7eb40c` against
-`origin/v4.1-dev` tip `88949b7144`; the seedless-shielded-bind API drift —
+2026-07-15: dashpay arm64-sim build green at app tip `5d90bac08` against
+`origin/v4.1-dev` tip `dc1d645df4` with a freshly rebuilt sim-slice
+xcframework; the seedless-shielded-bind API drift —
 `shieldedWithdraw`/`shieldedUnshield` gaining a per-operation
-`resolver:` — is adapted in `ShieldedTransferCoordinator`). Every app-required surface is upstream:
+`resolver:` — is adapted in `ShieldedTransferCoordinator`, and the tip's
+breaking managed-identity-top-up change (#4093) removed only legacy
+`SDK.identityTopUp`/`topUpIdentity` surfaces the app never called). Every app-required surface is upstream:
 tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
 `RawKeySigner` (#4097), the testnet faucet client (#4098), classified SPV peers,
 and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`

--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -98,7 +98,7 @@ Status meanings:
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
 | 14 | Wipe wallet | Done; teardown tail | Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |
 | 15 | Provider-key derivation | Done for retained scope | Owner/Voting are SDK-native; Operator/HPMN and legacy “used at” UI were intentionally dropped because the required public-key/list lookup surfaces are unavailable. |
-| 16 | DashPay identity creation | Done; invitation tail | Standard SDK-funded identity/name registration is migrated. Invitation-funded create/accept remains part of the invitation decision. |
+| 16 | DashPay identity creation | Done; invitation tail | Standard SDK-funded identity/name registration is migrated, with three funding paths (Core asset-lock, Platform Payment, shielded Type-20 — the privacy-preserving default, gated by `ShieldedIdentityFundingReadiness`). Invitation-funded create/accept remains part of the invitation decision. |
 | 17 | DashPay identity/profile read-write | Done; compatibility tail | Retire remaining `DSBlockchainIdentity`-typed profile properties/categories and route every old view directly through `DWCurrentUserIdentityInfo` / `DWProfileUpdateBridge`. |
 | 18 | DashPay contacts and pay-to-contact | Done | PR #787 rebuilt contacts on SwiftDashSDK/SwiftData/SwiftUI and removed the old contacts subsystem. Invitations were explicitly out of scope. |
 | 18a | Contested DPNS-name detection | Done for retained scope | Warning/bookmark behavior is SDK-native; richer resolution/status UX remains optional product work, not a DashSync blocker. |

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -894,6 +894,8 @@
 		A5D5DD000000000000000570 /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */; };
 		A5D5DD000000000000000571 /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000572 /* ShieldedWithdrawalStore.swift */; };
 		A5D5DD000000000000001102 /* DWRegistrationPhaseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001001 /* DWRegistrationPhaseAdapter.swift */; };
+		A5D5DD000000000000001419 /* ShieldedIdentityFundingReadiness.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001418 /* ShieldedIdentityFundingReadiness.swift */; };
+		A5D5DD00000000000000141B /* JoinDashPayReadinessScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD00000000000000141A /* JoinDashPayReadinessScreen.swift */; };
 		A5D5DD000000000000001104 /* DWIdentityRegistrationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001002 /* DWIdentityRegistrationController.swift */; };
 		A5D5DD000000000000001106 /* DWIdentityAuthorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001003 /* DWIdentityAuthorizer.swift */; };
 		A5D5DD000000000000001108 /* DWIdentityRegistrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000001004 /* DWIdentityRegistrationCoordinator.swift */; };
@@ -2726,6 +2728,8 @@
 		A5D5DD000000000000001008 /* DWProfileUpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWProfileUpdateCoordinator.swift; path = Identity/DWProfileUpdateCoordinator.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001009 /* DWProfileUpdateBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWProfileUpdateBridge.swift; path = Identity/DWProfileUpdateBridge.swift; sourceTree = "<group>"; };
 		A5D5DD00000000000000100A /* DWContestedNameStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DWContestedNameStatusService.swift; path = Identity/DWContestedNameStatusService.swift; sourceTree = "<group>"; };
+		A5D5DD000000000000001418 /* ShieldedIdentityFundingReadiness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ShieldedIdentityFundingReadiness.swift; path = Identity/ShieldedIdentityFundingReadiness.swift; sourceTree = "<group>"; };
+		A5D5DD00000000000000141A /* JoinDashPayReadinessScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinDashPayReadinessScreen.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001200 /* DWRegistrationPhaseAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DWRegistrationPhaseAdapterTests.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001300 /* SwiftDashSDKPhraseRepairer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKPhraseRepairer.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000001301 /* SwiftDashSDKInsightClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKInsightClient.swift; sourceTree = "<group>"; };
@@ -6172,6 +6176,7 @@
 				759AFDDF2CC6356D007072D2 /* JoinDashPayScreen.swift */,
 				754C27D02CC3C82300BA7B9F /* JoinDashPayInfoDialog.swift */,
 				757514E42B1735370026AD8E /* JoinDashPayView.swift */,
+				A5D5DD00000000000000141A /* JoinDashPayReadinessScreen.swift */,
 			);
 			path = CreateUsername;
 			sourceTree = "<group>";
@@ -6417,6 +6422,7 @@
 				A5D5DD000000000000001008 /* DWProfileUpdateCoordinator.swift */,
 				A5D5DD000000000000001009 /* DWProfileUpdateBridge.swift */,
 				A5D5DD00000000000000100A /* DWContestedNameStatusService.swift */,
+				A5D5DD000000000000001418 /* ShieldedIdentityFundingReadiness.swift */,
 				A5D5DD000000000000001407 /* DWIdentityKeyUpgrader.swift */,
 				A5D5DD000000000000001400 /* ContactItem.swift */,
 				A5D5DD000000000000001401 /* SwiftDashSDKContactsService.swift */,
@@ -9185,6 +9191,7 @@
 				C9D2C6B62A320AA000D15901 /* NumberKeyboardButton.swift in Sources */,
 				C9D2C6B72A320AA000D15901 /* IsDefaultEmail.swift in Sources */,
 				750CEFA42CCA713300E87A32 /* CreateUsernameViewController.swift in Sources */,
+				A5D5DD00000000000000141B /* JoinDashPayReadinessScreen.swift in Sources */,
 				C9D2C6BA2A320AA000D15901 /* DWUpholdAccountObject.m in Sources */,
 				C9D2C6BB2A320AA000D15901 /* DWFormTableViewController.m in Sources */,
 				C943B34D2A40A4C500AF23C5 /* DWInfoPopupViewController.m in Sources */,
@@ -9602,6 +9609,7 @@
 				A5D5DD000000000000000130 /* SwiftDashSDKWalletRuntime.swift in Sources */,
 				A5D5DD000000000000000272 /* SwiftDashSDKHost.swift in Sources */,
 				A5D5DD000000000000001102 /* DWRegistrationPhaseAdapter.swift in Sources */,
+				A5D5DD000000000000001419 /* ShieldedIdentityFundingReadiness.swift in Sources */,
 				A5D5DD000000000000001104 /* DWIdentityRegistrationController.swift in Sources */,
 				A5D5DD000000000000001106 /* DWIdentityAuthorizer.swift in Sources */,
 				A5D5DD000000000000001410 /* ContactItem.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
@@ -40,9 +40,26 @@ import SwiftDashSDK
 ///   Payment addresses via `registerIdentityFromAddresses`. Skips
 ///   the asset-lock IS/CL wait — there is no Core-chain asset-lock
 ///   in this path.
+/// - `shielded`: spend a fixed exit denomination from the wallet's
+///   shielded (Orchard) balance via `shieldedIdentityCreateFromPool`
+///   (Type 20). The privacy-preserving default when the shielded
+///   balance is funded, matured, and the pool clears the consensus
+///   minimum — see `ShieldedIdentityFundingReadiness`. No asset-lock.
 @objc public enum DWIdentityFundingSource: Int {
     case core = 0
     case platformPayment = 1
+    case shielded = 2
+}
+
+extension DWIdentityFundingSource {
+    /// Short tag for log lines.
+    var logLabel: String {
+        switch self {
+        case .core: return "core"
+        case .platformPayment: return "pp"
+        case .shielded: return "shielded"
+        }
+    }
 }
 
 @objc(DWIdentityRegistrationBridge)
@@ -122,7 +139,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
-        Self.logger.info("🪪 IDENT-BRIDGE :: startCreateUsername username=\(username, privacy: .public) funding=\(source == .core ? "core" : "pp", privacy: .public)")
+        Self.logger.info("🪪 IDENT-BRIDGE :: startCreateUsername username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public)")
         Task { @MainActor in
             do {
                 let identityId = try await DWIdentityRegistrationCoordinator.shared.startCreateUsername(
@@ -143,7 +160,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
-        Self.logger.info("🪪 IDENT-BRIDGE :: retry username=\(username, privacy: .public) funding=\(source == .core ? "core" : "pp", privacy: .public)")
+        Self.logger.info("🪪 IDENT-BRIDGE :: retry username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public)")
         Task { @MainActor in
             do {
                 let identityId = try await DWIdentityRegistrationCoordinator.shared.retry(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -29,11 +29,15 @@
 //
 //  v1 scope:
 //    - Single identity per wallet (`identityIndex` pinned at 0).
-//    - Two funding paths (PR 5):
-//      * Core-funded via `registerIdentityWithFunding` (default).
+//    - Three funding paths:
+//      * Core-funded via `registerIdentityWithFunding` (legacy default).
 //      * Platform Payment via `registerIdentityFromAddresses` —
 //        spends credits already on DIP-17 platform addresses.
 //        Skips the Core-chain asset-lock IS/CL wait.
+//      * Shielded via `shieldedIdentityCreateFromPool` (Type 20) —
+//        spends a fixed exit denomination from the wallet's Orchard
+//        pool. Pre-flighted against `ShieldedIdentityFundingReadiness`
+//        (funding / maturity / pool-size gates); no asset-lock.
 //    - No crash-resume (`resumeIdentityWithAssetLock` deferred to v2).
 //
 
@@ -136,6 +140,11 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         case dpnsRegistration(Error)
         case availabilityCheck(Error)
         case insufficientPlatformCredits(required: UInt64, available: UInt64)
+        case insufficientShieldedBalance(requiredCredits: UInt64, availableCredits: UInt64)
+        case shieldedBalanceImmature(readyAt: Date)
+        case shieldedPoolTooSmall(currentNotes: UInt64)
+        case noShieldedFallbackAddress
+        case shieldedCreateUnconfirmed
         case alreadyInFlight
 
         var errorDescription: String? {
@@ -162,6 +171,21 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 return underlying.localizedDescription
             case .insufficientPlatformCredits:
                 return NSLocalizedString("Not enough Platform credits to register an identity", comment: "DashPay")
+            case .insufficientShieldedBalance:
+                return NSLocalizedString("Not enough shielded balance to register an identity", comment: "DashPay")
+            case .shieldedBalanceImmature(let readyAt):
+                let time = DateFormatter.localizedString(from: readyAt, dateStyle: .none, timeStyle: .short)
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("Your shielded balance is still maturing. It will be ready around %@.", comment: "DashPay"),
+                    time)
+            case .shieldedPoolTooSmall(let currentNotes):
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum.", comment: "DashPay"),
+                    Int(currentNotes), Int(ShieldedIdentityFundingReadiness.minimumPoolNotes))
+            case .noShieldedFallbackAddress:
+                return NSLocalizedString("No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing.", comment: "DashPay")
+            case .shieldedCreateUnconfirmed:
+                return NSLocalizedString("The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately.", comment: "DashPay")
             case .alreadyInFlight:
                 return NSLocalizedString("Identity registration already in progress", comment: "DashPay")
             }
@@ -187,7 +211,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         _ username: String,
         fundingSource: DWIdentityFundingSource = .core
     ) async throws -> Identifier {
-        Self.logger.info("🪪 IDENT-COORD :: startCreateUsername username=\(username, privacy: .public) funding=\(fundingSource == .core ? "core" : "pp", privacy: .public)")
+        Self.logger.info("🪪 IDENT-COORD :: startCreateUsername username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public)")
 
         // Preconditions — resolved once up-front so failures are
         // surfaced before the PIN prompt.
@@ -331,15 +355,30 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                     identitySigner: signer,
                     addressSigner: signer)
                 identityId = created.identityId
+
+            case .shielded:
+                identityId = try await createIdentityFromShieldedPool(
+                    username: username,
+                    walletId: wallet.walletId,
+                    modelContainer: modelContainer,
+                    pubkeys: pubkeys,
+                    signer: signer)
             }
             Self.logger.info("🪪 IDENT-COORD :: identity created, id=\(identityId.map { String(format: "%02x", $0) }.joined().prefix(8), privacy: .public)…")
         } catch let coordError as CoordinatorError {
-            // `buildPlatformPaymentInputs` throws our own typed error
-            // before any FFI call — surface as a registration failure
-            // anchored at `.processingPayment` since nothing has hit
-            // the network yet.
+            // Typed errors are almost all pre-flight
+            // (`buildPlatformPaymentInputs`, the shielded readiness
+            // gates) thrown before any FFI call — anchored at
+            // `.processingPayment` since nothing has hit the network
+            // yet. The one exception is the shielded unconfirmed
+            // outcome, which arrives AFTER the Type-20 submit and so
+            // anchors at `.creatingID`.
             Self.logger.error("🪪 IDENT-COORD :: identity creation precondition failed: \(String(describing: coordError), privacy: .public)")
-            failedAtPhase = .processingPayment
+            if case .shieldedCreateUnconfirmed = coordError {
+                failedAtPhase = .creatingID
+            } else {
+                failedAtPhase = .processingPayment
+            }
             lastErrorMessage = coordError.localizedDescription
             newController.enterFailed(coordError.localizedDescription)
             throw coordError
@@ -355,7 +394,9 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             switch fundingSource {
             case .core:
                 failedAtPhase = assetLockStatus < 2 ? .processingPayment : .creatingID
-            case .platformPayment:
+            case .platformPayment, .shielded:
+                // Neither path has a Core-chain asset-lock; the FFI
+                // submit is the only on-chain step.
                 failedAtPhase = .creatingID
             }
             lastErrorMessage = error.localizedDescription
@@ -428,7 +469,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         _ username: String,
         fundingSource: DWIdentityFundingSource = .core
     ) async throws -> Identifier {
-        Self.logger.info("🪪 IDENT-COORD :: retry username=\(username, privacy: .public) funding=\(fundingSource == .core ? "core" : "pp", privacy: .public)")
+        Self.logger.info("🪪 IDENT-COORD :: retry username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public)")
         return try await startCreateUsername(username, fundingSource: fundingSource)
     }
 
@@ -761,5 +802,115 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             remaining -= spend
         }
         return inputs
+    }
+
+    /// Shielded (Type-20) funding path: spend a fixed exit denomination
+    /// from the wallet's Orchard pool into a brand-new identity via
+    /// `shieldedIdentityCreateFromPool`.
+    ///
+    /// Pre-flighted against `ShieldedIdentityFundingReadiness` so the
+    /// three gates (funding, maturity, pool size) fail with typed,
+    /// user-explainable errors BEFORE the ~30 s Halo 2 proof starts.
+    /// Drive re-enforces the pool minimum server-side, so an unknown
+    /// pool count doesn't block here — the FFI error is the backstop.
+    ///
+    /// The denomination is the smallest consensus exit covering the
+    /// name's cost: 0.1 DASH standard, 0.3 DASH for contested names
+    /// (≥ the 0.25 DASH contested requirement). The metered fee is
+    /// taken FROM the denomination, so the new identity starts at
+    /// denomination − fee and no extra headroom is required.
+    ///
+    /// `ShieldedIdentityCreateUnconfirmedError` (broadcast accepted but
+    /// result unconfirmed) maps to `.shieldedCreateUnconfirmed` — NOT
+    /// retryable immediately; if the create actually landed, the SDK's
+    /// pending-spend redrive persists the identity row on a later sync
+    /// and the next attempt resumes past IdentityCreate via
+    /// `lookupExistingIdentityId`.
+    private func createIdentityFromShieldedPool(
+        username: String,
+        walletId: Data,
+        modelContainer: ModelContainer,
+        pubkeys: [ManagedPlatformWallet.IdentityPubkey],
+        signer: KeychainSigner
+    ) async throws -> Identifier {
+        guard let manager = SwiftDashSDKHost.shared.manager else {
+            throw CoordinatorError.noSDK
+        }
+
+        let contested = DWContestedNameStatusService.isContestedLabel(username)
+        let denomination = ShieldedIdentityFundingReadiness.requiredCredits(forContestedName: contested)
+
+        guard let readiness = ShieldedIdentityFundingReadiness.shared
+            .evaluate(requiredCredits: denomination) else {
+            throw CoordinatorError.noWallet
+        }
+        switch readiness.state {
+        case .needsFunding:
+            throw CoordinatorError.insufficientShieldedBalance(
+                requiredCredits: denomination,
+                availableCredits: readiness.unspentCredits)
+        case .maturing(let readyAt):
+            throw CoordinatorError.shieldedBalanceImmature(readyAt: readyAt)
+        case .poolTooSmall(let current):
+            throw CoordinatorError.shieldedPoolTooSmall(currentNotes: current)
+        case .ready:
+            break
+        }
+
+        // REQUIRED Type-20 fallback: if identity creation fails a
+        // stateful check, the spend still finalizes and the value lands
+        // at this address (bound into the transition sighash). Same
+        // encoding the address-funded inputs use: 1-byte variant tag +
+        // 20-byte hash.
+        guard let fallbackAddressBytes = shieldedFallbackAddressBytes(
+            walletId: walletId,
+            modelContainer: modelContainer) else {
+            throw CoordinatorError.noShieldedFallbackAddress
+        }
+
+        Self.logger.info("🪪 IDENT-COORD :: shielded create denomination=\(denomination, privacy: .public) contested=\(contested, privacy: .public)")
+        do {
+            return try await manager.shieldedIdentityCreateFromPool(
+                walletId: walletId,
+                // Per-operation Orchard spend authority (seedless
+                // shielded bind) — same pattern as the app's other
+                // shielded spends in `ShieldedTransferCoordinator`.
+                resolver: MnemonicResolver(),
+                account: 0,
+                identityIndex: Self.pinnedIdentityIndex,
+                identityPubkeys: pubkeys,
+                denomination: denomination,
+                sendToAddressOnCreationFailure: fallbackAddressBytes,
+                identitySigner: signer)
+        } catch let unconfirmed as ShieldedIdentityCreateUnconfirmedError {
+            Self.logger.warning("🪪 IDENT-COORD :: shielded create unconfirmed id=\(unconfirmed.identityId.map { String(format: "%02x", $0) }.joined().prefix(8), privacy: .public)…")
+            throw CoordinatorError.shieldedCreateUnconfirmed
+        }
+    }
+
+    /// Lowest-indexed Platform Payment address as raw 21-byte
+    /// `PlatformAddress` storage bytes (`[addressType] + addressHash`)
+    /// for the Type-20 creation-failure fallback. Deterministic — the
+    /// same wallet always produces the same fallback. nil when no
+    /// Platform address row exists yet (pre-first-platform-sync).
+    private func shieldedFallbackAddressBytes(
+        walletId: Data,
+        modelContainer: ModelContainer
+    ) -> Data? {
+        let accountDescriptor = FetchDescriptor<PersistentAccount>(
+            predicate: #Predicate { account in
+                account.accountType == 14
+                    && account.wallet.walletId == walletId
+            }
+        )
+        guard let accounts = try? modelContainer.mainContext.fetch(accountDescriptor) else {
+            return nil
+        }
+        guard let row = accounts
+            .flatMap({ $0.platformAddresses })
+            .min(by: { $0.addressIndex < $1.addressIndex }) else {
+            return nil
+        }
+        return Data([row.addressType]) + row.addressHash
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWRegistrationPhaseAdapter.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWRegistrationPhaseAdapter.swift
@@ -70,13 +70,15 @@ enum DWRegistrationPhaseAdapter {
                 }
                 return .registrationUsername
 
-            case .platformPayment:
-                // Platform Payment path skips Core-chain asset-lock
-                // entirely — `registerIdentityFromAddresses` consumes
-                // credits already on Platform addresses. There is no
-                // IS/CL wait, so the UI jumps straight to "Creating
-                // ID" as soon as the FFI submit goes in flight.
-                // `assetLockStatus` is intentionally ignored here.
+            case .platformPayment, .shielded:
+                // Neither path has a Core-chain asset-lock —
+                // `registerIdentityFromAddresses` consumes credits
+                // already on Platform addresses, and the Type-20
+                // shielded create spends Orchard notes in one opaque
+                // FFI call (proof + submit). There is no IS/CL wait,
+                // so the UI jumps straight to "Creating ID" as soon
+                // as the FFI submit goes in flight. `assetLockStatus`
+                // is intentionally ignored here.
                 return .creatingID
             }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/ShieldedIdentityFundingReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/ShieldedIdentityFundingReadiness.swift
@@ -1,0 +1,276 @@
+//
+//  ShieldedIdentityFundingReadiness.swift
+//  DashWallet
+//
+//  Single source of truth for "can this wallet fund a DashPay identity
+//  from its shielded balance right now?". Read by the Join DashPay
+//  banner, the get-ready interstitial, and the Create Username funding
+//  picker so all three surfaces agree on the same answer.
+//
+//  Three gates, priority-ordered (the returned state is the FIRST
+//  unmet gate):
+//
+//  1. Funding — unspent shielded notes must cover the Type-20 exit
+//     denomination. `IdentityCreateFromShieldedPool` spends a fixed
+//     denomination from the consensus set {0.1, 0.3, 0.5, 1.0} DASH
+//     (`shielded_identity_create_denominations`, rs-platform-version);
+//     the metered fee is taken FROM the denomination and any excess
+//     spent value returns to the pool as change, so the gate is simply
+//     `unspent >= denomination`.
+//
+//  2. Maturity — an app-side privacy policy, not a protocol rule: the
+//     notes funding the identity must have rested in the pool for
+//     `maturityWindow` so the shielded deposit and the (public)
+//     identity creation are separated in time. Computed from
+//     `PersistentShieldedNote.createdAt` (first-observed time). For
+//     restored wallets old notes are re-observed as new, which makes
+//     the gate conservative (over-waits) — the safe direction for a
+//     privacy timer.
+//
+//  3. Pool size — client-side mirror of the consensus rule
+//     `minimum_pool_notes_for_outgoing = 250` (rs-platform-version):
+//     Drive rejects outgoing shielded transitions, including Type-20
+//     identity creation, while the pool holds fewer than 250 notes.
+//     The count is latched from the shielded sync's tree-progress
+//     signal (`PlatformWalletManager.currentShieldedTreeTotal` — the
+//     on-chain note count fetched at the start of each pass; nil
+//     between passes). An UNKNOWN count does not block: the server
+//     enforces the real rule and the registration coordinator surfaces
+//     its `InsufficientPoolNotesError` message as the backstop.
+//
+//  Singleton rationale (guardrail #4): the pool-count latch must
+//  outlive any one screen (the sync signal is nil between passes), and
+//  the three consuming surfaces must observe one shared recomputation
+//  stream — per-screen instances would each re-derive and could
+//  disagree mid-countdown.
+//
+
+import Combine
+import Foundation
+import SwiftData
+import SwiftDashSDK
+
+@MainActor
+final class ShieldedIdentityFundingReadiness: ObservableObject {
+
+    static let shared = ShieldedIdentityFundingReadiness()
+
+    // MARK: - Policy constants
+
+    /// Consensus minimum pool size for outgoing shielded transitions
+    /// (`minimum_pool_notes_for_outgoing`). Mirrored here only to show
+    /// progress before submit; Drive enforces the real rule.
+    static let minimumPoolNotes: UInt64 = 250
+
+    /// Smallest consensus exit denomination — 0.1 DASH in credits.
+    /// Funds a standard (uncontested) username registration; the new
+    /// identity starts at denomination − metered fee, comfortably above
+    /// the 0.03 DASH the transparent funding paths provision.
+    static let standardDenominationCredits: UInt64 = 10_000_000_000
+
+    /// Exit denomination for contested usernames — 0.3 DASH in credits,
+    /// the smallest consensus denomination covering
+    /// `DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME` (0.25 DASH).
+    static let contestedDenominationCredits: UInt64 = 30_000_000_000
+
+    /// How long shielded notes must rest before funding an identity.
+    /// DEBUG builds shorten the window so the maturing → ready flip is
+    /// testable in one QA session; release policy is 3 hours.
+    #if DEBUG
+    static let maturityWindow: TimeInterval = 10 * 60
+    #else
+    static let maturityWindow: TimeInterval = 3 * 60 * 60
+    #endif
+
+    static func requiredCredits(forContestedName contested: Bool) -> UInt64 {
+        contested ? contestedDenominationCredits : standardDenominationCredits
+    }
+
+    // MARK: - State
+
+    enum State: Equatable {
+        /// Unspent shielded notes don't cover the denomination.
+        case needsFunding(shortfallCredits: UInt64)
+        /// Funded, but the covering notes are younger than
+        /// `maturityWindow`. `readyAt` is when the oldest sufficient
+        /// subset matures.
+        case maturing(readyAt: Date)
+        /// The on-chain pool is below the consensus minimum; Drive
+        /// would reject the transition. Only reported when the count
+        /// is actually known.
+        case poolTooSmall(current: UInt64)
+        case ready
+    }
+
+    struct Snapshot: Equatable {
+        let state: State
+        let requiredCredits: UInt64
+        /// Unspent credits old enough to spend under the maturity policy.
+        let matureCredits: UInt64
+        /// All unspent credits (mature + still-maturing).
+        let unspentCredits: UInt64
+        /// Last known on-chain pool note count; nil until a shielded
+        /// sync pass has reported one.
+        let poolNoteCount: UInt64?
+    }
+
+    /// Readiness for a standard (uncontested) registration — the value
+    /// the banner and interstitial display. Contested requirements are
+    /// evaluated on demand via `evaluate(requiredCredits:)`.
+    /// nil while the SDK host has no hydrated wallet.
+    @Published private(set) var standardSnapshot: Snapshot?
+
+    /// See gate 3 above. Kept latched (not zeroed between passes).
+    @Published private(set) var latchedPoolNoteCount: UInt64?
+
+    private var managerCancellables = Set<AnyCancellable>()
+    private var notificationCancellable: AnyCancellable?
+    /// Re-evaluation alarm for the next maturing → ready flip.
+    private var maturityFlipTask: Task<Void, Never>?
+
+    private init() {
+        notificationCancellable = NotificationCenter.default
+            .publisher(for: SwiftDashSDKWalletState.activeWalletDidChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                // The runtime rebuild may have replaced the manager —
+                // re-wire the sync-event subscriptions to the new one.
+                self?.wireManagerIfNeeded(rewire: true)
+                self?.refresh()
+            }
+        wireManagerIfNeeded(rewire: false)
+        refresh()
+    }
+
+    // MARK: - Evaluation
+
+    /// Compute readiness for an arbitrary requirement (contested names
+    /// need the 0.3 DASH denomination). Returns nil while the SDK host
+    /// has no hydrated wallet or storage.
+    func evaluate(requiredCredits: UInt64, now: Date = Date()) -> Snapshot? {
+        wireManagerIfNeeded(rewire: false)
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let modelContainer = SwiftDashSDKHost.shared.modelContainer else {
+            return nil
+        }
+        latchPoolCount()
+
+        let walletId = wallet.walletId
+        let descriptor = FetchDescriptor<PersistentShieldedNote>(
+            predicate: PersistentShieldedNote.unspentPredicate(walletId: walletId),
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+        let notes = (try? modelContainer.mainContext.fetch(descriptor)) ?? []
+
+        let unspent = notes.reduce(UInt64(0)) { $0 + $1.value }
+        let maturityCutoff = now.addingTimeInterval(-Self.maturityWindow)
+        let mature = notes
+            .filter { $0.createdAt <= maturityCutoff }
+            .reduce(UInt64(0)) { $0 + $1.value }
+
+        let state: State
+        if unspent < requiredCredits {
+            state = .needsFunding(shortfallCredits: requiredCredits - unspent)
+        } else if mature < requiredCredits {
+            // Oldest-first accumulation: the covering subset's youngest
+            // note decides when the requirement is met.
+            var accumulated: UInt64 = 0
+            var readyAt = now.addingTimeInterval(Self.maturityWindow)
+            for note in notes {
+                accumulated += note.value
+                if accumulated >= requiredCredits {
+                    readyAt = note.createdAt.addingTimeInterval(Self.maturityWindow)
+                    break
+                }
+            }
+            state = .maturing(readyAt: readyAt)
+        } else if let poolCount = latchedPoolNoteCount, poolCount < Self.minimumPoolNotes {
+            state = .poolTooSmall(current: poolCount)
+        } else {
+            state = .ready
+        }
+
+        return Snapshot(
+            state: state,
+            requiredCredits: requiredCredits,
+            matureCredits: mature,
+            unspentCredits: unspent,
+            poolNoteCount: latchedPoolNoteCount)
+    }
+
+    /// Recompute `standardSnapshot` and (re)arm the maturity alarm.
+    func refresh() {
+        let snapshot = evaluate(requiredCredits: Self.standardDenominationCredits)
+        if snapshot != standardSnapshot {
+            standardSnapshot = snapshot
+        }
+        armMaturityFlip(for: snapshot)
+    }
+
+    /// Kick a shielded sync pass so the pool count (and any new notes)
+    /// arrive promptly — used by screens that display readiness the
+    /// moment they appear. No-ops into the SDK's own single-flight
+    /// guard when a pass is already running.
+    func requestFreshSignals() {
+        guard let manager = SwiftDashSDKHost.shared.manager else { return }
+        Task {
+            try? await manager.syncShieldedNow()
+        }
+    }
+
+    // MARK: - Wiring
+
+    /// Subscribe to the live `PlatformWalletManager`'s shielded-sync
+    /// publishers. The manager can be created after this service (cold
+    /// start) and replaced by a runtime rebuild (wallet/network switch),
+    /// so wiring is idempotent-with-rewire rather than init-once.
+    private func wireManagerIfNeeded(rewire: Bool) {
+        if rewire {
+            managerCancellables.removeAll()
+        }
+        guard managerCancellables.isEmpty,
+              let manager = SwiftDashSDKHost.shared.manager else { return }
+
+        manager.$lastShieldedSyncEvent
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &managerCancellables)
+
+        manager.$currentShieldedTreeTotal
+            .receive(on: RunLoop.main)
+            .sink { [weak self] total in
+                guard let self else { return }
+                if let total, total > 0, total != self.latchedPoolNoteCount {
+                    self.latchedPoolNoteCount = total
+                    self.refresh()
+                }
+            }
+            .store(in: &managerCancellables)
+    }
+
+    /// Pull the current tree-total directly (the publisher only fires
+    /// on change, and a pass may already have reported before we wired).
+    private func latchPoolCount() {
+        if let total = SwiftDashSDKHost.shared.manager?.currentShieldedTreeTotal,
+           total > 0, total != latchedPoolNoteCount {
+            latchedPoolNoteCount = total
+        }
+    }
+
+    /// Schedule a one-shot re-evaluation at `readyAt` so `.maturing`
+    /// flips to `.ready` without the user leaving and re-entering the
+    /// screen. Cancelled/re-armed on every refresh.
+    private func armMaturityFlip(for snapshot: Snapshot?) {
+        maturityFlipTask?.cancel()
+        maturityFlipTask = nil
+        guard case .maturing(let readyAt) = snapshot?.state else { return }
+        let delay = readyAt.timeIntervalSinceNow
+        guard delay > 0 else { return }
+        maturityFlipTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64((delay + 1) * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.refresh()
+        }
+    }
+}

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -76,12 +76,18 @@ struct CreateUsernameView: View {
     @FocusState private var isTextInputFocused: Bool
     @State private var inProgress: Bool = false
     @State private var screenLockedAfterAuth: Bool = false
-    /// Funding source for the SwiftDashSDK identity registration. Defaults
-    /// to Core; auto-pinned to Platform when only PP credits are available;
-    /// user-selectable via the segmented picker when both sources have enough.
-    /// Written into `DWIdentityRegistrationBridge.shared.preferredFundingSource`
+    /// Funding source for the SwiftDashSDK identity registration.
+    /// Auto-pinned by `syncFundingSourceToViableSource()` to the first
+    /// viable source in privacy-descending order (Shielded → Platform →
+    /// Core) until the user explicitly picks one; user-selectable via
+    /// the segmented picker when two or more sources qualify. Written
+    /// into `DWIdentityRegistrationBridge.shared.preferredFundingSource`
     /// in the Continue handler right before the submit call.
     @State private var fundingSource: DWIdentityFundingSource = .core
+    /// True once the user has manually changed the picker; auto-pinning
+    /// then only corrects a selection that became non-viable, instead
+    /// of overriding the user's explicit choice.
+    @State private var didUserPickFundingSource: Bool = false
     /// Tracks the contested-name confirmation alert. Continue routes
     /// through this alert (instead of submitting directly) when the
     /// typed name is contested-eligible — `viewModel.isContestedCandidate`.
@@ -149,23 +155,31 @@ struct CreateUsernameView: View {
                     .padding(.top, 20)
             }
 
-            // Funding source picker. Visible only when both Core and
-            // Platform Payment have enough balance to cover the
-            // identity-registration cost. When only one source is
-            // viable, the picker stays hidden and `fundingSource` is
-            // auto-pinned by `.onChange` so the Continue handler
-            // routes correctly without UI clutter.
-            if viewModel.hasMinimumRequiredCoreBalance && viewModel.hasMinimumRequiredPlatformBalance {
+            // Shielded readiness hint. Shown while the privacy-preserving
+            // funding path is NOT yet available (needs funds / maturing /
+            // pool below the consensus minimum) so the user learns what
+            // the wait is for without being blocked — the transparent
+            // sources below remain an explicit choice.
+            shieldedReadinessHint
+
+            // Funding source picker. Visible when two or more sources
+            // can cover the identity-registration cost. When only one
+            // is viable, the picker stays hidden and `fundingSource` is
+            // auto-pinned by `syncFundingSourceToViableSource()` so the
+            // Continue handler routes correctly without UI clutter.
+            if viableFundingSources.count >= 2 {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(NSLocalizedString("Pay with", comment: "Usernames"))
                         .foregroundColor(.secondaryText)
                         .font(.caption)
-                    Picker("", selection: $fundingSource) {
-                        Text("Core (\(viewModel.balance) Dash)").tag(DWIdentityFundingSource.core)
-                        Text("Platform (\(viewModel.platformPaymentBalance) Dash)").tag(DWIdentityFundingSource.platformPayment)
+                    Picker("", selection: userFundingSourceBinding) {
+                        ForEach(viableFundingSources, id: \.rawValue) { source in
+                            Text(fundingSourceLabel(source)).tag(source)
+                        }
                     }
                     .pickerStyle(.segmented)
                     .disabled(screenLockedAfterAuth)
+                    fundingPrivacyFootnote
                 }
                 .padding(.top, 20)
             }
@@ -209,6 +223,9 @@ struct CreateUsernameView: View {
         .onChange(of: viewModel.hasMinimumRequiredPlatformBalance) { _ in
             syncFundingSourceToViableSource()
         }
+        .onChange(of: viewModel.shieldedReadiness) { _ in
+            syncFundingSourceToViableSource()
+        }
         .alert(
             NSLocalizedString("Contested name", comment: "Usernames"),
             isPresented: $showContestedConfirmation
@@ -250,6 +267,57 @@ struct CreateUsernameView: View {
             }
         } message: {
             Text(registrationErrorMessage ?? "")
+        }
+    }
+
+    /// Blue informational callout shown while the shielded funding
+    /// path is not yet available, explaining which gate is unmet and
+    /// what will unlock it. Purely informative — the transparent
+    /// sources stay selectable.
+    @ViewBuilder
+    private var shieldedReadinessHint: some View {
+        if let snapshot = viewModel.shieldedReadiness, snapshot.state != .ready {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "shield.lefthalf.filled")
+                    .foregroundColor(.blue)
+                    .font(.system(size: 20))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(NSLocalizedString("Private registration", comment: "Usernames"))
+                        .font(.subheadline.bold())
+                        .foregroundColor(.blue)
+                    Text(shieldedHintText(for: snapshot))
+                        .font(.caption)
+                        .foregroundColor(.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.blue.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .padding(.top, 20)
+        }
+    }
+
+    private func shieldedHintText(for snapshot: ShieldedIdentityFundingReadiness.Snapshot) -> String {
+        switch snapshot.state {
+        case .needsFunding(let shortfallCredits):
+            // Credits → duffs (÷1000) for display.
+            let shortfallDash = (shortfallCredits / 1_000).dashAmount.formattedDashAmountWithoutCurrencySymbol
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds.", comment: "Usernames"),
+                shortfallDash)
+        case .maturing(let readyAt):
+            let time = DateFormatter.localizedString(from: readyAt, dateStyle: .none, timeStyle: .short)
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Your Shielded balance is almost ready — you can register privately around %@.", comment: "Usernames"),
+                time)
+        case .poolTooSmall(let current):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum.", comment: "Usernames"),
+                Int(current), Int(ShieldedIdentityFundingReadiness.minimumPoolNotes))
+        case .ready:
+            return ""
         }
     }
 
@@ -311,21 +379,72 @@ struct CreateUsernameView: View {
         }
     }
 
-    /// Keep `fundingSource` pointing at a viable source when only one
-    /// of {Core, Platform} qualifies. When both qualify we leave the
-    /// selection alone so the picker preserves the user's pick.
-    private func syncFundingSourceToViableSource() {
-        let coreOk = viewModel.hasMinimumRequiredCoreBalance
-        let platformOk = viewModel.hasMinimumRequiredPlatformBalance
-        if coreOk && !platformOk {
-            fundingSource = .core
-        } else if platformOk && !coreOk {
-            fundingSource = .platformPayment
+    /// Viable funding sources in privacy-descending priority order.
+    /// Shielded leads: it is the default whenever its readiness gates
+    /// (funding, maturity, pool minimum) all pass.
+    private var viableFundingSources: [DWIdentityFundingSource] {
+        var sources: [DWIdentityFundingSource] = []
+        if viewModel.hasReadyShieldedFunding {
+            sources.append(.shielded)
         }
-        // Otherwise (both viable, or neither): leave `fundingSource`
-        // alone. With neither viable, the Continue button is disabled
-        // anyway; with both viable, the picker is shown and the user
-        // makes the call.
+        if viewModel.hasMinimumRequiredPlatformBalance {
+            sources.append(.platformPayment)
+        }
+        if viewModel.hasMinimumRequiredCoreBalance {
+            sources.append(.core)
+        }
+        return sources
+    }
+
+    /// Picker binding that records an explicit user pick, so the
+    /// auto-pinning in `syncFundingSourceToViableSource()` stops
+    /// overriding the selection. Programmatic assignments write
+    /// `fundingSource` directly and deliberately bypass this.
+    private var userFundingSourceBinding: Binding<DWIdentityFundingSource> {
+        Binding(
+            get: { fundingSource },
+            set: { newValue in
+                didUserPickFundingSource = true
+                fundingSource = newValue
+            })
+    }
+
+    private func fundingSourceLabel(_ source: DWIdentityFundingSource) -> String {
+        switch source {
+        case .shielded:
+            return "Shielded (\(viewModel.shieldedBalance) Dash)"
+        case .platformPayment:
+            return "Platform (\(viewModel.platformPaymentBalance) Dash)"
+        case .core:
+            return "Core (\(viewModel.balance) Dash)"
+        }
+    }
+
+    /// One-line privacy consequence of the current pick, shown under
+    /// the picker whenever it is visible.
+    private var fundingPrivacyFootnote: some View {
+        Text(fundingSource == .shielded
+            ? NSLocalizedString("Funded from your Shielded balance — your username can't be linked to your other Dash.", comment: "Usernames")
+            : NSLocalizedString("Transparent funding publicly links your username to these funds.", comment: "Usernames"))
+            .font(.caption2)
+            .foregroundColor(.secondaryText)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// Keep `fundingSource` pointing at a viable source. Until the
+    /// user explicitly picks one, pin to the highest-priority viable
+    /// source (Shielded → Platform → Core); after an explicit pick,
+    /// only correct a selection that is no longer viable.
+    private func syncFundingSourceToViableSource() {
+        let viable = viableFundingSources
+        guard let preferred = viable.first else {
+            // Nothing viable — leave the selection alone; the Continue
+            // button is disabled by the cost rule anyway.
+            return
+        }
+        if !viable.contains(fundingSource) || !didUserPickFundingSource {
+            fundingSource = preferred
+        }
     }
 
     private func getMessageForBlockedRule() -> String {

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -57,6 +57,12 @@ class CreateUsernameViewModel: ObservableObject {
     /// In-flight DPNS availability check. Cancelled and replaced on
     /// every revalidation so only the newest input hits the network.
     private var availabilityCheckTask: Task<Void, Never>?
+    /// One-shot revalidation alarm for a `.maturing` shielded snapshot.
+    /// The shared readiness service arms its own flip timer only for
+    /// the STANDARD denomination; a contested name's (0.3 DASH) ready
+    /// moment can be later, so the form re-validates itself at the
+    /// snapshot's own `readyAt`. Re-armed on every validation.
+    private var shieldedMaturityRevalidationTask: Task<Void, Never>?
     /// Mirrors the legacy `VALIDATION_DEBOUNCE_DELAY`
     /// (DWCheckExistenceUsernameValidationRule.m).
     private static let availabilityDebounceNanos: UInt64 = 400_000_000
@@ -92,6 +98,21 @@ class CreateUsernameViewModel: ObservableObject {
     /// Formatted Platform Payment balance (in DASH, derived from the
     /// duff-equivalent of `SwiftDashSDKWalletState.platformPaymentCredits`).
     @Published private(set) var platformPaymentBalance: String = ""
+
+    /// Shielded-funding readiness for the CURRENT typed name (contested
+    /// names need the 0.3 DASH exit denomination instead of 0.1).
+    /// Recomputed by `validateUsername` and on every readiness publish.
+    /// nil while the SDK host has no hydrated wallet.
+    @Published private(set) var shieldedReadiness: ShieldedIdentityFundingReadiness.Snapshot? = nil
+    /// Formatted unspent shielded balance in DASH, for the picker label.
+    @Published private(set) var shieldedBalance: String = ""
+
+    /// Shielded funding is offerable right now: funded + matured + pool
+    /// minimum cleared (or pool count unknown — Drive enforces the real
+    /// rule at submit).
+    var hasReadyShieldedFunding: Bool {
+        shieldedReadiness?.state == .ready
+    }
     
     var minimumRequiredBalance: String {
         return DWDP_MIN_BALANCE_TO_CREATE_USERNAME.dashAmount.formattedDashAmountWithoutCurrencySymbol
@@ -232,6 +253,11 @@ class CreateUsernameViewModel: ObservableObject {
         guard !username.isEmpty else {
             uiState = CreateUsernameUIState()
             isContestedCandidate = false
+            // Keep the shielded picker option + balance label live
+            // before the user types — evaluated against the standard
+            // (uncontested) denomination.
+            shieldedReadiness = ShieldedIdentityFundingReadiness.shared
+                .evaluate(requiredCredits: ShieldedIdentityFundingReadiness.standardDenominationCredits)
             return
         }
 
@@ -248,17 +274,23 @@ class CreateUsernameViewModel: ObservableObject {
         let contestedCandidate = isContested && lengthValid && !hasIllegalCharacters && !startsOrEndsWithHyphen
         isContestedCandidate = contestedCandidate
         let requiredCost = isContested ? DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME : DWDP_MIN_BALANCE_TO_CREATE_USERNAME
-        // Either funding source can satisfy the cost rule. Core
-        // spends BIP44 UTXOs via `registerIdentityWithFunding`;
-        // Platform Payment spends DIP-17 credits via
-        // `registerIdentityFromAddresses`. The picker in
-        // `CreateUsernameView` lets the user choose when both are
-        // viable; the form is unblocked as soon as either is.
+        // Any funding source can satisfy the cost rule. Core spends
+        // BIP44 UTXOs via `registerIdentityWithFunding`; Platform
+        // Payment spends DIP-17 credits via
+        // `registerIdentityFromAddresses`; Shielded spends a fixed
+        // exit denomination via `shieldedIdentityCreateFromPool` and
+        // is viable only when its readiness gates (funding, maturity,
+        // pool) all pass. The picker in `CreateUsernameView` lets the
+        // user choose among the viable sources; the form is unblocked
+        // as soon as any one is.
         let coreBalance = SwiftDashSDKWalletState.shared.balance?.total ?? 0
         let platformBalance = SwiftDashSDKWalletState.shared.platformPaymentCreditsAsDuffs
         let hasEnoughCore = coreBalance >= requiredCost
         let hasEnoughPlatform = platformBalance >= requiredCost
-        let hasEnoughBalance = hasEnoughCore || hasEnoughPlatform
+        let shieldedRequired = ShieldedIdentityFundingReadiness.requiredCredits(forContestedName: isContested)
+        shieldedReadiness = ShieldedIdentityFundingReadiness.shared.evaluate(requiredCredits: shieldedRequired)
+        armShieldedMaturityRevalidation()
+        let hasEnoughBalance = hasEnoughCore || hasEnoughPlatform || hasReadyShieldedFunding
         let canContinue = lengthValid && !hasIllegalCharacters && !startsOrEndsWithHyphen && hasEnoughBalance
 
         uiState = CreateUsernameUIState(
@@ -350,6 +382,35 @@ class CreateUsernameViewModel: ObservableObject {
                 self.checkBalance()
             }
             .store(in: &cancellableBag)
+        // Shielded readiness changes (a note maturing, a shielded sync
+        // pass landing new notes, the pool count arriving) re-run the
+        // same validation so the picker's shielded option and the
+        // inline readiness hint stay live.
+        ShieldedIdentityFundingReadiness.shared.$standardSnapshot
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                self.validateUsername(username: self.username)
+                self.checkBalance()
+            }
+            .store(in: &cancellableBag)
+    }
+
+    /// Schedule a one-shot revalidation at the current snapshot's
+    /// `readyAt` (+1 s of slack) so the `.maturing` hint flips to a
+    /// selectable Shielded option without further user input.
+    private func armShieldedMaturityRevalidation() {
+        shieldedMaturityRevalidationTask?.cancel()
+        shieldedMaturityRevalidationTask = nil
+        guard case .maturing(let readyAt) = shieldedReadiness?.state else { return }
+        let delay = readyAt.timeIntervalSinceNow
+        guard delay > 0 else { return }
+        shieldedMaturityRevalidationTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64((delay + 1) * 1_000_000_000))
+            guard !Task.isCancelled, let self else { return }
+            self.validateUsername(username: self.username)
+            self.checkBalance()
+        }
     }
 
     private func checkBalance() {
@@ -357,6 +418,10 @@ class CreateUsernameViewModel: ObservableObject {
         let platformDuffs = SwiftDashSDKWalletState.shared.platformPaymentCreditsAsDuffs
         self.balance = balance.dashAmount.formattedDashAmountWithoutCurrencySymbol
         self.platformPaymentBalance = platformDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol
+        // Credits → duffs (÷1000) for display; the readiness snapshot
+        // keeps the canonical credit-denominated values.
+        let shieldedDuffs = (shieldedReadiness?.unspentCredits ?? 0) / 1_000
+        self.shieldedBalance = shieldedDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol
         hasMinimumRequiredCoreBalance = balance >= DWDP_MIN_BALANCE_TO_CREATE_USERNAME
         hasMinimumRequiredPlatformBalance = platformDuffs >= DWDP_MIN_BALANCE_TO_CREATE_USERNAME
         // `hasMinimumRequiredBalance` stays as the legacy OR view —

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
@@ -1,0 +1,251 @@
+//
+//  JoinDashPayReadinessScreen.swift
+//  DashWallet
+//
+//  "Get ready to join DashPay" interstitial. Shown between the Join
+//  DashPay entry points and the Create Username form whenever the
+//  shielded (privacy-preserving) funding path isn't ready yet, so the
+//  user starts the privacy clock at first intent instead of hitting a
+//  "come back in a few hours" wall after picking a name.
+//
+//  Live checklist of the three `ShieldedIdentityFundingReadiness`
+//  gates: fund the shielded balance (button opens the existing
+//  Shielded-balance transfer screen pre-filled with the shortfall),
+//  let it rest (`maturityWindow`, countdown target shown), and the
+//  consensus pool minimum (usually already met; surfaced only for
+//  completeness/fresh networks). Continue unlocks at `.ready`; an
+//  explicit "use transparent balance" escape keeps the old funding
+//  paths one tap away for users who opt out of the wait.
+//
+
+import SwiftUI
+
+struct JoinDashPayReadinessScreen: View {
+    @ObservedObject private var readiness = ShieldedIdentityFundingReadiness.shared
+
+    /// Open the Shielded-balance transfer screen pre-filled with the
+    /// suggested deposit (in DASH).
+    let onAddFunds: (Decimal) -> Void
+    /// Push the Create Username form. Used by both Continue (shielded
+    /// ready — the form's picker auto-pins to Shielded) and the
+    /// transparent escape (the picker pins to the viable transparent
+    /// source).
+    let onProceed: () -> Void
+
+    /// Suggested deposit headroom (0.001 DASH in credits) added to the
+    /// shortfall prefill: the Core→Shielded route carves the Platform
+    /// pool fee from the locked value, so depositing the bare shortfall
+    /// would net slightly under the denomination. Only a suggestion —
+    /// the gates re-evaluate on the notes that actually land.
+    private static let fundingFeeHeadroomCredits: UInt64 = 100_000_000
+
+    private var snapshot: ShieldedIdentityFundingReadiness.Snapshot? {
+        readiness.standardSnapshot
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(NSLocalizedString("Get ready to join DashPay", comment: "Usernames"))
+                .font(.title1)
+                .foregroundColor(.primaryText)
+                .padding(.top, 12)
+
+            Text(NSLocalizedString("Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.", comment: "Usernames"))
+                .font(.system(size: 14))
+                .foregroundColor(.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.top, 8)
+
+            VStack(alignment: .leading, spacing: 18) {
+                fundingRow
+                maturityRow
+                poolRow
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.top, 24)
+
+            Spacer()
+
+            DashButton(
+                text: NSLocalizedString("Continue", comment: ""),
+                isEnabled: snapshot?.state == .ready
+            ) {
+                onProceed()
+            }
+
+            if snapshot?.state != .ready && transparentSourceViable {
+                Button(action: onProceed) {
+                    Text(NSLocalizedString("Use transparent balance instead", comment: "Usernames"))
+                        .font(.footnote)
+                        .foregroundColor(.secondaryText)
+                        .frame(maxWidth: .infinity)
+                }
+                .padding(.top, 12)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.primaryBackground.ignoresSafeArea())
+        .onAppear {
+            readiness.refresh()
+            // Pull fresh notes + the pool count so the checklist isn't
+            // stale from the last periodic pass.
+            readiness.requestFreshSignals()
+        }
+    }
+
+    // MARK: - Checklist rows
+
+    private var requiredCredits: UInt64 {
+        snapshot?.requiredCredits ?? ShieldedIdentityFundingReadiness.standardDenominationCredits
+    }
+
+    private var isFunded: Bool {
+        (snapshot?.unspentCredits ?? 0) >= requiredCredits
+    }
+
+    private var isMatured: Bool {
+        (snapshot?.matureCredits ?? 0) >= requiredCredits
+    }
+
+    private var fundingRow: some View {
+        checklistRow(
+            met: isFunded,
+            pendingIcon: "circle",
+            title: String.localizedStringWithFormat(
+                NSLocalizedString("Add at least %@ Dash to your Shielded balance", comment: "Usernames"),
+                formatCredits(requiredCredits)),
+            subtitle: isFunded
+                ? String.localizedStringWithFormat(
+                    NSLocalizedString("%@ Dash available", comment: "Usernames"),
+                    formatCredits(snapshot?.unspentCredits ?? 0))
+                : String.localizedStringWithFormat(
+                    NSLocalizedString("You have %@ Dash so far", comment: "Usernames"),
+                    formatCredits(snapshot?.unspentCredits ?? 0)),
+            trailing: isFunded ? nil : (
+                NSLocalizedString("Add", comment: ""),
+                {
+                    let shortfall: UInt64
+                    if case .needsFunding(let credits) = snapshot?.state {
+                        shortfall = credits
+                    } else {
+                        shortfall = requiredCredits
+                    }
+                    onAddFunds(Self.dashAmount(credits: shortfall + Self.fundingFeeHeadroomCredits))
+                }
+            ))
+    }
+
+    private var maturityRow: some View {
+        let subtitle: String
+        if isMatured {
+            subtitle = NSLocalizedString("Done — your balance has rested long enough", comment: "Usernames")
+        } else if case .maturing(let readyAt) = snapshot?.state {
+            let time = DateFormatter.localizedString(from: readyAt, dateStyle: .none, timeStyle: .short)
+            subtitle = String.localizedStringWithFormat(
+                NSLocalizedString("Ready around %@", comment: "Usernames"), time)
+        } else {
+            subtitle = NSLocalizedString("Starts after you add funds", comment: "Usernames")
+        }
+        return checklistRow(
+            met: isMatured,
+            pendingIcon: isFunded ? "clock" : "circle",
+            title: NSLocalizedString("Let it rest for a few hours", comment: "Usernames"),
+            subtitle: subtitle,
+            trailing: nil)
+    }
+
+    private var poolRow: some View {
+        let met: Bool
+        let pendingIcon: String
+        let subtitle: String
+        if let count = snapshot?.poolNoteCount {
+            met = count >= ShieldedIdentityFundingReadiness.minimumPoolNotes
+            pendingIcon = "circle"
+            subtitle = met
+                ? NSLocalizedString("Minimum met", comment: "Usernames")
+                : String.localizedStringWithFormat(
+                    NSLocalizedString("%ld of %ld deposits", comment: "Usernames"),
+                    Int(count), Int(ShieldedIdentityFundingReadiness.minimumPoolNotes))
+        } else {
+            // Count not reported yet. Never claim the check passed —
+            // but an unknown count doesn't block Continue either
+            // (readiness fails open here); Drive enforces the real
+            // rule at registration, so say exactly that.
+            met = false
+            pendingIcon = "questionmark.circle"
+            subtitle = NSLocalizedString("Verified during registration", comment: "Usernames")
+        }
+        return checklistRow(
+            met: met,
+            pendingIcon: pendingIcon,
+            title: NSLocalizedString("Shared privacy pool at minimum size", comment: "Usernames"),
+            subtitle: subtitle,
+            trailing: nil)
+    }
+
+    private func checklistRow(
+        met: Bool,
+        pendingIcon: String,
+        title: String,
+        subtitle: String,
+        trailing: (String, () -> Void)?
+    ) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: met ? "checkmark.circle.fill" : pendingIcon)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(met ? .green : .gray300)
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(subtitle)
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let (label, action) = trailing {
+                Button(action: action) {
+                    Text(label)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 7)
+                        .background(Color.dashBlue)
+                        .clipShape(Capsule())
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// The transparent escape is only offered when it can actually
+    /// complete a registration — otherwise it would land the user on a
+    /// form whose Continue is disabled by the cost rule.
+    private var transparentSourceViable: Bool {
+        let core = SwiftDashSDKWalletState.shared.balance?.total ?? 0
+        let platform = SwiftDashSDKWalletState.shared.platformPaymentCreditsAsDuffs
+        return core >= DWDP_MIN_BALANCE_TO_CREATE_USERNAME
+            || platform >= DWDP_MIN_BALANCE_TO_CREATE_USERNAME
+    }
+
+    /// Credits → whole-DASH decimal (1e11 credits per DASH).
+    private static func dashAmount(credits: UInt64) -> Decimal {
+        Decimal(credits) / Decimal(100_000_000_000)
+    }
+
+    /// Credits → formatted DASH string (credits ÷ 1000 = duffs).
+    private func formatCredits(_ credits: UInt64) -> String {
+        (credits / 1_000).dashAmount.formattedDashAmountWithoutCurrencySymbol
+    }
+}

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
@@ -27,7 +27,11 @@ public struct JoinDashPayScreen: View {
             TextIntro(
                 buttonLabel: NSLocalizedString("Continue", comment: ""),
                 action: { navigateToVotingInfo = true },
-                isActionEnabled: viewModel.hasMinimumRequiredBalance,
+                // A transparent balance is no longer a hard precondition:
+                // the shielded route starts with ADDING funds (via the
+                // get-ready checklist after Continue), so the button only
+                // stays disabled while the wallet hasn't hydrated yet.
+                isActionEnabled: viewModel.hasMinimumRequiredBalance || viewModel.shieldedReadiness != nil,
                 inProgress: .constant(false),
                 topText: {
                     FeatureTopText(
@@ -38,7 +42,8 @@ public struct JoinDashPayScreen: View {
                 features: {[
                     FeatureSingleItem(iconName: .custom("username.letter"), title: NSLocalizedString("Create a username", comment: ""), description: NSLocalizedString("Pay to usernames. No more alphanumeric addresses.", comment: "")),
                     FeatureSingleItem(iconName: .custom("friends.add"), title: NSLocalizedString("Add your friends & family", comment: ""), description: NSLocalizedString("Invite your family, find your friends by searching their usernames.", comment: "")),
-                    FeatureSingleItem(iconName: .custom("profile.personalized"), title: NSLocalizedString("Personalise profile", comment: ""), description: NSLocalizedString("Upload your picture, personalize your identity.", comment: ""))
+                    FeatureSingleItem(iconName: .custom("profile.personalized"), title: NSLocalizedString("Personalise profile", comment: ""), description: NSLocalizedString("Upload your picture, personalize your identity.", comment: "")),
+                    FeatureSingleItem(iconName: .system("shield.lefthalf.filled"), title: NSLocalizedString("Private by design", comment: "Usernames"), description: NSLocalizedString("Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.", comment: "Usernames"))
                 ]},
                 info: getInfo()
             )
@@ -56,11 +61,21 @@ public struct JoinDashPayScreen: View {
         if viewModel.hasRecommendedBalance {
             return nil
         }
-        
+
         if viewModel.hasMinimumRequiredBalance {
             return String.localizedStringWithFormat(NSLocalizedString("You have %@ Dash.\nSome usernames cost up to %@ Dash.", comment: "Usernames"), viewModel.balance, viewModel.recommendedBalance)
         }
-        
-        return String.localizedStringWithFormat(NSLocalizedString("You need to have more than %@ Dash to create a username", comment: "Usernames"), viewModel.minimumRequiredBalance)
+
+        if viewModel.hasReadyShieldedFunding {
+            // No transparent balance, but the shielded route is fully
+            // ready — nothing to warn about.
+            return nil
+        }
+
+        let shieldedMinimum = (ShieldedIdentityFundingReadiness.standardDenominationCredits / 1_000)
+            .dashAmount.formattedDashAmountWithoutCurrencySymbol
+        return String.localizedStringWithFormat(
+            NSLocalizedString("Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it.", comment: "Usernames"),
+            shieldedMinimum)
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
@@ -36,6 +36,11 @@ extension JoinDashPayState {
 
 struct JoinDashPayView: View {
     @StateObject var viewModel: JoinDashPayViewModel
+    /// Drives the `.callToAction` subtitle nudge: the banner is the
+    /// earliest surface where "fund your Shielded balance now, register
+    /// in a few hours" can reach the user, so the copy tracks the
+    /// shielded readiness state (add funds → maturing countdown → ready).
+    @ObservedObject private var shieldedReadiness = ShieldedIdentityFundingReadiness.shared
     var onTap: (JoinDashPayState) -> Void
     var onActionButton: ((JoinDashPayState) -> Void)? = nil
     var onDismissButton: ((JoinDashPayState) -> Void)? = nil
@@ -140,7 +145,17 @@ struct JoinDashPayView: View {
         case .none:
             return NSLocalizedString("Request your username", comment: "")
         case .callToAction:
-            return NSLocalizedString("Request a username and say goodbye to numerical addresses", comment: "")
+            switch shieldedReadiness.standardSnapshot?.state {
+            case .maturing(let readyAt):
+                let time = DateFormatter.localizedString(from: readyAt, dateStyle: .none, timeStyle: .short)
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("Your Shielded balance is resting — you can register privately around %@", comment: "Usernames"),
+                    time)
+            case .ready:
+                return NSLocalizedString("Your Shielded balance is ready — register your username privately now", comment: "Usernames")
+            case .needsFunding, .poolTooSmall, nil:
+                return NSLocalizedString("Add to your Shielded balance now and register your username privately a few hours later", comment: "Usernames")
+            }
         case .voting:
             let endDate = Date(timeIntervalSince1970: VotingConstants.votingEndTime)
             let endDateStr = DWDateFormatter.sharedInstance.dateOnly(from: endDate)

--- a/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
@@ -167,6 +167,39 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate, ExploreView
 
     func showCreateUsername(withInvitation invitationURL: URL?, definedUsername: String?) {
         #if DASHPAY
+        // Route through the shielded get-ready interstitial whenever
+        // the privacy-preserving funding path isn't ready (needs funds
+        // / maturing / pool below minimum) so the privacy clock starts
+        // at first intent. `nil` (host not hydrated yet) falls through
+        // to the form — its own cost rules gate submission.
+        let readiness = ShieldedIdentityFundingReadiness.shared.evaluate(
+            requiredCredits: ShieldedIdentityFundingReadiness.standardDenominationCredits)
+        if let readiness, readiness.state != .ready {
+            showJoinDashPayReadiness()
+        } else {
+            pushCreateUsernameForm()
+        }
+        #endif
+    }
+
+    #if DASHPAY
+    private func showJoinDashPayReadiness() {
+        let screen = JoinDashPayReadinessScreen(
+            onAddFunds: { [weak self] suggestedDash in
+                let controller = InternalTransferHostingController(prefillDashAmount: suggestedDash)
+                controller.hidesBottomBarWhenPushed = true
+                self?.navigationController?.pushViewController(controller, animated: true)
+            },
+            onProceed: { [weak self] in
+                self?.pushCreateUsernameForm()
+            })
+        let hosting = UIHostingController(rootView: screen)
+        hosting.view.backgroundColor = UIColor.dw_background()
+        hosting.hidesBottomBarWhenPushed = true
+        navigationController?.pushViewController(hosting, animated: true)
+    }
+
+    private func pushCreateUsernameForm() {
         let controller = CreateUsernameViewController(dashPayModel: model.dashPayModel, invitationURL: nil, definedUsername: nil)
         controller.hidesBottomBarWhenPushed = true
         controller.completionHandler = { result in
@@ -177,8 +210,8 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate, ExploreView
             }
         }
         self.navigationController?.pushViewController(controller, animated: true)
-        #endif
     }
+    #endif
 
     private func showExploreDash() {
         let controller = ExploreViewController()

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferHostingController.swift
@@ -11,6 +11,17 @@ final class InternalTransferHostingController: UIViewController {
 
     private let viewModel = InternalTransferViewModel()
 
+    /// Open the screen pre-filled for the "fund your Shielded balance"
+    /// flow (Join DashPay readiness): direction is already the default
+    /// `.toShielded`; this just seeds the amount so the user can
+    /// confirm instead of retyping the suggested deposit.
+    convenience init(prefillDashAmount: Decimal) {
+        self.init(nibName: nil, bundle: nil)
+        // `Decimal`'s description always uses a dot, which the view
+        // model's parser normalises for — locale-safe as a seed value.
+        viewModel.amountText = "\(prefillDashAmount)"
+    }
+
     private lazy var hostingController: UIHostingController<InternalTransferScreen> = {
         let screen = InternalTransferScreen(viewModel: viewModel) { [weak self] in
             // After a successful transfer the user taps "Done" inside the

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* CrowdNode */
 " Terms of Use " = " Terms of Use ";
 
+/* Usernames */
+"%@ Dash available" = "%@ Dash available";
+
 /* No comment provided by engineer. */
 "%@ has accepted your contact request" = "%@ has accepted your contact request";
 
@@ -30,6 +33,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld of %ld deposits";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -90,6 +96,90 @@
 
 /* Explore Dash: Filters */
 "80 km" = "80 km";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Add at least %@ Dash to your Shielded balance";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Add to your Shielded balance now and register your username privately a few hours later";
+
+/* Usernames */
+"Done — your balance has rested long enough" = "Done — your balance has rested long enough";
+
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Funded from your Shielded balance — your username can't be linked to your other Dash.";
+
+/* Usernames */
+"Get ready to join DashPay" = "Get ready to join DashPay";
+
+/* Usernames */
+"Minimum met" = "Minimum met";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing.";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";
+
+/* Usernames */
+"Private by design" = "Private by design";
+
+/* Usernames */
+"Private registration" = "Private registration";
+
+/* Usernames */
+"Ready around %@" = "Ready around %@";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it.";
+
+/* Usernames */
+"Shared privacy pool at minimum size" = "Shared privacy pool at minimum size";
+
+/* Usernames */
+"Starts after you add funds" = "Starts after you add funds";
+
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum.";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparent funding publicly links your username to these funds.";
+
+/* Usernames */
+"Use transparent balance instead" = "Use transparent balance instead";
+
+/* Usernames */
+"Verified during registration" = "Verified during registration";
+
+/* Usernames */
+"You have %@ Dash so far" = "You have %@ Dash so far";
+
+/* Usernames */
+"Your Shielded balance is almost ready — you can register privately around %@." = "Your Shielded balance is almost ready — you can register privately around %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Your Shielded balance is ready — register your username privately now";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Your Shielded balance is resting — you can register privately around %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Your shielded balance is still maturing. It will be ready around %@.";
+
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.";
 
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word" = "\"%@\" is not a recovery phrase word";

--- a/DashWalletTests/DWRegistrationPhaseAdapterTests.swift
+++ b/DashWalletTests/DWRegistrationPhaseAdapterTests.swift
@@ -217,4 +217,43 @@ final class DWRegistrationPhaseAdapterTests: XCTestCase {
                 failedAtPhase: .creatingID),
             .creatingID)
     }
+
+    // MARK: - Shielded (Type-20) funding path
+
+    // Like Platform Payment, the shielded path has no Core-chain
+    // asset-lock — the whole spend (Halo 2 proof + submit) is one
+    // opaque FFI call, so `.inFlight` must map straight to
+    // `.creatingID` regardless of any stale `assetLockStatus`.
+
+    func test_shielded_inFlight_anyAssetLockStatus_isCreatingID() {
+        for status in 0...4 {
+            XCTAssertEqual(
+                DWRegistrationPhaseAdapter.map(
+                    phase: .inFlight,
+                    assetLockStatus: status,
+                    fundingSource: .shielded),
+                .creatingID,
+                "Shielded .inFlight with assetLockStatus=\(status) should map to creatingID")
+        }
+    }
+
+    func test_shielded_completed_isDone() {
+        let dummyId = Data(count: 32)
+        XCTAssertEqual(
+            DWRegistrationPhaseAdapter.map(
+                phase: .completed(identityId: dummyId),
+                assetLockStatus: 0,
+                fundingSource: .shielded),
+            .done)
+    }
+
+    func test_shielded_failed_usesFailedAtPhase() {
+        XCTAssertEqual(
+            DWRegistrationPhaseAdapter.map(
+                phase: .failed("shieldedIdentityCreateFromPool failed"),
+                assetLockStatus: 0,
+                fundingSource: .shielded,
+                failedAtPhase: .creatingID),
+            .creatingID)
+    }
 }


### PR DESCRIPTION
## What

Makes the **shielded (Orchard) balance the default funding source for DashPay identity creation**, with Core and Platform Payment remaining as explicit transparent options — and builds the UX around the two constraints that make private registration work:

1. the funding notes should be **hours old** (timing separation between your deposit and your public username), and
2. the shielded pool must hold **≥ 250 notes** before outgoing transitions are accepted.

## Funding path

- `DWIdentityFundingSource` gains `.shielded` (raw 2, appended). The coordinator routes it through the SDK's `shieldedIdentityCreateFromPool` (**Type 20**): it spends a fixed consensus **exit denomination** — 0.1 DASH standard, 0.3 DASH for contested names (≥ the 0.25 requirement). The metered fee is taken *from* the denomination, so the new identity starts at `denomination − fee`; excess spent value returns to the pool as change.
- The REQUIRED Type-20 creation-failure fallback is the wallet's lowest-indexed Platform Payment address (same `[type]+hash` encoding as the address-funded inputs).
- `ShieldedIdentityCreateUnconfirmedError` maps to a distinct, non-immediately-retryable error. The Rust side arms a persisted **redrive** for the ambiguous case; if the create actually landed, the next attempt resumes past IdentityCreate via the existing `lookupExistingIdentityId` path.
- `DWRegistrationPhaseAdapter` treats `.shielded` like `.platformPayment` (no asset-lock; `.inFlight` → Creating ID). Compile-ready adapter tests added for the new case.

## Readiness model — `ShieldedIdentityFundingReadiness`

Single source of truth read by the banner, the interstitial, and the form. Priority-ordered gates:

| Gate | Basis | Behavior |
|---|---|---|
| Funding | unspent `PersistentShieldedNote` sum ≥ denomination | `needsFunding(shortfall)` |
| Maturity | **app-side privacy policy** (no protocol rule): covering notes must rest **3 h** (10 min in DEBUG so the flip is QA-able) — computed oldest-first from `createdAt`, so `readyAt` is exact | `maturing(readyAt)` + one-shot re-eval timers |
| Pool ≥ 250 | client mirror of consensus `minimum_pool_notes_for_outgoing`, latched from the shielded sync's tree-progress signal (`currentShieldedTreeTotal`) | `poolTooSmall(n)`; **unknown count fails open** — Drive enforces the real rule and its error is surfaced |

Restored wallets re-observe old notes as new, so the maturity gate over-waits — the safe direction for a privacy timer.

## UX — start the privacy clock at first intent

- **Get-ready interstitial** (`JoinDashPayReadinessScreen`): Join DashPay entry points route here whenever shielded isn't ready. Live checklist — *add ≥ 0.1 DASH* (button opens the Shielded-balance transfer screen pre-filled with the shortfall + 0.001 DASH fee headroom), *let it rest a few hours* (ready-at time), *pool minimum* (auto-met on testnet's pre-seeded pool; “Verified during registration” when the count is unknown). Continue unlocks at ready; a **"Use transparent balance instead"** escape (shown only when transparent funding can actually complete) preserves the old paths as an informed choice.
- **Home banner nudge**: the Join DashPay `callToAction` subtitle tracks readiness — "Add to your Shielded balance now and register privately a few hours later" → "resting until HH:MM" → "ready". This is the *deposit-hours-before-you-join* prompt, visible before the user enters the flow.
- **Create Username**: three-way funding picker (Shielded default whenever ready, then Platform, then Core; explicit user picks are respected), an inline readiness hint while shielded is unavailable, and a one-line privacy footnote per source ("can't be linked" vs "publicly links").
- **Join DashPay info dialog**: new "Private by design" feature row sets the two-step expectation up front; Continue no longer hard-requires a transparent balance (the shielded route starts by adding funds).

## Not in scope

- No platform/SDK changes — every API used is already on `v4.1-dev` (no xcframework rebuild needed).
- Invitation-funded registration (existing teardown decision) untouched.
- The legacy ObjC `shouldShowCreateUserNameButton` core-balance gate is left as-is; the live entry point (banner) isn't balance-gated.

## Verification

- `dashpay` Debug arm64-sim build green at each phase and at the final tree (`plutil -lint` clean on pbxproj; en strings lint clean, additions purely additive).
- Unit-test target remains pre-existing broken; adapter tests are compile-ready documentation-as-tests.

### QA smokes (PIN-gated — need a driver)

1. Fresh testnet wallet with 0 shielded: Join DashPay banner → interstitial shows shortfall → Add → transfer screen pre-filled → after deposit lands, row 1 ✓ and row 2 shows ready-at (10 min on DEBUG).
2. After maturity: banner flips to "ready", interstitial Continue unlocks, Create Username picker defaults to **Shielded**; register a username and confirm the identity + DPNS name land (identity starts at ~0.1 DASH minus fee).
3. Transparent escape: with core balance ≥ 0.03 and no shielded, "Use transparent balance instead" → form pins to Core; registration behaves as before.
4. Contested name (≤19 chars): requirement flips to 0.3 DASH — hint/denomination follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)