### PR TITLE
fix(uphold): don't crash on Buy & Sell when Topper-Info.plist lacks sandbox keys

### DIFF
--- a/DashWallet/Sources/UI/Uphold/TopperViewModel.swift
+++ b/DashWallet/Sources/UI/Uphold/TopperViewModel.swift
@@ -27,12 +27,17 @@ class TopperViewModel {
         var widgetId = ""
         var privateKey = ""
         
+        // Missing keys degrade to empty credentials — the same posture as a
+        // missing plist (the widget just won't authenticate). Force-casting
+        // here crashed the app on Buy & Sell open for any build whose
+        // gitignored Topper-Info.plist lacks the SANDBOX_* keys, which is
+        // every placeholder plist while fresh installs default to testnet.
         if let path = Bundle.main.path(forResource: "Topper-Info", ofType: "plist"),
            let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject] {
             let prefix = isSandbox ? "SANDBOX_" : ""
-            keyId = dict["\(prefix)KEY_ID"] as! String
-            widgetId = dict["\(prefix)WIDGET_ID"] as! String
-            privateKey = dict["\(prefix)PRIVATE_KEY"] as! String
+            keyId = dict["\(prefix)KEY_ID"] as? String ?? ""
+            widgetId = dict["\(prefix)WIDGET_ID"] as? String ?? ""
+            privateKey = dict["\(prefix)PRIVATE_KEY"] as? String ?? ""
         }
         
         topper = Topper(keyId: keyId, widgetId: widgetId, privateKey: privateKey, isSandbox: isSandbox)


### PR DESCRIPTION
## Summary

Opening **Buy & Sell** (main menu or shortcut) crashes any build whose gitignored `Topper-Info.plist` is a placeholder or lacks the `SANDBOX_*` keys: `TopperViewModel.init` force-casts (`as!`) `SANDBOX_KEY_ID` / `SANDBOX_WIDGET_ID` / `SANDBOX_PRIVATE_KEY`, and since fresh installs currently default to testnet, the sandbox branch runs for everyone.

Crash signature (from today's QA sim `.ips`):
```
libswiftCore assertionFailure
TopperViewModel.init → TopperViewModel.shared
BuySellPortalViewController.init ← MainMenuScreen.showBuySellPortal
```

Missing keys now read as empty strings — the same already-supported posture as a missing plist file: the Topper widget just won't authenticate. No behavior change for correctly-provisioned plists.

## Test plan
- [x] Clean `dashpay` simulator build (arm64)
- [ ] With an empty-dict `Topper-Info.plist` on testnet: Buy & Sell opens without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)