### PR TITLE
feat(menu): Wallets category on main menu with per-account breakdown

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -543,6 +543,14 @@
 		4AC8F492DD74101C71A5EA5E /* PlatformSendExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */; };
 		4B8A9492829B622FCDAF4F19 /* SecureTimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47594B5DDCF9D335C0C7AB7 /* SecureTimeService.swift */; };
 		4DB882B7974693571FD16952 /* WalletsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F134B2E67D68A97892FD760 /* WalletsScreen.swift */; };
+		9A891339E42C1BE3AED09CBB /* WalletAccountDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */; };
+		7190FF8B29307603641F6B5A /* WalletAccountDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */; };
+		DE146DFF383C96BD9DDD692A /* WalletAccountDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */; };
+		2AD2319F6C528CF6E17656F9 /* WalletAccountDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */; };
+		45EAD8E50593EE5158E92E9B /* WalletAccountsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285B961142AB3AFF2442F4EB /* WalletAccountsScreen.swift */; };
+		22B03841025A55A573432CC9 /* WalletAccountsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285B961142AB3AFF2442F4EB /* WalletAccountsScreen.swift */; };
+		1A9AA76AC3F7489DCE8850ED /* WalletAccountsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F334C7FE582BF48AB47BDAA2 /* WalletAccountsViewModel.swift */; };
+		5EE4B9063E1F3D890E811B1F /* WalletAccountsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F334C7FE582BF48AB47BDAA2 /* WalletAccountsViewModel.swift */; };
 		5010C6015DD809969DF514ED /* DWRecoverModel+Mnemonic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE4B9497B1F276EA0BDB20D /* DWRecoverModel+Mnemonic.swift */; };
 		510336D02FEBB0C9002E0899 /* GiftCardDetailsInfoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C0B001D6C0B001D6C0B001 /* GiftCardDetailsInfoCard.swift */; };
 		510336D12FEBB0C9002E0899 /* GiftCardDetailsMerchantHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C0B002D6C0B002D6C0B002 /* GiftCardDetailsMerchantHeader.swift */; };
@@ -2578,6 +2586,10 @@
 		2DCBA057E553F81F54ACE6E1 /* StorageRecordDetailViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageRecordDetailViews.swift; sourceTree = "<group>"; };
 		2E7EE6B2E027DC4062E9983E /* ContactProfileSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactProfileSheet.swift; sourceTree = "<group>"; };
 		2F134B2E67D68A97892FD760 /* WalletsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletsScreen.swift; sourceTree = "<group>"; };
+		F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailScreen.swift; sourceTree = "<group>"; };
+		BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailViewModel.swift; sourceTree = "<group>"; };
+		285B961142AB3AFF2442F4EB /* WalletAccountsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountsScreen.swift; sourceTree = "<group>"; };
+		F334C7FE582BF48AB47BDAA2 /* WalletAccountsViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountsViewModel.swift; sourceTree = "<group>"; };
 		31271807D89A63FB9413C936 /* SwiftDashSDKTransactionSender.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKTransactionSender.swift; sourceTree = "<group>"; };
 		31AECC5C20684C9293F22A38 /* TransferAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountViewModel.swift; sourceTree = "<group>"; };
 		3242A021AC6065EB9FFBA997 /* WalletSwitchDialog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletSwitchDialog.swift; sourceTree = "<group>"; };
@@ -8791,6 +8803,10 @@
 		FB64DD5B1F2691BC2FC4149B /* Wallets */ = {
 			isa = PBXGroup;
 			children = (
+				285B961142AB3AFF2442F4EB /* WalletAccountsScreen.swift */,
+				F334C7FE582BF48AB47BDAA2 /* WalletAccountsViewModel.swift */,
+				F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */,
+				BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */,
 				2F134B2E67D68A97892FD760 /* WalletsScreen.swift */,
 				76AB0835FF44EA88F36991E0 /* WalletsViewModel.swift */,
 			);
@@ -10395,6 +10411,10 @@
 				2AB76051F87248AC36AED99B /* NetworkReachability.swift in Sources */,
 				A92AEDB6AD391E61F696809C /* MasternodeAPYCalculator.swift in Sources */,
 				4DB882B7974693571FD16952 /* WalletsScreen.swift in Sources */,
+				9A891339E42C1BE3AED09CBB /* WalletAccountDetailScreen.swift in Sources */,
+				DE146DFF383C96BD9DDD692A /* WalletAccountDetailViewModel.swift in Sources */,
+				45EAD8E50593EE5158E92E9B /* WalletAccountsScreen.swift in Sources */,
+				1A9AA76AC3F7489DCE8850ED /* WalletAccountsViewModel.swift in Sources */,
 				E5B549CD6364E8982A7262C0 /* WalletsViewModel.swift in Sources */,
 				938DE0B52BD0B57A76CDEE90 /* WalletSwitchDialog.swift in Sources */,
 				5D8D3B4397A957BA6DD6FC0C /* DWAboutModel+MasternodeSync.swift in Sources */,
@@ -11332,6 +11352,10 @@
 				C20BF8237F3E1009AD3B7716 /* DarkCoinMessageFraming.swift in Sources */,
 				8DD6758D2AC6F5BB23D5504D /* WalletSendService.swift in Sources */,
 				90BCB843A2C5965C115C04CC /* WalletsScreen.swift in Sources */,
+				7190FF8B29307603641F6B5A /* WalletAccountDetailScreen.swift in Sources */,
+				2AD2319F6C528CF6E17656F9 /* WalletAccountDetailViewModel.swift in Sources */,
+				22B03841025A55A573432CC9 /* WalletAccountsScreen.swift in Sources */,
+				5EE4B9063E1F3D890E811B1F /* WalletAccountsViewModel.swift in Sources */,
 				6C4AA7FD67FEE5A9E5CF9781 /* WalletsViewModel.swift in Sources */,
 				EC5D47238700BFBE0CB8FE6F /* DWParsedPaymentURI.swift in Sources */,
 				FACED5DF2BA8E7234BE6BE8D /* DWRecoverModel+Mnemonic.swift in Sources */,

--- a/DashWallet/Resources/AppAssets.xcassets/Menu/image.wallets.imageset/Contents.json
+++ b/DashWallet/Resources/AppAssets.xcassets/Menu/image.wallets.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "wallets.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/DashWallet/Resources/AppAssets.xcassets/Menu/image.wallets.imageset/wallets.svg
+++ b/DashWallet/Resources/AppAssets.xcassets/Menu/image.wallets.imageset/wallets.svg
@@ -1,0 +1,5 @@
+<svg width="90" height="90" viewBox="0 0 90 90" xmlns="http://www.w3.org/2000/svg">
+  <path fill="#008DE4" d="M25 15 H65 A8 8 0 0 1 73 23 H17 A8 8 0 0 1 25 15 Z"/>
+  <path fill="#008DE4" fill-rule="evenodd" clip-rule="evenodd" d="M21 27 H69 A10 10 0 0 1 79 37 V63 A10 10 0 0 1 69 73 H21 A10 10 0 0 1 11 63 V37 A10 10 0 0 1 21 27 Z M61 42 H69 A8 8 0 0 1 77 50 A8 8 0 0 1 69 58 H61 A8 8 0 0 1 53 50 A8 8 0 0 1 61 42 Z"/>
+  <circle fill="#008DE4" cx="65" cy="50" r="4.5"/>
+</svg>

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -152,6 +152,7 @@ struct MainMenuScreen: View {
     @State private var openSettings: Bool = false
     @State private var showTools: Bool = false
     @State private var showSyncInfo: Bool = false
+    @State private var showWallets: Bool = false
     @State private var showSecurity: Bool = false
     @State private var showDashPayInfo: Bool = false
     @State private var showCreditsPurchasedToast: Bool = false
@@ -346,6 +347,13 @@ struct MainMenuScreen: View {
             }
 
             NavigationLink(
+                destination: WalletsScreen(vc: vc, wipeDelegate: delegateInternal.wipeDelegate),
+                isActive: $showWallets
+            ) {
+                EmptyView()
+            }
+
+            NavigationLink(
                 destination: SecurityMenuScreen(vc: vc, wipeDelegate: delegateInternal.wipeDelegate),
                 isActive: $showSecurity
             ) {
@@ -421,6 +429,8 @@ struct MainMenuScreen: View {
             showExplore()
         case .syncInfo:
             showSyncInfo = true
+        case .wallets:
+            showWallets = true
         case .security:
             showSecurity = true
         case .settings:

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -22,6 +22,7 @@ enum MainMenuNavigationDestination {
     case buySellPortal
     case explore
     case syncInfo
+    case wallets
     case security
     case settings
     case tools
@@ -104,6 +105,15 @@ class MainMenuViewModel: ObservableObject {
             icon: .system("arrow.triangle.2.circlepath"),
             action: { [weak self] in
                 self?.navigationDestination = .syncInfo
+            }
+        ))
+
+        // Wallets
+        allItems.append(MenuItemModel(
+            title: NSLocalizedString("Wallets", comment: ""),
+            icon: .custom("image.wallets", maxHeight: 30),
+            action: { [weak self] in
+                self?.navigationDestination = .wallets
             }
         ))
 

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -130,10 +130,6 @@ struct SecurityMenuScreen: View {
                     self.vc.pushViewController(controller, animated: true)
                 }
             }
-        case .wallets:
-            let controller = UIHostingController(rootView: WalletsScreen(vc: vc, wipeDelegate: delegateInternal.wipeDelegate))
-            controller.hidesBottomBarWhenPushed = true
-            self.vc.pushViewController(controller, animated: true)
         case .resetWalletDebug:
             showResetWalletDebugAlert = true
         case .none:

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
@@ -23,7 +23,6 @@ enum SecurityMenuNavigationDestination {
     case viewRecoveryPhrase
     case changePin
     case advancedSecurity
-    case wallets
     case resetWalletDebug
 }
 
@@ -120,16 +119,8 @@ class SecurityMenuViewModel: ObservableObject {
         ))
         
         menuItems.append(MenuItemModel(
-            title: NSLocalizedString("Wallets", comment: ""),
-            icon: .custom("image.reset.wallet", maxHeight: 22),
-            action: { [weak self] in
-                self?.navigationDestination = .wallets
-            }
-        ))
-
-        menuItems.append(MenuItemModel(
             title: "Reset Wallet (Debug)",
-            icon: .custom("image.reset.wallet", maxHeight: 22),
+            icon: .custom("image-menu-reset_wallet", maxHeight: 22),
             action: { [weak self] in
                 self?.navigationDestination = .resetWalletDebug
             }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift
@@ -1,0 +1,344 @@
+//
+//  WalletAccountDetailScreen.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Account detail screen (Wallets → wallet → tap an account). Shows the
+//  account's overview, balance, address-pool stats, per-pool address lists
+//  (tap an address to copy it), and the extended public key for provider
+//  key accounts — the same information as the SwiftExampleApp's
+//  `AccountDetailView`, in the app's house style. All logic lives in
+//  `WalletAccountDetailViewModel`; this view only renders.
+//
+
+import SwiftUI
+import UIKit
+
+struct WalletAccountDetailScreen: View {
+    private let vc: UINavigationController
+
+    @StateObject private var viewModel: WalletAccountDetailViewModel
+    /// Address string just copied, for a transient "Copied" confirmation.
+    @State private var copiedAddress: String? = nil
+
+    init(vc: UINavigationController, walletId: Data, account: WalletAccountRow) {
+        self.vc = vc
+        _viewModel = StateObject(
+            wrappedValue: WalletAccountDetailViewModel(walletId: walletId, account: account))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.primaryBackground.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 0) {
+                header
+
+                if let detail = viewModel.detail {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 16) {
+                            overviewCard(detail)
+
+                            if detail.isProviderKeyAccount {
+                                extendedPublicKeyCard(detail)
+                            } else if detail.showsBalance {
+                                balanceCard(detail)
+                            }
+
+                            if !detail.isProviderKeyAccount {
+                                poolSummaryCard(detail)
+                            }
+
+                            ForEach(detail.addressSections) { section in
+                                addressListCard(section, isPlatform: detail.isPlatformPayment)
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.top, 4)
+                        .padding(.bottom, 20)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        NSLocalizedString("Account Not Found", comment: "Wallet accounts"),
+                        systemImage: "exclamationmark.triangle",
+                        description: Text(NSLocalizedString(
+                            "This account is no longer in the wallet's store.",
+                            comment: "Wallet accounts")))
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .navigationBarHidden(true)
+        .onAppear { viewModel.reload() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Button(action: { vc.popViewController(animated: true) }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.primary)
+                        .frame(width: 36, height: 36)
+                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 5)
+            .padding(.top, 10)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(viewModel.detail?.typeName ?? NSLocalizedString("Account", comment: "Wallet accounts"))
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primaryText)
+                if let detail = viewModel.detail, detail.showsBalance {
+                    Text("#\(detail.accountIndex)")
+                        .font(.subheadline)
+                        .foregroundColor(.secondaryText)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 30)
+            .padding(.bottom, 10)
+        }
+    }
+
+    // MARK: - Cards
+
+    private func overviewCard(_ detail: WalletAccountDetail) -> some View {
+        card(
+            title: NSLocalizedString("Account Information", comment: "Wallet accounts"),
+            systemImage: "info.circle.fill"
+        ) {
+            infoRow(NSLocalizedString("Type", comment: "Wallet accounts"), detail.typeName)
+            infoRow(NSLocalizedString("Index", comment: "Wallet accounts"), "#\(detail.accountIndex)", monospaced: true)
+            infoRow(NSLocalizedString("Network", comment: "Wallet accounts"), detail.networkName)
+        }
+    }
+
+    private func balanceCard(_ detail: WalletAccountDetail) -> some View {
+        card(
+            title: NSLocalizedString("Balance", comment: ""),
+            systemImage: detail.isPlatformPayment ? "creditcard" : "circle.hexagongrid.fill"
+        ) {
+            if detail.isPlatformPayment {
+                infoRow(
+                    NSLocalizedString("Platform Credits", comment: "Wallet accounts"),
+                    Self.formatCredits(detail.platformCredits))
+                infoRow(
+                    NSLocalizedString("Raw Credits", comment: "Wallet accounts"),
+                    "\(detail.platformCredits)",
+                    monospaced: true)
+            } else {
+                infoRow(NSLocalizedString("Confirmed", comment: "Wallet accounts"), detail.confirmed.formattedDashAmount)
+                if detail.unconfirmed > 0 {
+                    infoRow(NSLocalizedString("Pending", comment: "Wallet accounts"), detail.unconfirmed.formattedDashAmount)
+                }
+                Divider()
+                HStack {
+                    Text(NSLocalizedString("Total Balance", comment: "Wallet accounts"))
+                        .font(.footnote)
+                        .foregroundColor(.secondaryText)
+                    Spacer()
+                    Text((detail.confirmed + detail.unconfirmed).formattedDashAmount)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(.primaryText)
+                }
+            }
+        }
+    }
+
+    private func poolSummaryCard(_ detail: WalletAccountDetail) -> some View {
+        card(
+            title: NSLocalizedString("Address Pool", comment: "Wallet accounts"),
+            systemImage: "square.stack.3d.up.fill"
+        ) {
+            if detail.isPlatformPayment {
+                // DIP-17 pools are flat — no external/internal split, no
+                // core transactions, no UTXOs.
+                infoRow(NSLocalizedString("Total Addresses", comment: "Wallet accounts"), "\(detail.platformAddressesTotal)")
+                infoRow(NSLocalizedString("Addresses Used", comment: "Wallet accounts"), "\(detail.platformAddressesUsed)")
+                infoRow(
+                    NSLocalizedString("Highest Used", comment: "Wallet accounts"),
+                    detail.platformHighestUsed.map { "\($0)" } ?? "—")
+            } else {
+                if detail.externalPoolSize > 0 {
+                    infoRow(NSLocalizedString("Pool Size (External)", comment: "Wallet accounts"), "\(detail.externalPoolSize)")
+                }
+                if detail.internalPoolSize > 0 {
+                    infoRow(NSLocalizedString("Pool Size (Internal)", comment: "Wallet accounts"), "\(detail.internalPoolSize)")
+                }
+                infoRow(
+                    NSLocalizedString("Highest Used (External)", comment: "Wallet accounts"),
+                    detail.externalHighestUsed.map { "\($0)" } ?? "—")
+                infoRow(
+                    NSLocalizedString("Highest Used (Internal)", comment: "Wallet accounts"),
+                    detail.internalHighestUsed.map { "\($0)" } ?? "—")
+                infoRow(NSLocalizedString("Transactions", comment: ""), "\(detail.transactionCount)")
+                infoRow(NSLocalizedString("TXOs", comment: "Wallet accounts"), "\(detail.txoCount)")
+            }
+        }
+    }
+
+    private func addressListCard(_ section: AccountAddressSection, isPlatform: Bool) -> some View {
+        card(
+            title: String(
+                format: NSLocalizedString("%@ Addresses (%d)", comment: "Wallet accounts — pool name + count"),
+                section.name, section.items.count),
+            systemImage: Self.poolIcon(for: section.name)
+        ) {
+            ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, item in
+                addressRow(item, isPlatform: isPlatform)
+                if idx < section.items.count - 1 {
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func addressRow(_ item: AccountAddressItem, isPlatform: Bool) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.address)
+                    .font(.system(.caption, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundColor(.primaryText)
+                HStack(spacing: 6) {
+                    Text("#\(item.index)")
+                    if item.isUsed {
+                        Text("• " + NSLocalizedString("used", comment: "Wallet accounts — address flag"))
+                    }
+                    if item.balance > 0 {
+                        Text(isPlatform
+                            ? "• \(item.balance) credits"
+                            : "• \(item.balance.formattedDashAmount)")
+                    }
+                }
+                .font(.caption2)
+                .foregroundColor(.secondaryText)
+            }
+            Spacer()
+            if copiedAddress == item.address {
+                Label(NSLocalizedString("Copied", comment: ""), systemImage: "checkmark")
+                    .font(.caption2)
+                    .foregroundColor(.green)
+            } else {
+                Image(systemName: "doc.on.doc")
+                    .font(.caption2)
+                    .foregroundColor(.dashBlue)
+            }
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .onTapGesture { copy(item.address) }
+    }
+
+    /// Extended-public-key card for provider key-material accounts
+    /// (operator = BLS, platform node = Ed25519). These accounts derive
+    /// masternode / platform-node keys and hold no on-chain addresses or
+    /// balance. The per-index derived keys live in Tools → Masternode Keys.
+    private func extendedPublicKeyCard(_ detail: WalletAccountDetail) -> some View {
+        card(
+            title: NSLocalizedString("Extended Public Key", comment: "Wallet accounts"),
+            systemImage: "key.horizontal.fill"
+        ) {
+            if let hex = detail.extendedPublicKeyHex, !hex.isEmpty {
+                Text(NSLocalizedString(
+                    "This account derives masternode keys. It has no on-chain addresses or balance.",
+                    comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+                Text(hex)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundColor(.primaryText)
+                    .textSelection(.enabled)
+            } else {
+                Text(NSLocalizedString(
+                    "No extended public key has been persisted for this account yet.",
+                    comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+            }
+        }
+    }
+
+    // MARK: - Building blocks
+
+    private func card(
+        title: String,
+        systemImage: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(title, systemImage: systemImage)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.primaryText)
+            Divider()
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
+        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+    }
+
+    private func infoRow(_ label: String, _ value: String, monospaced: Bool = false) -> some View {
+        HStack {
+            Text(label)
+                .font(.footnote)
+                .foregroundColor(.secondaryText)
+            Spacer()
+            Text(value)
+                .font(monospaced ? .system(.footnote, design: .monospaced) : .system(.footnote))
+                .fontWeight(.medium)
+                .foregroundColor(.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+
+    private func copy(_ address: String) {
+        UIPasteboard.general.string = address
+        copiedAddress = address
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            if copiedAddress == address { copiedAddress = nil }
+        }
+    }
+
+    private static func poolIcon(for name: String) -> String {
+        switch name {
+        case "External": return "arrow.down.circle"
+        case "Internal": return "arrow.triangle.2.circlepath"
+        case NSLocalizedString("Platform Addresses", comment: "Wallet accounts"): return "creditcard"
+        default: return "square.stack"
+        }
+    }
+
+    private static func formatCredits(_ credits: UInt64) -> String {
+        let dash = Double(credits) / 100_000_000_000.0
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        let number = formatter.string(from: NSNumber(value: dash)) ?? String(format: "%.8f", dash)
+        return "\(number) DASH"
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailViewModel.swift
@@ -1,0 +1,229 @@
+//
+//  WalletAccountDetailViewModel.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  ViewModel for the account detail screen (Wallets → wallet → tap an
+//  account). Projects one `PersistentAccount` — overview, live balance,
+//  address-pool stats, per-pool address lists, and the extended public key
+//  for provider key accounts — mirroring the SwiftExampleApp's
+//  `AccountDetailView` data flow. All SDK and SwiftData work lives here —
+//  the SwiftUI screen only renders `detail` (SwiftUI-first guardrail).
+//
+
+import Combine
+import Foundation
+import OSLog
+import SwiftData
+import SwiftDashSDK
+
+/// One address of an account's pool, as rendered by the detail screen.
+struct AccountAddressItem: Identifiable, Equatable {
+    /// Base58check (core pools) or bech32m (DIP-17 platform pool).
+    let address: String
+    let index: UInt32
+    let isUsed: Bool
+    /// Duffs for core addresses; credits for platform addresses.
+    let balance: UInt64
+
+    var id: String { address }
+}
+
+/// One pool section ("External", "Internal", …) of the address list.
+struct AccountAddressSection: Identifiable, Equatable {
+    let name: String
+    let items: [AccountAddressItem]
+
+    var id: String { name }
+}
+
+/// Everything the detail screen shows for one account — a pure value
+/// projection of `PersistentAccount` + the manager's live `AccountBalance`.
+struct WalletAccountDetail: Equatable {
+    let typeName: String
+    let accountIndex: UInt32
+    let networkName: String
+
+    let showsBalance: Bool
+    let isPlatformPayment: Bool
+    /// Provider operator (BLS, tag 10) / platform-node (EdDSA, tag 11)
+    /// key-material accounts: no addresses or balance — show the xpub.
+    let isProviderKeyAccount: Bool
+
+    /// Live balances in duffs (funds accounts only).
+    let confirmed: UInt64
+    let unconfirmed: UInt64
+    /// PlatformPayment only: total balance in credits.
+    let platformCredits: UInt64
+
+    /// Core pool stats (non-platform accounts).
+    let externalPoolSize: Int
+    let internalPoolSize: Int
+    /// Highest used derivation index, or nil when the pool is unused.
+    let externalHighestUsed: Int32?
+    let internalHighestUsed: Int32?
+    /// Distinct transactions this account participates in: the union of the
+    /// TXO-derived set (each TXO's creating + spending tx) and the
+    /// payload-only `involvedTransactions` join, de-duped by txid.
+    let transactionCount: Int
+    let txoCount: Int
+
+    /// Platform pool stats (PlatformPayment accounts).
+    let platformAddressesTotal: Int
+    let platformAddressesUsed: Int
+    let platformHighestUsed: UInt32?
+
+    /// Address lists grouped by pool, in stable display order.
+    let addressSections: [AccountAddressSection]
+
+    /// Bincode-encoded extended public key hex (provider key accounts), or
+    /// nil when the account has none persisted yet.
+    let extendedPublicKeyHex: String?
+}
+
+@MainActor
+final class WalletAccountDetailViewModel: ObservableObject {
+    private static let logger = Logger(
+        subsystem: "org.dashfoundation.dash",
+        category: "wallet-account-detail")
+
+    /// Nil until `reload()` finds the account; the screen shows an
+    /// unavailable state then.
+    @Published private(set) var detail: WalletAccountDetail? = nil
+
+    private let walletId: Data
+    private let account: WalletAccountRow
+
+    init(walletId: Data, account: WalletAccountRow) {
+        self.walletId = walletId
+        self.account = account
+    }
+
+    func reload() {
+        guard let context = SwiftDashSDKHost.shared.modelContainer?.mainContext else {
+            Self.logger.error("reload: no model container")
+            detail = nil
+            return
+        }
+
+        // The displayed accounts exclude the DashPay friendship tags, so
+        // (wallet, type, index, standardTag, registrationIndex, keyClass)
+        // is unique per the persister's match logic.
+        let targetId = walletId
+        let type = account.accountType
+        let index = account.accountIndex
+        let standardTag = account.standardTag
+        let registrationIndex = account.registrationIndex
+        let keyClass = account.keyClass
+        var descriptor = FetchDescriptor<PersistentAccount>(
+            predicate: #Predicate {
+                $0.wallet.walletId == targetId &&
+                    $0.accountType == type &&
+                    $0.accountIndex == index &&
+                    $0.standardTag == standardTag &&
+                    $0.registrationIndex == registrationIndex &&
+                    $0.keyClass == keyClass
+            })
+        descriptor.fetchLimit = 1
+
+        guard let persisted = (try? context.fetch(descriptor))?.first else {
+            Self.logger.error("reload: account row not found")
+            detail = nil
+            return
+        }
+
+        let live = (SwiftDashSDKHost.shared.manager?.accountBalances(for: walletId) ?? [])
+            .first { entry in
+                UInt32(entry.typeTag) == type &&
+                    entry.standardTag == standardTag &&
+                    entry.index == index
+            }
+
+        detail = Self.project(persisted, live: live)
+    }
+
+    private static func project(
+        _ account: PersistentAccount,
+        live: PlatformWalletManager.AccountBalance?
+    ) -> WalletAccountDetail {
+        let showsBalance = account.accountType == 0 || account.accountType == 1 || account.accountType == 14
+        let isPlatformPayment = account.accountType == 14
+
+        // Distinct transactions: TXO walk (creating + spending tx per TXO)
+        // unioned with the payload-only involvement join, de-duped by txid —
+        // same derivation as the SwiftExampleApp's AccountDetailView.
+        var txids = Set<Data>()
+        var txoCount = 0
+        for address in account.coreAddresses {
+            for txo in address.txos {
+                txoCount += 1
+                if let tx = txo.transaction { txids.insert(tx.txid) }
+                if let spending = txo.spendingTransaction { txids.insert(spending.txid) }
+            }
+        }
+        for tx in account.involvedTransactions { txids.insert(tx.txid) }
+
+        // Address lists grouped by pool tag, in stable display order (pool
+        // names via `PersistentCoreAddress.poolTypeName` — the shared
+        // taxonomy; tags 2/3 are the on-demand "Additional" pools).
+        let grouped = Dictionary(grouping: account.coreAddresses) { $0.poolTypeTag }
+        let sections: [AccountAddressSection]
+        if isPlatformPayment {
+            let items = account.platformAddresses
+                .sorted { $0.addressIndex < $1.addressIndex }
+                .map { AccountAddressItem(address: $0.address, index: $0.addressIndex, isUsed: $0.isUsed, balance: $0.balance) }
+            sections = items.isEmpty
+                ? []
+                : [AccountAddressSection(
+                    name: NSLocalizedString("Platform Addresses", comment: "Wallet accounts"),
+                    items: items)]
+        } else {
+            sections = [UInt8(0), 1, 2, 3].compactMap { tag in
+                guard let bucket = grouped[tag], !bucket.isEmpty else { return nil }
+                let items = bucket
+                    .sorted { $0.addressIndex < $1.addressIndex }
+                    .map { AccountAddressItem(address: $0.address, index: $0.addressIndex, isUsed: $0.isUsed, balance: $0.balance) }
+                return AccountAddressSection(name: bucket[0].poolTypeName, items: items)
+            }
+        }
+
+        let platformUsed = account.platformAddresses.filter { $0.isUsed }
+        return WalletAccountDetail(
+            typeName: account.accountTypeName,
+            accountIndex: account.accountIndex,
+            networkName: account.wallet.network?.displayName
+                ?? NSLocalizedString("Unknown", comment: ""),
+            showsBalance: showsBalance,
+            isPlatformPayment: isPlatformPayment,
+            isProviderKeyAccount: account.accountType == 10 || account.accountType == 11,
+            confirmed: live?.confirmed ?? account.balanceConfirmed,
+            unconfirmed: live?.unconfirmed ?? account.balanceUnconfirmed,
+            platformCredits: account.platformAddresses.reduce(0) { $0 + $1.balance },
+            externalPoolSize: account.coreAddresses.filter { $0.poolTypeTag == 0 }.count,
+            internalPoolSize: account.coreAddresses.filter { $0.poolTypeTag == 1 }.count,
+            externalHighestUsed: account.externalHighestUsed >= 0 ? account.externalHighestUsed : nil,
+            internalHighestUsed: account.internalHighestUsed >= 0 ? account.internalHighestUsed : nil,
+            transactionCount: txids.count,
+            txoCount: txoCount,
+            platformAddressesTotal: account.platformAddresses.count,
+            platformAddressesUsed: platformUsed.count,
+            platformHighestUsed: platformUsed.map { $0.addressIndex }.max(),
+            addressSections: sections,
+            extendedPublicKeyHex: account.accountExtendedPubKeyBytes.map {
+                $0.map { String(format: "%02x", $0) }.joined()
+            })
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift
@@ -1,0 +1,301 @@
+//
+//  WalletAccountsScreen.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Per-wallet Accounts screen (Wallets → tap a wallet). Lists every account
+//  of the wallet — type, per-account balance, and address-pool usage —
+//  modeled on the SwiftExampleApp's `AccountListView`. Read-only: adding an
+//  extra account is not supported yet, so there is deliberately no Add
+//  control. All logic lives in `WalletAccountsViewModel`; this view only
+//  renders.
+//
+
+import SwiftUI
+import UIKit
+
+struct WalletAccountsScreen: View {
+    private let vc: UINavigationController
+    private let walletId: Data
+
+    @StateObject private var viewModel: WalletAccountsViewModel
+
+    init(vc: UINavigationController, walletId: Data, walletName: String) {
+        self.vc = vc
+        self.walletId = walletId
+        _viewModel = StateObject(
+            wrappedValue: WalletAccountsViewModel(walletId: walletId, walletName: walletName))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.primaryBackground.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 0) {
+                header
+
+                if viewModel.rows.isEmpty {
+                    ContentUnavailableView(
+                        NSLocalizedString("No Accounts", comment: "Wallet accounts"),
+                        systemImage: "folder",
+                        description: Text(NSLocalizedString(
+                            "Accounts are created automatically when the wallet syncs.",
+                            comment: "Wallet accounts")))
+                } else {
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            ForEach(viewModel.rows) { row in
+                                AccountRowView(row: row)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture { showDetail(row) }
+                                if row.id != viewModel.rows.last?.id {
+                                    Divider().padding(.leading, 16)
+                                }
+                            }
+                        }
+                        .background(Color.secondaryBackground)
+                        .cornerRadius(12)
+                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 4)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .navigationBarHidden(true)
+        .onAppear { viewModel.reload() }
+    }
+
+    /// Push the tapped account's detail screen.
+    private func showDetail(_ row: WalletAccountRow) {
+        let controller = UIHostingController(
+            rootView: WalletAccountDetailScreen(vc: vc, walletId: walletId, account: row))
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            NavigationBar(
+                leading: { NavigationBarElement.back.button { vc.popViewController(animated: true) } },
+                central: {
+                    Text(viewModel.walletName)
+                        .font(.headline)
+                        .foregroundColor(.primaryText)
+                        .lineLimit(1)
+                        .padding(.horizontal, 60)
+                }
+            )
+
+            HStack {
+                Text(NSLocalizedString("Accounts", comment: "Wallet accounts"))
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primaryText)
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 10)
+            .padding(.bottom, 10)
+        }
+    }
+}
+
+// MARK: - Row
+
+/// One account: colored icon + name, type chip, then a balance breakdown for
+/// funds accounts (Standard / CoinJoin / PlatformPayment) or a
+/// special-purpose caption, and an address-pool usage footer. Mirrors the
+/// SwiftExampleApp's `AccountRowView` in the app's house style.
+private struct AccountRowView: View {
+    let row: WalletAccountRow
+
+    private var label: String {
+        row.showsBalance ? "\(row.typeName) #\(row.accountIndex)" : row.typeName
+    }
+
+    private var iconName: String {
+        switch row.accountType {
+        case 0:
+            return row.standardTag == 0 ? "star.circle.fill" : "tray.full"
+        case 1: return "shuffle.circle"
+        case 14: return "creditcard"
+        case 2, 3, 4, 5: return "person.crop.circle"
+        case 6, 7: return "arrow.up.circle"
+        case 8: return "key.viewfinder"
+        case 9: return "key.horizontal"
+        case 10: return "wrench.and.screwdriver"
+        case 11: return "network"
+        default: return "folder"
+        }
+    }
+
+    private var iconColor: Color {
+        switch row.accountType {
+        case 0: return row.standardTag == 0
+            ? (row.accountIndex == 0 ? .green : .blue)
+            : .teal
+        case 1: return .orange
+        case 14: return .indigo
+        case 2, 3, 4, 5, 6, 7: return .purple
+        case 8: return .red
+        case 9: return .pink
+        case 10: return .indigo
+        case 11: return .cyan
+        default: return .gray
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(label, systemImage: iconName)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(iconColor)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text(row.typeName)
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(iconColor.opacity(0.2))
+                    .cornerRadius(4)
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.secondaryText)
+            }
+
+            if row.isPlatformPayment {
+                platformBalanceRow
+            } else if row.showsBalance {
+                coreBalanceRow
+            } else {
+                Text(NSLocalizedString("Special Purpose Account", comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+                    .italic()
+            }
+
+            footer
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    private var coreBalanceRow: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("Confirmed", comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+                Text(row.confirmed.formattedDashAmount)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primaryText)
+            }
+
+            if row.unconfirmed > 0 {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(NSLocalizedString("Pending", comment: "Wallet accounts"))
+                        .font(.caption)
+                        .foregroundColor(.secondaryText)
+                    Text(row.unconfirmed.formattedDashAmount)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.orange)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(NSLocalizedString("Total", comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+                Text((row.confirmed + row.unconfirmed).formattedDashAmount)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(iconColor)
+            }
+        }
+    }
+
+    /// PlatformPayment balance is held in credits (1 DASH = 100 000 000 000
+    /// credits), so it can't reuse the duff formatter.
+    private var platformBalanceRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(NSLocalizedString("Balance", comment: "Wallet accounts"))
+                    .font(.caption)
+                    .foregroundColor(.secondaryText)
+                Text(Self.formatCredits(row.platformCredits))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(iconColor)
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if row.isPlatformPayment {
+            // DIP-17 pools are flat — no external/internal split.
+            HStack(spacing: 16) {
+                Label(
+                    String(format: NSLocalizedString("%d used", comment: "Wallet accounts — address pool"), row.platformAddressesUsed),
+                    systemImage: "checkmark.circle")
+                Label(
+                    String(format: NSLocalizedString("%d total", comment: "Wallet accounts — address pool"), row.platformAddressesTotal),
+                    systemImage: "tray.full")
+                Spacer()
+            }
+            .font(.caption)
+            .foregroundColor(.secondaryText)
+        } else if row.receiveAddressCount > 0 || row.changeAddressCount > 0 {
+            HStack(spacing: 16) {
+                if row.receiveAddressCount > 0 {
+                    Label(
+                        String(format: NSLocalizedString("%d receive", comment: "Wallet accounts — address pool"), row.receiveAddressCount),
+                        systemImage: "arrow.down.circle")
+                }
+                if row.changeAddressCount > 0 {
+                    Label(
+                        String(format: NSLocalizedString("%d change", comment: "Wallet accounts — address pool"), row.changeAddressCount),
+                        systemImage: "arrow.up.arrow.down.circle")
+                }
+                Spacer()
+            }
+            .font(.caption)
+            .foregroundColor(.secondaryText)
+        }
+    }
+
+    private static func formatCredits(_ credits: UInt64) -> String {
+        let dash = Double(credits) / 100_000_000_000.0
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 8
+        let number = formatter.string(from: NSNumber(value: dash)) ?? String(format: "%.8f", dash)
+        return "\(number) DASH"
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsViewModel.swift
@@ -1,0 +1,159 @@
+//
+//  WalletAccountsViewModel.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  ViewModel for the per-wallet Accounts screen (Wallets → tap a wallet).
+//  Sources the wallet's persisted accounts (SwiftData `PersistentAccount`)
+//  joined with the live per-account balances from the Rust wallet manager,
+//  mirroring the SwiftExampleApp's `AccountListView` data flow. All SDK and
+//  SwiftData work lives here — the SwiftUI screen only renders `rows`
+//  (SwiftUI-first guardrail).
+//
+
+import Combine
+import Foundation
+import OSLog
+import SwiftData
+import SwiftDashSDK
+
+/// One account of a wallet as rendered by the Accounts screen. A pure value
+/// projection of `PersistentAccount` + the manager's live `AccountBalance`.
+struct WalletAccountRow: Identifiable, Equatable {
+    /// `AccountTypeTagFFI` discriminant (0 = Standard, 1 = CoinJoin,
+    /// 14 = PlatformPayment, …).
+    let accountType: UInt32
+    /// BIP44 (0) vs BIP32 (1) within Standard; meaningless otherwise.
+    let standardTag: UInt8
+    let accountIndex: UInt32
+    /// Human-readable type name persisted by the SDK ("Standard (BIP44)", …).
+    let typeName: String
+    /// Confirmed balance in duffs (funds accounts only).
+    let confirmed: UInt64
+    /// Unconfirmed balance in duffs (funds accounts only).
+    let unconfirmed: UInt64
+    /// Derived-and-used receive / change address counts for the footer.
+    let receiveAddressCount: Int
+    let changeAddressCount: Int
+    /// PlatformPayment only: total balance in credits and the flat DIP-17
+    /// pool's used/total counts. Zero elsewhere.
+    let platformCredits: UInt64
+    let platformAddressesUsed: Int
+    let platformAddressesTotal: Int
+
+    /// Full account-identity tuple minus the identity ids (hidden DashPay
+    /// friendship accounts are filtered out before rows are built, so the
+    /// remaining fields are unique per the persister's match logic).
+    var id: String { "\(accountType)-\(standardTag)-\(accountIndex)-\(registrationIndex)-\(keyClass)" }
+    let registrationIndex: UInt32
+    let keyClass: UInt32
+
+    /// Whether this is a funds account whose balance is worth showing
+    /// (Standard / CoinJoin / PlatformPayment) — mirrors the example app.
+    var showsBalance: Bool { accountType == 0 || accountType == 1 || accountType == 14 }
+    var isPlatformPayment: Bool { accountType == 14 }
+}
+
+@MainActor
+final class WalletAccountsViewModel: ObservableObject {
+    private static let logger = Logger(
+        subsystem: "org.dashfoundation.dash",
+        category: "wallet-accounts-screen")
+
+    @Published private(set) var rows: [WalletAccountRow] = []
+
+    let walletName: String
+    private let walletId: Data
+
+    init(walletId: Data, walletName: String) {
+        self.walletId = walletId
+        self.walletName = walletName
+    }
+
+    /// Rebuild `rows` from the wallet's persisted accounts joined with the
+    /// manager's live in-memory balances. DashPay friendship accounts (tags
+    /// 12 receiving / 13 external) are hidden: they're per-contact protocol
+    /// plumbing, one pair per friendship, and would crowd the list as
+    /// contacts grow (same rationale as the SwiftExampleApp).
+    func reload() {
+        guard let context = SwiftDashSDKHost.shared.modelContainer?.mainContext else {
+            Self.logger.error("reload: no model container")
+            rows = []
+            return
+        }
+
+        let targetId = walletId
+        let descriptor = FetchDescriptor<PersistentAccount>(
+            predicate: #Predicate { $0.wallet.walletId == targetId })
+        let accounts: [PersistentAccount]
+        do {
+            accounts = try context.fetch(descriptor)
+        } catch {
+            Self.logger.error("account fetch failed: \(String(describing: error), privacy: .public)")
+            rows = []
+            return
+        }
+
+        let liveBalances = SwiftDashSDKHost.shared.manager?.accountBalances(for: walletId) ?? []
+
+        rows = accounts
+            .filter { $0.accountType != 12 && $0.accountType != 13 }
+            .map { account in
+                // Live in-memory balance when the manager tracks this account,
+                // else the persisted snapshot (kept current by the SDK's
+                // persistence handler).
+                let live = liveBalances.first { entry in
+                    UInt32(entry.typeTag) == account.accountType &&
+                        entry.standardTag == account.standardTag &&
+                        entry.index == account.accountIndex
+                }
+                return WalletAccountRow(
+                    accountType: account.accountType,
+                    standardTag: account.standardTag,
+                    accountIndex: account.accountIndex,
+                    typeName: account.accountTypeName,
+                    confirmed: live?.confirmed ?? account.balanceConfirmed,
+                    unconfirmed: live?.unconfirmed ?? account.balanceUnconfirmed,
+                    receiveAddressCount: max(Int(account.externalHighestUsed) + 1, 0),
+                    changeAddressCount: max(Int(account.internalHighestUsed) + 1, 0),
+                    platformCredits: account.platformAddresses.reduce(0) { $0 + $1.balance },
+                    platformAddressesUsed: account.platformAddresses.filter { $0.isUsed }.count,
+                    platformAddressesTotal: account.platformAddresses.count,
+                    registrationIndex: account.registrationIndex,
+                    keyClass: account.keyClass)
+            }
+            .sorted { Self.sortKey(for: $0) < Self.sortKey(for: $1) }
+    }
+
+    /// Stable display order — grouped by logical priority rather than by raw
+    /// type tag, so BIP44 leads, PlatformPayment sits next, BIP32 follows,
+    /// CoinJoin after, and every special-purpose account tails off in tag
+    /// order (same ordering as the SwiftExampleApp's account list).
+    private static func sortKey(for row: WalletAccountRow) -> (UInt8, UInt32, UInt8, UInt32) {
+        let group: UInt8
+        switch row.accountType {
+        case 0:
+            group = row.standardTag == 0 ? 0 : 2
+        case 14:
+            group = 1
+        case 1:
+            group = 3
+        default:
+            group = 4
+        }
+        return (group, row.accountType, row.standardTag, row.accountIndex)
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
@@ -16,10 +16,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-//  "Wallets" screen (Security menu). Lists the on-device SwiftDashSDK wallets
-//  for the current network, one marked active, and offers switch-on-tap,
-//  rename, and per-wallet remove. Add Wallet is Phase 3 and is intentionally
-//  absent. All logic lives in `WalletsViewModel`; this view only renders.
+//  "Wallets" screen (main menu). Lists the on-device SwiftDashSDK wallets
+//  for the current network, one marked active. Tapping a wallet opens its
+//  per-account breakdown (`WalletAccountsScreen`); switch, rename, and
+//  per-wallet remove live in the row's menu. All logic lives in
+//  `WalletsViewModel`; this view only renders.
 //
 
 import SwiftUI
@@ -58,16 +59,22 @@ struct WalletsScreen: View {
                         ForEach(viewModel.rows) { row in
                             WalletRowView(
                                 row: row,
+                                onSwitch: { pendingSwitch = row },
                                 onRename: {
                                     renameText = row.displayName
                                     renameTarget = row
                                 },
                                 onRemove: { beginRemove(row) })
                                 .contentShape(Rectangle())
-                                .onTapGesture {
-                                    if !row.isActive { pendingSwitch = row }
-                                }
+                                .onTapGesture { showAccounts(row) }
                                 .contextMenu {
+                                    if !row.isActive {
+                                        Button {
+                                            pendingSwitch = row
+                                        } label: {
+                                            Label(NSLocalizedString("Switch to this wallet", comment: "Wallets"), systemImage: "arrow.left.arrow.right")
+                                        }
+                                    }
                                     Button {
                                         renameText = row.displayName
                                         renameTarget = row
@@ -224,6 +231,16 @@ struct WalletsScreen: View {
         }
     }
 
+    // MARK: - Accounts
+
+    /// Push the tapped wallet's per-account breakdown.
+    private func showAccounts(_ row: WalletRow) {
+        let controller = UIHostingController(
+            rootView: WalletAccountsScreen(vc: vc, walletId: row.walletId, walletName: row.displayName))
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
+    }
+
     // MARK: - Remove routing
 
     /// The last remaining wallet routes to the existing full reset flow
@@ -244,6 +261,7 @@ struct WalletsScreen: View {
 
 private struct WalletRowView: View {
     let row: WalletRow
+    let onSwitch: () -> Void
     let onRename: () -> Void
     let onRemove: () -> Void
 
@@ -273,9 +291,16 @@ private struct WalletRowView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.dashBlue)
             }
-            // Visible entry point for rename/remove — the long-press context
-            // menu duplicates these but is undiscoverable on its own.
+            // Visible entry point for switch/rename/remove — the long-press
+            // context menu duplicates these but is undiscoverable on its own.
             Menu {
+                if !row.isActive {
+                    Button {
+                        onSwitch()
+                    } label: {
+                        Label(NSLocalizedString("Switch to this wallet", comment: "Wallets"), systemImage: "arrow.left.arrow.right")
+                    }
+                }
                 Button {
                     onRename()
                 } label: {
@@ -293,6 +318,9 @@ private struct WalletRowView: View {
                     .frame(width: 32, height: 32)
                     .contentShape(Rectangle())
             }
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.secondaryText)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)


### PR DESCRIPTION
## Summary
- Move **Wallets** out of the Security menu onto the main menu, between Sync Info and Security, with a new custom bifold-wallet icon (`image.wallets`, SVG in Dash blue #008DE4 matching the existing menu icon set).
- Wallet rows are now tappable and open a new **Accounts** screen listing every account of that wallet — modeled on the SwiftExampleApp's `AccountListView`: same logical ordering (BIP44 → Platform Payment → BIP32 → CoinJoin → special-purpose), colored type icons and chips, Confirmed/Pending/Total balances (live from the Rust manager, persisted snapshot as fallback), address-pool usage footers, and DashPay friendship accounts (tags 12/13) hidden. The top bar shows the wallet name as its title. No add-account control — adding accounts isn't supported yet.
- Accounts are tappable too and open a **detail screen** mirroring the SwiftExampleApp's `AccountDetailView` in house style: Account Information, Balance (credits-denominated for Platform Payment), Address Pool stats (pool sizes, highest used, distinct tx count via TXO-union ∪ payload-only involvement, TXO count), grouped address lists with tap-to-copy, and the Extended Public Key card for provider key accounts (per-index derived keys stay in Tools → Masternode Keys).
- Wallet switching moves from row tap to the row's ⋯ / long-press menu ("Switch to this wallet"), same confirmation alert.
- Fixes a silent pre-existing bug: the menu referenced a non-existent `image.reset.wallet` asset, so the Wallets and Reset Wallet (Debug) rows rendered without icons; Reset Wallet (Debug) now uses the real `image-menu-reset_wallet`.

## Test plan
- Clean `dashpay` scheme build (arm64 sim).
- Smoke-tested on an iPhone 16 Pro simulator (testnet): main menu shows Wallets with the new icon between Sync Info and Security; wallet → accounts list renders BIP44/Platform Payment/BIP32/CoinJoin/identity accounts with balances and pool counts; account → detail shows overview/balance/pool/address cards; address tap copies; switch/rename/remove reachable from the wallet row menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)