### PR TITLE
feat(payments): balance-row receive sheet with full internal transfer routes

### DIFF
--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -36,7 +36,12 @@ extension UIViewController {
 
             return vc
         } else if let vc = presentedViewController {
-            return vc
+            // Recurse like the container branches above: stopping one level
+            // into the presentation stack made every "present from the top"
+            // caller present from a controller that was itself already
+            // presenting (e.g. PIN prompt over the receive sheet's confirm
+            // sheet), which UIKit silently drops.
+            return vc.topController()
         }
 
         return self

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -233,15 +233,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         else { throw SendError.p2shNotSupported }
 
         let context = container.mainContext
-
-        let allDescriptor = FetchDescriptor<PersistentPlatformAddress>(
-            predicate: #Predicate<PersistentPlatformAddress> { $0.walletId == walletId })
-        let allRows = try context.fetch(allDescriptor)
-        guard let senderRow = allRows
-            .filter({ $0.balance > 0 })
-            .max(by: { $0.balance < $1.balance })
-        else { throw SendError.noFundedAddress }
-        let senderAccountIndex = senderRow.accountIndex
+        let senderAccountIndex = try highestBalanceAccountIndex(context: context, walletId: walletId)
 
         let output = ManagedPlatformAddressWallet.TransferOutput(
             addressType: recipient.ffiAddressType,
@@ -263,8 +255,36 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             outputs: [output],
             signer: signer)
 
-        // Idempotent with the Rust persister callback; keeps @Query-bound
-        // rows fresh even if the callback ordering ever changes.
+        applyUpdatedBalances(updated, context: context)
+
+        Task { await self.syncNow() }
+    }
+
+    /// Account index holding the highest-balance Platform address — the
+    /// account `transfer`/`withdrawAllToCore` spend from.
+    private func highestBalanceAccountIndex(context: ModelContext, walletId: Data) throws -> UInt32 {
+        try highestBalanceRow(context: context, walletId: walletId).accountIndex
+    }
+
+    /// The highest-balance funded Platform address row.
+    private func highestBalanceRow(context: ModelContext, walletId: Data) throws -> PersistentPlatformAddress {
+        let allDescriptor = FetchDescriptor<PersistentPlatformAddress>(
+            predicate: #Predicate<PersistentPlatformAddress> { $0.walletId == walletId })
+        let allRows = try context.fetch(allDescriptor)
+        guard let senderRow = allRows
+            .filter({ $0.balance > 0 })
+            .max(by: { $0.balance < $1.balance })
+        else { throw SendError.noFundedAddress }
+        return senderRow
+    }
+
+    /// Apply the FFI-reported per-address balances to SwiftData — idempotent
+    /// with the Rust persister callback; keeps @Query-bound rows fresh even
+    /// if the callback ordering ever changes.
+    private func applyUpdatedBalances(
+        _ updated: [ManagedPlatformAddressWallet.UpdatedBalance],
+        context: ModelContext
+    ) {
         for entry in updated {
             let entryHash = entry.hash
             let descriptor = FetchDescriptor<PersistentPlatformAddress>(
@@ -276,8 +296,173 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             row.lastUpdated = Date()
         }
         try? context.save()
+    }
 
+    // MARK: - Core ↔ Platform balance movement
+
+    /// Preflight of the full-balance Platform → Core withdrawal for the
+    /// account holding the highest Platform address balance (the same
+    /// account `transfer` spends from). See `withdrawAllToCore` for why
+    /// there is no partial-amount form.
+    public func preflightWithdrawal() async throws -> ManagedPlatformAddressWallet.WithdrawalPreflight {
+        guard isRunning,
+              let addressWallet = platformAddressWallet,
+              let container = modelContainer,
+              let walletId = wallet?.walletId
+        else { throw SendError.coordinatorNotReady }
+        let accountIndex = try highestBalanceAccountIndex(
+            context: container.mainContext, walletId: walletId)
+        return try await addressWallet.preflightWithdrawal(accountIndex: accountIndex)
+    }
+
+    /// Withdraw the selected account's ENTIRE withdrawable Platform credit
+    /// balance to `coreAddress`. The SDK's address-credit withdrawal has no
+    /// partial-amount form — AUTO input selection withdraws every non-dust
+    /// input, less the transition fee — so callers must present this as a
+    /// full-balance operation. The L1 payout arrives asynchronously once the
+    /// chain processes the withdrawal.
+    public func withdrawAllToCore(address coreAddress: String) async throws {
+        guard isRunning,
+              let addressWallet = platformAddressWallet,
+              let container = modelContainer,
+              let walletId = wallet?.walletId,
+              let network = runningNetwork
+        else { throw SendError.coordinatorNotReady }
+        let context = container.mainContext
+        let accountIndex = try highestBalanceAccountIndex(context: context, walletId: walletId)
+        let signer = KeychainSigner(modelContainer: container, network: network)
+
+        Self.logger.info("🛰️ PLATFORM-WITHDRAW :: full balance → core account=\(accountIndex)")
+
+        let updated = try await addressWallet.withdraw(
+            accountIndex: accountIndex,
+            coreAddress: coreAddress,
+            signer: signer)
+
+        applyUpdatedBalances(updated, context: context)
         Task { await self.syncNow() }
+    }
+
+    /// Partial Platform → Core withdrawal: pays out exactly `amountCredits`
+    /// to `coreAddress`, drawn from the single largest-balance Platform
+    /// address (explicit input selection). The transition fee is deducted
+    /// from that address's REMAINING balance, so it must retain at least
+    /// `feeHeadroomCredits` after the withdrawal — pass the preflight's
+    /// `estimatedFee` (a conservative bound for a single input), or nil to
+    /// preflight here. Amounts above the single-address cap should go
+    /// through `withdrawAllToCore` (AUTO, all addresses) instead.
+    public func withdrawToCore(
+        amountCredits: UInt64,
+        address coreAddress: String,
+        feeHeadroomCredits: UInt64? = nil
+    ) async throws {
+        guard isRunning,
+              let addressWallet = platformAddressWallet,
+              let container = modelContainer,
+              let walletId = wallet?.walletId,
+              let network = runningNetwork
+        else { throw SendError.coordinatorNotReady }
+        let context = container.mainContext
+        let senderRow = try highestBalanceRow(context: context, walletId: walletId)
+
+        let headroom: UInt64
+        if let feeHeadroomCredits {
+            headroom = feeHeadroomCredits
+        } else {
+            headroom = try await addressWallet
+                .preflightWithdrawal(accountIndex: senderRow.accountIndex)
+                .estimatedFee
+        }
+        guard senderRow.balance >= headroom,
+              amountCredits <= senderRow.balance - headroom
+        else { throw SendError.noFundedAddress }
+
+        let signer = KeychainSigner(modelContainer: container, network: network)
+        let input = ManagedPlatformAddressWallet.WithdrawalInput(
+            addressType: 0,
+            hash: senderRow.addressHash,
+            credits: amountCredits)
+
+        Self.logger.info(
+            "🛰️ PLATFORM-WITHDRAW :: partial amount=\(amountCredits) account=\(senderRow.accountIndex)")
+
+        let updated = try await addressWallet.withdraw(
+            accountIndex: senderRow.accountIndex,
+            coreAddress: coreAddress,
+            inputs: [input],
+            signer: signer)
+
+        applyUpdatedBalances(updated, context: context)
+        Task { await self.syncNow() }
+    }
+
+    /// Fund the wallet's own Platform balance from the Core L1 balance via
+    /// an asset lock (funding type 4, `AssetLockAddressTopUp`). `amountDuffs`
+    /// is locked on L1; the credited amount is that value minus the fees the
+    /// Rust side carves from the single remainder recipient (the wallet's
+    /// own next unused Platform address).
+    public func fundFromCore(amountDuffs: UInt64) async throws {
+        let (addressWallet, container, recipient, accountIndex) = try resolveFundEnvironment()
+        let signer = KeychainSigner(modelContainer: container, network: runningNetwork!)
+
+        Self.logger.info("🛰️ PLATFORM-FUND :: core → platform amount=\(amountDuffs) account=\(accountIndex)")
+
+        let updated = try await addressWallet.fundFromAssetLock(
+            amountDuffs: amountDuffs,
+            fundingAccountIndex: 0,
+            platformAccountIndex: accountIndex,
+            recipients: [recipient],
+            signer: signer)
+
+        applyUpdatedBalances(updated, context: container.mainContext)
+        Task { await self.syncNow() }
+    }
+
+    /// Resume a stuck Core → Platform funding whose asset lock is committed
+    /// on-chain (Broadcast/IS-locked/CL-locked) but whose address-funding
+    /// state transition never landed. Sibling of `fundFromCore` — picks up
+    /// the existing outpoint instead of building (and stranding) a second
+    /// lock. See `ShieldedTransferCoordinator.resumeAssetLock` for the same
+    /// pattern on the shielded route.
+    public func resumeFundFromCore(outPointTxid: Data, outPointVout: UInt32) async throws {
+        let (addressWallet, container, recipient, accountIndex) = try resolveFundEnvironment()
+        let signer = KeychainSigner(modelContainer: container, network: runningNetwork!)
+
+        Self.logger.info("🛰️ PLATFORM-FUND :: resume core → platform vout=\(outPointVout)")
+
+        let updated = try await addressWallet.resumeFundFromAssetLock(
+            outPointTxid: outPointTxid,
+            outPointVout: outPointVout,
+            platformAccountIndex: accountIndex,
+            recipients: [recipient],
+            signer: signer)
+
+        applyUpdatedBalances(updated, context: container.mainContext)
+        Task { await self.syncNow() }
+    }
+
+    /// Shared readiness + recipient resolution for `fundFromCore` /
+    /// `resumeFundFromCore`: the single credits-nil recipient is the
+    /// remainder output (absorbs the locked value less fees), pointed at the
+    /// wallet's own next receive address.
+    private func resolveFundEnvironment() throws -> (
+        wallet: ManagedPlatformAddressWallet,
+        container: ModelContainer,
+        recipient: ManagedPlatformAddressWallet.FundFromAssetLockRecipient,
+        accountIndex: UInt32
+    ) {
+        guard isRunning,
+              let addressWallet = platformAddressWallet,
+              let container = modelContainer,
+              runningNetwork != nil
+        else { throw SendError.coordinatorNotReady }
+        guard let target = derivedAddresses.nextReceiveAddress,
+              let parsed = Self.parsePlatformRecipient(bech32m: target.address),
+              parsed.ffiAddressType == 0
+        else { throw SendError.noPlatformReceiveAddress }
+        let recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient(
+            addressType: 0, hash: parsed.hash, credits: nil)
+        return (addressWallet, container, recipient, target.accountIndex)
     }
 
     /// Clear the UI counters/display without tearing down the sync loop.
@@ -749,6 +934,7 @@ extension PlatformAddressSyncCoordinator {
         case noFundedAddress
         case invalidDestination
         case p2shNotSupported
+        case noPlatformReceiveAddress
         case mnemonicUnavailable
         case keyDecodeFailed(String)
 
@@ -770,6 +956,10 @@ extension PlatformAddressSyncCoordinator {
                 return NSLocalizedString(
                     "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.",
                     comment: "")
+            case .noPlatformReceiveAddress:
+                return NSLocalizedString(
+                    "Could not resolve a destination Platform Payment address",
+                    comment: "InternalTransfer")
             case .mnemonicUnavailable:
                 return NSLocalizedString(
                     "Wallet mnemonic is unavailable. Unlock the wallet and try again.",
@@ -905,5 +1095,21 @@ final class ShieldedTxLookup {
         lock.lock()
         infoByTxid = map
         lock.unlock()
+    }
+}
+
+// MARK: - DerivedPlatformAddress selection
+
+extension Array where Element == DerivedPlatformAddress {
+    /// The wallet's own next receive address: lowest-indexed unused address,
+    /// falling back to the lowest-indexed overall. Single shared
+    /// implementation for the Receive screen, the unshield destination, and
+    /// Core → Platform funding.
+    var nextReceiveAddress: DerivedPlatformAddress? {
+        if let unused = filter({ !$0.isUsed })
+            .min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) }) {
+            return unused
+        }
+        return self.min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) })
     }
 }

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -237,6 +237,29 @@ class Transaction: TransactionDataItem, Identifiable {
             && snapshot.outputAddresses.contains { ShieldedWithdrawalStore.shared.contains($0) }
     }
 
+    /// The balance-to-balance route of an internal transfer, driving the
+    /// route-specific icon pair on the tx row (source icon + destination
+    /// badge). `nil` for anything that isn't a transfer of own funds.
+    ///
+    /// Only Core-side legs exist as L1 transactions, so these are the only
+    /// routes a tx-list row can represent; Platform ↔ Shielded transfers
+    /// happen entirely on Platform and never appear in this list.
+    enum InternalTransferRoute {
+        /// "To Shielded" funding asset lock (Core → Shielded).
+        case coreToShielded
+        /// L1 payout of a shielded withdrawal (Shielded → Core).
+        case shieldedToCore
+        /// Self-send within the transparent wallet.
+        case coreToCore
+    }
+
+    var internalTransferRoute: InternalTransferRoute? {
+        if isShieldedTransfer { return .coreToShielded }
+        if isShieldedWithdrawalReceipt { return .shieldedToCore }
+        if direction == .moved { return .coreToCore }
+        return nil
+    }
+
     /// True when the shielded transfer is still pending / stuck — its asset
     /// lock is broadcast/IS-locked/CL-locked (`statusRaw` 1…3) but the shield
     /// state transition hasn't consumed it yet (4 = consumed = success). Drives
@@ -376,6 +399,13 @@ class Transaction: TransactionDataItem, Identifiable {
             }
             return NSLocalizedString("Shielded transfer",
                                      comment: "Transfer of own funds into the private shielded balance")
+        }
+        // The L1 payout of a Shielded → Core withdrawal is a transfer of own
+        // funds, not an external receive — label it as such (the row's route
+        // icons show the direction).
+        if isShieldedWithdrawalReceipt {
+            return NSLocalizedString("Shielded withdrawal",
+                                     comment: "Transfer of own funds from the private shielded balance back to the transparent wallet")
         }
         switch transactionType {
         case .classic:

--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -20,9 +20,13 @@ import Combine
 import SwiftUI
 import DashUIKit
 
-@objc(DWHomeViewControllerDelegate)
+// Swift-only (no ObjC references remain): lets requirements use Swift-only
+// types like `ChainNetwork`.
 protocol HomeViewControllerDelegate: AnyObject {
     func showPaymentsController(withActivePage pageIndex: Int)
+    /// Opens the payments landing on the Receive tab with `network`
+    /// preselected in its Core/Platform/Shielded toggle.
+    func showReceiveLanding(network: ChainNetwork)
 }
 
 class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
@@ -678,6 +682,10 @@ extension HomeViewController: HomeViewDelegate {
         if navigationController?.topViewController === self {
             navigationController?.setNavigationBarHidden(shouldHide, animated: true)
         }
+    }
+
+    func homeViewShowReceive(network: ChainNetwork) {
+        delegate?.showReceiveLanding(network: network)
     }
 
     func homeViewShowInternalTransfer(direction: InternalTransferDirection, source: InternalTransferSource) {

--- a/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertViewController.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertViewController.swift
@@ -54,6 +54,11 @@ final class SyncingAlertViewController: BaseViewController {
         let hosting = UIHostingController(rootView: SyncingAlertView(viewModel: viewModel) { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         })
+        // The alert's height changes after presentation (the connected-peers
+        // and stall sections appear once their publishers fire); without this
+        // the hosting view keeps its initially measured height and the grown
+        // content clips at the card's bottom edge.
+        hosting.sizingOptions = [.intrinsicContentSize]
         hosting.view.backgroundColor = .clear
         hosting.view.translatesAutoresizingMaskIntoConstraints = false
         addChild(hosting)

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
@@ -28,17 +28,19 @@ enum HomeBalanceViewState: Int {
 
 /// Home header: the combined total (transparent + platform + shielded)
 /// as the hero amount, then one row per balance with its fiat value and
-/// circular in/out transfer buttons. Rows map onto the routes the app
-/// actually supports:
-///   - Transparent: in = Receive, out = Send (external money);
-///   - Platform:    in = Shielded → Platform, out = Platform → Shielded;
-///   - Shielded:    in = Transparent → Shielded, out = Shielded → Transparent.
+/// circular in/out transfer buttons. Every row's in-arrow opens the
+/// payments landing on the Receive tab with that balance's network
+/// preselected (its hero tabs keep Internal transfer one tap away);
+/// the out-arrows keep their direct routes:
+///   - Transparent: out = Send (external money);
+///   - Platform:    out = Platform → Shielded;
+///   - Shielded:    out = Shielded → Transparent.
 struct HomeBalanceView: View {
     @ObservedObject var viewModel: BalanceModel
     @ObservedObject private var platformSync = PlatformAddressSyncCoordinator.shared
     @State private var opacity: Double = 0.3
     var onLongPress: () -> Void
-    var onReceive: () -> Void = {}
+    var onReceive: (ChainNetwork) -> Void = { _ in }
     var onSend: () -> Void = {}
     var onTransfer: (InternalTransferDirection, InternalTransferSource) -> Void = { _, _ in }
 
@@ -126,21 +128,21 @@ struct HomeBalanceView: View {
                 icon: "wallet.pass",
                 title: NSLocalizedString("Transparent", comment: "Balance breakdown"),
                 duffs: viewModel.value,
-                inAction: onReceive,
+                inAction: { onReceive(.core) },
                 outAction: onSend)
             rowDivider
             balanceRow(
                 icon: "cloud",
                 title: NSLocalizedString("Platform", comment: ""),
                 duffs: platformDuffs,
-                inAction: { onTransfer(.fromShielded, .platform) },
+                inAction: { onReceive(.platform) },
                 outAction: { onTransfer(.toShielded, .platform) })
             rowDivider
             balanceRow(
                 icon: "shield",
                 title: NSLocalizedString("Shielded", comment: ""),
                 duffs: shieldedDuffs,
-                inAction: { onTransfer(.toShielded, .core) },
+                inAction: { onReceive(.shielded) },
                 outAction: { onTransfer(.fromShielded, .core) })
         }
         .padding(.horizontal, 12)

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -25,6 +25,10 @@ import DashUIKit
 protocol HomeViewDelegate: AnyObject {
     func homeViewShowSyncingStatus()
     func homeViewShowInternalTransfer(direction: InternalTransferDirection, source: InternalTransferSource)
+    /// Opens the payments landing on the Receive tab with `network`
+    /// preselected — the balance rows' receive arrows land on the QR for
+    /// the balance the user tapped, with the Internal tab one tap away.
+    func homeViewShowReceive(network: ChainNetwork)
     /// Scroll-derived chrome: false at the top of the feed (bar hidden,
     /// balance header owns the space), true once the user scrolls down.
     func homeViewDidChangeTopBarVisibility(shouldShow: Bool)
@@ -73,19 +77,25 @@ final class HomeView: UIView {
         headerView = HomeHeaderView(frame: CGRect.zero, viewModel: viewModel)
         headerView.delegate = self
         
+        // Resolve the shortcuts delegate lazily (through the computed property)
+        // rather than passing its current value: it is still nil here —
+        // HomeViewController assigns it right after this init returns.
+        let performShortcut: (ShortcutAction) -> Void = { [weak self] action in
+            self?.shortcutsDelegate?.shortcutsView(didSelectAction: action, sender: nil)
+        }
         #if DASHPAY
         let content = HomeViewContent(
             viewModel: self.viewModel,
             joinDPViewModel: self.joinDPViewModel,
             delegate: self.delegate,
-            shortcutsDelegate: self.shortcutsDelegate,
+            performShortcut: performShortcut,
             headerView: { UIViewWrapper(uiView: self.headerView) }
         )
         #else
         let content = HomeViewContent(
             viewModel: self.viewModel,
             delegate: self.delegate,
-            shortcutsDelegate: self.shortcutsDelegate,
+            performShortcut: performShortcut,
             headerView: { UIViewWrapper(uiView: self.headerView) }
         )
         #endif
@@ -194,7 +204,11 @@ struct HomeViewContent<Content: View>: View {
     @ObservedObject var joinDPViewModel: JoinDashPayViewModel
     #endif
     weak var delegate: HomeViewDelegate?
-    weak var shortcutsDelegate: ShortcutsActionDelegate?
+    /// Resolves the shortcuts delegate at tap time. A stored weak delegate
+    /// captured here would be permanently nil: this struct is built inside
+    /// `HomeView.init`, before `HomeViewController.loadView` assigns
+    /// `homeView.shortcutsDelegate` (which forwards into the header view).
+    var performShortcut: (ShortcutAction) -> Void = { _ in }
     @ViewBuilder var headerView: () -> Content
     
     private let topOverscrollSize: CGFloat = 1000 // Fixed value for top overscroll area
@@ -212,16 +226,13 @@ struct HomeViewContent<Content: View>: View {
                     HomeBalanceView(
                         viewModel: balanceModel,
                         onLongPress: {
-                            let action = ShortcutAction(type: .localCurrency)
-                            shortcutsDelegate?.shortcutsView(didSelectAction: action, sender: nil)
+                            performShortcut(ShortcutAction(type: .localCurrency))
                         },
-                        onReceive: {
-                            let action = ShortcutAction(type: .receive)
-                            shortcutsDelegate?.shortcutsView(didSelectAction: action, sender: nil)
+                        onReceive: { network in
+                            delegate?.homeViewShowReceive(network: network)
                         },
                         onSend: {
-                            let action = ShortcutAction(type: .send)
-                            shortcutsDelegate?.shortcutsView(didSelectAction: action, sender: nil)
+                            performShortcut(ShortcutAction(type: .send))
                         },
                         onTransfer: { direction, source in
                             delegate?.homeViewShowInternalTransfer(direction: direction, source: source)
@@ -442,6 +453,30 @@ struct HomeViewContent<Content: View>: View {
         return (.custom(txItem.iconName), nil)
     }
 
+    /// SF-symbol pair for an internal transfer's route: the source balance as
+    /// the main icon, the destination as the corner badge. Symbols match the
+    /// InternalTransferScreen cards (Core = d.circle, Shielded = shield).
+    /// Core → Core self-sends return nil and keep the generic internal icon.
+    private func transferRouteSymbols(txItem: Transaction) -> (source: String, destination: String)? {
+        switch txItem.internalTransferRoute {
+        case .coreToShielded: return ("d.circle.fill", "shield.fill")
+        case .shieldedToCore: return ("shield.fill", "d.circle.fill")
+        case .coreToCore, nil: return nil
+        }
+    }
+
+    /// Blue glyph in a tinted circle — the InternalTransferScreen card icon
+    /// treatment, scaled to the 30 pt tx-row icon slot.
+    private func transferRouteIcon(_ systemName: String) -> AnyView {
+        AnyView(
+            Image(systemName: systemName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.dashBlue)
+                .frame(width: 30, height: 30)
+                .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+        )
+    }
+
     @ViewBuilder
     private func TransactionPreviewFrom(
         txItem txDataItem: TransactionListDataItem
@@ -488,15 +523,19 @@ struct HomeViewContent<Content: View>: View {
             
         case .tx(let txItem, let metadata):
             let icons = transactionRowIcons(txItem: txItem, metadata: metadata)
+            // Service/merchant metadata wins over the route pair — such rows
+            // are external payments, not transfers of own funds.
+            let routeSymbols = metadata == nil ? transferRouteSymbols(txItem: txItem) : nil
 
             DashUIKit.TransactionView(
                 // A merchant logo is a bitmap and goes through `iconView` so it can be clipped to a
                 // circle; every other row resolves to a named icon.
-                icon: metadata?.icon == nil ? icons.primary.dashIconSource : nil,
+                icon: metadata?.icon == nil && routeSymbols == nil ? icons.primary.dashIconSource : nil,
                 iconView: metadata?.icon.map {
                     AnyView(Image(uiImage: $0).resizable().scaledToFit().clipShape(Circle()))
-                },
-                secondaryIcon: icons.secondary?.dashIconSource,
+                } ?? routeSymbols.map { transferRouteIcon($0.source) },
+                secondaryIcon: routeSymbols.map { DashIconSource.system($0.destination) }
+                    ?? icons.secondary?.dashIconSource,
                 title: metadata?.title ?? txItem.stateTitle,
                 subtitle: txItem.shortTimeString,
                 details: txItem.isPendingShieldedTransfer

--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -457,12 +457,40 @@ extension MainTabbarController: HomeViewControllerDelegate {
         presentPaymentsLandingScreen(activeTab: tab)
     }
 
-    private func presentPaymentsLandingScreen(activeTab: PaymentsLandingTab) {
-        let controller = PaymentsLandingHostingController(activeTab: activeTab)
+    /// The balance-row receive arrows open a focused two-tab sheet
+    /// (Receive ↔ Internal transfer, no Send) for the tapped balance,
+    /// rather than the full-screen three-tab landing.
+    func showReceiveLanding(network: ChainNetwork) {
+        presentPaymentsLandingScreen(
+            activeTab: .receive,
+            receiveNetwork: network,
+            visibleTabs: [.receive, .internalTransfer],
+            embedInternalTransfer: true,
+            showsHeader: false,
+            asSheet: true)
+    }
+
+    private func presentPaymentsLandingScreen(activeTab: PaymentsLandingTab,
+                                              receiveNetwork: ChainNetwork = .core,
+                                              visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
+                                              embedInternalTransfer: Bool = false,
+                                              showsHeader: Bool = true,
+                                              asSheet: Bool = false) {
+        let controller = PaymentsLandingHostingController(
+            activeTab: activeTab, receiveNetwork: receiveNetwork,
+            visibleTabs: visibleTabs, embedInternalTransfer: embedInternalTransfer,
+            showsHeader: showsHeader)
         let navigationController = BaseNavigationController(rootViewController: controller)
         navigationController.isNavigationBarHidden = true
         navigationController.isModalInPresentation = false
-        navigationController.modalPresentationStyle = .fullScreen
+        if asSheet {
+            if let sheet = navigationController.sheetPresentationController {
+                sheet.detents = [.large()]
+                sheet.prefersGrabberVisible = true
+            }
+        } else {
+            navigationController.modalPresentationStyle = .fullScreen
+        }
         presentModal(navigationController)
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -15,20 +15,27 @@ import SwiftDashSDK
 ///   - `.success`        → green check + amount + Done.
 ///   - `.failed(msg)`    → summary card with red error + Try again / Close.
 ///
-/// Confirm routes to one of four SDK paths via the coordinator, keyed by
-/// `direction` then `source`:
-///   - `.toShielded` + `.core`       → `performAssetLock(amountDuffs:)`
-///   - `.toShielded` + `.platform`   → `performShield(amountCredits:)`
-///   - `.fromShielded` + `.core`     → `performWithdraw(amountCredits:)`
-///   - `.fromShielded` + `.platform` → `performUnshield(amountCredits:)`
+/// Confirm executes `route` via the coordinator:
+///   - `.coreToShielded`     → `performAssetLock(amountDuffs:)`
+///   - `.platformToShielded` → `performShield(amountCredits:)`
+///   - `.shieldedToCore`     → `performWithdraw(amountCredits:)`
+///   - `.shieldedToPlatform` → `performUnshield(amountCredits:)`
+///   - `.coreToPlatform`     → `performFundPlatform(amountDuffs:)`
+///   - `.platformToCore`     → `performPlatformWithdrawAll()` (full balance)
 struct InternalTransferConfirmSheet: View {
 
-    let source: InternalTransferSource
-    let direction: InternalTransferDirection
+    let route: InternalTransferRoute
     let dashDuffs: Int64
     let amountDuffsUnsigned: UInt64
     let creditsAmount: UInt64
     let fiatText: String
+    /// Preflighted `AddressCreditWithdrawalTransition` fee — only meaningful
+    /// for `.platformToCore` (the fee headroom / netting basis).
+    var withdrawalFeeCredits: UInt64? = nil
+    /// `.platformToCore` only: the amount equals the full-balance net payout,
+    /// so Confirm runs the AUTO (all-addresses) withdrawal instead of the
+    /// single-input partial form.
+    var isFullPlatformWithdrawal: Bool = false
     var onCancel: () -> Void
     var onCompleted: () -> Void
 
@@ -198,24 +205,34 @@ struct InternalTransferConfirmSheet: View {
     /// Platform credits per DASH (1e11).
     private static let creditsPerDash: Decimal = 100_000_000_000
 
-    /// Flat shielded fee (credits) for the active route, computed offline by
+    /// Flat fee estimate (credits) for the active route, computed offline by
     /// the SDK against the latest protocol version (so it matches the carved
-    /// fee). `nil` if the SDK estimate is unavailable.
+    /// fee). `nil` if the estimate is unavailable → the row shows "—".
     private var networkFeeCredits: UInt64? {
-        switch (direction, source) {
-        case (.toShielded, .core):
+        switch route {
+        case .coreToShielded:
             // ShieldFromAssetLock: base shielded fee + asset-lock base cost.
             guard let base = try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
             else { return nil }
             return base + Self.assetLockBaseCostCredits
-        case (.toShielded, .platform):
+        case .platformToShielded:
             // Shield (Type 15): base shielded fee. Real metered storage is
             // extra and only knowable on-chain, so this is a lower bound.
             return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
-        case (.fromShielded, .core):
+        case .shieldedToCore:
             return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 2)
-        case (.fromShielded, .platform):
+        case .shieldedToPlatform:
             return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)
+        case .coreToPlatform:
+            // Address-funding asset lock: the required processing balance
+            // (the same 50k-duff base the Rust side reserves for address
+            // funding). The funding ST's metered fee is extra and only
+            // knowable on-chain, so this is a lower bound.
+            return Self.assetLockBaseCostCredits
+        case .platformToCore:
+            // The exact transition fee the preflight already netted out of
+            // the payout amount.
+            return withdrawalFeeCredits
         }
     }
 
@@ -251,35 +268,29 @@ struct InternalTransferConfirmSheet: View {
         .cornerRadius(12)
     }
 
-    /// "From" side of the summary. Forward = the picked source; reverse =
-    /// the shielded balance.
-    private var fromLabel: String {
-        switch direction {
-        case .toShielded:
-            return sourceLabel
-        case .fromShielded:
-            return NSLocalizedString("Shielded balance", comment: "")
+    /// From/To endpoint names for the summary card, straight off the route.
+    private var fromLabel: String { Self.balanceName(routeEndpoints.from) }
+    private var toLabel: String { Self.balanceName(routeEndpoints.to) }
+
+    private var routeEndpoints: (from: ChainNetwork, to: ChainNetwork) {
+        switch route {
+        case .coreToShielded: return (.core, .shielded)
+        case .platformToShielded: return (.platform, .shielded)
+        case .shieldedToCore: return (.shielded, .core)
+        case .shieldedToPlatform: return (.shielded, .platform)
+        case .coreToPlatform: return (.core, .platform)
+        case .platformToCore: return (.platform, .core)
         }
     }
 
-    /// "To" side of the summary. Forward = the shielded balance; reverse =
-    /// the transparent Dash Wallet.
-    private var toLabel: String {
-        switch direction {
-        case .toShielded:
-            return NSLocalizedString("Shielded balance", comment: "")
-        case .fromShielded:
-            // Reverse destination is the picked transparent endpoint.
-            return sourceLabel
-        }
-    }
-
-    private var sourceLabel: String {
-        switch source {
+    private static func balanceName(_ network: ChainNetwork) -> String {
+        switch network {
         case .core:
-            return NSLocalizedString("Dash Wallet", comment: "")
+            return NSLocalizedString("Transparent balance", comment: "The transparent (Core) balance of the Dash Wallet")
         case .platform:
-            return NSLocalizedString("Platform Payment", comment: "")
+            return NSLocalizedString("Platform balance", comment: "The Dash Platform credits balance")
+        case .shielded:
+            return NSLocalizedString("Shielded balance", comment: "")
         }
     }
 
@@ -342,39 +353,57 @@ struct InternalTransferConfirmSheet: View {
     }
 
     /// The tip card is route-aware:
-    /// - forward (any source): privacy nudge.
-    /// - reverse → Dash Wallet (L1 withdraw): up-to-10-minute spend delay.
-    /// - reverse → Platform Payment (unshield): settles fast, so a privacy nudge.
-    private var showsWithdrawDelayTip: Bool {
-        direction == .fromShielded && source == .core
-    }
-
+    /// - to Shielded (either source): privacy nudge.
+    /// - Shielded → Core (L1 withdraw): up-to-10-minute spend delay.
+    /// - Shielded → Platform (unshield) / Core → Platform: settles fast.
+    /// - Platform → Core: full-balance withdrawal + network processing delay.
     private var privacyTipIcon: String {
-        showsWithdrawDelayTip ? "clock.fill" : "shield.fill"
+        switch route {
+        case .shieldedToCore, .platformToCore: return "clock.fill"
+        default: return "shield.fill"
+        }
     }
 
     private var privacyTipTitle: String {
-        showsWithdrawDelayTip
-            ? NSLocalizedString("Up to 10 minutes to spend", comment: "")
-            : NSLocalizedString("Privacy tip", comment: "")
+        switch route {
+        case .shieldedToCore:
+            return NSLocalizedString("Up to 10 minutes to spend", comment: "")
+        case .platformToCore:
+            return isFullPlatformWithdrawal
+                ? NSLocalizedString("Withdraws the entire balance", comment: "Full-balance Platform → Transparent withdrawal")
+                : NSLocalizedString("Processing time", comment: "Platform → Transparent withdrawal")
+        default:
+            return NSLocalizedString("Privacy tip", comment: "")
+        }
     }
 
     private var privacyTipBody: String {
-        if showsWithdrawDelayTip {
-            return NSLocalizedString(
-                "After this transfer, it can take up to 10 minutes before you can use your Dash. This delay is part of how your privacy is protected.",
-                comment: "")
-        }
-        switch direction {
-        case .toShielded:
+        switch route {
+        case .coreToShielded, .platformToShielded:
             return NSLocalizedString(
                 "For best privacy, wait at least 2 hours before using these funds.",
                 comment: "")
-        case .fromShielded:
+        case .shieldedToCore:
+            return NSLocalizedString(
+                "After this transfer, it can take up to 10 minutes before you can use your Dash. This delay is part of how your privacy is protected.",
+                comment: "")
+        case .shieldedToPlatform:
             // Unshield to Platform Payment settles quickly.
             return NSLocalizedString(
                 "These funds move to your Platform Payment balance and are ready to spend right away.",
                 comment: "")
+        case .coreToPlatform:
+            return NSLocalizedString(
+                "These funds move to your Platform balance and are ready to spend as soon as the transfer completes.",
+                comment: "")
+        case .platformToCore:
+            return isFullPlatformWithdrawal
+                ? NSLocalizedString(
+                    "This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal.",
+                    comment: "")
+                : NSLocalizedString(
+                    "The Dash arrives in your Transparent balance once the network processes the withdrawal.",
+                    comment: "")
         }
     }
 
@@ -393,10 +422,17 @@ struct InternalTransferConfirmSheet: View {
         var steps: [ShieldedTransferStepList.Step] = [
             .init(label: NSLocalizedString("Authorizing", comment: ""), phase: .signing)
         ]
-        if direction == .toShielded && source == .core {
+        // Asset-lock routes have the on-chain locking stage.
+        if route == .coreToShielded || route == .coreToPlatform {
             steps.append(.init(label: NSLocalizedString("Locking funds", comment: ""), phase: .locking))
         }
-        steps.append(.init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving))
+        // Only shielded legs build an Orchard proof.
+        switch route {
+        case .coreToShielded, .platformToShielded, .shieldedToCore, .shieldedToPlatform:
+            steps.append(.init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving))
+        case .coreToPlatform, .platformToCore:
+            break
+        }
         steps.append(.init(label: NSLocalizedString("Broadcasting", comment: ""), phase: .broadcasting))
         return steps
     }
@@ -405,39 +441,49 @@ struct InternalTransferConfirmSheet: View {
 
     private func confirm() {
         Task {
-            switch direction {
-            case .toShielded:
-                switch source {
-                case .core:
-                    await coordinator.performAssetLock(amountDuffs: amountDuffsUnsigned)
-                case .platform:
-                    await coordinator.performShield(amountCredits: creditsAmount)
-                }
-            case .fromShielded:
-                switch source {
-                case .core:
-                    await coordinator.performWithdraw(amountCredits: creditsAmount)
-                case .platform:
-                    await coordinator.performUnshield(amountCredits: creditsAmount)
-                }
+            switch route {
+            case .coreToShielded:
+                await coordinator.performAssetLock(amountDuffs: amountDuffsUnsigned)
+            case .platformToShielded:
+                await coordinator.performShield(amountCredits: creditsAmount)
+            case .shieldedToCore:
+                await coordinator.performWithdraw(amountCredits: creditsAmount)
+            case .shieldedToPlatform:
+                await coordinator.performUnshield(amountCredits: creditsAmount)
+            case .coreToPlatform:
+                await coordinator.performFundPlatform(amountDuffs: amountDuffsUnsigned)
+            case .platformToCore:
+                await coordinator.performPlatformWithdraw(
+                    amountCredits: creditsAmount,
+                    fullBalance: isFullPlatformWithdrawal,
+                    feeHeadroomCredits: withdrawalFeeCredits)
             }
         }
     }
 
     private func tryAgain() {
-        // If the just-failed Core→Shielded attempt already committed an asset
-        // lock, RESUME that exact outpoint instead of building a second lock
-        // (which strands the first). Capture before reset() clears it. Every
-        // other case (no committed lock — auth-cancel / preflight failure — or
-        // a non-asset-lock route) falls through to a fresh retry.
-        if direction == .toShielded, source == .core,
-           let op = coordinator.lastAssetLockOutPoint {
-            coordinator.reset()
-            Task { await coordinator.resumeAssetLock(outPointTxidWire: op.txidWire, outPointVout: op.vout) }
-        } else {
-            coordinator.reset()
-            confirm()
+        // If the just-failed asset-lock attempt (Core→Shielded or
+        // Core→Platform) already committed a lock, RESUME that exact outpoint
+        // instead of building a second lock (which strands the first).
+        // Capture before reset() clears it. Every other case (no committed
+        // lock — auth-cancel / preflight failure — or a non-asset-lock route)
+        // falls through to a fresh retry.
+        if let op = coordinator.lastAssetLockOutPoint {
+            switch route {
+            case .coreToShielded:
+                coordinator.reset()
+                Task { await coordinator.resumeAssetLock(outPointTxidWire: op.txidWire, outPointVout: op.vout) }
+                return
+            case .coreToPlatform:
+                coordinator.reset()
+                Task { await coordinator.resumeFundPlatform(outPointTxidWire: op.txidWire, outPointVout: op.vout) }
+                return
+            default:
+                break
+            }
         }
+        coordinator.reset()
+        confirm()
     }
 }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -14,30 +14,49 @@ struct InternalTransferScreen: View {
     /// to `navigationController?.popViewController`.
     var onCompleted: () -> Void = {}
 
+    /// False when embedded under a host that renders its own title
+    /// (the balance-row receive sheet) — hides the built-in header.
+    var showsHeader: Bool = true
+
+    /// Receive-sheet variant: fixes the destination card (the balance being
+    /// received into) at the bottom, turns the rows above it into the
+    /// source picker, and hides the swap badge. `nil` = the standard
+    /// swappable transfer screen.
+    var receiveInto: ChainNetwork? = nil
+
     @State private var showConfirm: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-                .padding(.horizontal, 20)
-                .padding(.top, 10)
-
-            VStack(spacing: 16) {
-                amountRow
+            if showsHeader {
+                header
                     .padding(.horizontal, 20)
-                    .padding(.top, 12)
-
-                directionCards
-                    .padding(.horizontal, 20)
-
-                if viewModel.canContinue {
-                    transferPreview
-                        .padding(.horizontal, 20)
-                }
+                    .padding(.top, 10)
             }
-            .padding(.bottom, 8)
 
-            Spacer(minLength: 0)
+            // Scrollable so the keypad and action button stay fully on
+            // screen when vertical space is tight — embedded in the
+            // balance-row receive sheet the host's header + hero selector
+            // eat ~110pt the standalone layout has to spare. When the
+            // content fits (standalone), this behaves like the old
+            // fixed layout: top-aligned content, keypad pinned below.
+            ScrollView {
+                VStack(spacing: 16) {
+                    amountRow
+                        .padding(.horizontal, 20)
+                        .padding(.top, showsHeader ? 12 : 0)
+
+                    directionCards
+                        .padding(.horizontal, 20)
+
+                    if viewModel.canContinue {
+                        transferPreview
+                            .padding(.horizontal, 20)
+                    }
+                }
+                .padding(.bottom, 8)
+            }
+            .scrollBounceBehavior(.basedOnSize)
 
             NumericKeyboardView(
                 value: keypadBinding,
@@ -52,12 +71,13 @@ struct InternalTransferScreen: View {
         .background(Color.primaryBackground)
         .sheet(isPresented: $showConfirm) {
             InternalTransferConfirmSheet(
-                source: viewModel.source,
-                direction: viewModel.direction,
+                route: viewModel.route,
                 dashDuffs: viewModel.dashDuffs,
                 amountDuffsUnsigned: viewModel.dashDuffsUnsigned,
                 creditsAmount: viewModel.creditsPreview,
                 fiatText: viewModel.fiatAmountString,
+                withdrawalFeeCredits: viewModel.withdrawalPreflight?.estimatedFee,
+                isFullPlatformWithdrawal: viewModel.isFullPlatformWithdrawal,
                 onCancel: { showConfirm = false },
                 onCompleted: {
                     showConfirm = false
@@ -104,7 +124,7 @@ struct InternalTransferScreen: View {
                 unitPill(label: "DASH", selected: viewModel.unit == .dash) {
                     viewModel.unit = .dash
                 }
-                unitPill(label: "FIAT", selected: viewModel.unit == .fiat) {
+                unitPill(label: viewModel.fiatCurrencyCode, selected: viewModel.unit == .fiat) {
                     viewModel.unit = .fiat
                 }
             }
@@ -152,7 +172,16 @@ struct InternalTransferScreen: View {
 
     // MARK: - From / To cards
 
+    @ViewBuilder
     private var directionCards: some View {
+        if let target = receiveInto {
+            receiveCards(target: target)
+        } else {
+            swappableCards
+        }
+    }
+
+    private var swappableCards: some View {
         ZStack {
             VStack(spacing: 8) {
                 switch viewModel.direction {
@@ -176,21 +205,97 @@ struct InternalTransferScreen: View {
         }
     }
 
+    /// Receive-sheet layout: the destination stays pinned as the bottom
+    /// card; the rows above pick the source among the other two balances.
+    /// No swap badge — the destination is fixed by the tapped balance row.
+    @ViewBuilder
+    private func receiveCards(target: ChainNetwork) -> some View {
+        VStack(spacing: 8) {
+            switch target {
+            case .shielded:
+                coreSourceCard
+                platformSourceCard
+                toCard
+            case .core:
+                receiveSourceRow(.shielded)
+                receiveSourceRow(.platform)
+                toTransparentCard
+            case .platform:
+                receiveSourceRow(.shielded)
+                receiveSourceRow(.core)
+                toPlatformCard
+            }
+        }
+    }
+
+    /// Selectable From row of the receive sheet, bound to
+    /// `viewModel.receiveSource` (the .shielded target reuses the legacy
+    /// `source`-bound cards instead).
+    private func receiveSourceRow(_ network: ChainNetwork) -> some View {
+        let icon: String
+        let title: String
+        let trailing: AnyView
+        switch network {
+        case .core:
+            icon = "d.circle.fill"
+            title = NSLocalizedString("Transparent", comment: "Balance breakdown")
+            trailing = dashBalanceTrailing(viewModel.coreBalanceFormatted)
+        case .platform:
+            icon = "creditcard.fill"
+            title = NSLocalizedString("Platform", comment: "Dash Platform chain")
+            trailing = dashBalanceTrailing(viewModel.platformCreditsFormatted)
+        case .shielded:
+            icon = "shield.fill"
+            title = NSLocalizedString("Shielded", comment: "")
+            trailing = dashBalanceTrailing(viewModel.shieldedBalanceFormatted)
+        }
+        return sourceRow(
+            iconSystemName: icon,
+            caption: NSLocalizedString("From", comment: ""),
+            title: title,
+            balanceTrailing: trailing,
+            selected: viewModel.receiveSource == network,
+            action: { viewModel.receiveSource = network })
+    }
+
+    private var toTransparentCard: some View {
+        directionCard(
+            iconSystemName: "d.circle.fill",
+            iconColor: .blue,
+            caption: NSLocalizedString("To", comment: ""),
+            title: NSLocalizedString("Transparent", comment: "Balance breakdown"),
+            balanceTrailing: dashBalanceTrailing(viewModel.coreBalanceFormatted))
+    }
+
+    private var toPlatformCard: some View {
+        directionCard(
+            iconSystemName: "creditcard.fill",
+            iconColor: .blue,
+            caption: NSLocalizedString("To", comment: ""),
+            title: NSLocalizedString("Platform", comment: "Dash Platform chain"),
+            balanceTrailing: dashBalanceTrailing(viewModel.platformCreditsFormatted))
+    }
+
+    /// Trailing balance amount + Dash currency glyph, shared by every card.
+    private func dashBalanceTrailing(_ formatted: String) -> AnyView {
+        AnyView(
+            HStack(spacing: 2) {
+                Text(formatted)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.primaryText)
+                Image("icon_dash_currency")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 14, height: 14)
+            })
+    }
+
     private var coreSourceCard: some View {
         sourceRow(
             iconSystemName: "d.circle.fill",
             caption: sourceCaption,
-            title: NSLocalizedString("Dash Wallet", comment: ""),
-            balanceTrailing: AnyView(
-                HStack(spacing: 2) {
-                    Text(viewModel.coreBalanceFormatted)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.primaryText)
-                    Image("icon_dash_currency")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 14, height: 14)
-                }),
+            title: NSLocalizedString("Transparent", comment: "Balance breakdown"),
+            balanceTrailing: dashBalanceTrailing(viewModel.coreBalanceFormatted),
             selected: viewModel.source == .core,
             action: { viewModel.source = .core })
     }
@@ -199,17 +304,8 @@ struct InternalTransferScreen: View {
         sourceRow(
             iconSystemName: "creditcard.fill",
             caption: sourceCaption,
-            title: NSLocalizedString("Platform Payment", comment: ""),
-            balanceTrailing: AnyView(
-                HStack(spacing: 2) {
-                    Text(viewModel.platformCreditsFormatted)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.primaryText)
-                    Image("icon_dash_currency")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 14, height: 14)
-                }),
+            title: NSLocalizedString("Platform", comment: "Dash Platform chain"),
+            balanceTrailing: dashBalanceTrailing(viewModel.platformCreditsFormatted),
             selected: viewModel.source == .platform,
             action: { viewModel.source = .platform })
     }
@@ -219,7 +315,7 @@ struct InternalTransferScreen: View {
             iconSystemName: "shield.fill",
             iconColor: .blue,
             caption: NSLocalizedString("To", comment: ""),
-            title: NSLocalizedString("Shielded balance", comment: ""),
+            title: NSLocalizedString("Shielded", comment: ""),
             balanceTrailing: AnyView(
                 Text(viewModel.shieldedBalanceFormatted)
                     .font(.system(size: 14, weight: .semibold))
@@ -236,7 +332,7 @@ struct InternalTransferScreen: View {
             iconSystemName: "shield.fill",
             iconColor: .blue,
             caption: NSLocalizedString("From", comment: ""),
-            title: NSLocalizedString("Shielded balance", comment: ""),
+            title: NSLocalizedString("Shielded", comment: ""),
             balanceTrailing: AnyView(
                 Text(viewModel.shieldedBalanceFormatted)
                     .font(.system(size: 14, weight: .semibold))

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -30,6 +30,27 @@ enum InternalTransferDirection {
     case fromShielded
 }
 
+/// Every balance-to-balance route the transfer engine can execute. The
+/// canonical read for validation, fees, and execution — derived from the
+/// receive sheet's (source, target) pair when pinned, otherwise from the
+/// standalone screen's legacy (direction, source) pair (which can only
+/// express the four shielded-centric routes).
+enum InternalTransferRoute: Equatable {
+    /// BIP44 UTXOs → asset lock → Type 18 shield.
+    case coreToShielded
+    /// DIP-17 credits → Type 15 shield.
+    case platformToShielded
+    /// Orchard notes → L1 transparent payout.
+    case shieldedToCore
+    /// Orchard notes → DIP-17 credits (unshield).
+    case shieldedToPlatform
+    /// BIP44 UTXOs → asset lock → Platform address credits (funding type 4).
+    case coreToPlatform
+    /// FULL-BALANCE address-credit withdrawal → L1 payout. The SDK has no
+    /// partial-amount form for this route.
+    case platformToCore
+}
+
 @MainActor
 final class InternalTransferViewModel: ObservableObject {
 
@@ -50,6 +71,114 @@ final class InternalTransferViewModel: ObservableObject {
     /// toggled by the swap badge. Reverse has a single fixed destination
     /// (Dash Wallet), so `source` is ignored while `.fromShielded`.
     @Published var direction: InternalTransferDirection = .toShielded
+
+    /// Fixed destination when this VM drives the receive sheet's embedded
+    /// form: the balance being received into. `nil` = the standalone
+    /// swappable screen (legacy direction/source model).
+    @Published private(set) var receiveTarget: ChainNetwork? = nil
+
+    /// The source balance picked on the receive sheet's From rows. Only
+    /// meaningful for `receiveTarget` .core / .platform (the .shielded
+    /// target reuses the legacy `source` picker). Changing it re-derives
+    /// `route`, and kicks the withdrawal preflight when the full-balance
+    /// Platform → Core route becomes active.
+    @Published var receiveSource: ChainNetwork = .shielded {
+        didSet { routeDidChange() }
+    }
+
+    /// Live result of `preflightWithdrawal()` for the Platform → Core route:
+    /// whether a full-balance withdrawal can fund, its net payout, and the
+    /// reserved fee. `nil` while unknown (loading/failed) — affordability
+    /// fails closed.
+    @Published private(set) var withdrawalPreflight: ManagedPlatformAddressWallet.WithdrawalPreflight?
+    private var preflightTask: Task<Void, Never>?
+
+    /// Pins the route for the receive sheet: a transfer INTO `target`.
+    /// The From rows pick the source among the other two balances —
+    /// `source` for the .shielded target (legacy-expressible routes),
+    /// `receiveSource` for .core/.platform targets.
+    func applyReceiveRoute(into target: ChainNetwork) {
+        receiveTarget = target
+        switch target {
+        case .shielded:
+            direction = .toShielded
+            // `source` keeps the user's pick (.core default).
+        case .core:
+            // Valid sources: shielded (withdraw) or platform (full-balance
+            // address withdrawal). Reset an out-of-range carryover.
+            if receiveSource != .platform { receiveSource = .shielded }
+        case .platform:
+            // Valid sources: shielded (unshield) or core (asset-lock fund).
+            if receiveSource != .core { receiveSource = .shielded }
+        }
+        routeDidChange()
+    }
+
+    /// The canonical route for validation/fees/execution.
+    var route: InternalTransferRoute {
+        if let target = receiveTarget {
+            switch target {
+            case .shielded:
+                return source == .core ? .coreToShielded : .platformToShielded
+            case .core:
+                return receiveSource == .platform ? .platformToCore : .shieldedToCore
+            case .platform:
+                return receiveSource == .core ? .coreToPlatform : .shieldedToPlatform
+            }
+        }
+        switch (direction, source) {
+        case (.toShielded, .core): return .coreToShielded
+        case (.toShielded, .platform): return .platformToShielded
+        case (.fromShielded, .core): return .shieldedToCore
+        case (.fromShielded, .platform): return .shieldedToPlatform
+        }
+    }
+
+    /// Refreshes route-dependent async state. The Platform → Core route
+    /// needs the withdrawal preflight — for the fee headroom that bounds a
+    /// partial withdrawal, and for the net payout a Max (full-balance,
+    /// AUTO-path) withdrawal pays out.
+    private func routeDidChange() {
+        guard route == .platformToCore else {
+            preflightTask?.cancel()
+            preflightTask = nil
+            return
+        }
+        guard preflightTask == nil else { return }
+        preflightTask = Task { [weak self] in
+            let result = try? await PlatformAddressSyncCoordinator.shared.preflightWithdrawal()
+            guard let self, !Task.isCancelled else { return }
+            self.withdrawalPreflight = result
+            self.preflightTask = nil
+        }
+    }
+
+    /// Net payout of the full-balance (Max) Platform → Core withdrawal, in
+    /// duffs (credits / 1000). `nil` until the preflight resolves positively.
+    var platformWithdrawableDuffs: UInt64? {
+        guard let preflight = withdrawalPreflight, preflight.canWithdraw else { return nil }
+        return preflight.netWithdrawable / 1000
+    }
+
+    /// Upper bound (credits) for a PARTIAL Platform → Core withdrawal: the
+    /// largest single address balance minus the preflighted fee headroom
+    /// (the fee is deducted from that address's remaining balance). 0 until
+    /// the preflight resolves — affordability fails closed.
+    var partialWithdrawCapCredits: UInt64 {
+        guard let preflight = withdrawalPreflight, preflight.canWithdraw else { return 0 }
+        let largest = PlatformAddressSyncCoordinator.shared
+            .derivedAddresses.map(\.balance).max() ?? 0
+        return largest > preflight.estimatedFee ? largest - preflight.estimatedFee : 0
+    }
+
+    /// True when the typed amount is exactly the full-balance net payout —
+    /// the confirm flow then executes the AUTO (all-addresses) withdrawal
+    /// instead of the single-input partial form.
+    var isFullPlatformWithdrawal: Bool {
+        route == .platformToCore
+            && platformWithdrawableDuffs != nil
+            && dashDuffsUnsigned == platformWithdrawableDuffs
+    }
 
     /// BIP44-only Core balance in duffs — the same number as
     /// `SwiftDashSDKWalletState.balance.total`. Used to validate
@@ -141,30 +270,35 @@ final class InternalTransferViewModel: ObservableObject {
         // otherwise the credit routes would submit a nonzero amount while the
         // UI shows 0.
         guard dashDuffsUnsigned > 0 else { return false }
-        switch direction {
-        case .toShielded:
-            switch source {
-            case .core:
-                // Asset-lock route: the Platform pool fee is carved from the
-                // locked value (not charged on top of the Core balance) and the
-                // Rust side rejects an undersized lock, so no source-balance fee
-                // headroom is reserved here.
-                return dashDuffsUnsigned <= coreBalanceDuffs
-            case .platform:
-                // Shield (Type 15): the SDK's input selection requires
-                // balance ≥ amount + reserve. Fail closed if the reserve is
-                // unavailable. Subtraction keeps the UInt64 add overflow-safe.
-                guard let reserve = feeReserveCredits else { return false }
-                return platformCredits >= reserve
-                    && creditsPreview <= platformCredits - reserve
-            }
-        case .fromShielded:
+        switch route {
+        case .coreToShielded, .coreToPlatform:
+            // Asset-lock routes: the pool/processing fee is carved from the
+            // locked value (not charged on top of the Core balance) and the
+            // Rust side rejects an undersized lock, so no source-balance fee
+            // headroom is reserved here.
+            return dashDuffsUnsigned <= coreBalanceDuffs
+        case .platformToShielded:
+            // Shield (Type 15): the SDK's input selection requires
+            // balance ≥ amount + reserve. Fail closed if the reserve is
+            // unavailable. Subtraction keeps the UInt64 add overflow-safe.
+            guard let reserve = feeReserveCredits else { return false }
+            return platformCredits >= reserve
+                && creditsPreview <= platformCredits - reserve
+        case .shieldedToCore, .shieldedToPlatform:
             // Unshield/withdraw: the SDK debits amount + fee from the shielded
             // pool (recipient receives the full amount), so the balance must
             // cover amount + fee. Fail closed if the reserve is unavailable.
             guard let reserve = feeReserveCredits else { return false }
             return shieldedBalance >= reserve
                 && creditsPreview <= shieldedBalance - reserve
+        case .platformToCore:
+            // Either the exact full-balance net payout (Max → AUTO path over
+            // every address), or a partial amount within the single-input
+            // cap (largest address balance − fee headroom). Fails closed
+            // while the preflight is unknown.
+            guard withdrawalPreflight?.canWithdraw == true else { return false }
+            if isFullPlatformWithdrawal { return true }
+            return creditsPreview <= partialWithdrawCapCredits
         }
     }
 
@@ -182,21 +316,26 @@ final class InternalTransferViewModel: ObservableObject {
     /// fail closed (block). A literal `0` (the asset-lock route) is NOT `nil` —
     /// that route reserves nothing from the source balance.
     private var feeReserveCredits: UInt64? {
-        switch (direction, source) {
-        case (.toShielded, .core):
+        switch route {
+        case .coreToShielded, .coreToPlatform:
+            // Asset-lock routes reserve nothing from the source balance.
             return 0
-        case (.toShielded, .platform):
+        case .platformToShielded:
             // Shield: fixed 1e9-credit selection reserve, not the (smaller) fee.
             return Self.shieldSelectionReserveCredits
-        case (.fromShielded, .core):
+        case .shieldedToCore:
             // The withdraw/unshield fee scales with the number of spent notes;
             // the SDK recomputes it from real note selection (up to the
             // 16-action `max_shielded_transition_actions` cap) at send time.
             // Reserve that worst case so a fragmented wallet can't pass the
             // affordability check and then fail SDK note selection.
             return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 16)
-        case (.fromShielded, .platform):
+        case .shieldedToPlatform:
             return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 16)
+        case .platformToCore:
+            // Full-balance withdrawal: the fee is already netted out of the
+            // preflight's `netWithdrawable`; no reserve on top.
+            return 0
         }
     }
 
@@ -260,43 +399,63 @@ final class InternalTransferViewModel: ObservableObject {
         parsedDashAmount.formattedDashAmountWithoutCurrencySymbol
     }
 
-    /// Formatted BIP44 balance as DASH (no currency symbol). Used by the
-    /// Dash Wallet source row.
+    /// Formatted BIP44 balance as DASH for the balance cards — display
+    /// precision only (max 5 fraction digits); full precision stays
+    /// everywhere amounts are typed or submitted.
     var coreBalanceFormatted: String {
-        coreBalanceDuffs.formattedDashAmountWithoutCurrencySymbol
+        Self.cardBalanceString(duffs: coreBalanceDuffs)
     }
 
-    /// Formatted Platform Payment balance as DASH (no currency symbol). The
-    /// credits-to-duffs conversion is `/ 1000` (1e8 duffs per DASH vs 1e11
-    /// credits per DASH).
+    /// Formatted Platform Payment balance as DASH for the balance cards
+    /// (max 5 fraction digits). The credits-to-duffs conversion is `/ 1000`
+    /// (1e8 duffs per DASH vs 1e11 credits per DASH).
     var platformCreditsFormatted: String {
-        (platformCredits / 1000).formattedDashAmountWithoutCurrencySymbol
+        Self.cardBalanceString(duffs: platformCredits / 1000)
     }
 
-    /// Formatted live shielded balance as DASH (no currency symbol).
-    /// Credits → duffs is `/ 1000` (1e8 duffs per DASH vs 1e11 credits).
+    /// Formatted live shielded balance as DASH for the balance cards
+    /// (max 5 fraction digits). Credits → duffs is `/ 1000`.
     var shieldedBalanceFormatted: String {
-        (shieldedBalance / 1000).formattedDashAmountWithoutCurrencySymbol
+        Self.cardBalanceString(duffs: shieldedBalance / 1000)
+    }
+
+    /// Active fiat currency code (e.g. "THB") — the amount row's second
+    /// unit pill label.
+    var fiatCurrencyCode: String {
+        App.fiatCurrency
+    }
+
+    /// Card-row balance display: plain decimal, no grouping, at most 5
+    /// fraction digits (rounded) so long balances don't wrap the card.
+    private static func cardBalanceString(duffs: UInt64) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 5
+        return formatter.string(from: NSDecimalNumber(decimal: duffs.dashAmount))
+            ?? duffs.formattedDashAmountWithoutCurrencySymbol
     }
 
     /// Source-aware Max fill. Keeps the same unit semantics — DASH or fiat —
     /// but draws the upper bound from whichever bucket the user picked.
     func fillMaxFromWallet() {
         let sourceDuffs: UInt64
-        switch direction {
-        case .toShielded:
-            switch source {
-            case .core:
-                sourceDuffs = coreBalanceDuffs
-            case .platform:
-                // Reserve the fee the SDK charges on top of the amount so Max
-                // stays sendable (credits → duffs: integer divide by 1000).
-                sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
-            }
-        case .fromShielded:
+        switch route {
+        case .coreToShielded, .coreToPlatform:
+            sourceDuffs = coreBalanceDuffs
+        case .platformToShielded:
+            // Reserve the fee the SDK charges on top of the amount so Max
+            // stays sendable (credits → duffs: integer divide by 1000).
+            sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
+        case .shieldedToCore, .shieldedToPlatform:
             // Reverse: upper bound is the shielded balance minus the fee reserve
             // (debited on top of the amount), so Max stays sendable.
             sourceDuffs = creditsMinusFeeReserve(shieldedBalance) / 1000
+        case .platformToCore:
+            // Max = the full-balance net payout (executed via the AUTO,
+            // all-addresses path); 0 until the preflight resolves.
+            sourceDuffs = platformWithdrawableDuffs ?? 0
         }
 
         switch unit {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -2,13 +2,17 @@
 //  ShieldedTransferCoordinator.swift
 //  DashWallet
 //
-//  Drives a single user-initiated shielded-funding transfer:
+//  Drives a single user-initiated internal transfer between the wallet's
+//  balances (all six InternalTransferRoute legs):
 //   - PIN/biometric gate via `DWIdentityAuthorizer`.
-//   - Routes to one of the two SDK shielded-funding entry points:
-//       * `.core`     → `PlatformWalletManager.shieldedFundFromAssetLock(...)`
-//         (BIP44 UTXOs → Type 18 asset-lock → Halo 2 proof → broadcast).
-//       * `.platform` → `PlatformWalletManager.shieldedShield(...)`
-//         (DIP-17 Platform Payment credits → Type 15 shield).
+//   - Shielded-centric legs call `PlatformWalletManager` directly:
+//       * Core → Shielded   `shieldedFundFromAssetLock` (Type 18 lock,
+//         Halo 2 proof); Platform → Shielded `shieldedShield` (Type 15);
+//       * Shielded → Core   `shieldedWithdraw`; Shielded → Platform
+//         `shieldedUnshield`.
+//   - Core ↔ Platform legs go through `PlatformAddressSyncCoordinator`
+//     (the app's platform address-wallet seam): `fundFromCore` (asset-lock
+//     address top-up) and `withdrawAllToCore` (full-balance withdrawal).
 //   - Publishes a stage `phase` so the confirm sheet can show a multi-step
 //     progress checklist. For the asset-lock route, real stage transitions
 //     are mirrored from `PersistentAssetLock.statusRaw` (0/1 → .locking,
@@ -67,6 +71,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// `AssetLockShieldedAddressTopUp` (see
     /// `rs-platform-wallet-ffi/src/asset_lock_persistence.rs`).
     private static let shieldedAssetLockFundingType: Int = 5
+
+    /// `PersistentAssetLock.fundingTypeRaw` for `AssetLockAddressTopUp` —
+    /// the Core → Platform address-funding lock (same Rust source).
+    private static let addressAssetLockFundingType: Int = 4
 
     /// Same 0.5 s cadence as `DWIdentityRegistrationCoordinator` — enough
     /// for the four observable transitions (Built → Broadcast → IS/CL →
@@ -271,10 +279,11 @@ final class ShieldedTransferCoordinator: ObservableObject {
     private func captureLatestAssetLockOutPoint(
         walletId: Data,
         modelContainer: ModelContainer,
-        since startTime: Date
+        since startTime: Date,
+        fundingType: Int = ShieldedTransferCoordinator.shieldedAssetLockFundingType
     ) {
         guard lastAssetLockOutPoint == nil else { return }
-        let shieldedFundingType = Self.shieldedAssetLockFundingType
+        let shieldedFundingType = fundingType
         var descriptor = FetchDescriptor<PersistentAssetLock>(
             predicate: #Predicate { row in
                 row.walletId == walletId
@@ -427,10 +436,9 @@ final class ShieldedTransferCoordinator: ObservableObject {
         }
 
         // Destination Platform Payment (bech32m) address — the wallet's own
-        // next receive address, mirroring `PaymentsLandingViewModel
-        // .pickNextPlatformAddress`. Resolve before advancing the phase.
-        guard let platformAddress = Self.pickPlatformAddress(
-                from: PlatformAddressSyncCoordinator.shared.derivedAddresses),
+        // next receive address. Resolve before advancing the phase.
+        guard let platformAddress = PlatformAddressSyncCoordinator.shared
+                .derivedAddresses.nextReceiveAddress?.address,
               !platformAddress.isEmpty else {
             handleFailure(CoordinatorError.noPlatformAddress)
             return
@@ -468,19 +476,150 @@ final class ShieldedTransferCoordinator: ObservableObject {
         schedulePlatformResync()
     }
 
-    /// Lowest-indexed unused Platform Payment address (fallback: lowest-indexed
-    /// overall) for the wallet's own receive — mirrors the selection in
-    /// `PaymentsLandingViewModel.pickNextPlatformAddress(from:)`. Pure; the
-    /// `derivedAddresses` read happens on the `@MainActor` caller.
-    private static func pickPlatformAddress(from addresses: [DerivedPlatformAddress]) -> String? {
-        if let unused = addresses
-            .filter({ !$0.isUsed })
-            .min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) }) {
-            return unused.address
+    /// Route 5: BIP44 Core UTXOs → asset lock → the wallet's own Platform
+    /// address credits (funding type 4, `AssetLockAddressTopUp`). Stages:
+    /// `.signing → .locking → .broadcasting → .success` — no Orchard proof,
+    /// so `.proving` may only appear transiently via the lock-status polling
+    /// (IS/CL-locked) before the funding ST lands. On failure after the lock
+    /// committed, `lastAssetLockOutPoint` is captured so "Try again" resumes
+    /// that lock via `resumeFundPlatform` instead of stranding it.
+    func performFundPlatform(amountDuffs: UInt64) async {
+        guard beginTransfer() else { return }
+        lastAssetLockOutPoint = nil
+        Self.logger.info("🛡️ SHIELD-TX :: core→platform fund route amount=\(amountDuffs)")
+
+        let env: BasicEnvironment
+        do {
+            env = try resolveBasicEnvironment()
+        } catch {
+            handleFailure(error)
+            return
         }
-        return addresses
-            .min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) })?
-            .address
+
+        do {
+            try await authorize()
+        } catch {
+            handleFailure(error)
+            return
+        }
+
+        phase = .locking
+        let startTime = Date()
+        startAssetLockPolling(
+            walletId: env.walletId,
+            modelContainer: env.modelContainer,
+            startTime: startTime,
+            fundingType: Self.addressAssetLockFundingType)
+
+        do {
+            try await PlatformAddressSyncCoordinator.shared.fundFromCore(amountDuffs: amountDuffs)
+        } catch {
+            stopAssetLockPolling()
+            captureLatestAssetLockOutPoint(
+                walletId: env.walletId,
+                modelContainer: env.modelContainer,
+                since: startTime,
+                fundingType: Self.addressAssetLockFundingType)
+            handleFailure(CoordinatorError.transferFailed(error))
+            return
+        }
+
+        stopAssetLockPolling()
+        Self.logger.info("🛡️ SHIELD-TX :: core→platform fund route completed")
+        phase = .broadcasting
+        phase = .success
+        schedulePlatformResync()
+    }
+
+    /// Resume of route 5 after its asset lock committed but the address-
+    /// funding ST never landed — drives the remaining stages on the SAME
+    /// outpoint. Mirrors `resumeAssetLock` on the shielded route.
+    func resumeFundPlatform(outPointTxidWire: Data, outPointVout: UInt32) async {
+        guard beginTransfer() else { return }
+        Self.logger.info("🛡️ SHIELD-TX :: resume core→platform fund vout=\(outPointVout)")
+
+        do {
+            _ = try resolveBasicEnvironment()
+        } catch {
+            handleFailure(error)
+            return
+        }
+
+        do {
+            try await authorize()
+        } catch {
+            handleFailure(error)
+            return
+        }
+
+        // The lock is already on-chain; only the funding ST remains.
+        phase = .broadcasting
+
+        do {
+            try await PlatformAddressSyncCoordinator.shared.resumeFundFromCore(
+                outPointTxid: outPointTxidWire,
+                outPointVout: outPointVout)
+        } catch {
+            handleFailure(CoordinatorError.transferFailed(error))
+            return
+        }
+
+        Self.logger.info("🛡️ SHIELD-TX :: resume core→platform fund completed")
+        phase = .success
+        schedulePlatformResync()
+    }
+
+    /// Route 6: Platform address credits → Core L1 payout
+    /// (`AddressCreditWithdrawalTransition`). Stages: `.signing →
+    /// .broadcasting → .success` — a single opaque call, no proof and no
+    /// asset lock. `fullBalance` picks the execution form: the AUTO
+    /// withdrawal (every non-dust address, payout = balance − fee) when the
+    /// user withdrew Max, else an explicit partial withdrawal paying out
+    /// exactly `amountCredits` from the largest funded address. The L1
+    /// payout arrives asynchronously once the chain processes the
+    /// withdrawal; it shows as a regular incoming transaction.
+    func performPlatformWithdraw(
+        amountCredits: UInt64,
+        fullBalance: Bool,
+        feeHeadroomCredits: UInt64?
+    ) async {
+        guard beginTransfer() else { return }
+        Self.logger.info("🛡️ SHIELD-TX :: platform→core withdraw route full=\(fullBalance) amount=\(amountCredits)")
+
+        // Destination Core (BIP44, Base58Check) receive address — same
+        // resolution as the shielded withdraw route.
+        guard let coreAddress = SwiftDashSDKReceiveAddressReader.receiveAddress(),
+              !coreAddress.isEmpty else {
+            handleFailure(CoordinatorError.noReceiveAddress)
+            return
+        }
+
+        do {
+            try await authorize()
+        } catch {
+            handleFailure(error)
+            return
+        }
+
+        phase = .broadcasting
+
+        do {
+            if fullBalance {
+                try await PlatformAddressSyncCoordinator.shared.withdrawAllToCore(address: coreAddress)
+            } else {
+                try await PlatformAddressSyncCoordinator.shared.withdrawToCore(
+                    amountCredits: amountCredits,
+                    address: coreAddress,
+                    feeHeadroomCredits: feeHeadroomCredits)
+            }
+        } catch {
+            handleFailure(CoordinatorError.transferFailed(error))
+            return
+        }
+
+        Self.logger.info("🛡️ SHIELD-TX :: platform→core withdraw completed")
+        phase = .success
+        schedulePlatformResync()
     }
 
     /// Reset to `.idle` so the user can retry from a `.failed` state.
@@ -494,6 +633,13 @@ final class ShieldedTransferCoordinator: ObservableObject {
 
     // MARK: - Internal
 
+    private struct BasicEnvironment {
+        let manager: PlatformWalletManager
+        let walletId: Data
+        let network: Network
+        let modelContainer: ModelContainer
+    }
+
     private struct Environment {
         let manager: PlatformWalletManager
         let walletId: Data
@@ -502,7 +648,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
         let shieldedRecipient: Data
     }
 
-    private func resolveEnvironment() throws -> Environment {
+    /// Host readiness shared by every route. The Core↔Platform legs stop
+    /// here; the shielded legs also require the bound Orchard address
+    /// (`resolveEnvironment`).
+    private func resolveBasicEnvironment() throws -> BasicEnvironment {
         guard let manager = SwiftDashSDKHost.shared.manager else {
             throw CoordinatorError.noManager
         }
@@ -515,10 +664,18 @@ final class ShieldedTransferCoordinator: ObservableObject {
         guard let modelContainer = SwiftDashSDKHost.shared.modelContainer else {
             throw CoordinatorError.noModelContainer
         }
-        let walletId = wallet.walletId
+        return BasicEnvironment(
+            manager: manager,
+            walletId: wallet.walletId,
+            network: network,
+            modelContainer: modelContainer)
+    }
+
+    private func resolveEnvironment() throws -> Environment {
+        let basic = try resolveBasicEnvironment()
         let recipient: Data?
         do {
-            recipient = try manager.shieldedDefaultAddress(walletId: walletId, account: 0)
+            recipient = try basic.manager.shieldedDefaultAddress(walletId: basic.walletId, account: 0)
         } catch {
             throw CoordinatorError.transferFailed(error)
         }
@@ -526,10 +683,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
             throw CoordinatorError.noShieldedAddress
         }
         return Environment(
-            manager: manager,
-            walletId: walletId,
-            network: network,
-            modelContainer: modelContainer,
+            manager: basic.manager,
+            walletId: basic.walletId,
+            network: basic.network,
+            modelContainer: basic.modelContainer,
             shieldedRecipient: recipient)
     }
 
@@ -626,7 +783,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// Defensive about the row not existing yet (or ever): the FFI emits
     /// the row asynchronously and earlier statuses may already be skipped
     /// past by the time we look.
-    private func startAssetLockPolling(walletId: Data, modelContainer: ModelContainer, startTime: Date) {
+    private func startAssetLockPolling(
+        walletId: Data,
+        modelContainer: ModelContainer,
+        startTime: Date,
+        fundingType: Int = ShieldedTransferCoordinator.shieldedAssetLockFundingType
+    ) {
         assetLockPollingTask?.cancel()
         assetLockPollingTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -635,7 +797,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 await self?.pollAssetLockStatus(
                     walletId: walletId,
                     modelContainer: modelContainer,
-                    startTime: startTime)
+                    startTime: startTime,
+                    fundingType: fundingType)
             }
         }
     }
@@ -645,7 +808,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
         assetLockPollingTask = nil
     }
 
-    private func pollAssetLockStatus(walletId: Data, modelContainer: ModelContainer, startTime: Date) async {
+    private func pollAssetLockStatus(
+        walletId: Data,
+        modelContainer: ModelContainer,
+        startTime: Date,
+        fundingType: Int = ShieldedTransferCoordinator.shieldedAssetLockFundingType
+    ) async {
         // Only meaningful while the asset-lock route is in-flight.
         switch phase {
         case .locking, .proving, .broadcasting:
@@ -655,7 +823,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         }
 
         let context = modelContainer.mainContext
-        let shieldedFundingType = Self.shieldedAssetLockFundingType
+        let shieldedFundingType = fundingType
         var descriptor = FetchDescriptor<PersistentAssetLock>(
             predicate: #Predicate { row in
                 row.walletId == walletId

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -10,6 +10,12 @@ import UIKit
 final class PaymentsLandingHostingController: DWBasePayViewController {
 
     private let viewModel: PaymentsLandingViewModel
+    /// Non-nil only for the balance-row receive sheet: the Internal tab
+    /// then embeds the transfer form directly, preconfigured as a transfer
+    /// INTO the balance whose arrow opened the sheet (Core/Platform receive
+    /// from Shielded; Shielded receives from Core). The swap badge on the
+    /// form can still reverse it.
+    private let embeddedTransferViewModel: InternalTransferViewModel?
     private lazy var hostingController: UIHostingController<PaymentsLandingScreen> = {
         let screen = PaymentsLandingScreen(
             viewModel: viewModel,
@@ -19,9 +25,16 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
             onSpecifyAmount: { [weak self] in self?.pushSpecifyAmount() },
             onScanQR: { [weak self] in self?.performScanQRCodeAction() },
             onSendToAddress: { [weak self] in self?.pushSendScreen() },
-            onShieldedBalance: { [weak self] in self?.handleShieldedBalanceTap() })
+            onShieldedBalance: { [weak self] in self?.handleShieldedBalanceTap() },
+            embeddedTransferViewModel: embeddedTransferViewModel,
+            onTransferCompleted: { [weak self] in self?.dismiss(animated: true) },
+            showsHeader: showsHeader)
         return UIHostingController(rootView: screen)
     }()
+
+    /// False for the balance-row receive sheet (grabber + hero selector
+    /// only); the full-screen landing keeps its X + title row.
+    private let showsHeader: Bool
 
     private static let shieldedBalanceTimingShownKey = "DWShieldedBalanceTimingShown"
 
@@ -29,11 +42,32 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         let resolved = PaymentsLandingTab.allCases.first { $0.rawValue == Self.tabRawValue(for: activeTab) }
             ?? .send
         self.viewModel = PaymentsLandingViewModel(activeTab: resolved)
+        self.embeddedTransferViewModel = nil
+        self.showsHeader = true
         super.init(nibName: nil, bundle: nil)
     }
 
-    init(activeTab: PaymentsLandingTab) {
-        self.viewModel = PaymentsLandingViewModel(activeTab: activeTab)
+    /// `receiveNetwork` preselects the Receive tab's Core/Platform/Shielded
+    /// toggle — the balance-row receive arrows open the landing on the
+    /// balance the user tapped. `visibleTabs` narrows the hero selector
+    /// (the receive sheet shows only Receive + Internal), and
+    /// `embedInternalTransfer` makes the Internal tab the transfer form
+    /// itself rather than the action-row list.
+    init(activeTab: PaymentsLandingTab,
+         receiveNetwork: ChainNetwork = .core,
+         visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
+         embedInternalTransfer: Bool = false,
+         showsHeader: Bool = true) {
+        self.viewModel = PaymentsLandingViewModel(
+            activeTab: activeTab, network: receiveNetwork, visibleTabs: visibleTabs)
+        self.showsHeader = showsHeader
+        if embedInternalTransfer {
+            let transferViewModel = InternalTransferViewModel()
+            transferViewModel.applyReceiveRoute(into: receiveNetwork)
+            self.embeddedTransferViewModel = transferViewModel
+        } else {
+            self.embeddedTransferViewModel = nil
+        }
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -114,6 +148,8 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     /// Pushes the internal-transfer screen onto the landing modal's own
     /// navigation stack, keeping the user inside the same presentation.
+    /// (Full-landing path only — the receive sheet embeds the form in its
+    /// Internal tab instead; see `embeddedTransferViewModel`.)
     private func pushInternalTransfer() {
         let target = InternalTransferHostingController()
         navigationController?.pushViewController(target, animated: true)
@@ -127,6 +163,17 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         default: return PaymentsLandingTab.send.rawValue
         }
     }
+}
+
+// MARK: NavigationBarDisplayable
+
+// Without this, BaseNavigationController's willShow pass re-shows the
+// (transparent) navigation bar — its safe-area inset was pushing the
+// whole landing content ~50pt down in both the sheet and full-screen
+// presentations. The landing draws its own chrome; no bar, no back button.
+extension PaymentsLandingHostingController: NavigationBarDisplayable {
+    var isBackButtonHidden: Bool { true }
+    var isNavigationBarHidden: Bool { true }
 }
 
 // MARK: SpecifyAmountViewControllerDelegate

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -16,26 +16,55 @@ struct PaymentsLandingScreen: View {
     var onScanQR: () -> Void
     var onSendToAddress: () -> Void
     var onShieldedBalance: () -> Void
+    /// When set, the Internal tab embeds the transfer form directly (the
+    /// same screen the balance-row arrows used to present standalone)
+    /// instead of the action-row list. Set by the receive sheet.
+    var embeddedTransferViewModel: InternalTransferViewModel? = nil
+    var onTransferCompleted: () -> Void = {}
+    /// False for the balance-row receive sheet: its grabber + hero selector
+    /// are the top chrome — no X close button or title row.
+    var showsHeader: Bool = true
 
     var body: some View {
-        VStack(alignment: .center, spacing: 20) {
-            header
+        // Tighter chrome when the Internal tab embeds the full transfer
+        // form — its amount + cards + keypad need most of the sheet.
+        let isEmbeddedTransfer = viewModel.activeTab == .internalTransfer
+            && embeddedTransferViewModel != nil
+        VStack(alignment: .center, spacing: isEmbeddedTransfer ? 12 : 20) {
+            if showsHeader {
+                header
+            }
 
             tabSelector
                 .padding(.horizontal, 20)
+                .padding(.top, showsHeader ? 0 : 12)
 
-            Group {
-                switch viewModel.activeTab {
-                case .receive:
-                    receiveContent
-                case .internalTransfer:
+            switch viewModel.activeTab {
+            case .receive:
+                receiveContent
+                Spacer()
+            case .internalTransfer:
+                if let transferViewModel = embeddedTransferViewModel {
+                    InternalTransferScreen(
+                        viewModel: transferViewModel,
+                        onCompleted: onTransferCompleted,
+                        showsHeader: false,
+                        receiveInto: viewModel.network)
+                        // Keep the pinned route in lockstep with the receive
+                        // toggle, so the fixed To card and the executed
+                        // transfer can never disagree.
+                        .onAppear { transferViewModel.applyReceiveRoute(into: viewModel.network) }
+                        .onChange(of: viewModel.network) { network in
+                            transferViewModel.applyReceiveRoute(into: network)
+                        }
+                } else {
                     internalContent
-                case .send:
-                    sendContent
+                    Spacer()
                 }
+            case .send:
+                sendContent
+                Spacer()
             }
-
-            Spacer()
         }
         .background(Color.primaryBackground)
         .navigationBarHidden(true)
@@ -75,7 +104,7 @@ struct PaymentsLandingScreen: View {
 
     private var tabSelector: some View {
         HStack(spacing: 4) {
-            ForEach(PaymentsLandingTab.allCases) { tab in
+            ForEach(viewModel.visibleTabs) { tab in
                 Button(action: { viewModel.activeTab = tab }) {
                     VStack(spacing: 4) {
                         Image(systemName: tab.iconSystemName)
@@ -105,7 +134,7 @@ struct PaymentsLandingScreen: View {
 
     private var receiveContent: some View {
         VStack(alignment: .center, spacing: 20) {
-            ChainNetworkToggle(selection: $viewModel.network)
+            ChainNetworkToggle(selection: $viewModel.network, options: ChainNetwork.allCases)
                 .padding(.horizontal, 20)
 
             qrCard
@@ -150,6 +179,10 @@ struct PaymentsLandingScreen: View {
                 .onTapGesture { onCopyAddress() }
             } else if viewModel.network == .platform && !viewModel.platformIsReady {
                 placeholder(NSLocalizedString("Platform sync starting…", comment: ""))
+            } else if viewModel.network == .shielded {
+                // Nil only until the shielded sub-wallet binds at startup
+                // (the view model retries as the platform stack comes up).
+                placeholder(NSLocalizedString("Shielded wallet starting…", comment: ""))
             } else {
                 placeholder(NSLocalizedString("No address available", comment: ""))
             }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -5,6 +5,7 @@
 
 import Combine
 import Foundation
+import SwiftDashSDK
 import UIKit
 
 enum PaymentsLandingTab: String, CaseIterable, Identifiable {
@@ -36,25 +37,38 @@ final class PaymentsLandingViewModel: ObservableObject {
 
     @Published var activeTab: PaymentsLandingTab
     @Published var network: ChainNetwork = .core
+    /// Which hero tabs this presentation offers. The full landing shows all
+    /// three; the balance-row receive sheet narrows to Receive + Internal.
+    let visibleTabs: [PaymentsLandingTab]
     @Published private(set) var coreAddress: String? = nil
     @Published private(set) var platformAddress: String? = nil
+    @Published private(set) var shieldedAddress: String? = nil
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(activeTab: PaymentsLandingTab) {
+    init(activeTab: PaymentsLandingTab,
+         network: ChainNetwork = .core,
+         visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases) {
         self.activeTab = activeTab
+        self.network = network
+        self.visibleTabs = visibleTabs
 
         reloadCoreAddress()
+        reloadShieldedAddress()
 
         PlatformAddressSyncCoordinator.shared.$derivedAddresses
             .receive(on: RunLoop.main)
             .sink { [weak self] addresses in
-                self?.platformAddress = Self.pickNextPlatformAddress(from: addresses)
+                self?.platformAddress = addresses.nextReceiveAddress?.address
+                // The shielded sub-wallet is bound by the same coordinator's
+                // startup, so a derived-addresses tick is also the retry
+                // signal for a shielded address that wasn't ready at init.
+                self?.reloadShieldedAddress()
             }
             .store(in: &cancellables)
 
-        platformAddress = Self.pickNextPlatformAddress(
-            from: PlatformAddressSyncCoordinator.shared.derivedAddresses)
+        platformAddress = PlatformAddressSyncCoordinator.shared
+            .derivedAddresses.nextReceiveAddress?.address
 
         NotificationCenter.default.publisher(for: NSNotification.Name.DWCurrentNetworkDidChange)
             .receive(on: RunLoop.main)
@@ -66,6 +80,7 @@ final class PaymentsLandingViewModel: ObservableObject {
         switch network {
         case .core: return coreAddress
         case .platform: return platformAddress
+        case .shielded: return shieldedAddress
         }
     }
 
@@ -82,16 +97,24 @@ final class PaymentsLandingViewModel: ObservableObject {
         coreAddress = SwiftDashSDKReceiveAddressReader.receiveAddress()
     }
 
-    private static func pickNextPlatformAddress(
-        from addresses: [DerivedPlatformAddress]
-    ) -> String? {
-        if let unused = addresses
-            .filter({ !$0.isUsed })
-            .min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) }) {
-            return unused.address
-        }
-        return addresses
-            .min(by: { ($0.accountIndex, $0.addressIndex) < ($1.accountIndex, $1.addressIndex) })?
-            .address
+    /// Resolves the wallet's default Orchard payment address and encodes it
+    /// for display. `shieldedDefaultAddress` returns nil until the shielded
+    /// sub-wallet is bound (PlatformAddressSyncCoordinator does that at
+    /// startup), so this is retried from the derived-addresses sink until it
+    /// resolves; the address is deterministic, so no reset on later ticks.
+    private func reloadShieldedAddress() {
+        guard shieldedAddress == nil,
+              let manager = SwiftDashSDKHost.shared.manager,
+              let wallet = SwiftDashSDKHost.shared.wallet,
+              let network = SwiftDashSDKHost.shared.runningNetwork,
+              let raw = ((try? manager.shieldedDefaultAddress(walletId: wallet.walletId)) ?? nil)
+        else { return }
+        // DIP-0018 display form: HRP `dash`/`tdash`, payload = 0x10 type
+        // byte + the 43 raw Orchard address bytes (see the SDK doc on
+        // `shieldedDefaultAddress`).
+        shieldedAddress = Bech32m.encode(
+            hrp: Bech32m.platformHrp(mainnet: network == .mainnet),
+            data: Data([0x10]) + raw)
     }
+
 }

--- a/DashWallet/Sources/UI/Payments/Pay/ChainNetworkToggle.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/ChainNetworkToggle.swift
@@ -8,6 +8,10 @@ import SwiftUI
 enum ChainNetwork: String, CaseIterable, Identifiable {
     case core
     case platform
+    /// The private shielded balance. Only offered where the wallet can
+    /// actually produce a shielded payment address (the Receive landing);
+    /// the Send screen can't pay to one, so its toggle never lists it.
+    case shielded
 
     var id: String { rawValue }
 
@@ -15,16 +19,20 @@ enum ChainNetwork: String, CaseIterable, Identifiable {
         switch self {
         case .core: return NSLocalizedString("Core", comment: "Dash Core chain")
         case .platform: return NSLocalizedString("Platform", comment: "Dash Platform chain")
+        case .shielded: return NSLocalizedString("Shielded", comment: "")
         }
     }
 }
 
 struct ChainNetworkToggle: View {
     @Binding var selection: ChainNetwork
+    /// Which networks this surface offers. Defaults to the sendable pair;
+    /// the Receive landing passes all cases to add Shielded.
+    var options: [ChainNetwork] = [.core, .platform]
 
     var body: some View {
         Picker("", selection: $selection) {
-            ForEach(ChainNetwork.allCases) { network in
+            ForEach(options) { network in
                 Text(network.title).tag(network)
             }
         }

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -88,6 +88,8 @@ struct SendScreen: View {
         switch viewModel.network {
         case .core: return NSLocalizedString("XpEBa5... or BIP21 URI", comment: "")
         case .platform: return NSLocalizedString("tdashevo1... / dashevo1...", comment: "")
+        // Not offered by this screen's toggle.
+        case .shielded: return ""
         }
     }
 
@@ -146,6 +148,9 @@ struct SendScreen: View {
             switch viewModel.network {
             case .core: onContinueCore(trimmed)
             case .platform: onContinuePlatform(trimmed)
+            // Not offered by this screen's toggle; `canContinue` is false
+            // for it, so Continue is disabled before this can fire.
+            case .shielded: break
             }
         }) {
             Text(NSLocalizedString("Continue", comment: ""))

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -90,6 +90,10 @@ final class SendViewModel: ObservableObject {
             return trimmed.isValidDashAddressForCurrentNetwork
         case .platform:
             return Self.looksLikePlatformAddress(trimmed)
+        case .shielded:
+            // Not offered by the Send toggle — sending to a shielded
+            // address isn't supported from this screen.
+            return false
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Receive/ReceiveViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Receive/ReceiveViewModel.swift
@@ -39,6 +39,9 @@ final class ReceiveViewModel: ObservableObject {
         switch network {
         case .core: return coreAddress
         case .platform: return platformAddress
+        // Not offered by this screen's toggle (shielded receive lives on
+        // the payments landing).
+        case .shielded: return nil
         }
     }
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2454,6 +2454,12 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform balance";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Processing time";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
@@ -3095,8 +3101,13 @@
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
+"Shielded wallet starting…" = "Shielded wallet starting…";
+
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded withdrawal" = "Shielded withdrawal";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -3624,6 +3635,21 @@
 
 /* Balance breakdown */
 "Transparent" = "Transparent";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparent balance";
+
+/* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "These funds move to your Platform balance and are ready to spend as soon as the transfer completes.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "The Dash arrives in your Transparent balance once the network processes the withdrawal.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal.";
+
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Withdraws the entire balance";
 
 /* Usernames */
 "Transparent funding publicly links your username to these funds." = "Transparent funding publicly links your username to these funds.";


### PR DESCRIPTION
## What

The home balance rows' receive (↓) arrows now open a focused two-tab sheet — Receive QR + embedded Internal transfer — for the tapped balance, and the internal transfer engine gains the missing Core↔Platform routes, completing the 6-route matrix between Transparent, Platform, and Shielded balances.

### Receive sheet (new surface)
- ↓ on Transparent/Platform/Shielded opens a sheet with a hero selector (Receive | Internal) as its top chrome; grabber dismisses. The full 3-tab landing (with Send) is unchanged for the Receive/Send shortcuts.
- Receive tab: QR preselected to the tapped balance. The network toggle gains **Shielded** — the wallet's default Orchard payment address (`shieldedDefaultAddress`, bech32m `dash1…`/`tdash1…` with the `0x10` type byte). The Send toggle deliberately does not gain it.
- Internal tab: the transfer form embedded directly — destination pinned as the bottom card, source picker above, no swap badge. Route follows the receive toggle so the To card and the executed transfer can never disagree.

### Internal transfer routes
- `InternalTransferRoute` (6 routes) is now the canonical model for validation, fee reserves, Max, and execution; the confirm sheet derives labels, fee rows, step checklists, and timing/privacy tips from it.
- **Core → Platform**: `AssetLockAddressTopUp` (funding type 4) asset lock via `PlatformAddressSyncCoordinator.fundFromCore`, with lock-status polling and resume-on-retry (a committed lock is never stranded).
- **Platform → Core**: partial amounts pay out exactly the requested value via explicit input selection (new swift-sdk wrapper, committed in the platform repo — see note); Max routes through the AUTO full-balance withdrawal. The preflight feeds the fee headroom, Max amount, and the confirm sheet's fee row.

### History rows
- Internal transfers render their route: source icon + destination badge (Core→Shielded, Shielded→Core). Shielded→Core payouts are titled "Shielded withdrawal" instead of a plain "Received".

### Fixes shaken out
- Transparent-row arrows + balance long-press were dead: the home SwiftUI content captured the shortcuts delegate before `HomeViewController` assigned it. Now resolved at tap time.
- Syncing alert clipped its OK button when the async peers section grew (`sizingOptions = .intrinsicContentSize`).
- Payments landing carried a phantom ~50pt top inset from `BaseNavigationController` re-showing a transparent nav bar (`NavigationBarDisplayable` conformance).
- `topController()` didn't recurse into `presentedViewController`, so the PIN prompt silently failed to present over stacked sheets — every auth-gated transfer from the new sheet reported "Authentication failed". One-line traversal fix; hardens all "present from the top" callers.
- Transfer screen scrolls its upper content at tight heights; keypad stays pinned.

### Copy/format
Cards read Transparent/Platform/Shielded; card balances cap at 5 fraction digits (display only); unit pills show DASH + the active fiat code (e.g. THB).

## Cross-repo dependency

The partial withdrawal uses a new Swift-only wrapper in the platform repo (`ManagedPlatformAddressWallet.withdraw(accountIndex:coreAddress:inputs:signer:)`, commit `5043b867c9` on `v4.1-dev-local`). No FFI/xcframework rebuild required — the FFI entry point already ships. Needs upstreaming with the rest of the platform pin per DASHSYNC_MIGRATION.md.

## Testing

Testnet smoke on the QA-iPhone16 simulator: receive QRs for all three balances; Core→Shielded, Shielded→Core, Core→Platform (25 tDASH end-to-end incl. PIN gate, lock polling, balance refresh), Platform→Core partial + Max preflight; sync alert; landing layouts. Unit-test target is pre-existing-broken per CLAUDE.md — verification standard was clean dashpay build + testnet smoke of touched flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)