### PR TITLE
fix(ui): address review findings and improve UI contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ TODO.md
 */Coinbase-Info.plist
 */ZenLedger-Info.plist
 */SwapKit-Info.plist
+*/Uphold-Info.plist
 
 # SQLite temporary files
 *.db-shm

--- a/DashWallet/Sources/UI/Swap/Buy/RefundAddress/RefundAddressView.swift
+++ b/DashWallet/Sources/UI/Swap/Buy/RefundAddress/RefundAddressView.swift
@@ -23,6 +23,7 @@ import UIKit
 
 struct RefundAddressView: View {
     @ObservedObject var viewModel: RefundAddressViewModel
+    @Environment(\.colorScheme) private var colorScheme
 
     var onBack: (() -> Void)?
     var onScanQR: (() -> Void)?
@@ -49,7 +50,7 @@ struct RefundAddressView: View {
                         title: NSLocalizedString("The refund address is required", comment: "Dash DEX"),
                         subtitle: NSLocalizedString("Your swap can NOT be processed without a refund address", comment: "Dash DEX"),
                         icon: .custom("info-rect", bundle: .dashUIKit),
-                        backgroundColor: Color.dash.blueAlpha5,
+                        backgroundColor: colorScheme == .dark ? Color.dash.blueAlpha10 : Color.dash.blueAlpha5,
                         onClose: {}
                     )
 

--- a/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewView.swift
+++ b/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewView.swift
@@ -107,7 +107,7 @@ struct OrderPreviewView: View {
 
                         Text(NSLocalizedString("Quote expires", comment: "Dash DEX"))
                             .dashFont(.subheadMedium)
-                            .foregroundColor(Color.dash.black)
+                            .foregroundColor(Color.dash.primaryText)
                     }
 
                     Spacer(minLength: 0)
@@ -115,7 +115,7 @@ struct OrderPreviewView: View {
                     //Timer ~ 10 sec
                     Text(viewModel.timerText)
                         .dashFont(.subheadMedium)
-                        .foregroundColor(Color.dash.black)
+                        .foregroundColor(Color.dash.primaryText)
                 }
                 .padding(.horizontal, 20)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Address review feedback in the Coinbase and swap flows, and improve contrast on the refund address and order preview screens. This branch intentionally excludes `Localizable.strings` updates.


## What was done?
- Added a bounded lookback when Coinbase receive timestamp metadata is unavailable so valid wallet receives are not missed.
- Ensured `SwapOrdersDAO` hydrates on subscription and returns publishers correctly from `observeAll()` / `observeActive()`.
- Fixed `CoinbaseMetadataProvider` so metadata state is committed before update notifications are published.
- Removed the DASH-denominated fallback in coin-mode max-amount messaging when the crypto rate is unavailable.
- Improved dark-mode contrast on the swap refund address and order preview screens.


## How Has This Been Tested?
- Ran `git diff --check` on the touched Swift files.
- Ran `swiftlint lint --no-cache` on the touched Swift files.
- Reviewed the staged diff to confirm only the intended code changes are included.


## Breaking Changes
None.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone