### PR TITLE
feat(wallet): in-app diagnostic log export for beta feedback

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -867,6 +867,9 @@
 		A5D5DD000000000000000267 /* KeychainWalletRecoveryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000268 /* KeychainWalletRecoveryCoordinator.swift */; };
 		A5D5DD000000000000000271 /* SwiftDashSDKHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000270 /* SwiftDashSDKHost.swift */; };
 		A5D5DD000000000000000272 /* SwiftDashSDKHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000270 /* SwiftDashSDKHost.swift */; };
+		A5D5DD00000000000000141D /* DiagnosticLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD00000000000000141C /* DiagnosticLogExporter.swift */; };
+		A5D5DD00000000000000141E /* DiagnosticLogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD00000000000000141C /* DiagnosticLogExporter.swift */; };
+		A5D5DD000000000000001420 /* DiagnosticLogExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD00000000000000141F /* DiagnosticLogExporterTests.swift */; };
 		A5D5DD000000000000000301 /* DWRecoverModel+Mnemonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000300 /* DWRecoverModel+Mnemonic.swift */; };
 		A5D5DD000000000000000302 /* DWRecoverModel+Mnemonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000300 /* DWRecoverModel+Mnemonic.swift */; };
 		A5D5DD000000000000000315 /* DWParsedPaymentURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D5DD000000000000000317 /* DWParsedPaymentURI.swift */; };
@@ -2673,6 +2676,8 @@
 		C7AE5D000000000000000005 /* PinStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinStore.swift; sourceTree = "<group>"; };
 		C7AE5D000000000000000008 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000000304 /* DWLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DWLogger.m; sourceTree = "<group>"; };
+		A5D5DD00000000000000141C /* DiagnosticLogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLogExporter.swift; sourceTree = "<group>"; };
+		A5D5DD00000000000000141F /* DiagnosticLogExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLogExporterTests.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000000124 /* SwiftDashSDKTransactionSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKTransactionSender.swift; sourceTree = "<group>"; };
 		A5D5DD00000000000000012E /* SwiftDashSDKWalletRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKWalletRuntime.swift; sourceTree = "<group>"; };
 		A5D5DD000000000000000131 /* SwiftDashSDKReceiveAddressReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKReceiveAddressReader.swift; sourceTree = "<group>"; };
@@ -5496,6 +5501,7 @@
 				47F006002971B1CE0029EB10 /* Currency Exchanger */,
 				A5D5DD000000000000000303 /* DWLogger.h */,
 				A5D5DD000000000000000304 /* DWLogger.m */,
+				A5D5DD00000000000000141C /* DiagnosticLogExporter.swift */,
 				47FA3B0029364743008D58DC /* Networking */,
 				C7AE5D000000000000000001 /* Authentication */,
 				4741255F287E77B4004E6BF3 /* Database */,
@@ -6325,6 +6331,7 @@
 				471DD1BB290AE30B00E030C8 /* String+DashWalletTests.swift */,
 				47976E492987772700612988 /* AmountObjectTests.swift */,
 				A5D5DD000000000000001200 /* DWRegistrationPhaseAdapterTests.swift */,
+				A5D5DD00000000000000141F /* DiagnosticLogExporterTests.swift */,
 				A5D5DD000000000000001310 /* PhraseRepairEngineTests.swift */,
 				328D8D5EF7D75440B3D9B83B /* PaymentProtocolTests.swift */,
 			);
@@ -8758,6 +8765,7 @@
 				A5D5DD000000000000001307 /* DamerauLevenshtein.swift in Sources */,
 				A5D5DD00000000000000012F /* SwiftDashSDKWalletRuntime.swift in Sources */,
 				A5D5DD000000000000000271 /* SwiftDashSDKHost.swift in Sources */,
+				A5D5DD00000000000000141D /* DiagnosticLogExporter.swift in Sources */,
 				A5D5DD0000000000000000FB /* SwiftDashSDKSPVCoordinator.swift in Sources */,
 				A5D5DD0000000000000000FE /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				A5D5DD000000000000000210 /* PlatformAddressSyncCoordinator.swift in Sources */,
@@ -9107,6 +9115,7 @@
 				471DD1C0290AECE900E030C8 /* String+DashWalletTests.swift in Sources */,
 				47976E4A2987772700612988 /* AmountObjectTests.swift in Sources */,
 				A5D5DD000000000000001201 /* DWRegistrationPhaseAdapterTests.swift in Sources */,
+				A5D5DD000000000000001420 /* DiagnosticLogExporterTests.swift in Sources */,
 				A5D5DD000000000000001311 /* PhraseRepairEngineTests.swift in Sources */,
 				3BCC8D1E7E9C2356A1B2E622 /* PaymentProtocolTests.swift in Sources */,
 			);
@@ -9608,6 +9617,7 @@
 				A5D5DD000000000000001308 /* DamerauLevenshtein.swift in Sources */,
 				A5D5DD000000000000000130 /* SwiftDashSDKWalletRuntime.swift in Sources */,
 				A5D5DD000000000000000272 /* SwiftDashSDKHost.swift in Sources */,
+				A5D5DD00000000000000141E /* DiagnosticLogExporter.swift in Sources */,
 				A5D5DD000000000000001102 /* DWRegistrationPhaseAdapter.swift in Sources */,
 				A5D5DD000000000000001419 /* ShieldedIdentityFundingReadiness.swift in Sources */,
 				A5D5DD000000000000001104 /* DWIdentityRegistrationController.swift in Sources */,

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import MessageUI
+import SwiftDashSDK
 
 @objc
 extension UIViewController {
@@ -55,49 +56,88 @@ extension UIViewController {
     }
 
     @objc func presentSupportEmailController() {
+        // Zip the recent SwiftDashSDK log sessions off the main actor
+        // first (blocking file I/O), then compose. App logs stay as
+        // loose attachments — the support workflow already expects
+        // them — while the SDK sessions ride along as one zip. A
+        // failed/empty SDK export (e.g. first launch after the update
+        // that enabled file logging) just omits the zip.
+        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
+        let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let appVersion = "\(short) (\(build))"
+        let currentSession = LoggingPreferences.currentSessionDirectory
+
+        Task { [weak self] in
+            let sdkLogsZip = await Task.detached(priority: .userInitiated) { () -> URL? in
+                try? DiagnosticLogExporter.export(
+                    network: network,
+                    appVersion: appVersion,
+                    currentSession: currentSession,
+                    appLogFiles: [])
+            }.value
+            self?.presentSupportEmailController(sdkLogsZip: sdkLogsZip)
+        }
+    }
+
+    private func presentSupportEmailController(sdkLogsZip: URL?) {
         let logFiles = DWLogger.sharedInstance().logFiles()
-        
+
         if MFMailComposeViewController.canSendMail() {
             let mailComposer = MFMailComposeViewController()
             mailComposer.mailComposeDelegate = self as? MFMailComposeViewControllerDelegate
-            
+
             let email = Bundle.main.infoDictionary?["SupportEmail"] as? String ?? ""
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
             mailComposer.setToRecipients([email])
             mailComposer.setSubject(String(format: NSLocalizedString("iOS Dash Wallet: %@ Reported issue", comment: ""), version))
-            
+
+            var totalSize: Int64 = 0
+            let maxSize: Int64 = 25 * 1024 * 1024 // 25MB in bytes
+
+            // SDK sessions first — one compressed zip; the app-log
+            // loop below fills the remaining attachment budget.
+            if let sdkLogsZip, let zipData = try? Data(contentsOf: sdkLogsZip) {
+                mailComposer.addAttachmentData(
+                    zipData,
+                    mimeType: "application/zip",
+                    fileName: sdkLogsZip.lastPathComponent)
+                totalSize += Int64(zipData.count)
+            }
+
             // Sort log files by modification date, most recent first
             let sortedLogFiles = logFiles.sorted { (url1, url2) -> Bool in
                 let date1 = try? url1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
                 let date2 = try? url2.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
                 return (date1 ?? .distantPast) > (date2 ?? .distantPast)
             }
-            
-            var totalSize: Int64 = 0
-            let maxSize: Int64 = 25 * 1024 * 1024 // 25MB in bytes
-            
+
             for logFileURL in sortedLogFiles {
                 guard let logData = try? Data(contentsOf: logFileURL) else {
                     continue
                 }
-                
+
                 // Break if this file would exceed the size limit
                 if totalSize + Int64(logData.count) > maxSize {
                     break
                 }
-                
+
                 let fileName = logFileURL.lastPathComponent
                 let mimeType = fileName.hasSuffix(".gz") ? "application/gzip" : "text/plain"
                 mailComposer.addAttachmentData(logData, mimeType: mimeType, fileName: fileName)
-                                                                
+
                 totalSize += Int64(logData.count)
             }
-            
+
             present(mailComposer, animated: true)
         }
         else {
+            var activityItems: [Any] = logFiles
+            if let sdkLogsZip {
+                activityItems.append(sdkLogsZip)
+            }
             let activityViewController = UIActivityViewController(
-                activityItems: logFiles,
+                activityItems: activityItems,
                 applicationActivities: nil
             )
             present(activityViewController, animated: true)

--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -1,0 +1,350 @@
+//
+//  DiagnosticLogExporter.swift
+//  DashWallet
+//
+//  Bundles the app's diagnostic logs into one shareable zip:
+//
+//   - SwiftDashSDK log sessions — each launch writes one timestamped
+//     directory of per-crate `run.log` files under
+//     `Library/Logs/SwiftDashSDK/` (installed by
+//     `LoggingPreferences.configure()` in `SwiftDashSDKHost`, pruned
+//     by the SDK to 20 sessions / 100 MB). The current run's session
+//     plus up to two before it are included: after a crash, the run
+//     that crashed is usually the session immediately before the
+//     current one.
+//   - The app's own CocoaLumberjack files (`DWLogger`) under
+//     `app-logs/`, newest-first up to a byte cap.
+//   - A `summary.txt` of build/device context.
+//
+//  Nothing is uploaded — callers hand the returned zip to a share
+//  sheet or mail composer and the user decides where it goes.
+//
+//  Session-selection policy and the dependency-free zip are ported
+//  from the SwiftDashSDK example app's `LogExporter`
+//  (platform #4131, `SwiftExampleApp/Services/LogExporter.swift`);
+//  the app-log staging and the two-stream summary are the
+//  dashwallet-specific additions.
+//
+
+import Foundation
+import SwiftDashSDK
+
+enum DiagnosticLogExportError: LocalizedError {
+    case noLogsFound
+    case zipFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noLogsFound:
+            return NSLocalizedString(
+                "No diagnostic logs were found on this device. Logs are written from the next launch onward.",
+                comment: "Log export")
+        case .zipFailed(let reason):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Could not create the log archive: %@", comment: "Log export"),
+                reason)
+        }
+    }
+}
+
+struct DiagnosticLogExporter {
+    /// Current run's SDK session + up to two before it.
+    static let maxSDKSessions = 3
+
+    /// Older SDK sessions stop being added once the archive's raw
+    /// input would pass this. The first selected session (the current
+    /// one when known) is always included even if it alone is bigger.
+    static let maxSDKSessionBytes: UInt64 = 15 * 1024 * 1024
+
+    /// Byte cap for the `app-logs/` group. `DWLogger` rolls at 5 MB ×
+    /// 10 files, so this keeps roughly the two newest rolls without
+    /// letting a pathological logs directory balloon the archive.
+    static let maxAppLogBytes: UInt64 = 10 * 1024 * 1024
+
+    struct SessionCandidate: Equatable {
+        let url: URL
+        let bytes: UInt64
+    }
+
+    /// Blocking (file I/O + compression) — call off the main actor.
+    ///
+    /// - Parameters:
+    ///   - network: display string for `summary.txt`, captured by the
+    ///     caller on the main actor.
+    ///   - appVersion: ditto.
+    ///   - currentSession: `LoggingPreferences.currentSessionDirectory`,
+    ///     captured by the caller on the main actor. `nil` when file
+    ///     logging didn't install this launch — the export then falls
+    ///     back to newest-on-disk ordering and says so in the summary.
+    ///   - appLogFiles: `DWLogger.sharedInstance().logFiles()`,
+    ///     captured by the caller (the shared logger is main-thread
+    ///     app infrastructure).
+    static func export(
+        network: String,
+        appVersion: String,
+        currentSession: URL?,
+        appLogFiles: [URL]
+    ) throws -> URL {
+        let fm = FileManager.default
+
+        // SDK sessions on disk (may be empty — e.g. first launch after
+        // the update that enabled file logging crashed early).
+        let onDisk: [URL]
+        if let root = LoggingPreferences.logsRootDirectory,
+           let entries = try? fm.contentsOfDirectory(
+               at: root,
+               includingPropertiesForKeys: [.isDirectoryKey],
+               options: [.skipsHiddenFiles]
+           ) {
+            onDisk = entries.filter {
+                (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            }
+        } else {
+            onDisk = []
+        }
+
+        let currentOnDisk = currentSession.flatMap { session in
+            onDisk.first { $0.lastPathComponent == session.lastPathComponent }
+        }
+        let current = currentOnDisk.map {
+            SessionCandidate(url: $0, bytes: directorySize(of: $0))
+        }
+        let others = onDisk
+            .filter { $0.lastPathComponent != currentOnDisk?.lastPathComponent }
+            .map { SessionCandidate(url: $0, bytes: directorySize(of: $0)) }
+        let selectedSessions = selectSessions(current: current, others: others)
+
+        let selectedAppLogs = selectAppLogs(appLogFiles)
+
+        guard !selectedSessions.isEmpty || !selectedAppLogs.isEmpty else {
+            throw DiagnosticLogExportError.noLogsFound
+        }
+
+        // Archive stamp: the newest included SDK session, or the
+        // export moment when only app logs exist.
+        let stamp: String
+        if let first = selectedSessions.first {
+            stamp = first.url.lastPathComponent
+        } else {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss'Z'"
+            stamp = formatter.string(from: Date())
+        }
+        let archiveName = "DashWallet-logs-\(stamp)"
+        let scratch = fm.temporaryDirectory
+            .appendingPathComponent("LogExport-\(UUID().uuidString)", isDirectory: true)
+        let staging = scratch.appendingPathComponent(archiveName, isDirectory: true)
+        defer { try? fm.removeItem(at: scratch) }
+
+        try fm.createDirectory(at: staging, withIntermediateDirectories: true)
+        for session in selectedSessions {
+            try fm.copyItem(
+                at: session.url,
+                to: staging.appendingPathComponent(session.url.lastPathComponent, isDirectory: true)
+            )
+        }
+        if !selectedAppLogs.isEmpty {
+            let appLogsDir = staging.appendingPathComponent("app-logs", isDirectory: true)
+            try fm.createDirectory(at: appLogsDir, withIntermediateDirectories: true)
+            for file in selectedAppLogs {
+                try fm.copyItem(
+                    at: file,
+                    to: appLogsDir.appendingPathComponent(file.lastPathComponent)
+                )
+            }
+        }
+
+        let summary = summaryText(
+            network: network,
+            appVersion: appVersion,
+            selectedSessions: selectedSessions,
+            currentIsKnown: current != nil,
+            totalSessionsOnDevice: onDisk.count,
+            appLogCount: selectedAppLogs.count,
+            totalAppLogsOnDevice: appLogFiles.count
+        )
+        try summary.write(
+            to: staging.appendingPathComponent("summary.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let zipURL = fm.temporaryDirectory.appendingPathComponent("\(archiveName).zip")
+        if fm.fileExists(atPath: zipURL.path) {
+            try? fm.removeItem(at: zipURL)
+        }
+        try zipDirectory(at: staging, to: zipURL)
+        return zipURL
+    }
+
+    /// Pure SDK-session selection policy, split out for unit testing.
+    ///
+    /// The current session (when known) is always first and always
+    /// included, no matter how its timestamp sorts against the rest —
+    /// it's the authoritative record of this run, not a candidate.
+    /// Older sessions then fill the remaining slots newest-first until
+    /// either cap is hit. The walk stops at the first session that
+    /// would breach the byte cap rather than skipping past it: a gap
+    /// in the middle of "the last three runs" would be more confusing
+    /// than a shorter archive.
+    static func selectSessions(
+        current: SessionCandidate?,
+        others: [SessionCandidate],
+        maxSessions: Int = DiagnosticLogExporter.maxSDKSessions,
+        maxTotalBytes: UInt64 = DiagnosticLogExporter.maxSDKSessionBytes
+    ) -> [SessionCandidate] {
+        var selected: [SessionCandidate] = []
+        var totalBytes: UInt64 = 0
+
+        if let current {
+            selected.append(current)
+            totalBytes = current.bytes
+        }
+
+        // Fixed-width UTC stamps: lexicographic == chronological.
+        let newestFirst = others.sorted {
+            $0.url.lastPathComponent > $1.url.lastPathComponent
+        }
+        for candidate in newestFirst {
+            guard selected.count < maxSessions else { break }
+            if !selected.isEmpty && totalBytes + candidate.bytes > maxTotalBytes { break }
+            selected.append(candidate)
+            totalBytes += candidate.bytes
+        }
+        return selected
+    }
+
+    /// App-log selection: newest-first (by modification date) until
+    /// the byte cap. The newest file is always included even if it
+    /// alone exceeds the cap — an empty `app-logs/` group would be
+    /// worse than a slightly oversized one.
+    static func selectAppLogs(
+        _ files: [URL],
+        maxTotalBytes: UInt64 = DiagnosticLogExporter.maxAppLogBytes
+    ) -> [URL] {
+        let described: [(url: URL, bytes: UInt64, modified: Date)] = files.map { url in
+            let values = try? url.resourceValues(
+                forKeys: [.fileSizeKey, .contentModificationDateKey])
+            return (
+                url: url,
+                bytes: UInt64(values?.fileSize ?? 0),
+                modified: values?.contentModificationDate ?? .distantPast
+            )
+        }
+        var selected: [URL] = []
+        var totalBytes: UInt64 = 0
+        for file in described.sorted(by: { $0.modified > $1.modified }) {
+            if !selected.isEmpty && totalBytes + file.bytes > maxTotalBytes { break }
+            selected.append(file.url)
+            totalBytes += file.bytes
+        }
+        return selected
+    }
+
+    /// Zip without third-party dependencies: a coordinated read with
+    /// `.forUploading` makes the system produce a zip of a directory
+    /// in a temporary location that is only valid inside the accessor,
+    /// so the copy to `destination` happens in the block.
+    private static func zipDirectory(at source: URL, to destination: URL) throws {
+        var coordinatorError: NSError?
+        var copyError: Error?
+        NSFileCoordinator().coordinate(
+            readingItemAt: source,
+            options: .forUploading,
+            error: &coordinatorError
+        ) { zippedURL in
+            do {
+                try FileManager.default.copyItem(at: zippedURL, to: destination)
+            } catch {
+                copyError = error
+            }
+        }
+        if let coordinatorError {
+            throw DiagnosticLogExportError.zipFailed(coordinatorError.localizedDescription)
+        }
+        if let copyError {
+            throw DiagnosticLogExportError.zipFailed(copyError.localizedDescription)
+        }
+    }
+
+    private static func directorySize(of directory: URL) -> UInt64 {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileSizeKey]
+        ) else { return 0 }
+
+        var total: UInt64 = 0
+        for case let file as URL in enumerator {
+            let values = try? file.resourceValues(
+                forKeys: [.totalFileAllocatedSizeKey, .fileSizeKey]
+            )
+            total += UInt64(values?.totalFileAllocatedSize ?? values?.fileSize ?? 0)
+        }
+        return total
+    }
+
+    private static func summaryText(
+        network: String,
+        appVersion: String,
+        selectedSessions: [SessionCandidate],
+        currentIsKnown: Bool,
+        totalSessionsOnDevice: Int,
+        appLogCount: Int,
+        totalAppLogsOnDevice: Int
+    ) -> String {
+        let iso = ISO8601DateFormatter()
+        let sizeFormatter = ByteCountFormatter()
+        sizeFormatter.countStyle = .file
+
+        var machine = utsname()
+        uname(&machine)
+        let model = withUnsafeBytes(of: &machine.machine) { raw in
+            String(decoding: raw.prefix(while: { $0 != 0 }), as: UTF8.self)
+        }
+        #if targetEnvironment(simulator)
+        let environment = "simulator"
+        #else
+        let environment = "device"
+        #endif
+
+        var lines: [String] = [
+            "Dash Wallet diagnostic log export",
+            "Generated: \(iso.string(from: Date()))",
+            "",
+            "App version: \(appVersion)",
+            "OS: \(ProcessInfo.processInfo.operatingSystemVersionString)",
+            "Hardware: \(model) (\(environment))",
+            "Network: \(network)",
+            "",
+            "SwiftDashSDK sessions included (one directory per app launch):",
+        ]
+        if selectedSessions.isEmpty {
+            lines.append("  none on this device (file logging starts on the next launch)")
+        }
+        for (index, session) in selectedSessions.enumerated() {
+            let role: String
+            switch (index, currentIsKnown) {
+            case (0, true): role = "current session"
+            case (0, false):
+                role = "newest session on disk (current session unknown — "
+                    + "file logging was not active this launch)"
+            case (1, _): role = "previous session — after a crash, the crashed run is usually this one"
+            default: role = "older session"
+            }
+            lines.append(
+                "  \(session.url.lastPathComponent)  "
+                    + "[\(sizeFormatter.string(fromByteCount: Int64(session.bytes)))] — \(role)"
+            )
+        }
+        lines.append("")
+        lines.append(
+            "Included \(selectedSessions.count) of \(totalSessionsOnDevice) SDK session(s) "
+                + "(limit: \(maxSDKSessions) sessions / "
+                + "\(sizeFormatter.string(fromByteCount: Int64(maxSDKSessionBytes))) raw) and "
+                + "\(appLogCount) of \(totalAppLogsOnDevice) app log file(s) under app-logs/ "
+                + "(limit: \(sizeFormatter.string(fromByteCount: Int64(maxAppLogBytes)))).")
+        return lines.joined(separator: "\n") + "\n"
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -63,16 +63,22 @@ final class SwiftDashSDKHost {
         if !sdkInitialized {
             // Install the SDK's Rust tracing subscriber BEFORE init so
             // wallet-side diagnostics (DashPay sync passes, payment
-            // reconciles, SPV events) reach the console. Without this
+            // reconciles, SPV events) are captured. Without this
             // every `tracing::warn!` in rs-platform-wallet is silently
             // dropped — the payments-attribution debugging session of
             // 2026-07-08 flew blind because of it. `RUST_LOG` overrides
             // the level when set (dev runs: SIMCTL_CHILD_RUST_LOG=…).
-            #if DEBUG
-            SDK.enableLogging(level: .info)
-            #else
-            SDK.enableLogging(level: .warn)
-            #endif
+            //
+            // `LoggingPreferences.configure()` installs FILE logging at
+            // .info (simulator and device): one timestamped session
+            // directory of per-crate `run.log` files per launch under
+            // `Library/Logs/SwiftDashSDK/`, pruned by the SDK to 20
+            // sessions / 100 MB. Nothing leaves the device — the
+            // sessions exist so `DiagnosticLogExporter` (Tools → Export
+            // Logs, support email) can bundle them when the user asks.
+            // Falls back to console logging when the log root isn't
+            // writable.
+            LoggingPreferences.configure()
             SDK.initialize()
             sdkInitialized = true
         }

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
@@ -150,6 +150,28 @@ struct ToolsMenuScreen: View {
                 ActivityView(activityItems: [csvData.file])
             }
         }
+        .sheet(
+            isPresented: Binding(
+                get: { viewModel.exportedLogsURL != nil },
+                set: { if !$0 { viewModel.exportedLogsURL = nil } }
+            )
+        ) {
+            if let url = viewModel.exportedLogsURL {
+                ActivityView(activityItems: [url])
+            }
+        }
+        .alert(
+            NSLocalizedString("Export Logs", comment: "Log export"),
+            isPresented: Binding(
+                get: { viewModel.logExportErrorMessage != nil },
+                set: { if !$0 { viewModel.logExportErrorMessage = nil } }
+            ),
+            presenting: viewModel.logExportErrorMessage
+        ) { _ in
+            Button(NSLocalizedString("OK", comment: "")) { viewModel.logExportErrorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
         .sheet(isPresented: $showZenLedgerSheet, onDismiss: {
             if let link = viewModel.safariLink {
                 openSafariLink(link)

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Combine
+import SwiftDashSDK
 
 enum ToolsMenuNavigationDestination {
     case extendedPublicKeys
@@ -37,6 +38,13 @@ class ToolsMenuViewModel: ObservableObject {
     @Published var safariLink: String?
     @Published var showCoinJoinSweepConfirmation = false
     @Published var coinJoinSweepErrorMessage: String?
+    /// True while the diagnostic-log archive is being staged + zipped
+    /// (file I/O off the main actor). Guards re-entry from row taps.
+    @Published var isExportingLogs = false
+    /// Non-nil presents the share sheet with the finished zip.
+    @Published var exportedLogsURL: URL?
+    /// Non-nil presents the log-export failure alert.
+    @Published var logExportErrorMessage: String?
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -116,6 +124,14 @@ class ToolsMenuViewModel: ObservableObject {
                 }
             ),
             MenuItemModel(
+                title: NSLocalizedString("Export Logs", comment: "Log export"),
+                subtitle: NSLocalizedString("Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files", comment: "Log export"),
+                icon: .system("square.and.arrow.up"),
+                action: { [weak self] in
+                    self?.exportDiagnosticLogs()
+                }
+            ),
+            MenuItemModel(
                 title: "Storage Explorer",
                 icon: .system("cylinder.split.1x2"),
                 action: { [weak self] in
@@ -169,6 +185,51 @@ class ToolsMenuViewModel: ObservableObject {
         }
     }
     
+    /// Zip the recent diagnostic logs (SwiftDashSDK sessions + app
+    /// CocoaLumberjack files) and hand the archive to the share sheet.
+    /// The staging + compression is file I/O, so it runs detached;
+    /// only the resulting URL (or error) comes back to the main actor.
+    /// Mirrors the export flow the SwiftDashSDK example app shipped in
+    /// platform #4131.
+    func exportDiagnosticLogs() {
+        guard !isExportingLogs else { return }
+        isExportingLogs = true
+
+        // Context captured on the main actor; the detached task only
+        // does file work.
+        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
+        let bundle = Bundle.main
+        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let appVersion = "\(short) (\(build))"
+        // Authoritative record of which directory this run is writing
+        // to — timestamp sorting alone can be fooled by a clock
+        // rollback or a stale future-dated directory.
+        let currentSession = LoggingPreferences.currentSessionDirectory
+        let appLogFiles = DWLogger.sharedInstance().logFiles()
+
+        Task.detached(priority: .userInitiated) {
+            let result: Result<URL, Error> = Result {
+                try DiagnosticLogExporter.export(
+                    network: network,
+                    appVersion: appVersion,
+                    currentSession: currentSession,
+                    appLogFiles: appLogFiles
+                )
+            }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.isExportingLogs = false
+                switch result {
+                case .success(let url):
+                    self.exportedLogsURL = url
+                case .failure(let error):
+                    self.logExportErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
     func resetNavigation() {
         navigationDestination = nil
         showCSVExportActivity = false

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -106,8 +106,17 @@
 /* Usernames */
 "Add to your Shielded balance now and register your username privately a few hours later" = "Add to your Shielded balance now and register your username privately a few hours later";
 
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files";
+
+/* Log export */
+"Could not create the log archive: %@" = "Could not create the log archive: %@";
+
 /* Usernames */
 "Done — your balance has rested long enough" = "Done — your balance has rested long enough";
+
+/* Log export */
+"Export Logs" = "Export Logs";
 
 /* Usernames */
 "Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.";
@@ -123,6 +132,9 @@
 
 /* DashPay */
 "No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing.";
+
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "No diagnostic logs were found on this device. Logs are written from the next launch onward.";
 
 /* DashPay */
 "Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";

--- a/DashWalletTests/DiagnosticLogExporterTests.swift
+++ b/DashWalletTests/DiagnosticLogExporterTests.swift
@@ -1,0 +1,159 @@
+//
+//  DiagnosticLogExporterTests.swift
+//  DashWalletTests
+//
+//  Behavioral tests for the pure selection policies in
+//  `DiagnosticLogExporter` — which SDK log sessions and which app log
+//  files go into a diagnostic export.
+//
+//  Session-policy invariants (mirroring the SwiftDashSDK example
+//  app's `LogExporterSelectionTests`, the source of the ported
+//  policy):
+//  - the caller-provided current session is authoritative: always
+//    first and always included, regardless of how its timestamp sorts
+//    against other directories and regardless of the byte cap;
+//  - older sessions fill remaining slots newest-first, subject to the
+//    session-count cap and the total-bytes cap;
+//  - the walk stops at the first over-budget session instead of
+//    skipping past it, so the archive is a contiguous run of the most
+//    recent history;
+//  - with no known current session, the newest directory on disk
+//    still gets exported.
+//
+//  App-log invariants: newest-first by modification date under a byte
+//  cap; the newest file is always included even when it alone exceeds
+//  the cap.
+//
+//  NOTE: the DashWalletTests bundle is pre-existing broken (see
+//  DWRegistrationPhaseAdapterTests). These are compile-ready
+//  documentation-as-tests until the bundle is repaired.
+//
+
+import XCTest
+@testable import dashwallet
+
+final class DiagnosticLogExporterTests: XCTestCase {
+    private func candidate(_ stamp: String, bytes: UInt64) -> DiagnosticLogExporter.SessionCandidate {
+        DiagnosticLogExporter.SessionCandidate(
+            url: URL(fileURLWithPath: "/logs/\(stamp)", isDirectory: true),
+            bytes: bytes
+        )
+    }
+
+    // MARK: - SDK session selection
+
+    func testCurrentSessionIsFirstEvenWhenOlderStampedThanOthers() {
+        // A stale future-dated directory sorts lexicographically after
+        // the real current session. It must not displace it.
+        let current = candidate("2026-07-15T10-00-00Z", bytes: 100)
+        let futureStale = candidate("2027-01-01T00-00-00Z", bytes: 100)
+        let previous = candidate("2026-07-14T09-00-00Z", bytes: 100)
+
+        let selected = DiagnosticLogExporter.selectSessions(
+            current: current,
+            others: [previous, futureStale]
+        )
+
+        XCTAssertEqual(selected.first, current)
+        XCTAssertEqual(selected.count, 3)
+        XCTAssertEqual(selected[1], futureStale)
+        XCTAssertEqual(selected[2], previous)
+    }
+
+    func testSessionCountCap() {
+        let current = candidate("2026-07-15T10-00-00Z", bytes: 1)
+        let others = (1...5).map {
+            candidate("2026-07-10T0\($0)-00-00Z", bytes: 1)
+        }
+
+        let selected = DiagnosticLogExporter.selectSessions(current: current, others: others)
+
+        XCTAssertEqual(selected.count, DiagnosticLogExporter.maxSDKSessions)
+        XCTAssertEqual(selected.first, current)
+        XCTAssertEqual(
+            selected.dropFirst().map { $0.url.lastPathComponent },
+            ["2026-07-10T05-00-00Z", "2026-07-10T04-00-00Z"]
+        )
+    }
+
+    func testByteCapStopsAtFirstOverBudgetSession() {
+        let current = candidate("2026-07-15T10-00-00Z", bytes: 4)
+        // The big middle session breaches the cap; the walk must stop
+        // there, NOT skip past it to the small older one.
+        let big = candidate("2026-07-14T09-00-00Z", bytes: 100)
+        let small = candidate("2026-07-13T08-00-00Z", bytes: 1)
+
+        let selected = DiagnosticLogExporter.selectSessions(
+            current: current,
+            others: [big, small],
+            maxTotalBytes: 10
+        )
+
+        XCTAssertEqual(selected, [current])
+    }
+
+    func testCurrentAlwaysIncludedEvenWhenAloneOverBudget() {
+        let current = candidate("2026-07-15T10-00-00Z", bytes: 1_000)
+
+        let selected = DiagnosticLogExporter.selectSessions(
+            current: current,
+            others: [],
+            maxTotalBytes: 10
+        )
+
+        XCTAssertEqual(selected, [current])
+    }
+
+    func testNoCurrentSessionFallsBackToNewestOnDisk() {
+        let older = candidate("2026-07-13T08-00-00Z", bytes: 1)
+        let newest = candidate("2026-07-14T09-00-00Z", bytes: 1)
+
+        let selected = DiagnosticLogExporter.selectSessions(
+            current: nil,
+            others: [older, newest]
+        )
+
+        XCTAssertEqual(selected.first, newest)
+        XCTAssertEqual(selected.count, 2)
+    }
+
+    // MARK: - App-log selection
+
+    /// Temp files with controlled sizes + modification dates —
+    /// `selectAppLogs` reads both from the filesystem.
+    private func makeTempLog(name: String, bytes: Int, modified: Date) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DiagnosticLogExporterTests", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try Data(count: bytes).write(to: url)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modified], ofItemAtPath: url.path)
+        return url
+    }
+
+    func testAppLogsSelectedNewestFirstUnderByteCap() throws {
+        let newest = try makeTempLog(name: "c.log", bytes: 4, modified: Date(timeIntervalSince1970: 300))
+        let middle = try makeTempLog(name: "b.log", bytes: 4, modified: Date(timeIntervalSince1970: 200))
+        let oldest = try makeTempLog(name: "a.log", bytes: 4, modified: Date(timeIntervalSince1970: 100))
+
+        let selected = DiagnosticLogExporter.selectAppLogs(
+            [oldest, newest, middle],
+            maxTotalBytes: 8
+        )
+
+        XCTAssertEqual(selected, [newest, middle])
+    }
+
+    func testNewestAppLogIncludedEvenWhenAloneOverCap() throws {
+        let huge = try makeTempLog(name: "huge.log", bytes: 64, modified: Date(timeIntervalSince1970: 300))
+        let old = try makeTempLog(name: "old.log", bytes: 1, modified: Date(timeIntervalSince1970: 100))
+
+        let selected = DiagnosticLogExporter.selectAppLogs(
+            [old, huge],
+            maxTotalBytes: 10
+        )
+
+        XCTAssertEqual(selected, [huge])
+    }
+}


### PR DESCRIPTION
## What

dashwallet port of [platform #4131](https://github.com/dashpay/platform/pull/4131) (the SwiftDashSDK example app's in-app log export): make the SDK's Rust-side diagnostics **persist on beta devices** and give users a one-tap way to hand them to us.

Until now the SDK's tracing output (`SDK.enableLogging`) went to the console only — a TestFlight user reporting a sync or shielded-spend problem could attach the app's own CocoaLumberjack logs (Report an Issue email) but never the Rust traces where the actual SPV/DashPay/shielded story lives.

## Changes

**File logging on (SDK side already shipped in #4131 — this just adopts it)**
`SwiftDashSDKHost.ensureSDKInitialized` now calls `LoggingPreferences.configure()` instead of bare `SDK.enableLogging`. Each launch writes one timestamped session directory of per-crate `run.log` files under `Library/Logs/SwiftDashSDK/`, on simulator **and device**, at `.info`. The SDK prunes to 20 sessions / 100 MB at startup; falls back to console logging when the log root isn't writable. Nothing leaves the device until the user exports.

**`DiagnosticLogExporter`** (new, both app targets) — stages and zips:
- the current run's SDK session + up to two before it (15 MB raw cap; after a crash, the crashed run is usually the previous session). The current session is passed in from `LoggingPreferences.currentSessionDirectory`, never inferred from timestamp order (clock rollbacks / stale future-dated dirs can't displace it);
- the newest `DWLogger` CocoaLumberjack files under `app-logs/` (10 MB cap) — the dashwallet twist: one archive carries both log streams;
- a `summary.txt` with app version, OS, hardware, network, and per-session roles.

Zip is dependency-free (`NSFileCoordinator` `.forUploading`). Selection policies are pure static functions; the SDK-session policy is byte-for-byte the example app's test-covered one.

**UI**
- **Tools → Export Logs**: stages off the main actor, then presents a share sheet with the zip (AirDrop / Mail / Files); failure shows an alert. Mirrors the existing CSV-export presentation pattern.
- **Report an Issue** (support email): now also attaches a `DashWallet-logs-<stamp>.zip` of the SDK sessions alongside the existing loose app-log attachments, counted against the same 25 MB budget. When no sessions exist yet (first launch after this update) the zip is silently omitted and the email behaves exactly as before. The no-Mail fallback share sheet includes the zip too.

**Tests**: compile-ready `DiagnosticLogExporterTests` mirror the upstream selection invariants (current-session authority, count cap, stop-at-first-over-budget, no-current fallback) plus the app-log newest-first/byte-cap policy. (Test bundle remains pre-existing broken.)

## Verification

- `dashpay` Debug arm64-sim build green; `plutil -lint` clean (pbxproj + en strings; string additions purely additive).
- Registered in **both** app targets (its consumers — host, Tools menu, support email — are in both).

### QA smoke (needs a driver)
1. Launch → relaunch (two sessions exist) → Tools → Export Logs → share sheet appears; save to Files and confirm the zip contains two session dirs + `app-logs/` + `summary.txt`.
2. Report an Issue → mail composer shows the SDK zip attachment alongside the usual `.log` files.
3. First-launch case: wipe app, install, immediately Report an Issue → email composes without the zip (no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)