### PR TITLE
fix(wallet): imported wallets scan from genesis, not from the newest checkpoint

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -86,6 +86,18 @@ final class SwiftDashSDKHost {
 
     private init() {}
 
+    // MARK: - Import scan floor
+
+    /// Birth height for imported / unknown-provenance mnemonics, per
+    /// network. Mainnet imports scan from block 200,000 rather than
+    /// genesis (owner decision 2026-07-15): early-2015 and older
+    /// blocks predate any wallet this app could import, so starting
+    /// there skips a year of filter work without risking missed
+    /// funds. Testnet (and anything else) scans from 0.
+    static func importedWalletBirthHeight(for network: Network) -> UInt32 {
+        network == .mainnet ? 200_000 : 0
+    }
+
     // MARK: - Wallet presence
 
     /// True when at least one SDK wallet mnemonic is persisted in
@@ -265,11 +277,14 @@ final class SwiftDashSDKHost {
                 network: handles.network,
                 modelContainer: handles.modelContainer,
                 // Imported mnemonics may hold history from long before
-                // this device: birth height 0 makes SPV scan from
-                // genesis (the SDK's documented import semantics).
-                // Freshly generated mnemonics keep nil — nothing can
-                // predate them, so the scan anchors at the tip.
-                birthHeight: isImported ? 0 : nil)
+                // this device: scan from the network's import floor
+                // (genesis on testnet, block 200,000 on mainnet — see
+                // `importedWalletBirthHeight`). Freshly generated
+                // mnemonics keep nil — nothing can predate them, so
+                // the scan anchors at the tip.
+                birthHeight: isImported
+                    ? Self.importedWalletBirthHeight(for: handles.network)
+                    : nil)
         } catch {
             // `createOrImportWallet` owns a freshly-built (not yet published)
             // runtime, so tear it down on failure. `createAndPersist` has
@@ -340,8 +355,11 @@ final class SwiftDashSDKHost {
             network: network,
             modelContainer: modelContainer,
             // Same semantics as `createOrImportWallet`: imports scan
-            // from genesis, freshly generated wallets from the tip.
-            birthHeight: isImported ? 0 : nil)
+            // from the network's import floor, freshly generated
+            // wallets from the tip.
+            birthHeight: isImported
+                ? Self.importedWalletBirthHeight(for: network)
+                : nil)
 
         Self.logger.info("🪺 HOST :: added managed wallet for \(network.rawValue, privacy: .public) (additive)")
         return .added(walletId: createdWallet.walletId)
@@ -556,10 +574,11 @@ final class SwiftDashSDKHost {
                     // existed on this network (first switch). Its true
                     // creation height is unknown and the wallet may
                     // hold history from long before this registration,
-                    // so scan from genesis — the conservative-correct
-                    // choice; a needless full scan is recoverable, a
-                    // tip-anchored miss of old funds is not.
-                    birthHeight: 0)
+                    // so scan from the network's import floor — the
+                    // conservative-correct choice; a needless full
+                    // scan is recoverable, a tip-anchored miss of old
+                    // funds is not.
+                    birthHeight: Self.importedWalletBirthHeight(for: handles.network))
                 if created.walletId != entry.walletId {
                     try? storage.storeMnemonic(entry.mnemonic, for: created.walletId)
                 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -242,7 +242,7 @@ final class SwiftDashSDKHost {
     /// publishes it as bound. Onboarding's first wallet uses this.
     ///
     /// For adding a wallet ALONGSIDE existing ones without rebinding the
-    /// active wallet, use `addWallet(mnemonic:)` instead — this path replaces
+    /// active wallet, use `addWallet(mnemonic:isImported:)` instead — this path replaces
     /// the running runtime and is not additive.
     @discardableResult
     func createOrImportWallet(
@@ -263,7 +263,13 @@ final class SwiftDashSDKHost {
                 mnemonic: mnemonic,
                 manager: handles.manager,
                 network: handles.network,
-                modelContainer: handles.modelContainer)
+                modelContainer: handles.modelContainer,
+                // Imported mnemonics may hold history from long before
+                // this device: birth height 0 makes SPV scan from
+                // genesis (the SDK's documented import semantics).
+                // Freshly generated mnemonics keep nil — nothing can
+                // predate them, so the scan anchors at the tip.
+                birthHeight: isImported ? 0 : nil)
         } catch {
             // `createOrImportWallet` owns a freshly-built (not yet published)
             // runtime, so tear it down on failure. `createAndPersist` has
@@ -282,7 +288,7 @@ final class SwiftDashSDKHost {
         return createdWallet
     }
 
-    /// Outcome of `addWallet(mnemonic:)`.
+    /// Outcome of `addWallet(mnemonic:isImported:)`.
     enum AddWalletResult {
         /// The wallet was created and its mnemonic persisted; the running
         /// runtime is unchanged (the caller switches to it explicitly).
@@ -308,7 +314,7 @@ final class SwiftDashSDKHost {
     /// `createOrImportWallet` (`createAndPersist`); differs only in that it
     /// uses the LIVE manager and does not publish or set-active.
     @discardableResult
-    func addWallet(mnemonic: String) throws -> AddWalletResult {
+    func addWallet(mnemonic: String, isImported: Bool) throws -> AddWalletResult {
         guard !mnemonic.isEmpty, Mnemonic.validate(mnemonic) else {
             throw HostError.invalidMnemonic
         }
@@ -332,7 +338,10 @@ final class SwiftDashSDKHost {
             mnemonic: mnemonic,
             manager: manager,
             network: network,
-            modelContainer: modelContainer)
+            modelContainer: modelContainer,
+            // Same semantics as `createOrImportWallet`: imports scan
+            // from genesis, freshly generated wallets from the tip.
+            birthHeight: isImported ? 0 : nil)
 
         Self.logger.info("🪺 HOST :: added managed wallet for \(network.rawValue, privacy: .public) (additive)")
         return .added(walletId: createdWallet.walletId)
@@ -344,11 +353,17 @@ final class SwiftDashSDKHost {
     /// `HostError`. Does NOT touch the registry, publish, or stop the host —
     /// runtime bookkeeping is the caller's (so this body is shared by the
     /// rebuild path `createOrImportWallet` and the additive `addWallet`).
+    /// `birthHeight` follows the SDK's `createWallet` contract: `nil`
+    /// anchors the SPV scan at the current tip (fresh mnemonic — with
+    /// unsynced headers the SDK falls back to the network's newest
+    /// hardcoded checkpoint), `0` scans from genesis (imported mnemonic
+    /// whose history predates this device).
     private func createAndPersist(
         mnemonic: String,
         manager: PlatformWalletManager,
         network: Network,
-        modelContainer: ModelContainer
+        modelContainer: ModelContainer,
+        birthHeight: UInt32?
     ) throws -> ManagedPlatformWallet {
         let createdWallet: ManagedPlatformWallet
         do {
@@ -356,7 +371,8 @@ final class SwiftDashSDKHost {
                 mnemonic: mnemonic,
                 network: network,
                 name: "dashwallet",
-                createDefaultAccounts: true)
+                createDefaultAccounts: true,
+                birthHeight: birthHeight)
         } catch {
             Self.logger.error("🪺 HOST :: createWallet failed: \(String(describing: error), privacy: .public)")
             throw HostError.walletCreationFailed(error)
@@ -534,7 +550,16 @@ final class SwiftDashSDKHost {
                     mnemonic: entry.mnemonic,
                     network: handles.network,
                     name: "dashwallet",
-                    createDefaultAccounts: true)
+                    createDefaultAccounts: true,
+                    // This path registers a keychain mnemonic whose
+                    // SwiftData rows are gone (reinstall) or never
+                    // existed on this network (first switch). Its true
+                    // creation height is unknown and the wallet may
+                    // hold history from long before this registration,
+                    // so scan from genesis — the conservative-correct
+                    // choice; a needless full scan is recoverable, a
+                    // tip-anchored miss of old funds is not.
+                    birthHeight: 0)
                 if created.walletId != entry.walletId {
                     try? storage.storeMnemonic(entry.mnemonic, for: created.walletId)
                 }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -200,7 +200,7 @@ final class WalletsViewModel: ObservableObject {
 
         let result: SwiftDashSDKHost.AddWalletResult
         do {
-            result = try SwiftDashSDKHost.shared.addWallet(mnemonic: normalized)
+            result = try SwiftDashSDKHost.shared.addWallet(mnemonic: normalized, isImported: isImported)
         } catch {
             Self.logger.error("addWallet failed: \(String(describing: error), privacy: .public)")
             errorMessage = error.localizedDescription

--- a/DashWallet/Sources/UI/Menu/Tools/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/SwiftDashSDKSPVStatusScreen.swift
@@ -171,7 +171,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
             Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
         } message: {
             Text(NSLocalizedString(
-                "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device.",
+                "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet.",
                 comment: "SPV diagnostics"))
         }
         .alert(

--- a/DashWallet/Sources/UI/Menu/Tools/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/SwiftDashSDKSPVStatusScreen.swift
@@ -50,6 +50,16 @@ struct SwiftDashSDKSPVStatusScreen: View {
     @State private var rescanResultMessage: String?
     @State private var rescanResultIsError = false
 
+    /// Presents the birth-height edit alert (numeric entry, mirrors the
+    /// "From height…" rescan alert).
+    @State private var showBirthHeightEntry = false
+    /// Bound to the birth-height text field; validated to a `UInt32`
+    /// before use, never defaulted.
+    @State private var birthHeightEntryText = ""
+    /// Non-nil presents the post-save "rescan now?" prompt carrying the
+    /// height that was just written.
+    @State private var savedBirthHeightPendingRescan: UInt32?
+
     init(vc: UINavigationController) {
         self.vc = vc
     }
@@ -147,6 +157,43 @@ struct SwiftDashSDKSPVStatusScreen: View {
                 "Enter the core block height to re-check filters from.",
                 comment: "SPV diagnostics"))
         }
+        .alert(
+            NSLocalizedString("Edit birth height", comment: "SPV diagnostics"),
+            isPresented: $showBirthHeightEntry
+        ) {
+            TextField(
+                NSLocalizedString("Block height", comment: "SPV diagnostics"),
+                text: $birthHeightEntryText)
+                .keyboardType(.numberPad)
+            Button(NSLocalizedString("Save", comment: "")) {
+                saveEnteredBirthHeight()
+            }
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString(
+                "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device.",
+                comment: "SPV diagnostics"))
+        }
+        .alert(
+            NSLocalizedString("Birth height updated", comment: "SPV diagnostics"),
+            isPresented: Binding(
+                get: { savedBirthHeightPendingRescan != nil },
+                set: { if !$0 { savedBirthHeightPendingRescan = nil } }
+            ),
+            presenting: savedBirthHeightPendingRescan
+        ) { height in
+            Button(NSLocalizedString("Rescan now", comment: "SPV diagnostics")) {
+                savedBirthHeightPendingRescan = nil
+                performRescan(fromHeight: height)
+            }
+            Button(NSLocalizedString("Later", comment: ""), role: .cancel) {
+                savedBirthHeightPendingRescan = nil
+            }
+        } message: { _ in
+            Text(NSLocalizedString(
+                "The saved height becomes the scan floor from the next launch. Rescan filters from it now to pick up any missed history immediately.",
+                comment: "SPV diagnostics"))
+        }
     }
 
     // MARK: - Cards
@@ -199,6 +246,30 @@ struct SwiftDashSDKSPVStatusScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             row(title: "Tip height", value: "\(coordinator.tipHeight)")
             row(title: "Best peer height", value: "\(coordinator.bestPeerHeight)")
+            // Birth height (the wallet's filter-scan floor) with an
+            // edit affordance — the escape hatch for wallets stamped
+            // with a wrong creation height (e.g. imports made before
+            // the import-birth-height fix): set 0 and rescan to
+            // recover pre-import history.
+            HStack {
+                Text(NSLocalizedString("Wallet birth height", comment: "SPV diagnostics"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.primaryText)
+                Spacer()
+                Text(walletBirthHeight.map { "\($0)" } ?? "—")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.primaryText)
+                    .monospacedDigit()
+                Button(action: {
+                    birthHeightEntryText = walletBirthHeight.map { "\($0)" } ?? ""
+                    showBirthHeightEntry = true
+                }) {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.dashBlue)
+                }
+                .disabled(walletBirthHeight == nil)
+            }
         }
         .padding(16)
         .background(Color.secondaryBackground)
@@ -592,5 +663,56 @@ extension SwiftDashSDKSPVStatusScreen {
             rescanResultMessage = error.localizedDescription
             Self.logger.error("🛰️ SPV-STATUS :: rescan filters failed: \(String(describing: error), privacy: .public)")
         }
+    }
+
+    /// Validate the birth-height text field and write it onto the
+    /// bound wallet's `PersistentWallet` row. The row is the durable
+    /// source: the SDK's `loadWallets` restore sends `birthHeight`
+    /// back to Rust at every launch, so the edit becomes the wallet's
+    /// scan floor from the next start. The LIVE session's floor is
+    /// unchanged (Rust read it at configure) — the post-save prompt
+    /// offers an immediate filter rescan from the new height, which
+    /// reads the row and therefore honors the edit right away.
+    func saveEnteredBirthHeight() {
+        let trimmed = birthHeightEntryText.trimmingCharacters(in: .whitespaces)
+        guard let height = UInt32(trimmed) else {
+            rescanResultIsError = true
+            rescanResultMessage = NSLocalizedString(
+                "Enter a valid block height.", comment: "SPV diagnostics")
+            return
+        }
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let container = SwiftDashSDKHost.shared.modelContainer else {
+            rescanResultIsError = true
+            rescanResultMessage = NSLocalizedString(
+                "Available only while SPV is running with a wallet bound.",
+                comment: "SPV diagnostics")
+            return
+        }
+        let walletId = wallet.walletId
+        var descriptor = FetchDescriptor<PersistentWallet>(
+            predicate: #Predicate { $0.walletId == walletId })
+        descriptor.fetchLimit = 1
+        guard let row = (try? container.mainContext.fetch(descriptor))?.first else {
+            rescanResultIsError = true
+            rescanResultMessage = NSLocalizedString(
+                "No persisted wallet row found for the bound wallet.",
+                comment: "SPV diagnostics")
+            return
+        }
+        let previous = row.birthHeight
+        guard height != previous else { return }
+        row.birthHeight = height
+        do {
+            try container.mainContext.save()
+        } catch {
+            row.birthHeight = previous
+            rescanResultIsError = true
+            rescanResultMessage = error.localizedDescription
+            Self.logger.error("🛰️ SPV-STATUS :: birth-height save failed: \(String(describing: error), privacy: .public)")
+            return
+        }
+        Self.logger.info("🛰️ SPV-STATUS :: birth height \(previous, privacy: .public) → \(height, privacy: .public)")
+        savedBirthHeightPendingRescan = height
     }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -185,7 +185,7 @@
 "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum.";
 
 /* SPV diagnostics */
-"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device." = "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device.";
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet." = "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet.";
 
 /* Usernames */
 "Transparent funding publicly links your username to these funds." = "Transparent funding publicly links your username to these funds.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -106,6 +106,9 @@
 /* Usernames */
 "Add to your Shielded balance now and register your username privately a few hours later" = "Add to your Shielded balance now and register your username privately a few hours later";
 
+/* SPV diagnostics */
+"Birth height updated" = "Birth height updated";
+
 /* Log export */
 "Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files";
 
@@ -114,6 +117,9 @@
 
 /* Usernames */
 "Done — your balance has rested long enough" = "Done — your balance has rested long enough";
+
+/* SPV diagnostics */
+"Edit birth height" = "Edit birth height";
 
 /* Log export */
 "Export Logs" = "Export Logs";
@@ -127,6 +133,9 @@
 /* Usernames */
 "Get ready to join DashPay" = "Get ready to join DashPay";
 
+/* No comment provided by engineer. */
+"Later" = "Later";
+
 /* Usernames */
 "Minimum met" = "Minimum met";
 
@@ -135,6 +144,9 @@
 
 /* Log export */
 "No diagnostic logs were found on this device. Logs are written from the next launch onward." = "No diagnostic logs were found on this device. Logs are written from the next launch onward.";
+
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "No persisted wallet row found for the bound wallet.";
 
 /* DashPay */
 "Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";
@@ -151,6 +163,9 @@
 /* Usernames */
 "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it.";
 
+/* SPV diagnostics */
+"Rescan now" = "Rescan now";
+
 /* Usernames */
 "Shared privacy pool at minimum size" = "Shared privacy pool at minimum size";
 
@@ -160,11 +175,17 @@
 /* DashPay */
 "The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately.";
 
+/* SPV diagnostics */
+"The saved height becomes the scan floor from the next launch. Rescan filters from it now to pick up any missed history immediately." = "The saved height becomes the scan floor from the next launch. Rescan filters from it now to pick up any missed history immediately.";
+
 /* Usernames */
 "The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum.";
 
 /* DashPay */
 "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum.";
+
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device." = "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set 0 for an imported wallet whose history may predate this device.";
 
 /* Usernames */
 "Transparent funding publicly links your username to these funds." = "Transparent funding publicly links your username to these funds.";
@@ -174,6 +195,9 @@
 
 /* Usernames */
 "Verified during registration" = "Verified during registration";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Wallet birth height";
 
 /* Usernames */
 "You have %@ Dash so far" = "You have %@ Dash so far";


### PR DESCRIPTION
## The bug

Import a wallet and its creation/birth height gets stamped as **2,500,000** — dash-spv's newest hardcoded *mainnet* checkpoint (testnet's would be 1,500,000). Consequence: the imported wallet's SPV compact-filter scan starts at ~now, so **funds and history received before the import never appear**, and Tools → Rescan Filters can't recover them either — it rescans from `PersistentWallet.birthHeight`, i.e. from the same wrong height.

## Root cause

The SDK's `createWallet(birthHeight:)` contract is explicit:
- `nil` → freshly **generated** mnemonic: anchor the scan at the current tip (with unsynced headers at first launch, the SDK falls back to the network's newest hardcoded checkpoint — hence the exact 2,500,000)
- `0` → **importing/restoring**: scan from genesis

dashwallet called `createWallet` without the parameter on *every* path, so imports were silently treated as freshly generated. The `isImported` provenance flag already existed at every call site (onboarding creator, Wallets add sheet, DashSync key migrator) — it just was never threaded into the host's `createWallet` calls. This is an app bug, not an SDK bug.

## Fix

- `createOrImportWallet` and `addWallet` (now `addWallet(mnemonic:isImported:)`) pass the network's **import floor** for imports (`importedWalletBirthHeight`: mainnet **200,000** — pre-2015 blocks predate any importable wallet, skipping a year of filter work — testnet **0**/genesis) and keep `nil` (tip) for freshly generated mnemonics; `WalletsViewModel` threads the flag it already had. The DashSync upgrade migrator passes `isImported: true` already, so migrated wallets get genesis scans with no further change.
- `recoverPersistedWallet` (reinstall recovery / first registration after a network switch) passes `0` unconditionally: provenance is unknown there — the SwiftData rows are gone or never existed on this network — and the mnemonic may hold years of history. A needless full scan is recoverable; a tip-anchored miss of old funds is not.
- The one untouched `manager.addWallet` (in `derivationWallet()`) is the throwaway key-derivation stack — no SPV scan, birth height not applicable.

## Escape hatch for already-stamped wallets

Wallets imported **before** this fix keep their wrong stamp (there's no way to distinguish them from legitimately-new wallets after the fact), so the second commit adds the recovery affordance: **Tools → SwiftDashSDK SPV Status now shows the wallet's birth height with an edit control**. Saving writes `PersistentWallet.birthHeight` (durable — the SDK's `loadWallets` restore feeds the row back to Rust at every launch) and then offers an immediate filter rescan from the new height. Set it to 0 on a mis-stamped import and rescan to recover pre-import history without wiping.

## Verification

- `dashpay` Debug arm64-sim build green.
- QA smoke (no PIN needed for the observation): import a funded testnet wallet → Storage Explorer / SPV Status should show birth height **0**, and the wallet's pre-existing transactions should appear as the filter scan progresses from genesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

