### PR TITLE
feat(dashpay): rebuild the invitation claim on SwiftDashSDK + restore merge-dropped l10n

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -112,6 +112,9 @@
 		1CDA90D00719D6249F2761AC /* ContactItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE7E8766B8C1601A85AAB4F /* ContactItem.swift */; };
 		1F3FF21B0295D5A326F08B74 /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		1FAFEA3F516E6CBDD2B49010 /* SwiftDashSDKContactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02357928871603392E797C9A /* SwiftDashSDKContactsService.swift */; };
+		A11E57A70006C0DE0006B006 /* DWInvitationLinkNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E57A70001C0DE0001B001 /* DWInvitationLinkNormalizer.swift */; };
+		A11E57A70007C0DE0007B007 /* DWInvitationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E57A70002C0DE0002B002 /* DWInvitationService.swift */; };
+		A11E57A70008C0DE0008B008 /* ClaimInvitationScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11E57A70003C0DE0003B003 /* ClaimInvitationScreen.swift */; };
 		20C8591E86D33DE8DCD6ADC2 /* ReceiveScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CA1CAD519B199EE20CFB7E /* ReceiveScreen.swift */; };
 		2284B63F1C7BD28F0012ECDF /* BRAWKeypad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F45A0A1C30EAB700B07A15 /* BRAWKeypad.swift */; };
 		22E89B6C00B546D294D7F331 /* SelfSizingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CB7E093E994D2391D36DEC /* SelfSizingSheet.swift */; };
@@ -2000,6 +2003,9 @@
 /* Begin PBXFileReference section */
 		01D55D0FA9AE953CD23DE6B6 /* DWIdentityRegistrationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DWIdentityRegistrationController.swift; sourceTree = "<group>"; };
 		02357928871603392E797C9A /* SwiftDashSDKContactsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKContactsService.swift; sourceTree = "<group>"; };
+		A11E57A70001C0DE0001B001 /* DWInvitationLinkNormalizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DWInvitationLinkNormalizer.swift; sourceTree = "<group>"; };
+		A11E57A70002C0DE0002B002 /* DWInvitationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DWInvitationService.swift; sourceTree = "<group>"; };
+		A11E57A70003C0DE0003B003 /* ClaimInvitationScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaimInvitationScreen.swift; sourceTree = "<group>"; };
 		0286D4D1CADBBD51F09BE8E8 /* SwapMenuStyles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwapMenuStyles.swift; sourceTree = "<group>"; };
 		0448A6769BCF20987BE9960C /* DiagnosticLogExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiagnosticLogExporter.swift; sourceTree = "<group>"; };
 		05723F61BFF76C3BB9EF3CDC /* InternalTransferConfirmSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalTransferConfirmSheet.swift; sourceTree = "<group>"; };
@@ -7155,9 +7161,27 @@
 			path = UsernamePending;
 			sourceTree = "<group>";
 		};
+		A11E57A70004C0DE0004B004 /* Invitations */ = {
+			isa = PBXGroup;
+			children = (
+				A11E57A70001C0DE0001B001 /* DWInvitationLinkNormalizer.swift */,
+				A11E57A70002C0DE0002B002 /* DWInvitationService.swift */,
+			);
+			path = Invitations;
+			sourceTree = "<group>";
+		};
+		A11E57A70005C0DE0005B005 /* Invitations */ = {
+			isa = PBXGroup;
+			children = (
+				A11E57A70003C0DE0003B003 /* ClaimInvitationScreen.swift */,
+			);
+			path = Invitations;
+			sourceTree = "<group>";
+		};
 		7E31813A79237F4E037063AA /* SwiftDashSDK */ = {
 			isa = PBXGroup;
 			children = (
+				A11E57A70004C0DE0004B004 /* Invitations */,
 				33FB75FCD21FC8C62840E6FD /* SwiftDashSDKKeyMigrator.swift */,
 				E3CA14DC8416012B813B5E2C /* SwiftDashSDKPhraseRepairer.swift */,
 				1A7BE8E4519203200CDFB460 /* SwiftDashSDKInsightClient.swift */,
@@ -7739,6 +7763,7 @@
 				C943B3E82A40A54600AF23C5 /* Profile */,
 				C943B4032A40A54600AF23C5 /* Items */,
 				C943B44B2A40A54600AF23C5 /* Invites */,
+				A11E57A70005C0DE0005B005 /* Invitations */,
 				7502A4852AE401DA00ACDDD3 /* Voting */,
 				75D656182B0792AB00D1A902 /* Usernames */,
 				75889B742AD296D500C17F5D /* CoinJoin */,
@@ -11295,6 +11320,9 @@
 				9A1606353B5B4E5481AC5C6A /* NotificationsScreen.swift in Sources */,
 				51629A945A8CEF6EF50F9A4A /* DWIdentityKeyUpgrader.swift in Sources */,
 				F4202BDB27E7066201C23A58 /* DWIdentityRegistrationCoordinator.swift in Sources */,
+				A11E57A70006C0DE0006B006 /* DWInvitationLinkNormalizer.swift in Sources */,
+				A11E57A70007C0DE0007B007 /* DWInvitationService.swift in Sources */,
+				A11E57A70008C0DE0008B008 /* ClaimInvitationScreen.swift in Sources */,
 				D2616FE9FE5ED53F26506A73 /* DWIdentityRegistrationBridge.swift in Sources */,
 				026B0383557D0181E034B64E /* SDKIdentityProfileSheet.swift in Sources */,
 				431DC6C9218C3DFAF6DE23C0 /* DWCurrentUserIdentityInfo.swift in Sources */,
@@ -13563,7 +13591,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dashpay/DashUIKit";
 			requirement = {
-				branch = import/final;
+				branch = master;
 				kind = branch;
 			};
 		};

--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dashpay/DashUIKit",
       "state" : {
-        "branch" : "import/final",
-        "revision" : "8ba562961c784587ece1a95e38345b4a708ae528"
+        "branch" : "master",
+        "revision" : "046f087514e12f01087ba20efd5e73c682172ebf"
       }
     }
   ],

--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -219,23 +219,21 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionH
 
 #if DASHPAY
 - (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler {
-    __weak typeof(self) weakSelf = self;
-    BOOL handled = [[FIRDynamicLinks dynamicLinks] handleUniversalLink:userActivity.webpageURL
-                                                            completion:^(FIRDynamicLink * _Nullable dynamicLink,
-                                                                         NSError * _Nullable error) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) {
-            return;
-        }
-
-        if (dynamicLink.url) {
-            DWInitialViewController *controller = (DWInitialViewController *)strongSelf.window.rootViewController;
-            if ([controller isKindOfClass:DWInitialViewController.class]) {
-                [controller handleDeeplink:dynamicLink.url];
-            }
-        }
-    }];
-    return handled;
+    // Universal links (invitations.dashpay.io applink). Firebase
+    // Dynamic Links previously unwrapped these; the service was shut
+    // down in 2025, so the invitation URL is now routed directly —
+    // normalization/validation happens in the redeem flow
+    // (DWInvitationLinkNormalizer + ClaimInvitationScreen).
+    NSURL *url = userActivity.webpageURL;
+    if (url == nil || ![DWInvitationLinkNormalizer isInvitationURL:url]) {
+        return NO;
+    }
+    DWInitialViewController *controller = (DWInitialViewController *)self.window.rootViewController;
+    if ([controller isKindOfClass:DWInitialViewController.class]) {
+        [controller handleDeeplink:url];
+        return YES;
+    }
+    return NO;
 }
 #endif
 
@@ -243,17 +241,16 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionH
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
 #if DASHPAY
-    FIRDynamicLink *dynamicLink = [[FIRDynamicLinks dynamicLinks] dynamicLinkFromCustomSchemeURL:url];
-    if (dynamicLink) {
-        if (dynamicLink.url) {
-            DWInitialViewController *controller = (DWInitialViewController *)self.window.rootViewController;
-            if ([controller isKindOfClass:DWInitialViewController.class]) {
-                [controller handleDeeplink:dynamicLink.url];
-            }
+    // dashpay://invite (and pasted-transport) invitation links open the
+    // redeem flow; every other scheme falls through to DWURLParser.
+    if ([DWInvitationLinkNormalizer isInvitationURL:url]) {
+        DWInitialViewController *controller = (DWInitialViewController *)self.window.rootViewController;
+        if ([controller isKindOfClass:DWInitialViewController.class]) {
+            [controller handleDeeplink:url];
         }
         return YES;
     }
-    
+
     // Handle URL Scheme instead
 #endif
     

--- a/DashWallet/Info.plist
+++ b/DashWallet/Info.plist
@@ -70,6 +70,16 @@
 				<string>dashid</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>dashpay</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>dashpay</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
@@ -32,7 +32,7 @@ import SwiftDashSDK
 /// Funding source for new-identity registration. Surfaced to Obj-C
 /// as an NSInteger-backed enum so the SwiftUI form can route the
 /// user's picker selection through the bridge without changing
-/// `DWDashPayProtocol.createUsername:invitation:`.
+/// `DWDashPayProtocol.createUsername:`.
 ///
 /// - `core`: spend Core BIP44 UTXOs via `registerIdentityWithFunding`.
 ///   Default and only path before PR 5.
@@ -45,10 +45,16 @@ import SwiftDashSDK
 ///   (Type 20). The privacy-preserving default when the shielded
 ///   balance is funded, matured, and the pool clears the consensus
 ///   minimum — see `ShieldedIdentityFundingReadiness`. No asset-lock.
+/// - `invitation`: fund the new identity from a DashPay invitation
+///   voucher (DIP-13) via `claimInvitation`. The asset-lock was built
+///   and broadcast by the INVITER, so there is no local asset-lock
+///   row to track. Never user-pickable — entered only through
+///   `DWIdentityRegistrationCoordinator.startClaimInvitation`.
 @objc public enum DWIdentityFundingSource: Int {
     case core = 0
     case platformPayment = 1
     case shielded = 2
+    case invitation = 3
 }
 
 extension DWIdentityFundingSource {
@@ -58,6 +64,7 @@ extension DWIdentityFundingSource {
         case .core: return "core"
         case .platformPayment: return "pp"
         case .shielded: return "shielded"
+        case .invitation: return "invite"
         }
     }
 }
@@ -111,7 +118,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
     /// attempt.
     ///
     /// Written by `CreateUsernameView`'s Continue handler immediately
-    /// before `DWDashPayModel.createUsername:invitation:` so the
+    /// before `DWDashPayModel.createUsername:` so the
     /// model→bridge call picks it up. Kept as a property (not a
     /// method parameter) to avoid widening `DWDashPayProtocol`'s
     /// surface for what is effectively SwiftDashSDK-path-only state.
@@ -260,7 +267,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         // Reset preferredFundingSource to the safe default on
         // `.completed` only. On `.failed`, preserve the source so a
         // retry (which goes through `DWDashPayModel.retry` →
-        // `createUsername:invitation:` → bridge without re-running the
+        // `createUsername:` → bridge without re-running the
         // SwiftUI picker) uses the same funding the user originally
         // picked — flipping a PP-funded failure back to `.core` would
         // strand a PP-only wallet on a path that has no Core balance.

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -29,7 +29,7 @@
 //
 //  v1 scope:
 //    - Single identity per wallet (`identityIndex` pinned at 0).
-//    - Three funding paths:
+//    - Four funding paths:
 //      * Core-funded via `registerIdentityWithFunding` (legacy default).
 //      * Platform Payment via `registerIdentityFromAddresses` —
 //        spends credits already on DIP-17 platform addresses.
@@ -38,6 +38,9 @@
 //        spends a fixed exit denomination from the wallet's Orchard
 //        pool. Pre-flighted against `ShieldedIdentityFundingReadiness`
 //        (funding / maturity / pool-size gates); no asset-lock.
+//      * Invitation via `claimInvitation` (DIP-13) — consumes the
+//        voucher asset-lock the INVITER built; entered through
+//        `startClaimInvitation(username:invitationURI:)` only.
 //    - No crash-resume (`resumeIdentityWithAssetLock` deferred to v2).
 //
 
@@ -145,6 +148,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         case shieldedPoolTooSmall(currentNotes: UInt64)
         case noShieldedFallbackAddress
         case shieldedCreateUnconfirmed
+        case missingInvitation
         case alreadyInFlight
 
         var errorDescription: String? {
@@ -186,6 +190,8 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 return NSLocalizedString("No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing.", comment: "DashPay")
             case .shieldedCreateUnconfirmed:
                 return NSLocalizedString("The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately.", comment: "DashPay")
+            case .missingInvitation:
+                return NSLocalizedString("This invitation link is not valid.", comment: "DashPay Invitations")
             case .alreadyInFlight:
                 return NSLocalizedString("Identity registration already in progress", comment: "DashPay")
             }
@@ -206,10 +212,16 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// (`registerIdentityFromAddresses` → direct address-funded ST).
     /// Defaults to `.core` for callers that don't care (legacy
     /// Obj-C entry points, retries after a terminal phase).
+    ///
+    /// `.invitation` is entered through
+    /// `startClaimInvitation(username:invitationURI:)`, which supplies
+    /// the voucher link; calling this method with `.invitation` and no
+    /// `invitationURI` fails with `.missingInvitation`.
     @discardableResult
     func startCreateUsername(
         _ username: String,
-        fundingSource: DWIdentityFundingSource = .core
+        fundingSource: DWIdentityFundingSource = .core,
+        invitationURI: String? = nil
     ) async throws -> Identifier {
         Self.logger.info("🪪 IDENT-COORD :: startCreateUsername username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public)")
 
@@ -363,6 +375,22 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                     modelContainer: modelContainer,
                     pubkeys: pubkeys,
                     signer: signer)
+
+            case .invitation:
+                // DIP-13 claim: register the invitee's identity funded
+                // by the voucher embedded in the link. The SDK refetches
+                // the funding tx and rebuilds the IS/CL proof itself;
+                // key prep above is identical to every other source.
+                guard let invitationURI else {
+                    throw CoordinatorError.missingInvitation
+                }
+                let managed = try await wallet.claimInvitation(
+                    uri: invitationURI,
+                    identityIndex: Self.pinnedIdentityIndex,
+                    identityPubkeys: pubkeys,
+                    signer: signer,
+                    nowUnix: UInt32(Date().timeIntervalSince1970))
+                identityId = try managed.getId()
             }
             Self.logger.info("🪪 IDENT-COORD :: identity created, id=\(identityId.map { String(format: "%02x", $0) }.joined().prefix(8), privacy: .public)…")
         } catch let coordError as CoordinatorError {
@@ -394,9 +422,10 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             switch fundingSource {
             case .core:
                 failedAtPhase = assetLockStatus < 2 ? .processingPayment : .creatingID
-            case .platformPayment, .shielded:
-                // Neither path has a Core-chain asset-lock; the FFI
-                // submit is the only on-chain step.
+            case .platformPayment, .shielded, .invitation:
+                // None of these paths has a LOCAL Core-chain asset-lock
+                // (the invitation voucher's was built by the inviter);
+                // the FFI submit is the only on-chain step here.
                 failedAtPhase = .creatingID
             }
             lastErrorMessage = error.localizedDescription
@@ -459,11 +488,35 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         return identityId
     }
 
+    /// DIP-13 invitation claim: register this wallet's identity funded
+    /// by the invitation voucher, then register `username` via DPNS.
+    /// Same PIN gate / key prep / phase reporting / resume semantics as
+    /// `startCreateUsername` — a claim that lands IdentityCreate but
+    /// fails DPNS retries past the (already consumed) voucher via the
+    /// persisted-identity resume path.
+    ///
+    /// `invitationURI` must be the normalized `dashpay://invite` /
+    /// applink URI (see `DWInvitationLinkNormalizer`); structural
+    /// validation should have happened in the redeem UI, but claim-time
+    /// SDK errors (malformed link, already-claimed voucher, wrong
+    /// network) surface here as `.identityRegistration`.
+    @discardableResult
+    func startClaimInvitation(
+        username: String,
+        invitationURI: String
+    ) async throws -> Identifier {
+        try await startCreateUsername(
+            username,
+            fundingSource: .invitation,
+            invitationURI: invitationURI)
+    }
+
     /// Restart the flow after a `.failed` terminal phase. Identical
     /// to `startCreateUsername(_:fundingSource:)` — the prior
     /// controller is discarded and a fresh attempt runs end-to-end.
     /// The Keychain-persisted identity keys from the prior attempt
-    /// are overwritten during pre-derive.
+    /// are overwritten during pre-derive. Invitation attempts retry
+    /// through `startClaimInvitation` (the URI is required), not here.
     @discardableResult
     func retry(
         _ username: String,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWRegistrationPhaseAdapter.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWRegistrationPhaseAdapter.swift
@@ -70,15 +70,17 @@ enum DWRegistrationPhaseAdapter {
                 }
                 return .registrationUsername
 
-            case .platformPayment, .shielded:
-                // Neither path has a Core-chain asset-lock —
+            case .platformPayment, .shielded, .invitation:
+                // None of these paths has a LOCAL Core-chain asset-lock —
                 // `registerIdentityFromAddresses` consumes credits
-                // already on Platform addresses, and the Type-20
-                // shielded create spends Orchard notes in one opaque
-                // FFI call (proof + submit). There is no IS/CL wait,
-                // so the UI jumps straight to "Creating ID" as soon
-                // as the FFI submit goes in flight. `assetLockStatus`
-                // is intentionally ignored here.
+                // already on Platform addresses, the Type-20 shielded
+                // create spends Orchard notes in one opaque FFI call
+                // (proof + submit), and an invitation claim consumes an
+                // asset-lock the INVITER built (no `PersistentAssetLock`
+                // row on this device). There is no IS/CL wait, so the
+                // UI jumps straight to "Creating ID" as soon as the FFI
+                // submit goes in flight. `assetLockStatus` is
+                // intentionally ignored here.
                 return .creatingID
             }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Invitations/DWInvitationLinkNormalizer.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Invitations/DWInvitationLinkNormalizer.swift
@@ -1,0 +1,114 @@
+//
+//  DWInvitationLinkNormalizer.swift
+//  DashWallet
+//
+//  Normalizes every inbound DashPay-invitation transport down to the
+//  canonical URI the SDK parser (`ManagedPlatformWallet.parseInvitation`)
+//  accepts. Pure string/URL logic — no SDK, no network — so it is
+//  unit-testable and safe to call from Obj-C deep-link plumbing.
+//
+//  Accepted transports:
+//    1. `dashpay://invite?…` — the canonical DIP-13 link (also what
+//       Android's `InvitationLinkData` emits). Passed through verbatim.
+//    2. `https://invitations.dashpay.io/applink?…` — the legacy
+//       universal-link form. The SDK parser accepts it natively, so it
+//       is passed through verbatim too.
+//    3. AppsFlyer OneLink URLs from Android-generated invites
+//       (`dashpay.onelink.me` / `dashpaytest.onelink.me`) — the inner
+//       `dashpay://invite` URI rides in a query parameter; unwrapped
+//       here (checked in Android's key order: af_dp, deep_link_value,
+//       link, af_sub1) and re-normalized.
+//
+//  The returned URI embeds the voucher private key (`pk`) — a bearer
+//  credential. Never log it.
+//
+
+import Foundation
+
+@objc(DWInvitationLinkNormalizer)
+final class DWInvitationLinkNormalizer: NSObject {
+
+    private static let invitationScheme = "dashpay"
+    private static let invitationHost = "invite"
+    private static let applinkHost = "invitations.dashpay.io"
+    private static let applinkPath = "/applink"
+    private static let oneLinkHosts: Set<String> = [
+        "dashpay.onelink.me",
+        "dashpaytest.onelink.me",
+    ]
+    /// OneLink query keys that may carry the inner deep link, in the
+    /// order Android's attribution handler tries them
+    /// (`WalletApplication.extractDeepLink`).
+    private static let oneLinkPayloadKeys = ["af_dp", "deep_link_value", "link", "af_sub1"]
+
+    private override init() {}
+
+    /// Canonical invitation URI for any accepted transport, or nil when
+    /// the input is not an invitation link. Pasted text is trimmed; the
+    /// result is suitable for `ManagedPlatformWallet.parseInvitation`
+    /// (which performs the actual structural validation — this function
+    /// only recognizes and unwraps transports).
+    static func normalize(_ input: String) -> String? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = URL(string: trimmed) else { return nil }
+        return normalize(url)
+    }
+
+    /// URL-typed variant of `normalize(_:)`.
+    static func normalize(_ url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased() else { return nil }
+        let host = url.host?.lowercased() ?? ""
+
+        switch scheme {
+        case invitationScheme:
+            guard host == invitationHost else { return nil }
+            return url.absoluteString
+
+        case "https", "http":
+            if host == applinkHost {
+                // Tolerate the hosting redirect's trailing slash, same
+                // as the SDK parser.
+                guard url.path.trimmingSuffix("/") == applinkPath else { return nil }
+                return url.absoluteString
+            }
+            if oneLinkHosts.contains(host) {
+                return unwrapOneLink(url)
+            }
+            return nil
+
+        default:
+            return nil
+        }
+    }
+
+    /// Obj-C entry for the AppDelegate's URL routing: `true` when the
+    /// URL is one of the invitation transports (without validating the
+    /// payload — that happens at parse time in the claim flow).
+    @objc static func isInvitationURL(_ url: URL) -> Bool {
+        normalize(url) != nil
+    }
+
+    /// Extract and re-normalize the inner deep link from a OneLink
+    /// long-form URL. Short OneLinks carry no payload in the URL and
+    /// cannot be resolved without the AppsFlyer SDK — those return nil
+    /// (the redeem UI's paste hint covers them).
+    private static func unwrapOneLink(_ url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let items = components.queryItems else { return nil }
+        for key in oneLinkPayloadKeys {
+            guard let value = items.first(where: { $0.name == key })?.value,
+                  !value.isEmpty else { continue }
+            if let inner = normalize(value) {
+                return inner
+            }
+        }
+        return nil
+    }
+}
+
+private extension String {
+    /// `hasSuffix`-conditional drop, e.g. `"/applink/" → "/applink"`.
+    func trimmingSuffix(_ suffix: String) -> String {
+        hasSuffix(suffix) ? String(dropLast(suffix.count)) : self
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Invitations/DWInvitationService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Invitations/DWInvitationService.swift
@@ -1,0 +1,99 @@
+//
+//  DWInvitationService.swift
+//  DashWallet
+//
+//  App boundary for DashPay invitations on SwiftDashSDK (DIP-13).
+//  PR-1 scope is the invitee side: recognizing/previewing invitation
+//  links and the post-claim contact request back to the inviter. The
+//  inviter side (create, history, claimed-status watcher, reclaim)
+//  lands with the invitation-history UI — see INVITATIONS_REBUILD_PLAN.md.
+//
+//  The claim itself (IdentityCreate funded by the voucher + DPNS
+//  register) runs through `DWIdentityRegistrationCoordinator`, which
+//  owns the PIN gate, key pre-persist, phase reporting, and resume
+//  semantics shared by every funding source.
+//
+//  Singleton justification (arch guardrail #4): the service is a
+//  stateless facade over `SwiftDashSDKHost.shared` (itself the single
+//  SDK owner) and `SwiftDashSDKContactsService.shared`; the protocol
+//  seam (`DWInvitationServicing`) is the injection point for tests and
+//  future callers.
+//
+
+import Foundation
+import SwiftDashSDK
+
+@MainActor
+protocol DWInvitationServicing: AnyObject {
+    /// Canonical invitation URI for any accepted transport, or nil.
+    func normalize(_ input: String) -> String?
+    /// Read-only structural preview of a normalized invitation URI.
+    /// nil while the wallet is not hydrated or on a hard parse error;
+    /// a malformed-but-recognized link returns a preview with
+    /// `structurallyValid == false`.
+    func preview(for uri: String) -> ManagedPlatformWallet.InvitationPreview?
+    /// True when this wallet already has a DashPay identity — claiming
+    /// an invitation registers a NEW identity, so the flow is not
+    /// offered to registered users.
+    var hasLocalIdentity: Bool { get }
+    /// Resolve the inviter's DPNS username and send them a contact
+    /// request from the (just-claimed) local identity. PIN-gated by the
+    /// contacts service; throws on resolution or send failure.
+    func sendContactRequestToInviter(username: String) async throws
+}
+
+@MainActor
+final class DWInvitationService: DWInvitationServicing {
+
+    static let shared = DWInvitationService()
+
+    enum ServiceError: LocalizedError {
+        case noWallet
+        case inviterNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noWallet:
+                return NSLocalizedString("Wallet is not ready for identity registration", comment: "DashPay")
+            case .inviterNotFound(let username):
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("%@ couldn't be found on the Dash network to send them a contact request.", comment: "DashPay Invitations"),
+                    username)
+            }
+        }
+    }
+
+    private init() {}
+
+    func normalize(_ input: String) -> String? {
+        DWInvitationLinkNormalizer.normalize(input)
+    }
+
+    func preview(for uri: String) -> ManagedPlatformWallet.InvitationPreview? {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
+        return try? wallet.parseInvitation(uri: uri)
+    }
+
+    var hasLocalIdentity: Bool {
+        DWCurrentUserIdentityInfo.shared.identityId != nil
+    }
+
+    func sendContactRequestToInviter(username: String) async throws {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            throw ServiceError.noWallet
+        }
+        // The link carries only the inviter's username (`du`), not their
+        // identity id — resolve via DPNS first (mirrors Android's
+        // `identityRepository.getUser(invite.user)` and the SDK example's
+        // claim sheet).
+        guard let inviterId = try await wallet.resolveDpnsName(username) else {
+            throw ServiceError.inviterNotFound(username)
+        }
+        // The contacts service owns the send: PIN gate, lazy DashPay
+        // enc/dec key upgrade for the new identity, and the local
+        // pending-row bookkeeping the contacts UI reads.
+        try await SwiftDashSDKContactsService.shared.sendContactRequest(
+            to: inviterId,
+            usernameHint: username)
+    }
+}

--- a/DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift
@@ -1,0 +1,246 @@
+//
+//  ClaimInvitationScreen.swift
+//  DashWallet
+//
+//  Redeem a DashPay invitation (DIP-13): paste or scan the invitation
+//  link, preview the inviter, and hand the normalized URI to the
+//  create-username flow, which claims the voucher through
+//  `DWIdentityRegistrationCoordinator.startClaimInvitation`.
+//
+//  Reached two ways:
+//    - a `dashpay://invite` / applink deep link (prefilled, field
+//      already populated);
+//    - manually from the Join DashPay dialog ("Have an invitation?")
+//      for the install-then-paste flow — the invitee installed the app
+//      first and brings the link over by paste or QR scan.
+//
+
+import SwiftUI
+import UIKit
+
+/// Push-based navigation glue shared by every redeem entry (deep link,
+/// Home join dialog, menu join dialog): redeem screen → username form
+/// in invitation mode. Kept here so the entries can't drift apart.
+@MainActor
+enum ClaimInvitationFlow {
+
+    /// Push the redeem screen; its Continue pushes the create-username
+    /// form claiming the normalized URI. `initialLink` prefills the
+    /// field (deep link); nil is the manual paste/scan entry.
+    static func pushRedeemScreen(
+        on navigation: UINavigationController?,
+        dashPayModel: DWDashPayProtocol,
+        initialLink: String? = nil,
+        definedUsername: String? = nil,
+        completionHandler: ((Bool) -> Void)? = nil
+    ) {
+        guard let navigation else { return }
+        let screen = ClaimInvitationScreen(initialLink: initialLink) { [weak navigation] uri in
+            guard let navigation else { return }
+            let controller = CreateUsernameViewController(
+                dashPayModel: dashPayModel,
+                invitationURL: URL(string: uri),
+                definedUsername: definedUsername)
+            controller.hidesBottomBarWhenPushed = true
+            controller.completionHandler = completionHandler
+            navigation.pushViewController(controller, animated: true)
+        }
+        let hosting = UIHostingController(rootView: screen)
+        hosting.view.backgroundColor = UIColor.dw_secondaryBackground()
+        hosting.hidesBottomBarWhenPushed = true
+        navigation.pushViewController(hosting, animated: true)
+    }
+}
+
+@MainActor
+final class ClaimInvitationViewModel: ObservableObject {
+
+    enum LinkState: Equatable {
+        /// Nothing entered yet.
+        case empty
+        /// Entered text is not a structurally valid invitation link.
+        case invalid
+        /// Recognized + structurally valid; `normalizedURI` is set.
+        case valid
+        /// This wallet already has a DashPay identity — claiming would
+        /// register a second one, which dashwallet doesn't support.
+        case alreadyRegistered
+    }
+
+    @Published var input: String = ""
+    @Published private(set) var state: LinkState = .empty
+    @Published private(set) var normalizedURI: String? = nil
+    /// The inviter's DPNS username (`du`) when the link carries one.
+    @Published private(set) var inviterUsername: String? = nil
+
+    private let service: DWInvitationServicing
+
+    init(service: DWInvitationServicing = DWInvitationService.shared) {
+        self.service = service
+    }
+
+    func evaluate() {
+        guard !service.hasLocalIdentity else {
+            state = .alreadyRegistered
+            normalizedURI = nil
+            inviterUsername = nil
+            return
+        }
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            state = .empty
+            normalizedURI = nil
+            inviterUsername = nil
+            return
+        }
+        guard let uri = service.normalize(trimmed),
+              let preview = service.preview(for: uri),
+              preview.structurallyValid else {
+            state = .invalid
+            normalizedURI = nil
+            inviterUsername = nil
+            return
+        }
+        normalizedURI = uri
+        inviterUsername = preview.hasInviter ? preview.inviterUsername : nil
+        state = .valid
+    }
+}
+
+struct ClaimInvitationScreen: View {
+    @StateObject private var viewModel = ClaimInvitationViewModel()
+    @State private var showScanner = false
+    @FocusState private var isInputFocused: Bool
+
+    /// Prefill from a deep link; nil for the manual paste/scan entry.
+    let initialLink: String?
+    /// Called with the normalized invitation URI when the user
+    /// continues to the username form.
+    var onContinue: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(NSLocalizedString("Claim your invitation", comment: "DashPay Invitations"))
+                .foregroundColor(.primaryText)
+                .font(.title1)
+                .padding(.top, 12)
+            Text(NSLocalizedString("Paste the invitation link you received, or scan its QR code. It funds your username registration.", comment: "DashPay Invitations"))
+                .foregroundColor(.secondaryText)
+                .font(.system(size: 14))
+                .padding(.top, 4)
+
+            TextField(
+                "dashpay://invite?…",
+                text: $viewModel.input,
+                axis: .vertical
+            )
+            .font(.system(size: 14, design: .monospaced))
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .lineLimit(2...5)
+            .focused($isInputFocused)
+            .padding(12)
+            .background(Color.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.top, 20)
+
+            Button {
+                showScanner = true
+            } label: {
+                Label(
+                    NSLocalizedString("Scan QR code", comment: "DashPay Invitations"),
+                    systemImage: "qrcode.viewfinder")
+                    .font(.subheadline)
+            }
+            .padding(.top, 12)
+
+            feedback
+                .padding(.top, 20)
+
+            Spacer()
+
+            DashButton(
+                text: NSLocalizedString("Continue", comment: ""),
+                isEnabled: viewModel.state == .valid
+            ) {
+                guard let uri = viewModel.normalizedURI else { return }
+                onContinue(uri)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .sheet(isPresented: $showScanner) {
+            GenericQRScannerView(
+                onQRCodeScanned: { value in
+                    viewModel.input = value
+                    showScanner = false
+                },
+                onCancel: { showScanner = false })
+        }
+        .onAppear {
+            if let initialLink, viewModel.input.isEmpty {
+                viewModel.input = initialLink
+            } else {
+                isInputFocused = true
+            }
+            viewModel.evaluate()
+        }
+        .onChange(of: viewModel.input) { _ in
+            viewModel.evaluate()
+        }
+    }
+
+    @ViewBuilder
+    private var feedback: some View {
+        switch viewModel.state {
+        case .empty:
+            EmptyView()
+
+        case .invalid:
+            Label(
+                NSLocalizedString("This is not a valid invitation link", comment: "DashPay Invitations"),
+                systemImage: "xmark.octagon")
+                .font(.subheadline)
+                .foregroundColor(.red)
+
+        case .alreadyRegistered:
+            Label(
+                NSLocalizedString("You cannot claim this invite since you already have a Dash username", comment: ""),
+                systemImage: "person.crop.circle.badge.exclamationmark")
+                .font(.subheadline)
+                .foregroundColor(.orange)
+
+        case .valid:
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "envelope.open")
+                    .foregroundColor(.dashBlue)
+                    .font(.system(size: 20))
+                VStack(alignment: .leading, spacing: 4) {
+                    if let inviter = viewModel.inviterUsername {
+                        Text(String.localizedStringWithFormat(
+                            NSLocalizedString("Invitation from %@", comment: "DashPay Invitations"),
+                            inviter))
+                            .font(.subheadline.bold())
+                            .foregroundColor(.primaryText)
+                    } else {
+                        Text(NSLocalizedString("Valid invitation", comment: "DashPay Invitations"))
+                            .font(.subheadline.bold())
+                            .foregroundColor(.primaryText)
+                    }
+                    // The voucher amount is not in the link — it is read
+                    // from the funding transaction during the claim — so
+                    // no amount is shown here.
+                    Text(NSLocalizedString("Continue to pick your username. The invitation pays the registration fee.", comment: "DashPay Invitations"))
+                        .font(.caption)
+                        .foregroundColor(.secondaryText)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.dashBlue.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+}

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -21,12 +21,20 @@ import SwiftUI
 class CreateUsernameViewController: UIViewController {
     @objc var completionHandler: ((Bool) -> ())?
 
+    /// Normalized invitation URI (see `DWInvitationLinkNormalizer`)
+    /// when this form is claiming a DIP-13 invitation; nil for the
+    /// regular self-funded registration.
+    private let invitationURI: String?
+    private let definedUsername: String?
+
     @objc
     init(dashPayModel: DWDashPayProtocol, invitationURL: URL?, definedUsername: String?) {
-        // TODO: invites. `dashPayModel` / `invitationURL` / `definedUsername`
-        // are part of the Obj-C navigation contract (3 call sites) but the
-        // new-user SwiftUI flow drives registration straight through
-        // `DWIdentityRegistrationBridge`, so none are stored here.
+        // `dashPayModel` is part of the Obj-C navigation contract but
+        // the SwiftUI flow drives registration straight through
+        // `DWIdentityRegistrationBridge` / the coordinator, so it is
+        // not stored here.
+        self.invitationURI = invitationURL?.absoluteString
+        self.definedUsername = definedUsername
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -39,7 +47,10 @@ class CreateUsernameViewController: UIViewController {
 
         self.view.backgroundColor = UIColor.dw_secondaryBackground()
 
-        let content = CreateUsernameView {
+        let content = CreateUsernameView(
+            invitationURI: invitationURI,
+            definedUsername: definedUsername
+        ) {
             let navigationController = self.navigationController
             #if DASHPAY
             let mainTabController = self.tabBarController as? MainTabbarController
@@ -99,6 +110,15 @@ struct CreateUsernameView: View {
     /// human-readable failure message. OK clears it and keeps the
     /// screen up so the user can edit or retry.
     @State private var registrationErrorMessage: String? = nil
+    /// Post-claim contact-request failure. The username IS registered
+    /// at this point — the alert reports the failed request and its OK
+    /// finishes the flow (the request is re-sendable from Contacts).
+    @State private var inviterContactErrorMessage: String? = nil
+    /// Normalized invitation URI when claiming (invitation mode); nil
+    /// for the regular self-funded registration.
+    var invitationURI: String? = nil
+    /// Username prefill carried by the deep link (`definedUsername`).
+    var definedUsername: String? = nil
     var finish: () -> Void
 
     var body: some View {
@@ -155,19 +175,30 @@ struct CreateUsernameView: View {
                     .padding(.top, 20)
             }
 
+            // Invitation-claim mode: the voucher funds the registration,
+            // so the shielded readiness hint and the funding-source
+            // picker below don't apply and stay hidden. A short banner
+            // states the funding instead.
+            if viewModel.isInvitationMode {
+                invitationFundingBanner
+                    .padding(.top, 20)
+            }
+
             // Shielded readiness hint. Shown while the privacy-preserving
             // funding path is NOT yet available (needs funds / maturing /
             // pool below the consensus minimum) so the user learns what
             // the wait is for without being blocked — the transparent
             // sources below remain an explicit choice.
-            shieldedReadinessHint
+            if !viewModel.isInvitationMode {
+                shieldedReadinessHint
+            }
 
             // Funding source picker. Visible when two or more sources
             // can cover the identity-registration cost. When only one
             // is viable, the picker stays hidden and `fundingSource` is
             // auto-pinned by `syncFundingSourceToViableSource()` so the
             // Continue handler routes correctly without UI clutter.
-            if viableFundingSources.count >= 2 {
+            if !viewModel.isInvitationMode, viableFundingSources.count >= 2 {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(NSLocalizedString("Pay with", comment: "Usernames"))
                         .foregroundColor(.secondaryText)
@@ -212,6 +243,12 @@ struct CreateUsernameView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear {
             isTextInputFocused = true
+            if let invitationURI {
+                viewModel.configureInvitationMode(uri: invitationURI)
+            }
+            if let definedUsername, !definedUsername.isEmpty, viewModel.username.isEmpty {
+                viewModel.username = definedUsername
+            }
             // Seed the picker selection so a wallet with only one
             // viable source (typical case) doesn't default to a
             // non-viable Core path.
@@ -243,11 +280,43 @@ struct CreateUsernameView: View {
             NSLocalizedString("Username registered", comment: "Usernames"),
             isPresented: $showSuccess
         ) {
-            Button(NSLocalizedString("OK", comment: "")) { finish() }
+            if let inviter = viewModel.invitationInviterUsername {
+                // Invitation claim with a known inviter: offer the
+                // contact-bootstrap (mirrors Android, where the request
+                // is sent after registration; here the user opts in).
+                Button(String.localizedStringWithFormat(
+                    NSLocalizedString("Add %@ as a contact", comment: "DashPay Invitations"),
+                    inviter)) {
+                    sendInviterContactRequest(inviter)
+                }
+                Button(NSLocalizedString("Not now", comment: ""), role: .cancel) { finish() }
+            } else {
+                Button(NSLocalizedString("OK", comment: "")) { finish() }
+            }
         } message: {
-            Text(String.localizedStringWithFormat(
-                NSLocalizedString("“%@” has been registered.", comment: "Usernames"),
-                viewModel.username))
+            if viewModel.invitationInviterUsername != nil {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("“%@” has been registered. Send a contact request to the person who invited you?", comment: "DashPay Invitations"),
+                    viewModel.username))
+            } else {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("“%@” has been registered.", comment: "Usernames"),
+                    viewModel.username))
+            }
+        }
+        .alert(
+            NSLocalizedString("Contact request failed", comment: "DashPay Invitations"),
+            isPresented: Binding(
+                get: { inviterContactErrorMessage != nil },
+                set: { if !$0 { inviterContactErrorMessage = nil; finish() } }
+            )
+        ) {
+            Button(NSLocalizedString("OK", comment: "")) {
+                inviterContactErrorMessage = nil
+                finish()
+            }
+        } message: {
+            Text(inviterContactErrorMessage ?? "")
         }
         .alert(
             NSLocalizedString("Registration failed", comment: "Usernames"),
@@ -353,8 +422,44 @@ struct CreateUsernameView: View {
     /// `.core` on every terminal phase, so a stale picker value
     /// can't leak into a future attempt; this single write is the
     /// only synchronization needed.
+    /// Invitation-claim funding banner (invitation mode only).
+    private var invitationFundingBanner: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "envelope.open")
+                .foregroundColor(.dashBlue)
+                .font(.system(size: 20))
+            Text(NSLocalizedString("Your invitation pays the registration fee for this username.", comment: "DashPay Invitations"))
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.dashBlue.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// Post-claim contact-bootstrap: resolve the `du` inviter and send
+    /// them a request. The username is already registered — a failure
+    /// here is reported (and re-sendable from Contacts) but never
+    /// unwinds the claim.
+    private func sendInviterContactRequest(_ inviter: String) {
+        Task {
+            inProgress = true
+            defer { inProgress = false }
+            do {
+                try await DWInvitationService.shared.sendContactRequestToInviter(username: inviter)
+                finish()
+            } catch {
+                inviterContactErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
     private func performSubmit() {
-        DWIdentityRegistrationBridge.shared.preferredFundingSource = fundingSource
+        if !viewModel.isInvitationMode {
+            DWIdentityRegistrationBridge.shared.preferredFundingSource = fundingSource
+        }
         Task {
             // `inProgress` keeps the Continue spinner up — and the screen
             // alive — across the PIN gate and the whole registration. The
@@ -417,6 +522,10 @@ struct CreateUsernameView: View {
             return "Platform (\(viewModel.platformPaymentBalance) Dash)"
         case .core:
             return "Core (\(viewModel.balance) Dash)"
+        case .invitation:
+            // Never user-pickable — `viableFundingSources` never
+            // contains it and the picker is hidden in invitation mode.
+            return ""
         }
     }
 

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -113,6 +113,27 @@ class CreateUsernameViewModel: ObservableObject {
     var hasReadyShieldedFunding: Bool {
         shieldedReadiness?.state == .ready
     }
+
+    /// Non-nil puts the form in invitation-claim mode (DIP-13): the
+    /// registration is funded by the voucher in this normalized link,
+    /// so the balance-based cost rule and the funding-source picker do
+    /// not apply, and submit routes through
+    /// `DWIdentityRegistrationCoordinator.startClaimInvitation`.
+    @Published private(set) var invitationURI: String? = nil
+    /// The inviter's DPNS username (`du`) when the invitation carries
+    /// one — drives the post-claim "send a contact request?" offer.
+    @Published private(set) var invitationInviterUsername: String? = nil
+
+    var isInvitationMode: Bool { invitationURI != nil }
+
+    /// Enter invitation-claim mode with a normalized invitation URI
+    /// (see `DWInvitationLinkNormalizer`). Re-runs validation so the
+    /// cost rule reflects the voucher funding.
+    func configureInvitationMode(uri: String) {
+        invitationURI = uri
+        invitationInviterUsername = DWInvitationService.shared.preview(for: uri)?.inviterUsername
+        validateUsername(username: username)
+    }
     
     var minimumRequiredBalance: String {
         return DWDP_MIN_BALANCE_TO_CREATE_USERNAME.dashAmount.formattedDashAmountWithoutCurrencySymbol
@@ -166,7 +187,7 @@ class CreateUsernameViewModel: ObservableObject {
     /// Kick off SwiftDashSDK identity + DPNS registration and suspend
     /// until the terminal phase. Routes straight to
     /// `DWIdentityRegistrationBridge` (instead of
-    /// `DWDashPayModel.createUsername:invitation:`) so the awaiting
+    /// `DWDashPayModel.createUsername:`) so the awaiting
     /// caller gets a one-shot success / cancel / failure signal to drive
     /// the on-screen popup. The model's `bridgeRegistrationStateChanged:`
     /// observer still mirrors progress to the home banner + writes the
@@ -181,6 +202,30 @@ class CreateUsernameViewModel: ObservableObject {
         submittedRegistrationUsername = submittedUsername
         didNotifyRegistrationStarted = false
         self.onRegistrationStarted = onRegistrationStarted
+
+        // Invitation-claim mode: same coordinator, but the voucher in
+        // the link funds the IdentityCreate, so the call carries the
+        // URI and is awaited directly (no Obj-C bridge completion to
+        // adapt). Phase-driven `onRegistrationStarted` still fires via
+        // `handleRegistrationPhase` — the coordinator publishes the
+        // same phases for every funding source.
+        if let invitationURI {
+            defer {
+                submittedRegistrationUsername = nil
+                didNotifyRegistrationStarted = false
+                self.onRegistrationStarted = nil
+            }
+            do {
+                _ = try await DWIdentityRegistrationCoordinator.shared.startClaimInvitation(
+                    username: submittedUsername,
+                    invitationURI: invitationURI)
+                return .success
+            } catch DWIdentityRegistrationCoordinator.CoordinatorError.authCancelled {
+                return .cancelled
+            } catch {
+                return .failure(error.localizedDescription)
+            }
+        }
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UsernameRegistrationOutcome, Never>) in
             DWIdentityRegistrationBridge.shared.startCreateUsername(submittedUsername) { [weak self] _, error in
@@ -290,13 +335,20 @@ class CreateUsernameViewModel: ObservableObject {
         let shieldedRequired = ShieldedIdentityFundingReadiness.requiredCredits(forContestedName: isContested)
         shieldedReadiness = ShieldedIdentityFundingReadiness.shared.evaluate(requiredCredits: shieldedRequired)
         armShieldedMaturityRevalidation()
-        let hasEnoughBalance = hasEnoughCore || hasEnoughPlatform || hasReadyShieldedFunding
+        // Invitation-claim mode: the voucher pays the registration, so
+        // no local balance is required and the cost rule stays hidden.
+        // Whether the voucher actually covers the cost is only known at
+        // claim time (the amount is not in the link) — the coordinator
+        // surfaces an insufficient-voucher failure through the normal
+        // error alert.
+        let voucherFunded = isInvitationMode
+        let hasEnoughBalance = voucherFunded || hasEnoughCore || hasEnoughPlatform || hasReadyShieldedFunding
         let canContinue = lengthValid && !hasIllegalCharacters && !startsOrEndsWithHyphen && hasEnoughBalance
 
         uiState = CreateUsernameUIState(
             lengthRule: lengthValid ? .valid : .invalid,
             allowedCharactersRule: hasIllegalCharacters || startsOrEndsWithHyphen ? .invalid : .valid,
-            costRule: hasEnoughBalance ? .valid : .invalid,
+            costRule: voucherFunded ? .hidden : (hasEnoughBalance ? .valid : .invalid),
             usernameBlockedRule: canContinue ? .loading : .hidden,
             requiredDash: requiredCost,
             canContinue: false

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayInfoDialog.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayInfoDialog.swift
@@ -20,13 +20,24 @@ import SwiftUI
 public struct JoinDashPayInfoDialog: View {
     @Environment(\.presentationMode) private var presentationMode
     var action: () -> Void
-    
+    /// Non-nil surfaces the "Have an invitation?" redeem entry on the
+    /// embedded join screen; the dialog dismisses before forwarding.
+    var onClaimInvitation: (() -> Void)? = nil
+
     public var body: some View {
         BottomSheet(showBackButton: Binding<Bool>.constant(false)) {
-            JoinDashPayScreen {
-                presentationMode.wrappedValue.dismiss()
-                action()
-            }
+            JoinDashPayScreen(
+                action: {
+                    presentationMode.wrappedValue.dismiss()
+                    action()
+                },
+                onClaimInvitation: onClaimInvitation.map { claim in
+                    {
+                        presentationMode.wrappedValue.dismiss()
+                        claim()
+                    }
+                }
+            )
         }
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
@@ -21,32 +21,46 @@ public struct JoinDashPayScreen: View {
     @StateObject private var viewModel = CreateUsernameViewModel.shared
     @State private var navigateToVotingInfo = false
     var action: () -> Void
-    
+    /// Non-nil renders the "Have an invitation?" entry — the
+    /// install-then-paste redeem path for invited users (DIP-13).
+    var onClaimInvitation: (() -> Void)? = nil
+
     public var body: some View {
         ZStack {
-            TextIntro(
-                buttonLabel: NSLocalizedString("Continue", comment: ""),
-                action: { navigateToVotingInfo = true },
-                // A transparent balance is no longer a hard precondition:
-                // the shielded route starts with ADDING funds (via the
-                // get-ready checklist after Continue), so the button only
-                // stays disabled while the wallet hasn't hydrated yet.
-                isActionEnabled: viewModel.hasMinimumRequiredBalance || viewModel.shieldedReadiness != nil,
-                inProgress: .constant(false),
-                topText: {
-                    FeatureTopText(
-                        title: NSLocalizedString("Join DashPay", comment: ""),
-                        text: NSLocalizedString("Forget about long crypto addresses, create the username, find friends and add them to your contacts", comment: "")
-                    )
-                },
-                features: {[
-                    FeatureSingleItem(iconName: .custom("username.letter"), title: NSLocalizedString("Create a username", comment: ""), description: NSLocalizedString("Pay to usernames. No more alphanumeric addresses.", comment: "")),
-                    FeatureSingleItem(iconName: .custom("friends.add"), title: NSLocalizedString("Add your friends & family", comment: ""), description: NSLocalizedString("Invite your family, find your friends by searching their usernames.", comment: "")),
-                    FeatureSingleItem(iconName: .custom("profile.personalized"), title: NSLocalizedString("Personalise profile", comment: ""), description: NSLocalizedString("Upload your picture, personalize your identity.", comment: "")),
-                    FeatureSingleItem(iconName: .system("shield.lefthalf.filled"), title: NSLocalizedString("Private by design", comment: "Usernames"), description: NSLocalizedString("Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.", comment: "Usernames"))
-                ]},
-                info: getInfo()
-            )
+            VStack(spacing: 0) {
+                TextIntro(
+                    buttonLabel: NSLocalizedString("Continue", comment: ""),
+                    action: { navigateToVotingInfo = true },
+                    // A transparent balance is no longer a hard precondition:
+                    // the shielded route starts with ADDING funds (via the
+                    // get-ready checklist after Continue), so the button only
+                    // stays disabled while the wallet hasn't hydrated yet.
+                    isActionEnabled: viewModel.hasMinimumRequiredBalance || viewModel.shieldedReadiness != nil,
+                    inProgress: .constant(false),
+                    topText: {
+                        FeatureTopText(
+                            title: NSLocalizedString("Join DashPay", comment: ""),
+                            text: NSLocalizedString("Forget about long crypto addresses, create the username, find friends and add them to your contacts", comment: "")
+                        )
+                    },
+                    features: {[
+                        FeatureSingleItem(iconName: .custom("username.letter"), title: NSLocalizedString("Create a username", comment: ""), description: NSLocalizedString("Pay to usernames. No more alphanumeric addresses.", comment: "")),
+                        FeatureSingleItem(iconName: .custom("friends.add"), title: NSLocalizedString("Add your friends & family", comment: ""), description: NSLocalizedString("Invite your family, find your friends by searching their usernames.", comment: "")),
+                        FeatureSingleItem(iconName: .custom("profile.personalized"), title: NSLocalizedString("Personalise profile", comment: ""), description: NSLocalizedString("Upload your picture, personalize your identity.", comment: "")),
+                        FeatureSingleItem(iconName: .system("shield.lefthalf.filled"), title: NSLocalizedString("Private by design", comment: "Usernames"), description: NSLocalizedString("Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.", comment: "Usernames"))
+                    ]},
+                    info: getInfo()
+                )
+
+                if let onClaimInvitation {
+                    Button(action: onClaimInvitation) {
+                        Text(NSLocalizedString("Have an invitation?", comment: "DashPay Invitations"))
+                            .font(.subheadline)
+                            .foregroundColor(.dashBlue)
+                    }
+                    .padding(.bottom, 12)
+                }
+            }
 
             NavigationLink(
                 destination: VotingInfoScreen(action: action).navigationBarHidden(true),

--- a/DashWallet/Sources/UI/DashPay/Setup/Model/DWDashPaySetupModel.m
+++ b/DashWallet/Sources/UI/DashPay/Setup/Model/DWDashPaySetupModel.m
@@ -41,7 +41,7 @@
     // nop
 }
 
-- (void)createUsername:(nonnull NSString *)username invitation:(nullable NSURL *)invitation {
+- (void)createUsername:(nonnull NSString *)username {
     NSAssert(NO, @"Should not be called");
     // nop
 }
@@ -60,11 +60,6 @@
 }
 
 - (void)updateUsernameStatus {
-    // nop
-}
-
-- (void)verifyDeeplink:(nonnull NSURL *)url completion:(nonnull void (^)(BOOL, NSString *_Nullable, NSString *_Nullable))completion {
-    NSAssert(NO, @"Should not be called");
     // nop
 }
 

--- a/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
@@ -170,6 +170,13 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
 
     func showCreateUsername(withInvitation invitationURL: URL?, definedUsername: String?) {
         #if DASHPAY
+        // Invitation claim: the voucher funds the registration, so the
+        // shielded get-ready interstitial doesn't apply — straight to
+        // the form in invitation mode.
+        if invitationURL != nil {
+            pushCreateUsernameForm(invitationURL: invitationURL, definedUsername: definedUsername)
+            return
+        }
         // Route through the shielded get-ready interstitial whenever
         // the privacy-preserving funding path isn't ready (needs funds
         // / maturing / pool below minimum) so the privacy clock starts
@@ -184,6 +191,16 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
         }
         #endif
     }
+
+    #if DASHPAY
+    /// Manual redeem entry (Join DashPay dialog → "Have an invitation?"):
+    /// paste/scan screen, then the username form in invitation mode.
+    func showClaimInvitation() {
+        ClaimInvitationFlow.pushRedeemScreen(
+            on: navigationController,
+            dashPayModel: model.dashPayModel)
+    }
+    #endif
 
     #if DASHPAY
     private func showJoinDashPayReadiness() {
@@ -202,8 +219,8 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
         navigationController?.pushViewController(hosting, animated: true)
     }
 
-    private func pushCreateUsernameForm() {
-        let controller = CreateUsernameViewController(dashPayModel: model.dashPayModel, invitationURL: nil, definedUsername: nil)
+    private func pushCreateUsernameForm(invitationURL: URL? = nil, definedUsername: String? = nil) {
+        let controller = CreateUsernameViewController(dashPayModel: model.dashPayModel, invitationURL: invitationURL, definedUsername: definedUsername)
         controller.hidesBottomBarWhenPushed = true
         controller.completionHandler = { result in
             if (result) {

--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -121,7 +121,7 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
 
     #if DASHPAY
     func handleDeeplink(_ url: URL, definedUsername: String?) {
-        if model.dashPayModel.blockchainIdentity != nil {
+        if DWInvitationService.shared.hasLocalIdentity {
             let title = NSLocalizedString("Username already found", comment: "")
             let message = NSLocalizedString("You cannot claim this invite since you already have a Dash username", comment: "")
             let alert = DPAlertViewController(icon: UIImage(named: "icon_invitation_error")!, title: title, description: message)
@@ -137,16 +137,18 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
             return
         }
 
-        model.handleDeeplink(url) { [weak self] success, errorTitle, errorMessage in
-            guard let self = self else { return }
-
-            if success {
-                self.showCreateUsername(withInvitation: url, definedUsername: definedUsername)
-            } else {
-                let alert = DPAlertViewController(icon: UIImage(named: "icon_invitation_error")!, title: errorTitle ?? "", description: errorMessage ?? "")
-                self.present(alert, animated: true, completion: nil)
-            }
-        }
+        // The redeem screen owns validation: an unrecognized or
+        // structurally invalid link renders its inline error state
+        // (and the field stays editable), so no pre-flight alert is
+        // needed. Claim-time failures (already claimed, wrong network,
+        // insufficient voucher) surface in the username form's error
+        // alert from the coordinator.
+        let prefill = DWInvitationLinkNormalizer.normalize(url) ?? url.absoluteString
+        ClaimInvitationFlow.pushRedeemScreen(
+            on: navigationController,
+            dashPayModel: model.dashPayModel,
+            initialLink: prefill,
+            definedUsername: definedUsername)
     }
     #endif
 
@@ -635,6 +637,12 @@ extension HomeViewController: HomeViewDelegate {
         let action = ShortcutAction(type: .createUsername)
         performAction(for: action, sender: nil)
     }
+
+    #if DASHPAY
+    func homeViewClaimInvitation() {
+        showClaimInvitation()
+    }
+    #endif
 
     func homeViewShowSyncingStatus() {
         let controller = SyncingAlertViewController()

--- a/DashWallet/Sources/UI/Home/Models/DWDashPayModel.m
+++ b/DashWallet/Sources/UI/Home/Models/DWDashPayModel.m
@@ -27,14 +27,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 NSNotificationName const DWDashPayRegistrationStatusUpdatedNotification = @"DWDashPayRegistrationStatusUpdatedNotification";
-NSNotificationName const DWDashPaySentContactRequestToInviter = @"kDWDashPaySentContactRequestToInviter";
 
 @interface DWDashPayModel ()
 
 @property (nullable, nonatomic, strong) DWDPRegistrationStatus *registrationStatus;
 @property (nullable, nonatomic, strong) NSError *lastRegistrationError;
 @property (nonatomic, assign) BOOL isInvitationNotificationAllowed;
-@property (nullable, nonatomic, strong) NSURL *invitation;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -146,48 +144,15 @@ NS_ASSUME_NONNULL_END
     return blockchainIdentity == nil;
 }
 
-- (void)createUsername:(NSString *)username invitation:(nullable NSURL *)invitationURL {
-    self.invitation = invitationURL;
+- (void)createUsername:(NSString *)username {
+    // Invitation-funded registration no longer goes through this
+    // model — the SwiftUI form drives
+    // `DWIdentityRegistrationCoordinator.startClaimInvitation` directly
+    // (see CreateUsernameViewModel).
     self.lastRegistrationError = nil;
     [DWGlobalOptions sharedInstance].dashpayUsername = username;
 
     DSWallet *wallet = [DWEnvironment sharedInstance].currentWallet;
-
-    if (invitationURL != nil) {
-        DSBlockchainInvitation *invitation = [[DSBlockchainInvitation alloc] initWithInvitationLink:invitationURL.absoluteString inWallet:wallet];
-
-        __weak typeof(self) weakSelf = self;
-        [invitation
-            acceptInvitationUsingWalletIndex:0
-            setDashpayUsername:username
-            authenticationPrompt:NSLocalizedString(@"Would you like to accept the invitation?", nil)
-            identityRegistrationSteps:[self invitationSteps]
-            stepCompletion:^(DSBlockchainIdentityRegistrationStep stepCompleted) {
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                if (!strongSelf) {
-                    return;
-                }
-
-                [strongSelf handleSteps:stepCompleted error:nil];
-            }
-            completion:^(DSBlockchainIdentityRegistrationStep stepsCompleted, NSError *_Nonnull error) {
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                if (!strongSelf) {
-                    return;
-                }
-
-                NSLog(@">>> completed invitation %@ - %@", @(stepsCompleted), error);
-
-                [strongSelf handleSteps:stepsCompleted error:error];
-
-                if (!error) {
-                    [strongSelf sendContactRequestToInviterUsingInvitationURL:invitationURL];
-                }
-            }
-            completionQueue:dispatch_get_main_queue()];
-
-        return;
-    }
 
     DSBlockchainIdentity *blockchainIdentity = wallet.defaultBlockchainIdentity;
 
@@ -254,54 +219,12 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-- (void)sendContactRequestToInviterUsingInvitationURL:(NSURL *)invitationURL {
-    NSURLComponents *components = [NSURLComponents componentsWithURL:invitationURL resolvingAgainstBaseURL:NO];
-    NSString *username;
-
-    for (NSURLQueryItem *item in components.queryItems) {
-        if ([item.name isEqualToString:@"du"]) {
-            username = item.value;
-            break;
-        }
-    }
-
-    if (!username) {
-        return;
-    }
-
-    DSIdentitiesManager *manager = [DWEnvironment sharedInstance].currentChainManager.identitiesManager;
-    __weak typeof(self) weakSelf = self;
-    [manager searchIdentityByDashpayUsername:username
-                              withCompletion:^(BOOL success, DSBlockchainIdentity *_Nullable blockchainIdentity, NSError *_Nullable error) {
-                                  if (success) {
-
-                                      DSWallet *wallet = [DWEnvironment sharedInstance].currentWallet;
-                                      DSBlockchainIdentity *myBlockchainIdentity = wallet.defaultBlockchainIdentity;
-
-                                      [myBlockchainIdentity sendNewFriendRequestToBlockchainIdentity:blockchainIdentity
-                                                                                          completion:^(BOOL success, NSArray<NSError *> *_Nullable errors) {
-                                                                                              DWLog(@"Friend request sent %i", success);
-                                                                                          }];
-                                  }
-                              }];
-}
-
-- (void)sendContactRequestToBlockchainIdentity:(DSBlockchainIdentity *)blockchainIdentity {
-
-    DSWallet *wallet = [DWEnvironment sharedInstance].currentWallet;
-    DSBlockchainIdentity *myBlockchainIdentity = wallet.defaultBlockchainIdentity;
-    [myBlockchainIdentity sendNewFriendRequestToBlockchainIdentity:blockchainIdentity
-                                                        completion:^(BOOL success, NSArray<NSError *> *_Nullable errors){
-
-                                                        }];
-}
-
 - (BOOL)canRetry {
     return self.username != nil;
 }
 
 - (void)retry {
-    [self createUsername:self.username invitation:self.invitation];
+    [self createUsername:self.username];
 }
 
 - (void)completeRegistration {
@@ -337,49 +260,6 @@ NS_ASSUME_NONNULL_END
 
 - (void)setHasEnoughBalanceForInvitationNotification:(BOOL)value {
     self.isInvitationNotificationAllowed = ([DWGlobalOptions sharedInstance].dpInvitationFlowEnabled && value);
-}
-
-- (void)verifyDeeplink:(NSURL *)url
-            completion:(void (^)(BOOL success,
-                                 NSString *_Nullable errorTitle,
-                                 NSString *_Nullable errorMessage))completion {
-    if (MOCK_DASHPAY) {
-        completion(YES, nil, nil);
-        return;
-    }
-
-    DSChain *chain = [DWEnvironment sharedInstance].currentChain;
-    [DSBlockchainInvitation
-        verifyInvitationLink:url.absoluteString
-                     onChain:chain
-                  completion:^(DSTransaction *_Nonnull transaction, bool spent, NSError *_Nonnull error) {
-                      NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-                      NSString *username = @"<unknown user>";
-                      for (NSURLQueryItem *item in components.queryItems) {
-                          if ([item.name isEqualToString:@"du"]) {
-                              username = item.value;
-                              break;
-                          }
-                      }
-                      if (transaction != nil) {
-                          completion(YES, nil, nil);
-                      }
-                      else {
-                          if (spent) {
-                              completion(
-                                  NO,
-                                  NSLocalizedString(@"Invitation already claimed", nil),
-                                  [NSString stringWithFormat:NSLocalizedString(@"Your invitation from %@ has been already claimed", nil), username]);
-                          }
-                          else {
-                              completion(
-                                  NO,
-                                  NSLocalizedString(@"Invalid Inviation", nil),
-                                  [NSString stringWithFormat:NSLocalizedString(@"Your invitation from %@ is not valid", nil), username]);
-                          }
-                      }
-                  }
-             completionQueue:dispatch_get_main_queue()];
 }
 
 #pragma mark - Notifications
@@ -513,12 +393,6 @@ NS_ASSUME_NONNULL_END
 
 - (DSBlockchainIdentityRegistrationStep)steps {
     return DSBlockchainIdentityRegistrationStep_RegistrationStepsWithUsername;
-}
-
-- (DSBlockchainIdentityRegistrationStep)invitationSteps {
-    return (DSBlockchainIdentityRegistrationStep_LocalInWalletPersistence |
-            DSBlockchainIdentityRegistrationStep_Identity |
-            DSBlockchainIdentityRegistrationStep_Username);
 }
 
 - (void)handleSteps:(DSBlockchainIdentityRegistrationStep)stepsCompleted error:(nullable NSError *)error {

--- a/DashWallet/Sources/UI/Home/Models/DWHomeModel.m
+++ b/DashWallet/Sources/UI/Home/Models/DWHomeModel.m
@@ -232,12 +232,6 @@ NS_ASSUME_NONNULL_BEGIN
     return canRegisterUsername && isSynced && isEnoughBalance;
 }
 
-- (void)handleDeeplink:(NSURL *)url
-            completion:(void (^)(BOOL success,
-                                 NSString *_Nullable errorTitle,
-                                 NSString *_Nullable errorMessage))completion {
-    [self.dashPayModel verifyDeeplink:url completion:completion];
-}
 #endif
 
 #pragma mark - Notifications

--- a/DashWallet/Sources/UI/Home/Protocols/DWDashPayProtocol.h
+++ b/DashWallet/Sources/UI/Home/Protocols/DWDashPayProtocol.h
@@ -20,7 +20,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSNotificationName const DWDashPayRegistrationStatusUpdatedNotification;
-extern NSNotificationName const DWDashPaySentContactRequestToInviter;
 
 @class DWDPRegistrationStatus;
 @class DSBlockchainIdentity;
@@ -50,17 +49,12 @@ extern NSNotificationName const DWDashPaySentContactRequestToInviter;
 @property (readonly, nonatomic, assign) BOOL hasIdentity;
 
 - (BOOL)shouldPresentRegistrationPaymentConfirmation;
-- (void)createUsername:(NSString *)username invitation:(nullable NSURL *)invitation;
+- (void)createUsername:(NSString *)username;
 - (BOOL)canRetry;
 - (void)retry;
 - (void)completeRegistration;
 - (void)updateUsernameStatus;
 - (void)setHasEnoughBalanceForInvitationNotification:(BOOL)value;
-
-- (void)verifyDeeplink:(NSURL *)url
-            completion:(void (^)(BOOL success,
-                                 NSString *_Nullable errorTitle,
-                                 NSString *_Nullable errorMessage))completion;
 
 @end
 

--- a/DashWallet/Sources/UI/Home/Protocols/DWHomeProtocol.h
+++ b/DashWallet/Sources/UI/Home/Protocols/DWHomeProtocol.h
@@ -53,13 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)retrySyncing;
 - (void)checkCrowdNodeState;
 
-#if DASHPAY
-- (void)handleDeeplink:(NSURL *)url
-            completion:(void (^)(BOOL success,
-                                 NSString *_Nullable errorTitle,
-                                 NSString *_Nullable errorMessage))completion;
-#endif
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -28,6 +28,7 @@ protocol HomeViewDelegate: AnyObject {
 #if DASHPAY
     func homeView(_ homeView: HomeView, didUpdateProfile identity: DSBlockchainIdentity?, unreadNotifications: UInt)
     func homeViewRequestUsername()
+    func homeViewClaimInvitation()
     func homeViewEditProfile()
 #endif
 }
@@ -162,6 +163,7 @@ struct HomeViewContent<Content: View>: View {
     @State private var showFilterDialog: Bool = false
     @State private var shouldShowJoinDashPayInfo: Bool = false
     @State private var navigateToDashPayFlow: Bool = false
+    @State private var navigateToClaimInvitation: Bool = false
     @State private var giftCardTxId: Data? = nil
     @State private var pendingShieldedRecovery: Transaction? = nil
 
@@ -297,10 +299,18 @@ struct HomeViewContent<Content: View>: View {
                 navigateToDashPayFlow = false
                 delegate?.homeViewRequestUsername()
             }
-        }) {
-            let joinDashPayDialog = JoinDashPayInfoDialog {
-                navigateToDashPayFlow = true
+            if navigateToClaimInvitation {
+                navigateToClaimInvitation = false
+                delegate?.homeViewClaimInvitation()
             }
+        }) {
+            let joinDashPayDialog = JoinDashPayInfoDialog(
+                action: {
+                    navigateToDashPayFlow = true
+                },
+                onClaimInvitation: {
+                    navigateToClaimInvitation = true
+                })
             
             if #available(iOS 16.0, *) {
                 joinDashPayDialog.presentationDetents([.height(600)])

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -353,9 +353,13 @@ struct MainMenuScreen: View {
         }
         #if DASHPAY
         .sheet(isPresented: $showDashPayInfo) {
-            let dialog = JoinDashPayInfoDialog {
-                self.joinDashPay()
-            }
+            let dialog = JoinDashPayInfoDialog(
+                action: {
+                    self.joinDashPay()
+                },
+                onClaimInvitation: {
+                    self.claimInvitation()
+                })
             
             if #available(iOS 16.0, *) {
                 dialog.presentationDetents([.height(600)])
@@ -486,6 +490,14 @@ struct MainMenuScreen: View {
         vc.pushViewController(controller, animated: true)
     }
     
+    #if DASHPAY
+    /// Manual redeem entry (Join DashPay dialog → "Have an invitation?").
+    private func claimInvitation() {
+        guard let dashPayModel = viewModel.dashPayModel else { return }
+        ClaimInvitationFlow.pushRedeemScreen(on: vc, dashPayModel: dashPayModel)
+    }
+    #endif
+
     private func joinDashPay() {
         guard let dashPayModel = viewModel.dashPayModel else { return }
         

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -16,6 +16,9 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* Usernames */
+"%@ Dash available" = "%@ Dash available";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
@@ -60,6 +63,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld of %ld deposits";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -184,11 +190,20 @@
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
 
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds.";
+
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Add at least %@ Dash to your Shielded balance";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Add to your Shielded balance now and register your username privately a few hours later";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -439,6 +454,9 @@
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
 
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files";
+
 /* Buy
    buy */
 "Buy" = "Buy";
@@ -681,6 +699,9 @@
 
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
+
+/* Log export */
+"Could not create the log archive: %@" = "Could not create the log archive: %@";
 
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
@@ -938,6 +959,9 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Done — your balance has rested long enough";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
@@ -1073,6 +1097,9 @@
 
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
+
+/* Log export */
+"Export Logs" = "Export Logs";
 
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
@@ -1239,6 +1266,12 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Funded from your Shielded balance — your username can't be linked to your other Dash.";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1286,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Get ready to join DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1847,6 +1883,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum met";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1972,6 +2011,9 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "No diagnostic logs were found on this device. Logs are written from the next launch onward.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
 
@@ -1992,6 +2034,9 @@
 
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing.";
 
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
@@ -2031,6 +2076,9 @@
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2314,11 +2362,17 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Private by design";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* Usernames */
+"Private registration" = "Private registration";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2361,6 +2415,9 @@
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Usernames */
+"Ready around %@" = "Ready around %@";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2427,6 +2484,9 @@
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it.";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2742,6 +2802,9 @@
 /* Share key */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Shared privacy pool at minimum size";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
 
@@ -2843,6 +2906,9 @@
 
 /* No comment provided by engineer. */
 "Staking" = "Staking";
+
+/* Usernames */
+"Starts after you add funds" = "Starts after you add funds";
 
 /* Step 1 */
 "Step %ld" = "Step %ld";
@@ -3048,6 +3114,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3230,6 +3305,9 @@
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
 
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparent funding publicly links your username to these funds.";
+
 /* An action */
 "Try again" = "Try again";
 
@@ -3353,6 +3431,9 @@
 /* Dash DEX */
 "URI" = "URI";
 
+/* Usernames */
+"Use transparent balance instead" = "Use transparent balance instead";
+
 /* Voting */
 "Username" = "Username";
 
@@ -3397,6 +3478,9 @@
 
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
+
+/* Usernames */
+"Verified during registration" = "Verified during registration";
 
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
@@ -3679,6 +3763,9 @@
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
 
 /* Usernames */
+"You have %@ Dash so far" = "You have %@ Dash so far";
+
+/* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
 
 /* CoinJoin */
@@ -3861,6 +3948,18 @@
 /* DashSpend */
 "Your session expired" = "Your session expired";
 
+/* Usernames */
+"Your Shielded balance is almost ready — you can register privately around %@." = "Your Shielded balance is almost ready — you can register privately around %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Your Shielded balance is ready — register your username privately now";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Your Shielded balance is resting — you can register privately around %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Your shielded balance is still maturing. It will be ready around %@.";
+
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
 
@@ -3884,6 +3983,9 @@
 
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
+
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.";
 
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -16,6 +16,9 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ couldn't be found on the Dash network to send them a contact request.";
+
 /* Usernames */
 "%@ Dash available" = "%@ Dash available";
 
@@ -192,6 +195,9 @@
 
 /* No comment provided by engineer. */
 "Add" = "Add";
+
+/* DashPay Invitations */
+"Add %@ as a contact" = "Add %@ as a contact";
 
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
@@ -569,6 +575,9 @@
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Claim your invitation";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
 
@@ -643,6 +652,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Contact request failed";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -672,6 +684,9 @@
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continue to pick your username. The invitation pays the registration fee.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -1365,6 +1380,9 @@
 /* Username has requested to be your friend */
 "has requested to be your friend" = "has requested to be your friend";
 
+/* DashPay Invitations */
+"Have an invitation?" = "Have an invitation?";
+
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
@@ -1604,6 +1622,9 @@
 
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
+
+/* DashPay Invitations */
+"Invitation from %@" = "Invitation from %@";
 
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
@@ -2110,6 +2131,9 @@
 /* DashPay */
 "Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";
 
+/* No comment provided by engineer. */
+"Not now" = "Not now";
+
 /* DashPay Contacts */
 "Note" = "Note";
 
@@ -2190,6 +2214,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Paste the invitation link you received, or scan its QR code. It funds your username registration.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -3255,6 +3282,12 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "This invitation link is not valid.";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "This is not a valid invitation link";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
@@ -3562,6 +3595,9 @@
 
 /* No comment provided by engineer. */
 "Users that matches %@ who are currently not in your contacts" = "Users that matches %@ who are currently not in your contacts";
+
+/* DashPay Invitations */
+"Valid invitation" = "Valid invitation";
 
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
@@ -4038,6 +4074,9 @@
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
 
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Your invitation pays the registration fee for this username.";
+
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
 
@@ -4115,3 +4154,6 @@
 
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” has been registered. Send a contact request to the person who invited you?";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -25,6 +25,9 @@
 /* Maya/SwapKit order preview - %@ is the executing provider, e.g. "Maya fee" or "NEAR fee" */
 "%@ fee" = "%@ fee";
 
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ has accepted your contact request";
+
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
 
@@ -185,10 +188,16 @@
 "Account Recovery" = "Account Recovery";
 
 /* No comment provided by engineer. */
+"Activity" = "Activity";
+
+/* No comment provided by engineer. */
 "Add" = "Add";
 
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History";
 
 /* Usernames */
 "Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds.";
@@ -643,6 +652,9 @@
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
 
+/* No comment provided by engineer. */
+"Contact Requests" = "Contact Requests";
+
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
 
@@ -769,6 +781,9 @@
 
 /* Usernames */
 "Create your username" = "Create your username";
+
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Create your Username, find friends & family with their usernames and add them to your contacts";
 
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
@@ -1164,6 +1179,9 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Find a user on the Dash Network";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
@@ -1343,6 +1361,9 @@
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "has requested to be your friend";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
@@ -1594,6 +1615,9 @@
 "Invite" = "Invite";
 
 /* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invite Someone to join the Dash Network";
+
+/* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
 
 /* Usernames */
@@ -1604,6 +1628,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invite your friends and family to the Dash Network";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1905,6 +1932,9 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "More Suggestions";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -2098,6 +2128,9 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Once %@ accepts your request you can Pay Directly to Username";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
 
@@ -2127,6 +2160,9 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* No comment provided by engineer. */
+"or" = "or";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2167,6 +2203,9 @@
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
 
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "Pay Directly to Username";
+
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
 
@@ -2205,6 +2244,9 @@
 
 /* DashPay Contacts */
 "Payments" = "Payments";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Payments made directly to addresses won’t be retained in activity.";
 
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
@@ -2566,6 +2608,9 @@
 /* Usernames */
 "Results" = "Results";
 
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "Retain Mutual Transaction History";
+
 /* No comment provided by engineer. */
 "Retry" = "Retry";
 
@@ -2623,11 +2668,29 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Search for a contact";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Search for a contact request";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Search for a User on the Dash Network";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Search for a username";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Search results for \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Searching for username %@ on the Dash Network";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2721,6 +2784,9 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Send to a Contact";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2747,6 +2813,12 @@
 
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Sending Contact Request";
+
+/* No comment provided by engineer. */
+"Sending to" = "Sending to";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2876,6 +2948,9 @@
 
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
+
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sort Contacts";
 
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
@@ -3133,7 +3208,19 @@
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
 /* No comment provided by engineer. */
+"them (Fetching Info)" = "them (Fetching Info)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "There are no new notifications";
+
+/* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "There are no users that match with the name %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "There are no users that match with the name %@ in your contacts";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3356,6 +3443,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Unable to provide suggestions";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3411,6 +3501,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Upgrade to Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3433,6 +3526,9 @@
 
 /* Usernames */
 "Use transparent balance instead" = "Use transparent balance instead";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "User (Fetching Info)";
 
 /* Voting */
 "Username" = "Username";
@@ -3463,6 +3559,9 @@
 
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Users that matches %@ who are currently not in your contacts";
 
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
@@ -3499,6 +3598,9 @@
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "View All";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3705,6 +3807,9 @@
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
 
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "You accepted the contact request from %@";
+
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
 
@@ -3752,6 +3857,9 @@
 
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
+
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "You do not have any contacts at the moment";
 
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
@@ -3833,6 +3941,9 @@
 
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
+
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "You sent the contact request to %@";
 
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";

--- a/INVITATIONS_REBUILD_PLAN.md
+++ b/INVITATIONS_REBUILD_PLAN.md
@@ -1,0 +1,244 @@
+# DashPay Invitations Rebuild Plan (T1: port)
+
+Resolves teardown item T1 in `DASHSYNC_TEARDOWN_PLAN.md` as **port** (not delete):
+rebuild invitations on SwiftDashSDK, delete the DashSync invitation subsystem in
+the same change, cross-platform-compatible with Android's shipping
+implementation (dash-wallet master, dashj/dpp stack).
+
+Readiness basis (surveyed 2026-07-16):
+
+- SDK (`../platform` @ `v4.1-dev`): create/parse/claim/reclaim + SwiftData
+  persistence are implemented and exercised by the SDK example app.
+  Key APIs: `ManagedPlatformWallet.createInvitation(amountDuffs:fundingAccount:inviterIdentityId:inviterUsername:nowUnix:)`,
+  `parseInvitation(uri:)`, `claimInvitation(uri:identityIndex:identityPubkeys:signer:nowUnix:)`,
+  `resumeIdentityWithAssetLock(...consumeInvitationVoucher:)`,
+  `resumeTopUpWithAssetLock(...consumeInvitationVoucher:)`; model
+  `PersistentInvitation` (registered in `DashModelContainer`). Derivation is
+  DIP-13 `m/9'/coinType'/5'/3'/index'` — matches Android's
+  `INVITATION_FUNDING` keychain, so restored wallets reconstruct the same
+  vouchers on both platforms.
+- Android (shipping on mainnet): link contract `dashpay://invite?du=…&assetlocktx=…&pk=…&islock=…[&display-name=…][&avatar-url=…]`,
+  AppsFlyer OneLink distribution (`dashpay.onelink.me` prod /
+  `dashpaytest.onelink.me` testnet, payload round-trips via `af_dp`), fee tiers
+  0.25 DASH (contested-capable, default) / 0.03 DASH, recipient minimum
+  0.003 DASH, claimed-detection by polling whether an identity exists for the
+  voucher outpoint, post-claim auto contact request to the `du` inviter.
+  Android has no reclaim.
+
+## Product decisions (confirm before/while building)
+
+| # | Decision | Recommendation |
+|---|---|---|
+| P1 | Offer reclaim of unclaimed invitations (SDK supports it; Android doesn't)? | Yes, behind the history screen — value returns as **identity credits** (new identity or top-up), never L1 Dash; copy must say so. Defer if scope-cutting. |
+| P2 | Fee tiers | Mirror Android: 0.25 (contested allowance, default) / 0.03. Requires S1. |
+| P3 | Distribution model | **Decided (2026-07-16): paste/scan-first, no third parties, no hosting.** Invites are shared as the raw `dashpay://invite` URI + QR; the invitee installs the app, then redeems by QR scan or paste. No AppsFlyer SDK (closed-source binary; bearer key would transit their servers), no OneLink, no hosted landing page. A static fallback page on `invitations.dashpay.io` (AASA/assetlinks already live there) remains a purely additive later enhancement — the link format doesn't change. |
+| P4 | Claimed-status copy | Watcher-based "Claimed" (parity with Android, see A5); status may lag platform polling. |
+
+## S. Upstream SDK changes (`../platform`, land on `v4.1-dev`)
+
+Per the platform-pin rule, these go upstream first; the app consumes a rebuilt
+xcframework (`./build_ios.sh --target ios --target sim`).
+
+- **S1 — raise the create cap.** `MAX_INVITATION_DUFFS = 5_000_000` (0.05) in
+  `rs-platform-wallet/src/wallet/identity/network/invitation.rs` blocks
+  Android's 0.25 contested tier. Raise to ≥ `25_000_000` (or make the bound a
+  caller parameter). Verify the **claim** path has no equivalent upper bound so
+  0.25 Android invites claim cleanly on iOS regardless.
+- **S2 — none otherwise.** `du`-optionality, big-endian txid, `islock="null"`
+  tolerance, and network-typed WIF are already Android-compatible. iOS simply
+  always supplies `inviterIdentityId`+`inviterUsername` (A2) because Android's
+  parser requires `du`.
+
+## A. App-side work (dashwallet-ios)
+
+### A1. Invitation service (new, `Sources/Infrastructure/SwiftDashSDK/Invitations/`)
+
+`DWInvitationService` behind a protocol seam (guardrail #4), injected where
+possible; resolves the wallet via `SwiftDashSDKHost` (never ad-hoc
+`WalletStorage()`); `@MainActor` published state for the UI.
+
+- `createInvitation(amount: UInt64) async throws -> String` — requires a
+  registered local username (source of `du`); wraps
+  `ManagedPlatformWallet.createInvitation`, funding account = the core BIP44
+  account index used by `.core` registration.
+- `parse(_ uri: String) throws -> InvitationPreview` — passthrough.
+- `invitations` — SwiftData `@Query`/fetch over `PersistentInvitation` filtered
+  by active `walletId`.
+- `normalize(_ url: URL) -> String?` — link unwrap (A4): accepts
+  `dashpay://invite`, OneLink URLs (extract `af_dp`), and legacy
+  `invitations.dashpay.io/applink`; returns the inner `dashpay://invite` URI
+  for `parseInvitation`.
+- Reclaim (P1): `reclaimIntoTopUp(_:)` / `reclaimIntoNewIdentity(_:)` with
+  `consumeInvitationVoucher: true`, mirroring the SDK example app's
+  `ReclaimInvitationSheet` failure classifier (foreign-claim vs own
+  interrupted reclaim via the `reclaimInFlight` marker).
+
+### A2. Create flow
+
+Replaces `DWConfirmInvitationViewController.m`'s
+`createBlockchainInvitation`/`registerOnNetwork:` machinery with one
+`createInvitation` call. Notes:
+
+- Gate on `SyncingActivityMonitor` `.syncDone` (never SPV `state == .synced`)
+  and on local identity registered + spendable balance ≥ selected tier.
+- Auth via `AuthenticationGate` before building; the SDK call broadcasts — the
+  confirm screen therefore shows amount + fee **before** invoking it (`prepare`
+  never broadcasts rule applies to the UI contract: no broadcast until the
+  user's explicit confirm tap invokes the service).
+- The SDK waits for the InstantSend proof and only then returns the link; the
+  voucher row is persisted before the wait, so an interrupted create surfaces
+  in history as reclaimable rather than lost. Show a "waiting for confirmation"
+  phase.
+- The returned URI embeds the bearer voucher key: never log it, never persist
+  it app-side (the SDK model stores no secret), share-sheet/QR/copy only.
+
+### A3. Accept (claim) flow
+
+- Entry plumbing **reused as-is**: `DWAppRootViewController.handleDeeplink:` →
+  `DWInvitationSetupState` stash (no wallet / locked) →
+  `HomeViewController.handleDeeplink(_:definedUsername:)`.
+- `DWDashPayModel.verifyDeeplink:` (DashSync) is replaced by
+  `DWInvitationService.parse` + an "already claimed?" platform lookup
+  (identity exists for the voucher outpoint) before showing the accept UI —
+  states mirror Android: valid / already-have-identity / already-claimed /
+  invalid / not-synced.
+- Claim executes inside `DWIdentityRegistrationCoordinator` so it inherits the
+  PIN gate, `prePersistIdentityKeysForRegistration`, `registerDpnsName`,
+  `DWRegistrationPhaseAdapter` phases, retry/cancel, and the
+  `DWGlobalOptions` mirror. Because `DWIdentityFundingSource` is an `@objc`
+  Int enum (no associated values), add a Swift-only entry point
+  `startCreateUsername(_ username: String, claimingInvitation uri: String)`
+  that routes the funding switch to `wallet.claimInvitation(...)`; the Int
+  enum gains `case invitation = 3` for phase/logging only. The caller is Swift
+  (`HomeViewController`) — do not extend the ObjC bridge for this;
+  the `showCreateUsername(withInvitation:)` shortcut regains a real
+  invitation path (it currently drops the URL, passing `invitationURL: nil`).
+- Post-claim contact-request bootstrap (Android parity): resolve `du` via DPNS,
+  send a contact request through the existing SDK contacts stack from #787.
+  Failure here must not fail the claim — surface as a soft retry.
+- Claim replaces the shielded/core funding choice for this registration; the
+  JoinDashPay readiness screens are bypassed when an invitation is present.
+
+### A4. Link distribution (paste/scan-first, no third parties — P3)
+
+- **Share side**: the share sheet offers the raw `dashpay://invite` URI as text
+  plus an app-rendered QR code (~600 chars, islock hex dominates; well within
+  QR capacity). No wrapping, shortening, or third-party upload — the URI is a
+  bearer instrument and never leaves the two devices except via the user's own
+  chosen channel. Suggested message template: install link (App Store /
+  Play Store) + the invite code.
+- **Redeem side**: a "Have an invitation?" entry point in onboarding and in the
+  create-username flow — paste field + the existing QR-scanner component. The
+  input goes through `DWInvitationService.normalize` (A1), which accepts the
+  raw `dashpay://invite` URI, the legacy `invitations.dashpay.io/applink` form,
+  and pasted Android OneLink long-URLs (unwraps `af_dp`) — so Android-generated
+  invites redeem on iOS via paste with no AppsFlyer SDK.
+- **First-launch pasteboard check**: if the invitee copied the invite before
+  installing, offer redemption on first launch via the iOS paste-permission
+  prompt (deferred deep linking with no third party; degrades to manual paste
+  if declined).
+- Remove `pod 'Firebase/DynamicLinks'` (both targets) and the `FIRDynamicLinks`
+  code in `AppDelegate.m` `continueUserActivity:` / `openURL:` — the service
+  was shut down in 2025; today this code silently eats universal links.
+- Registration/config additions:
+  - Info.plist: add `dashpay` to `CFBundleURLSchemes` (Android registers
+    `dashpay://` and `dashwallet://`; iOS currently registers only
+    `dash`/`dashwallet`/`pay`/`dashid`). With the app installed, a tapped raw
+    link opens directly wherever messengers linkify it.
+  - Entitlements: keep the existing `applinks:invitations.dashpay.io` (its AASA
+    is still live and lists our bundle IDs, so legacy-form links open the app
+    when installed). No OneLink domains added.
+  - `DWURLParser.canHandleURL:` gains the `dashpay` scheme, routed to the
+    invite handler (not the payment parser).
+
+### A5. History + claimed-status watcher
+
+- SwiftUI history screen over `PersistentInvitation` (newest-first, active
+  wallet only), statuses Created / Claimed / Reclaimed.
+- The Rust layer only ever emits `Created`. Adopt Android's semantics: a
+  lightweight watcher (`SyncingActivityMonitor`-gated, piggybacking on the
+  existing platform polling cadence) checks each `Created` invitation for an
+  identity at the voucher outpoint's derived identity ID and flips local
+  status to `Claimed`, also resolving the claimant's profile for display.
+  Reclaim success (P1) sets `Reclaimed` (or `Claimed` on the
+  "already consumed" consensus error), as the SDK example app does.
+  Status honesty per guardrail #3: rows are "Created" until *observed*
+  claimed — no fabricated freshness.
+
+### A6. SwiftUI screen set (all with `@MainActor` ViewModels; no FFI in views)
+
+| Screen | Replaces |
+|---|---|
+| `InvitationHistoryScreen` + rows/filter | `DWInvitationHistoryViewController` + cells/filter stack |
+| `CreateInvitationScreen` (intro + fee-tier picker P2) | `DWSendInviteFirstStepViewController`, `InvitationFeeDialog` (Android analog) |
+| `ConfirmInvitationSheet` (amount/fee, checkbox) | `DWConfirmInvitationViewController` + content view |
+| `InvitationShareScreen` (QR, copy, share sheet, tag/memo) | `BaseInvitationViewController` / `SuccessInvitationViewController` + card views |
+| `ClaimInvitationScreen` (preview → username form → progress) | `DWDashPayModel` accept arm + `DWInvitationPreviewViewController` |
+| `RedeemInvitationEntry` (paste field + QR scan; onboarding + create-username; A4) | — (new; replaces link-only entry) |
+| `ReclaimInvitationSheet` (P1, credits-only messaging) | — (new; SDK example app is the reference) |
+
+Localization: the 37 restored contacts/invitations keys (commit `bc5383381`)
+cover the legacy copy; new screens may add keys — keep `en` UTF-8, alphabetical.
+
+### A7. Deletion list (same change as the port — T1 rule, no disabled legacy)
+
+- `DashWallet/Sources/UI/DashPay/Invites/**` (flow controller, first-step,
+  confirmation, history, preview, invitation views, link builder, alert
+  additions) — all targets' pbxproj membership, xibs, bridging-header entries.
+- `DWDashPayModel.m`: `verifyDeeplink:`, `createUsername:invitation:`
+  invitation + existing-identity DashSync arms,
+  `sendContactRequestToInviterUsingInvitationURL:`, `invitationSteps`,
+  `DSBlockchainInvitation`/`DSIdentitiesManager` imports.
+- `DWHomeModel.handleDeeplink:` DashSync passthrough (retarget to the service).
+- `Firebase/DynamicLinks` pods + `FIRDynamicLinks` AppDelegate code (A4).
+- Mock invitation paths (`createBlockchainIdentity(forUsername:)` mock usage in
+  `BaseInvitationViewController`).
+- **Keep**: `DWInvitationSetupState` (DashSync-free stash), the root-VC
+  deep-link replay, `menu_invite` / `icon_invitation_error` assets, restored
+  l10n keys.
+- Grep gate after deletion: `DSBlockchainInvitation` must have zero hits
+  outside DashSync itself (teardown plan §163 guard).
+
+### A8. Docs (same change)
+
+- `DASHSYNC_MIGRATION.md`: row 16 tail → invitation-funded create/accept
+  migrated; current-state list item 1 shrinks to the legacy profile-view
+  compatibility types (which remain a separate cleanup).
+- `DASHSYNC_TEARDOWN_PLAN.md`: T1 decision recorded as "ported"; remaining
+  T1 scope reduced to the profile/`JoinDashPayViewModel` compatibility reads.
+
+## Sequencing
+
+1. **PR-0 (platform, `v4.1-dev`)**: S1 cap raise + claim-path bound check.
+2. **PR-1 (app)**: A1 service + A3 claim path + A4 link plumbing + claim UI;
+   DashSync accept arm deleted with it.
+3. **PR-2 (app)**: A2/A6 create + history + share UI (+P1 reclaim), the A5
+   claimed-status watcher (it needs the outpoint→identityId derivation and
+   only has meaning once the history UI displays statuses), remaining
+   deletions (A7) and docs (A8). Invitation code is DashSync-free at merge.
+
+PR-1/PR-2 may be collapsed into one if review size allows; the T1 "same
+change" rule binds deletion to the port of each arm, which both orderings keep.
+
+## Verification
+
+- `plutil -lint DashWallet.xcodeproj/project.pbxproj`; clean `dashpay` build
+  (`ARCHS=arm64`, sim) — and `dashwallet` scheme build for the `#if DASHPAY`
+  seams once compiling.
+- Two-simulator **testnet** smoke (mainnet Platform DAPI is unreachable in the
+  current SDK build; testnet-default posture stands): wallet A (registered
+  username) creates a 0.03 invite → shares as text + QR; wallet B (fresh)
+  redeems via **paste** (and once via the deep link with the app installed) →
+  preview shows inviter → claims → username registered → contact request
+  arrives at A. Then: B re-pastes the same invite → "already claimed";
+  A reclaims an unclaimed invite (P1) → credits top-up; A's history flips the
+  claimed row via the watcher. First-launch pasteboard offer verified once.
+- Cross-platform: **paste an Android-generated OneLink invite** into iOS
+  (normalizer unwraps `af_dp`) and open an iOS-generated raw link on Android
+  (their `dashpay://` intent filter); confirms `du`-required, big-endian txid,
+  and `islock` handling both directions. Tell the Android
+  team their little-endian iOS shims (`TopUpRepository.kt:229,277,826`) can be
+  retired once legacy iOS links are declared void (DashPay never shipped on
+  iOS).
+- Unit-test targets are still broken repo-wide; write link-normalization and
+  watcher tests compile-ready per the existing convention.

--- a/INVITATIONS_REBUILD_PLAN.md
+++ b/INVITATIONS_REBUILD_PLAN.md
@@ -180,6 +180,20 @@ Replaces `DWConfirmInvitationViewController.m`'s
 Localization: the 37 restored contacts/invitations keys (commit `bc5383381`)
 cover the legacy copy; new screens may add keys — keep `en` UTF-8, alphabetical.
 
+**Translation reuse (audited 2026-07-16 across all 42 lproj files):** the
+legacy claim-flow strings are translated in every language and MUST be
+reused rather than re-minted:
+- claim-time error mapping (typed SDK errors → localized copy; today the
+  Rust error text surfaces verbatim in English): "Invitation already
+  claimed", "Your invitation from %@ has been already claimed",
+  "Your invitation from %@ is not valid";
+- the create-side share message: "You have been invited by %@. Start using
+  Dash cryptocurrency.".
+The 37 restored contacts/invitations keys carry NO translations in the
+repo (dropped from source before the last Transifex pull) — they are
+English source only; server-side Transifex translation memory may
+re-match them after `tx push -s`.
+
 ### A7. Deletion list (same change as the port — T1 rule, no disabled legacy)
 
 - `DashWallet/Sources/UI/DashPay/Invites/**` (flow controller, first-step,


### PR DESCRIPTION
## What

One PR covering the invitation-claim rebuild and the localization repair, in three commits:

1. **l10n restore (×2)** — the release-8.7.0 merge (1ca07ebe6) resolved `en.lproj/Localizable.strings` mostly to master's side, silently dropping ~200 integration-branch entries. Restored the 34 still-referenced keys (shielded Usernames #801, log export #802) and all 37 DashPay contacts/invitations strings (their call sites die with the old subsystem, but the entries preserve Transifex source + translations for this rework). SPV-diagnostics entries deliberately left to `fix/birth-height-chain-resync`, which rewords them.

2. **Invitation claim on SwiftDashSDK** — resolves teardown item T1's accept arm as **port** (see `INVITATIONS_REBUILD_PLAN.md` for the full plan; create/history/reclaim follow in the next PR):
   - **Link contract**: DIP-13 `dashpay://invite?du=…&assetlocktx=…&pk=…&islock=…` — byte-compatible with Android's shipping implementation. `DWInvitationLinkNormalizer` also unwraps Android OneLink long-URLs (`af_dp`) and the legacy `invitations.dashpay.io/applink` form.
   - **Distribution is paste/scan-first, zero third parties**: install → "Have an invitation?" (Join DashPay dialog) → paste or QR-scan. Deep links (`dashpay://` scheme now registered + existing applink entitlement) open the same redeem screen directly. No AppsFlyer, no hosted landing page, no bearer key transiting anyone's servers.
   - **Claim path**: `DWIdentityRegistrationCoordinator.startClaimInvitation` — a fourth funding source reusing the PIN gate, key pre-persist, DPNS register, phase adapter, and identity-resume semantics. The username form gains an invitation mode (voucher pays; no balance rule, no funding picker) and offers a post-claim contact request to the `du` inviter through the contacts service.
   - **Deletions**: the DashSync accept arm (`verifyDeeplink`, `createUsername:invitation:` invitation branch, `DSIdentitiesManager` friend-request, `invitationSteps`), the `DWHomeModel` deeplink passthrough, and the dead Firebase Dynamic Links handling in AppDelegate (the service was shut down in 2025 and silently ate universal links). `Firebase/DynamicLinks` pod unlink deferred to the pod-teardown pass.
   - **DashUIKit** retargeted `import/final` → `master @ 046f0875` (matches release-8.7.0; the stale pin's tip stopped resolving).

## Verification

- Clean `dashpay` arm64-sim builds under **both** Xcode 26.3/Swift 6.2.4 and Xcode 26.6/Swift 6.3.3.
- Fresh-wallet simulator smoke of the full invitee flow: menu entry → paste synthetic link → parse/preview ("Invitation from smoketester") → username form on a **zero-balance** wallet with live DPNS availability → PIN gate → real SDK claim against testnet DAPI → the SDK's typed "funding transaction not found" failure surfaced in the error alert.
- `dashpay://` scheme registration confirmed via the OS open-in-app prompt. (On multi-install QA sims the scheme collides with the SwiftExampleApp — re-verify the deep-link route on a single-install device.)

## Companion changes (separate repos)

- **dashpay/platform** `fix/invitation-contested-tier-cap`: raise `MAX_INVITATION_DUFFS` 0.05 → 0.25 DASH so iOS can create Android's contested-username tier (claim never enforced the cap). Needed for the create side, not this PR.
- **dashsync-iOS**: one-line removal of the now-private `<netinet6/in6.h>` include in `DSReachabilityManager.m` — required to build any branch under the iOS 26.5 SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)