### PR TITLE
feat(ui): masternodes section in Tools + Masternode Keychain rename

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		02EDCC7635BCD84768554D9C /* StorageModelListViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A762BDA473947F1A7EF199 /* StorageModelListViews.swift */; };
 		02EED2FC7EAC55B96ECEAAD6 /* DWLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59C18FCF827D815007BAEF29 /* DWLogger.m */; };
 		0308E777B29CC6DE1DB30FDD /* PlatformSyncStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A58BF094C42E410DD1A71B6 /* PlatformSyncStatusScreen.swift */; };
+		51AA00212F970021005A0021 /* MasternodesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA00202F970020005A0020 /* MasternodesScreen.swift */; };
 		51AA00022F970002005A0002 /* SyncInfoMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA00012F970001005A0001 /* SyncInfoMenuScreen.swift */; };
 		51AA00032F970003005A0003 /* SyncInfoMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA00012F970001005A0001 /* SyncInfoMenuScreen.swift */; };
 		51AA00052F970005005A0005 /* SyncInfoMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA00042F970004005A0004 /* SyncInfoMenuViewModel.swift */; };
@@ -343,6 +344,7 @@
 		2C669744EE2749C5953E2EE7 /* SwiftDashSDKWalletSending.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BAA92B00D4109567DF870F /* SwiftDashSDKWalletSending.swift */; };
 		2D086D12D2112C53A36D4B06 /* ScriptAddressCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080B9ECCDC82A7B7FF4039C6 /* ScriptAddressCodec.swift */; };
 		2D354A4D6053027CA27F02CB /* PlatformSyncStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A58BF094C42E410DD1A71B6 /* PlatformSyncStatusScreen.swift */; };
+		51AA00222F970022005A0022 /* MasternodesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AA00202F970020005A0020 /* MasternodesScreen.swift */; };
 		2E08EC52344E430F9BC8DEAA /* TransferAmountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AECC5C20684C9293F22A38 /* TransferAmountViewModel.swift */; };
 		2EFDEC7DCA624B16DBBB482D /* SwiftDashSDKWalletCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B697D56A525CBF142F4401FE /* SwiftDashSDKWalletCreator.swift */; };
 		30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */; };
@@ -2825,6 +2827,7 @@
 		59C18FCF827D815007BAEF29 /* DWLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DWLogger.m; sourceTree = "<group>"; };
 		59C9D64AB542D03FE3704D02 /* ShieldedWithdrawalStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShieldedWithdrawalStore.swift; sourceTree = "<group>"; };
 		5A58BF094C42E410DD1A71B6 /* PlatformSyncStatusScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformSyncStatusScreen.swift; sourceTree = "<group>"; };
+		51AA00202F970020005A0020 /* MasternodesScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MasternodesScreen.swift; sourceTree = "<group>"; };
 		51AA00012F970001005A0001 /* SyncInfoMenuScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncInfoMenuScreen.swift; sourceTree = "<group>"; };
 		51AA00042F970004005A0004 /* SyncInfoMenuViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyncInfoMenuViewModel.swift; sourceTree = "<group>"; };
 		51AA00072F970007005A0007 /* DashPaySyncInfoScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashPaySyncInfoScreen.swift; sourceTree = "<group>"; };
@@ -4847,6 +4850,7 @@
 				2A8DBA772630A6BE009094BD /* ExtendedKeys */,
 				2A10EB322358994400C38B61 /* ImportWallet */,
 				FB3FF0B0222641210059A9A5 /* Masternode Keys */,
+				51AA00202F970020005A0020 /* MasternodesScreen.swift */,
 				7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */,
 				RC00C0032FA0000000000001 /* CSVExportSheet.swift */,
 				752F81A82E323FD000ADA76D /* ToolsMenuViewModel.swift */,
@@ -10342,6 +10346,7 @@
 				85448D7537BBD0AE40682EC8 /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				8EAA05FA797008525050A2A7 /* PlatformAddressSyncCoordinator.swift in Sources */,
 				2D354A4D6053027CA27F02CB /* PlatformSyncStatusScreen.swift in Sources */,
+				51AA00222F970022005A0022 /* MasternodesScreen.swift in Sources */,
 				51AA00022F970002005A0002 /* SyncInfoMenuScreen.swift in Sources */,
 				51AA00052F970005005A0005 /* SyncInfoMenuViewModel.swift in Sources */,
 				51AA00082F970008005A0008 /* DashPaySyncInfoScreen.swift in Sources */,
@@ -11361,6 +11366,7 @@
 				87AC92AAD9DF8CBF271609AC /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */,
 				0308E777B29CC6DE1DB30FDD /* PlatformSyncStatusScreen.swift in Sources */,
+				51AA00212F970021005A0021 /* MasternodesScreen.swift in Sources */,
 				51AA00032F970003005A0003 /* SyncInfoMenuScreen.swift in Sources */,
 				51AA00062F970006005A0006 /* SyncInfoMenuViewModel.swift in Sources */,
 				51AA00092F970009005A0009 /* DashPaySyncInfoScreen.swift in Sources */,

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -1,0 +1,486 @@
+//
+//  MasternodesScreen.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import SwiftDashSDK
+import UIKit
+
+// MARK: - MasternodesViewModel
+
+/// Tools → Masternodes: the wallet's masternodes/evonodes from the Rust
+/// aggregation (`PlatformWalletManager.masternodes(for:)`), the same source
+/// the masternode-keys usage resolver reads. Live snapshot — nothing is
+/// persisted on the app side.
+@MainActor
+final class MasternodesViewModel: ObservableObject {
+    @Published private(set) var masternodes: [PlatformMasternode] = []
+    @Published private(set) var loaded = false
+
+    /// In-wallet key index by base58 address for the two address-carrying
+    /// families. Operator/platform ownership comes pre-resolved on the
+    /// aggregation row; owner/voting is joined here against the derived
+    /// address pool (same join as `MasternodeKeyUsage`).
+    private var ownerIndexByAddress: [String: UInt32] = [:]
+    private var votingIndexByAddress: [String: UInt32] = [:]
+
+    /// Matches `MasternodeKeyUsage.scanWindow` / the SDK pre-derivation count.
+    private static let addressScanWindow: UInt32 = 20
+
+    func load() {
+        defer { loaded = true }
+        guard let manager = SwiftDashSDKHost.shared.manager,
+              let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
+            masternodes = []
+            return
+        }
+        masternodes = manager.masternodes(for: walletId)
+            .sorted { $0.orderIndex < $1.orderIndex }
+        guard !masternodes.isEmpty else { return }
+
+        ownerIndexByAddress = Self.indexByAddress(
+            family: .owner,
+            targets: Set(masternodes.compactMap(\.ownerAddress)))
+        votingIndexByAddress = Self.indexByAddress(
+            family: .voting,
+            targets: Set(masternodes.compactMap(\.votingAddress)))
+    }
+
+    private static func indexByAddress(family: MNKey, targets: Set<String>) -> [String: UInt32] {
+        guard !targets.isEmpty,
+              let deriver = MasternodeProviderKeyDeriver(key: family) else { return [:] }
+        var map: [String: UInt32] = [:]
+        for index in 0..<addressScanWindow {
+            guard let address = deriver.address(at: index),
+                  targets.contains(address) else { continue }
+            map[address] = index
+        }
+        return map
+    }
+
+    /// Ownership subtitle for the owner key ("ProviderOwnerKeys #4" /
+    /// "not in this wallet"), mirroring the SDK's `keyOwnershipLabel`.
+    func ownerOwnership(for masternode: PlatformMasternode) -> String {
+        ownershipLabel(index: masternode.ownerAddress.flatMap { ownerIndexByAddress[$0] },
+                       accountType: 9)
+    }
+
+    func votingOwnership(for masternode: PlatformMasternode) -> String {
+        ownershipLabel(index: masternode.votingAddress.flatMap { votingIndexByAddress[$0] },
+                       accountType: 8)
+    }
+
+    private func ownershipLabel(index: UInt32?, accountType: UInt8) -> String {
+        PersistentMasternode.keyOwnershipLabel(
+            inWallet: index != nil,
+            accountType: accountType,
+            index: index ?? 0)
+    }
+}
+
+// MARK: - PlatformMasternode display helpers
+
+/// Display formatting for the aggregation snapshot, following the SDK's
+/// `PersistentMasternode` conventions: txids render in block-explorer
+/// (reversed) hex, key hashes in forward order.
+private extension PlatformMasternode {
+    var typeName: String {
+        isEvonode
+            ? NSLocalizedString("Evonode", comment: "")
+            : NSLocalizedString("Masternode", comment: "")
+    }
+
+    /// "Evonode 2" / "Masternode 5" — evonodes and masternodes number
+    /// independently (1-based `typeIndex`).
+    var displayTitle: String {
+        "\(typeName) \(typeIndex)"
+    }
+
+    var masternodeStatus: MasternodeStatus {
+        MasternodeStatus(rawValue: status) ?? .unknown
+    }
+
+    var statusName: String {
+        switch masternodeStatus {
+        case .active: return NSLocalizedString("Active", comment: "Masternode status")
+        case .inactive: return NSLocalizedString("Inactive", comment: "Masternode status")
+        case .retired: return NSLocalizedString("Retired", comment: "Masternode status")
+        case .unknown: return NSLocalizedString("Unknown", comment: "Masternode status")
+        }
+    }
+
+    var statusColor: Color {
+        switch masternodeStatus {
+        case .active: return .green
+        case .inactive: return .orange
+        case .retired: return .red
+        case .unknown: return .secondary
+        }
+    }
+
+    var proTxHashHex: String {
+        proTxHash.reversed().map { String(format: "%02x", $0) }.joined()
+    }
+
+    var ownerKeyHashHex: String? {
+        ownerKeyHash.map { $0.map { String(format: "%02x", $0) }.joined() }
+    }
+
+    var votingKeyHashHex: String? {
+        votingKeyHash.map { $0.map { String(format: "%02x", $0) }.joined() }
+    }
+
+    var operatorPublicKeyHex: String? {
+        operatorPublicKey.map { $0.map { String(format: "%02x", $0) }.joined() }
+    }
+
+    var platformNodeIdHex: String? {
+        platformNodeId.map { $0.map { String(format: "%02x", $0) }.joined() }
+    }
+
+    var collateralDisplay: String? {
+        guard let txid = collateralTxid else { return nil }
+        let hex = txid.reversed().map { String(format: "%02x", $0) }.joined()
+        return "\(hex):\(collateralVout)"
+    }
+}
+
+// MARK: - MasternodesScreen
+
+struct MasternodesScreen: View {
+    @StateObject private var viewModel = MasternodesViewModel()
+
+    var body: some View {
+        List {
+            if viewModel.loaded && viewModel.masternodes.isEmpty {
+                Section {
+                    VStack(spacing: 12) {
+                        Image(systemName: "server.rack")
+                            .font(.system(size: 40))
+                            .foregroundColor(.gray)
+
+                        Text(NSLocalizedString("No masternodes yet", comment: "Masternodes"))
+                            .font(.headline)
+
+                        Text(NSLocalizedString("Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs.", comment: "Masternodes"))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 20)
+                }
+            } else {
+                Section {
+                    ForEach(viewModel.masternodes, id: \.proTxHash) { masternode in
+                        NavigationLink {
+                            MasternodeDetailScreen(
+                                masternode: masternode,
+                                ownerOwnership: viewModel.ownerOwnership(for: masternode),
+                                votingOwnership: viewModel.votingOwnership(for: masternode))
+                        } label: {
+                            MasternodeListRow(masternode: masternode)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.load()
+        }
+    }
+}
+
+// MARK: - MasternodeListRow
+
+private struct MasternodeListRow: View {
+    let masternode: PlatformMasternode
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(masternode.displayTitle)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                if let service = masternode.serviceAddress {
+                    Text(service)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Spacer()
+
+            Text(masternode.statusName)
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundColor(masternode.statusColor)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+// MARK: - MasternodeDetailScreen
+
+/// Read-only detail for one aggregated masternode, mirroring the
+/// SwiftExampleApp's `MasternodeDetailView`: overview, registration, keys,
+/// key ownership, collateral, revocation, and (evonodes) a read-only
+/// claimable Platform-credits balance. Claiming stays out — the withdraw
+/// FFI is a deliberate stub upstream.
+struct MasternodeDetailScreen: View {
+    let masternode: PlatformMasternode
+    let ownerOwnership: String
+    let votingOwnership: String
+
+    /// Evonode claimable balance = the masternode identity's credit
+    /// balance (identity id == display-order proTxHash). `nil` until
+    /// fetched / when the identity isn't found.
+    @State private var claimableCredits: UInt64?
+    @State private var balanceLoading = false
+    @State private var balanceError: String?
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    Label(masternode.typeName, systemImage: "server.rack")
+                        .font(.headline)
+                    Spacer()
+                    Text(masternode.statusName)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(masternode.statusColor)
+                }
+                if let service = masternode.serviceAddress {
+                    MasternodeDetailRow(label: NSLocalizedString("Service", comment: "Masternodes"), value: service)
+                }
+            }
+
+            Section(NSLocalizedString("Registration", comment: "Masternodes")) {
+                MasternodeCopyRow(label: "proTxHash", value: masternode.proTxHashHex)
+                MasternodeDetailRow(
+                    label: NSLocalizedString("Registered at", comment: "Masternodes"),
+                    value: masternode.hasRegistration
+                        ? String(format: NSLocalizedString("Height %u", comment: "Masternodes"), masternode.registrationHeight)
+                        : NSLocalizedString("Not in wallet history", comment: "Masternodes"))
+                MasternodeDetailRow(
+                    label: NSLocalizedString("Provider transactions", comment: "Masternodes"),
+                    value: "\(masternode.txCount)")
+            }
+
+            Section(NSLocalizedString("Keys", comment: "Masternodes")) {
+                if let owner = masternode.ownerAddress {
+                    MasternodeCopyRow(label: NSLocalizedString("Owner address", comment: "Masternodes"), value: owner)
+                }
+                if let ownerHash = masternode.ownerKeyHashHex {
+                    MasternodeCopyRow(label: NSLocalizedString("Owner key hash", comment: "Masternodes"), value: ownerHash)
+                }
+                if let voting = masternode.votingAddress {
+                    MasternodeCopyRow(label: NSLocalizedString("Voting address", comment: "Masternodes"), value: voting)
+                }
+                if let votingHash = masternode.votingKeyHashHex {
+                    MasternodeCopyRow(label: NSLocalizedString("Voting key hash", comment: "Masternodes"), value: votingHash)
+                }
+                if let operatorKey = masternode.operatorPublicKeyHex {
+                    MasternodeCopyRow(label: NSLocalizedString("Operator public key (BLS)", comment: "Masternodes"), value: operatorKey)
+                }
+                if let nodeId = masternode.platformNodeIdHex {
+                    MasternodeCopyRow(label: NSLocalizedString("Platform Node ID", comment: ""), value: nodeId)
+                }
+                if let payout = masternode.payoutAddress {
+                    MasternodeCopyRow(label: NSLocalizedString("Payout address", comment: "Masternodes"), value: payout)
+                }
+            }
+
+            Section(NSLocalizedString("Key ownership", comment: "Masternodes")) {
+                MasternodeDetailRow(label: NSLocalizedString("Owner", comment: "Masternodes"), value: ownerOwnership)
+                MasternodeDetailRow(label: NSLocalizedString("Voting", comment: "Masternodes"), value: votingOwnership)
+                if masternode.operatorPublicKey != nil {
+                    MasternodeDetailRow(
+                        label: NSLocalizedString("Operator", comment: "Masternodes"),
+                        value: PersistentMasternode.keyOwnershipLabel(
+                            inWallet: masternode.operatorInWallet,
+                            accountType: masternode.operatorAccountType,
+                            index: masternode.operatorKeyIndex))
+                }
+                if masternode.platformNodeId != nil {
+                    // When Rust couldn't check platform ownership (pool not
+                    // rehydrated yet), say so instead of claiming "not in
+                    // this wallet".
+                    MasternodeDetailRow(
+                        label: NSLocalizedString("Platform node", comment: "Masternodes"),
+                        value: masternode.platformOwnershipChecked
+                            ? PersistentMasternode.keyOwnershipLabel(
+                                inWallet: masternode.platformInWallet,
+                                accountType: masternode.platformAccountType,
+                                index: masternode.platformKeyIndex)
+                            : NSLocalizedString("Not checked yet", comment: "Masternodes"))
+                }
+            }
+
+            if let collateral = masternode.collateralDisplay {
+                Section(NSLocalizedString("Collateral", comment: "Masternodes")) {
+                    MasternodeCopyRow(label: NSLocalizedString("Outpoint", comment: "Masternodes"), value: collateral)
+                }
+            }
+
+            if masternode.revoked {
+                Section(NSLocalizedString("Revocation", comment: "Masternodes")) {
+                    MasternodeDetailRow(
+                        label: NSLocalizedString("Reason", comment: "Masternodes"),
+                        value: "\(masternode.revocationReason)")
+                }
+            }
+
+            // Platform credits accrue on the masternode's Platform identity
+            // (evonodes only). Read-only display; claiming is not offered —
+            // the owner-key withdrawal FFI is a stub upstream.
+            if masternode.isEvonode {
+                Section(NSLocalizedString("Claimable balance", comment: "Masternodes")) {
+                    if balanceLoading {
+                        HStack(spacing: 8) {
+                            // Explicitly SwiftUI's — the app declares its own
+                            // `ProgressView` UIKit class that shadows it here.
+                            SwiftUI.ProgressView().scaleEffect(0.8)
+                            Text(NSLocalizedString("Fetching…", comment: "Masternodes"))
+                                .foregroundColor(.secondary)
+                        }
+                    } else if let credits = claimableCredits {
+                        MasternodeDetailRow(
+                            label: NSLocalizedString("Credits", comment: "Masternodes"),
+                            value: "\(credits)")
+                        MasternodeDetailRow(label: "≈ DASH", value: Self.creditsAsDash(credits))
+                    } else if let error = balanceError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Button {
+                        Task { await fetchClaimableBalance() }
+                    } label: {
+                        Label(NSLocalizedString("Refresh", comment: ""), systemImage: "arrow.clockwise")
+                    }
+                    .disabled(balanceLoading)
+                }
+            }
+        }
+        .navigationTitle(masternode.displayTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if masternode.isEvonode {
+                await fetchClaimableBalance()
+            }
+        }
+    }
+
+    /// Fetch the masternode identity's credit balance. The identity id IS
+    /// the proTxHash in display (reversed) byte order; the stored bytes are
+    /// raw wire order, so reverse before keying the fetch. The FFI call is
+    /// blocking — run it off the main actor.
+    @MainActor
+    private func fetchClaimableBalance() async {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else {
+            balanceError = NSLocalizedString("Platform SDK not ready", comment: "Masternodes")
+            return
+        }
+        let identityId = Data(masternode.proTxHash.reversed())
+        balanceLoading = true
+        balanceError = nil
+        do {
+            let credits = try await Task.detached(priority: .userInitiated) {
+                try sdk.identities.getBalance(id: identityId)
+            }.value
+            claimableCredits = credits
+        } catch {
+            claimableCredits = nil
+            // Distinguish "no identity registered" from a transport failure
+            // so the copy isn't misleading on a transient network error.
+            let message = error.localizedDescription.lowercased()
+            if message.contains("not found") || message.contains("no identity")
+                || message.contains("does not exist") {
+                balanceError = NSLocalizedString("This masternode has no Platform identity yet.", comment: "Masternodes")
+            } else {
+                balanceError = NSLocalizedString("Couldn't fetch the balance (network error). Try Refresh.", comment: "Masternodes")
+            }
+        }
+        balanceLoading = false
+    }
+
+    /// 1 DASH = 100,000,000,000 credits.
+    private static func creditsAsDash(_ credits: UInt64) -> String {
+        String(format: "%.8f DASH", Double(credits) / 100_000_000_000.0)
+    }
+}
+
+// MARK: - Rows
+
+/// Label + trailing value row.
+private struct MasternodeDetailRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+/// Caption + monospaced, tap-to-copy value block for hashes / addresses.
+private struct MasternodeCopyRow: View {
+    let label: String
+    let value: String
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            UIPasteboard.general.string = value
+            withAnimation { copied = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                withAnimation { copied = false }
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                        .font(.caption)
+                        .foregroundColor(copied ? .green : .dashBlue)
+                }
+                Text(value)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundColor(.primary)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
@@ -196,6 +196,8 @@ struct ToolsMenuScreen: View {
             showExtendedPublicKeys()
         case .masternodeKeys:
             showMasternodeKeys()
+        case .masternodes:
+            showMasternodes()
         case .csvExport:
             showCSVExportSheet = true
         case .zenLedger:
@@ -266,6 +268,32 @@ struct ToolsMenuScreen: View {
         let controller = KeysOverviewViewController()
         controller.hidesBottomBarWhenPushed = true
         vc.pushViewController(controller, animated: true)
+    }
+
+    private func showMasternodes() {
+        let navController = vc
+        let popRoot: () -> Void = { [weak navController] in
+            _ = navController?.popViewController(animated: true)
+        }
+
+        let hosting = UIHostingController(
+            rootView: AnyView(
+                NavigationStack {
+                    MasternodesScreen()
+                        .navigationTitle(NSLocalizedString("Masternodes", comment: ""))
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button(action: popRoot) {
+                                    Image(systemName: "chevron.left")
+                                }
+                            }
+                        }
+                }
+            )
+        )
+        hosting.hidesBottomBarWhenPushed = true
+        vc.pushViewController(hosting, animated: true)
     }
     
     private func handleCSVExport() {

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -22,6 +22,7 @@ import SwiftDashSDK
 enum ToolsMenuNavigationDestination {
     case extendedPublicKeys
     case masternodeKeys
+    case masternodes
     case csvExport
     case zenLedger
     case storageExplorer
@@ -94,10 +95,18 @@ class ToolsMenuViewModel: ObservableObject {
                 }
             ),
             MenuItemModel(
-                title: NSLocalizedString("Show Masternode Keys", comment: ""),
+                title: NSLocalizedString("Masternode Keychain", comment: ""),
                 icon: .custom("image.masternode.keys", maxHeight: 30),
                 action: { [weak self] in
                     self?.navigationDestination = .masternodeKeys
+                }
+            ),
+            MenuItemModel(
+                title: NSLocalizedString("Masternodes", comment: ""),
+                subtitle: NSLocalizedString("Masternodes and evonodes using this wallet's keys", comment: "Masternodes"),
+                icon: .system("server.rack"),
+                action: { [weak self] in
+                    self?.navigationDestination = .masternodes
                 }
             ),
             MenuItemModel(

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -199,6 +199,9 @@
 /* No comment provided by engineer. */
 "Activity" = "Activity";
 
+/* Masternode status */
+"Active" = "Active";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
@@ -591,6 +594,14 @@
 "Claim your invitation" = "Claim your invitation";
 
 /* No comment provided by engineer. */
+"Claimable balance" = "Claimable balance";
+
+/* Masternodes */
+"Collateral" = "Collateral";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Couldn't fetch the balance (network error). Try Refresh.";
+
 "Claimed" = "Claimed";
 
 /* SPV diagnostics */
@@ -807,6 +818,9 @@
 
 /* Create new account */
 "Create new account" = "Create new account";
+
+/* Masternodes */
+"Credits" = "Credits";
 
 /* Wallets */
 "Create New Wallet" = "Create New Wallet";
@@ -1203,6 +1217,9 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Fetching…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
@@ -1432,6 +1449,9 @@
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
 
 /* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Height %u";
+
 "Hidden" = "Hidden";
 
 /* No comment provided by engineer. */
@@ -1576,6 +1596,9 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactive";
+
 "Income" = "Income";
 
 /* DashSpend */
@@ -1738,7 +1761,13 @@
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Key ownership";
+
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Keys";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1907,6 +1936,9 @@
 "Masternode IP address" = "Masternode IP address";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode Keychain";
+
 "Masternode keys" = "Masternode keys";
 
 /* SPV sync phase */
@@ -1935,6 +1967,15 @@
 
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes and evonodes using this wallet's keys";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -2117,6 +2158,9 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "No masternodes yet";
+
 "No matches for \"%@\"" = "No matches for \"%@\"";
 
 /* Coinbase/Buy Dash */
@@ -2170,6 +2214,9 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+/* Masternodes */
+"Not checked yet" = "Not checked yet";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
@@ -2183,6 +2230,9 @@
 "Not enough shielded balance to register an identity" = "Not enough shielded balance to register an identity";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Not in wallet history";
+
 "Not now" = "Not now";
 
 /* DashPay Contacts */
@@ -2248,8 +2298,26 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+/* Masternodes */
+"Operator" = "Operator";
+
 /* Masternode keys */
 "Operator keys" = "Operator keys";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operator public key (BLS)";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Masternodes */
+"Owner" = "Owner";
+
+/* Masternodes */
+"Owner address" = "Owner address";
+
+/* Masternodes */
+"Owner key hash" = "Owner key hash";
 
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
@@ -2259,6 +2327,9 @@
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* Masternodes */
+"Platform node" = "Platform node";
 
 /* Masternode keys */
 "Platform Node ID" = "Platform Node ID";
@@ -2336,6 +2407,9 @@
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
 
 /* CrowdNode */
+/* Masternodes */
+"Payout address" = "Payout address";
+
 "Payout Options" = "Payout Options";
 
 /* Coinbase/Payment Methods */
@@ -2385,6 +2459,9 @@
 
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform SDK not ready" = "Platform SDK not ready";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform sync is not running. Open Sync Info → Platform Sync Status to start it.";
@@ -2512,6 +2589,9 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Provider transactions";
+
 /* Masternode keys */
 "Public key" = "Public key";
 
@@ -2558,6 +2638,9 @@
 "Ready around %@" = "Ready around %@";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Reason";
+
 "Receive" = "Receive";
 
 /* Maya */
@@ -2606,6 +2689,9 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Refresh";
+
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2618,6 +2704,9 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registered at";
+
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
@@ -2627,6 +2716,9 @@
 "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it.";
 
 /* Usernames */
+/* Masternodes */
+"Registration" = "Registration";
+
 "Registration failed" = "Registration failed";
 
 /* Wallets */
@@ -2711,7 +2803,13 @@
 "Retain Mutual Transaction History" = "Retain Mutual Transaction History";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retired";
+
 "Retry" = "Retry";
+
+/* Masternodes */
+"Revocation" = "Revocation";
 
 /* AboutDash */
 "Review app" = "Review app";
@@ -2951,6 +3049,9 @@
 
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Service";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -3356,6 +3457,9 @@
 
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "This masternode has no Platform identity yet.";
 
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
@@ -3783,6 +3887,12 @@
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
 /* Voting keys */
+/* Masternodes */
+"Voting address" = "Voting address";
+
+/* Masternodes */
+"Voting key hash" = "Voting key hash";
+
 "Voting keys" = "Voting keys";
 
 /* CrowdNode */


### PR DESCRIPTION
## Summary

Adds a **Tools → Masternodes** section modeled on the SwiftExampleApp's masternodes list/detail, and renames the Tools row **"Show Masternode Keys" → "Masternode Keychain"**.

The screen reads live from the Rust masternode aggregation (`PlatformWalletManager.masternodes(for:)`) — the same source the masternode-keys usage resolver (#812) uses — with no app-side persistence layer.

## Changes

- **List**: one row per node — "Masternode 1" / "Evonode 2" (independent 1-based numbering, matching the example app), service `ip:port`, color-coded DML status (Active / Inactive / Retired / Unknown). Empty state explains nodes appear after sync.
- **Detail** (read-only, mirroring the example app's `MasternodeDetailView`):
  - Registration: proTxHash (block-explorer hex), registration height, provider tx count
  - Keys (tap-to-copy): owner/voting addresses + key hashes, operator BLS public key, Platform Node ID, payout address
  - Key ownership per family: `ProviderOwnerKeys #4` / "not in this wallet" — owner/voting joined against the derived address pool, operator/platform pre-resolved by Rust; shows "Not checked yet" when Rust couldn't verify platform ownership rather than fabricating a negative
  - Collateral outpoint, revocation reason
  - **Evonodes**: read-only claimable Platform-credits balance (identity balance keyed by display-order proTxHash) with a Refresh button. The Claim action is deliberately **not** ported — the owner-key withdrawal FFI is a stub upstream and the example app gates it off too.
- Tools menu: new "Masternodes" row (server-rack icon), pushed with the same NavigationStack-in-hosting-controller pattern as Storage Explorer; "Masternode Keychain" rename.
- ~35 new en localization strings; new file registered in `project.pbxproj` for both targets.
- One shadowing fix: the spinner is explicitly `SwiftUI.ProgressView` because the app's legacy UIKit `ProgressView` class shadows the SwiftUI type.

## Test plan

- [x] Clean `dashpay` arm64 simulator build
- [ ] Testnet smoke on a wallet with a registered masternode/evonode: list shows the node with correct type/number/status; detail fields match the example app for the same mnemonic
- [ ] Evonode claimable balance fetch succeeds / shows the "no Platform identity" copy appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)