### PR TITLE
fix(wallet): live balance refresh and withhold the Dash DEX shortcut

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -111,6 +111,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     private var runningNetwork: Network?
     private var progressCancellable: AnyCancellable?
     private var peersCancellable: AnyCancellable?
+    private var balanceRefreshCancellable: AnyCancellable?
 
     /// Network whose CoinJoin gap was widened for a one-time recovery scan
     /// during the current run, so a subsequent full sync can mark recovery
@@ -213,6 +214,8 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
         progressCancellable = nil
         peersCancellable?.cancel()
         peersCancellable = nil
+        balanceRefreshCancellable?.cancel()
+        balanceRefreshCancellable = nil
 
         if let manager = SwiftDashSDKHost.shared.manager {
             do {
@@ -309,6 +312,22 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
             .sink { [weak self] peers in
                 MainActor.assumeIsolated {
                     self?.connectedPeers = peers
+                }
+            }
+
+        // Refresh the published balance whenever Rust's persister commits a
+        // SwiftData batch (a detected/instant-locked tx writes PersistentTransaction
+        // rows → NSManagedObjectContextDidSave). The progress-tick refresh above
+        // stops firing once the chain is fully synced (steady state has no ticks),
+        // so an incoming payment while synced would otherwise not update the balance
+        // until the next foreground/restart. This is the same trigger the home tx
+        // list already uses; throttled to coalesce the save storm during sync.
+        balanceRefreshCancellable = NotificationCenter.default
+            .publisher(for: .NSManagedObjectContextDidSave)
+            .throttle(for: .seconds(1), scheduler: RunLoop.main, latest: true)
+            .sink { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.refreshBalanceBridge()
                 }
             }
     }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -881,6 +881,12 @@ extension HomeViewModel {
                     if type == .switchWallet && !canSwitchWallet {
                         type = .receive
                     }
+                    // Dash DEX is withheld for the migration release (frozen-DashSync
+                    // swap path); a saved DEX shortcut degrades to Spend. The saved
+                    // config is untouched, so it returns if DEX is restored.
+                    if type == .dashDEX {
+                        type = .spend
+                    }
                     return ShortcutAction(type: type)
                 }
                 .filter { action in

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
@@ -60,8 +60,11 @@ extension ShortcutActionType {
         var actions: [ShortcutActionType] = [
             .buySellDash, .explore, .spend, .atm, .receive,
             .send, .scanToPay, .payToAddress,
-            .coinbase, .uphold, .topper, .dashDEX
+            .coinbase, .uphold, .topper
         ]
+        // Dash DEX is withheld for the SwiftDashSDK migration release (its swap
+        // path builds through frozen DashSync), so it is not offered as a
+        // customizable shortcut. Mirrors the gated Buy & Sell portal card.
         let state = CrowdNode.shared.signUpState
         if state == .finished || state == .linkedOnline {
             actions.append(.crowdNode)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Two related post-merge fixes on `swift-sdk-integration`:

1. **Home balance didn't update on incoming payments** until the app was re-foregrounded/relaunched. Reproduced with the testnet faucet (tap tDash → funds arrive → balance stays stale, transaction list updates fine).
2. **Dash DEX was still reachable via the shortcut bar**, even though it's withheld for this migration release — its swap path builds through frozen DashSync and can't complete.

## What was done?
**Balance refresh (`d3a27f0`)** — Device logs show the SDK emits `TransactionDetected` / `TransactionInstantLocked` wallet events with the new balance, and Rust's persister writes `PersistentTransaction` rows → `NSManagedObjectContextDidSave`. The home tx list already reloads on that signal, but the balance was refreshed only by `refreshBalanceBridge()` on SPV start and on sync-progress ticks — which stop once the chain is fully synced (steady state). So an incoming payment while synced never updated the balance. Fix: subscribe the balance bridge to the same `NSManagedObjectContextDidSave` signal (throttled 1s to coalesce the sync-time save storm), reusing the existing `refreshBalanceBridge()`; cancelled in `performStop`.

**Dash DEX shortcut (`aacb286`)** — The release merge gated only the Buy & Sell portal card (`showsSwapKit = false`) and left the `.dashDEX` shortcut reachable. Removed `.dashDEX` from `customizableActions` (can't be added to the bar) and degrade an already-saved `.dashDEX` shortcut to `.spend` (same pattern as `getTestDash`/`switchWallet`). The enum case + icon/title are kept so persisted-config raw values stay stable and DEX returns if restored.

## How Has This Been Tested?
- `dashwallet-dashpay` scheme builds clean on the iOS Simulator (`ARCHS=arm64`).
- The balance fix is grounded in the attached device logs — the `NSManagedObjectContextDidSave` signal it hooks demonstrably fires live (the tx list updated to 3 txs in the same logs where the balance stayed stale).
- **Pending:** live on-device confirmation of the faucet flow (tap tDash → balance updates without relaunch). The DEX shortcut change is static/config and covered by the build.

## Breaking Changes
None. Dash DEX remains withheld (now consistently); no API or data changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet balances now refresh automatically after saved data changes, with updates stopped when wallet synchronization ends.
  * Existing Dash DEX shortcuts now safely display as Spend shortcuts when restored.

* **Changes**
  * Dash DEX is temporarily unavailable as a customizable shortcut option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->