### PR TITLE
feat(ui): raw transaction inspector on the transaction details sheet

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		4539AA3FC5C209480BA279AA /* PaymentProtocolMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4833BE986D59F69A555C5F /* PaymentProtocolMessages.swift */; };
 		4636DCF2B17C1DC56E9CDD84 /* PaymentURIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E3F6CC617DA824F467AADC /* PaymentURIBuilder.swift */; };
 		470617D6299A671900DCC667 /* CrowdNodeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470617D5299A671900DCC667 /* CrowdNodeCell.swift */; };
+		BA1B0002C0FFEE00B15B0002 /* RawTransactionInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B0001C0FFEE00B15B0001 /* RawTransactionInspector.swift */; };
 		47081197298CF20C003FCA3D /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47081196298CF20B003FCA3D /* Transaction.swift */; };
 		4708119F2990F56F003FCA3D /* TransactionDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4708119E2990F56F003FCA3D /* TransactionDataItem.swift */; };
 		4709C30F287E787700B4BD48 /* Migrations.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4709C30E287E787700B4BD48 /* Migrations.bundle */; };
@@ -463,6 +464,7 @@
 		47A2E3A92972B15F0032A63B /* RatesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A2E3A82972B15F0032A63B /* RatesProvider.swift */; };
 		47A2E3AC2972B1A60032A63B /* CoinbaseRatesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A2E3AB2972B1A60032A63B /* CoinbaseRatesProvider.swift */; };
 		47A50F3B2913BC0900C70123 /* TransferAmountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A50F3A2913BC0900C70123 /* TransferAmountModel.swift */; };
+		BA1B0012C0FFEE00B15B0012 /* RawTransactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B0011C0FFEE00B15B0011 /* RawTransactionView.swift */; };
 		47A514602848F75B005A8E3E /* TxDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */; };
 		47A514622848FEAD005A8E3E /* Tx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 47A514612848FEAD005A8E3E /* Tx.storyboard */; };
 		47A5146428491C60005A8E3E /* TxDetailCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5146328491C60005A8E3E /* TxDetailCells.swift */; };
@@ -1347,6 +1349,7 @@
 		C9D2C6BD2A320AA000D15901 /* UIAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4751137428DAF28800223B77 /* UIAssembly.swift */; };
 		C9D2C6BE2A320AA000D15901 /* DWLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AE8BAC28BFAE6700490F5E /* DWLocationManager.swift */; };
 		C9D2C6BF2A320AA000D15901 /* FetchingNextPageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AE8BCE28C1305E00490F5E /* FetchingNextPageCell.swift */; };
+		BA1B0003C0FFEE00B15B0003 /* RawTransactionInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B0001C0FFEE00B15B0001 /* RawTransactionInspector.swift */; };
 		C9D2C6C02A320AA000D15901 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47081196298CF20B003FCA3D /* Transaction.swift */; };
 		C9D2C6C22A320AA000D15901 /* DWPaymentOutput.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACCD84C23180E7E00A96B62 /* DWPaymentOutput.m */; };
 		C9D2C6C32A320AA000D15901 /* DWPayModelStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AB3415D23A8133A004E37A7 /* DWPayModelStub.m */; };
@@ -1369,6 +1372,7 @@
 		C9D2C6D42A320AA000D15901 /* DWRecoverTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A74EFFA2305464C00C475EB /* DWRecoverTextView.m */; };
 		C9D2C6D52A320AA000D15901 /* TransactionMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C314287EA11900B4BD48 /* TransactionMetadata.swift */; };
 		C9D2C6D82A320AA000D15901 /* AtmListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AE8BDD28C1305E00490F5E /* AtmListViewController.swift */; };
+		BA1B0013C0FFEE00B15B0013 /* RawTransactionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1B0011C0FFEE00B15B0011 /* RawTransactionView.swift */; };
 		C9D2C6D92A320AA000D15901 /* TxDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */; };
 		C9D2C6DA2A320AA000D15901 /* NSAttributedString+Builder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472D13E9299E5396006903F1 /* NSAttributedString+Builder.swift */; };
 		C9D2C6DB2A320AA000D15901 /* DWPreviewSeedPhraseContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AD1CE7922DB5F5200C99324 /* DWPreviewSeedPhraseContentView.m */; };
@@ -2615,6 +2619,7 @@
 		4457C976B1DB0CF402FF3C5F /* Pods-WatchApp Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WatchApp Extension.release.xcconfig"; path = "Target Support Files/Pods-WatchApp Extension/Pods-WatchApp Extension.release.xcconfig"; sourceTree = "<group>"; };
 		44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformSendExecutor.swift; sourceTree = "<group>"; };
 		470617D5299A671900DCC667 /* CrowdNodeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrowdNodeCell.swift; sourceTree = "<group>"; };
+		BA1B0001C0FFEE00B15B0001 /* RawTransactionInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawTransactionInspector.swift; sourceTree = "<group>"; };
 		47081196298CF20B003FCA3D /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		4708119E2990F56F003FCA3D /* TransactionDataItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDataItem.swift; sourceTree = "<group>"; };
 		47083B3129892D770010AF71 /* DSTransaction+DashWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DSTransaction+DashWallet.swift"; sourceTree = "<group>"; };
@@ -2717,6 +2722,7 @@
 		47A50F372912D9DC00C70123 /* PaymentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentController.swift; sourceTree = "<group>"; };
 		47A50F3A2913BC0900C70123 /* TransferAmountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountModel.swift; sourceTree = "<group>"; };
 		47A5145E2848F75A005A8E3E /* dashwallet-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "dashwallet-Bridging-Header.h"; sourceTree = "<group>"; };
+		BA1B0011C0FFEE00B15B0011 /* RawTransactionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawTransactionView.swift; sourceTree = "<group>"; };
 		47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailViewController.swift; sourceTree = "<group>"; };
 		47A514612848FEAD005A8E3E /* Tx.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Tx.storyboard; sourceTree = "<group>"; };
 		47A5146328491C60005A8E3E /* TxDetailCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailCells.swift; sourceTree = "<group>"; };
@@ -5771,6 +5777,7 @@
 		47081195298CF1FE003FCA3D /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				BA1B0001C0FFEE00B15B0001 /* RawTransactionInspector.swift */,
 				47081196298CF20B003FCA3D /* Transaction.swift */,
 			);
 			path = Model;
@@ -6614,6 +6621,7 @@
 			children = (
 				2A1B7D9E23239C7500BA8C6A /* Model */,
 				2A1B7D82232156A600BA8C6A /* Views */,
+				BA1B0011C0FFEE00B15B0011 /* RawTransactionView.swift */,
 				47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */,
 				75D2B4A02D9D28AC00228DB0 /* BlockExplorerSelectionView.swift */,
 			);
@@ -9688,6 +9696,7 @@
 				4751137528DAF28800223B77 /* UIAssembly.swift in Sources */,
 				47AE8BAD28BFAE6700490F5E /* DWLocationManager.swift in Sources */,
 				47AE8BF428C1306000490F5E /* FetchingNextPageCell.swift in Sources */,
+				BA1B0002C0FFEE00B15B0002 /* RawTransactionInspector.swift in Sources */,
 				47081197298CF20C003FCA3D /* Transaction.swift in Sources */,
 				5151CE192F9624D000F0A604 /* CurrencyItem.swift in Sources */,
 				2ACCD84D23180E7E00A96B62 /* DWPaymentOutput.m in Sources */,
@@ -9725,6 +9734,7 @@
 				4709C315287EA11900B4BD48 /* TransactionMetadata.swift in Sources */,
 				B3A1F2C4D5E6078901234568 /* ExtendedPublicKeySheet.swift in Sources */,
 				47AE8BFE28C1306000490F5E /* AtmListViewController.swift in Sources */,
+				BA1B0012C0FFEE00B15B0012 /* RawTransactionView.swift in Sources */,
 				47A514602848F75B005A8E3E /* TxDetailViewController.swift in Sources */,
 				472D13EA299E5396006903F1 /* NSAttributedString+Builder.swift in Sources */,
 				2AD1CE7A22DB5F5200C99324 /* DWPreviewSeedPhraseContentView.m in Sources */,
@@ -10559,6 +10569,7 @@
 				C943B4E32A40A54600AF23C5 /* DWPassthroughStackView.m in Sources */,
 				757422282DF87B8300CB0175 /* MerchantFiltersViewModel.swift in Sources */,
 				C943B32E2A408CED00AF23C5 /* DWAvatarGravatarViewController.m in Sources */,
+				BA1B0003C0FFEE00B15B0003 /* RawTransactionInspector.swift in Sources */,
 				C9D2C6C02A320AA000D15901 /* Transaction.swift in Sources */,
 				C943B3232A408CED00AF23C5 /* DWFaceDetector.m in Sources */,
 				5151CDF02F928D7D00F0A604 /* LocalCurrencyCellView.swift in Sources */,
@@ -10587,6 +10598,7 @@
 				C9D2C6D52A320AA000D15901 /* TransactionMetadata.swift in Sources */,
 				B3A1F2C4D5E6078901234569 /* ExtendedPublicKeySheet.swift in Sources */,
 				C9D2C6D82A320AA000D15901 /* AtmListViewController.swift in Sources */,
+				BA1B0013C0FFEE00B15B0013 /* RawTransactionView.swift in Sources */,
 				C9D2C6D92A320AA000D15901 /* TxDetailViewController.swift in Sources */,
 				C9D2C6DA2A320AA000D15901 /* NSAttributedString+Builder.swift in Sources */,
 				75D9EBB92DE5CC3A009416A2 /* AddGiftCardsTable.swift in Sources */,

--- a/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
@@ -1,0 +1,411 @@
+//
+//  RawTransactionInspector.swift
+//  DashWallet
+//
+
+import Foundation
+import SwiftData
+import SwiftDashSDK
+
+// MARK: - RawTransactionDetails
+
+/// Everything the transaction inspector shows for one transaction,
+/// consensus-decoded from the persisted raw bytes (display-only — nothing
+/// here feeds signing or validation). Structural fields come from the
+/// app-side parser below; addresses render via `ScriptAddressCodec` (outputs)
+/// and the SDK's `TransactionDecoder` (best-effort input sender addresses);
+/// amounts for spent inputs come from the wallet's own TXO rows when the
+/// input is ours.
+struct RawTransactionDetails {
+    struct Input {
+        let index: Int
+        /// Explorer-style (reversed) hex of the spent outpoint's txid.
+        let prevTxidDisplayHex: String
+        let prevVout: UInt32
+        let scriptSig: Data
+        let sequence: UInt32
+        /// Best-effort sender address recovered from a P2PKH scriptSig.
+        /// Unauthenticated — display only (see `DecodedTransaction.Input`).
+        let address: String?
+        /// Value of the spent outpoint when it is one of the wallet's own
+        /// TXOs; unknown (nil) for external inputs — the raw tx doesn't
+        /// carry input values.
+        let amountDuffs: UInt64?
+        /// True for a coinbase input (null outpoint).
+        let isCoinbase: Bool
+    }
+
+    struct Output {
+        enum Kind {
+            case standard(address: String)
+            /// OP_RETURN with the concatenated pushed data.
+            case opReturn(data: Data)
+            /// Any other non-standard script.
+            case nonStandard
+        }
+
+        let index: Int
+        let valueDuffs: UInt64
+        let scriptPubKey: Data
+        let kind: Kind
+    }
+
+    struct PayloadField {
+        let label: String
+        let value: String
+    }
+
+    let txidDisplayHex: String
+    let version: UInt16
+    let typeRaw: UInt16
+    /// DIP-2 special-transaction name; nil for a classic (type 0) tx.
+    let typeName: String?
+    let sizeBytes: Int
+    let lockTime: UInt32
+    let inputs: [Input]
+    let outputs: [Output]
+    /// DIP-2 extra payload bytes; nil for classic transactions.
+    let extraPayload: Data?
+    /// Parsed fields for payload types the app understands (coinbase height,
+    /// asset-lock credit outputs). Everything else shows as hex only —
+    /// unknown data is never guessed at.
+    let payloadFields: [PayloadField]
+    let rawHex: String
+    /// Fee the wallet recorded for this row, when known.
+    let feeDuffs: UInt64?
+    /// Mined height from the persisted row; nil while unmined.
+    let blockHeight: UInt32?
+}
+
+// MARK: - RawTransactionInspector
+
+/// Loads a transaction's raw bytes from the wallet's SwiftData store and
+/// consensus-decodes them for the inspector UI.
+enum RawTransactionInspector {
+
+    /// Full details for the inspector screen. Main-actor: reads the host's
+    /// main-context SwiftData rows.
+    @MainActor
+    static func load(txidWire: Data) -> RawTransactionDetails? {
+        guard let row = fetchRow(txidWire: txidWire) else { return nil }
+        return details(from: row)
+    }
+
+    /// Just the raw serialized transaction hex (for copy-to-pasteboard).
+    @MainActor
+    static func rawHex(txidWire: Data) -> String? {
+        guard let row = fetchRow(txidWire: txidWire), !row.transactionData.isEmpty else { return nil }
+        return row.transactionData.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @MainActor
+    private static func fetchRow(txidWire: Data) -> PersistentTransaction? {
+        guard let container = SwiftDashSDKHost.shared.modelContainer else { return nil }
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { $0.txid == txidWire })
+        descriptor.fetchLimit = 1
+        return try? container.mainContext.fetch(descriptor).first
+    }
+
+    @MainActor
+    private static func details(from row: PersistentTransaction) -> RawTransactionDetails? {
+        let data = row.transactionData
+        guard !data.isEmpty, let parsed = try? ParsedRawTransaction(data: data) else { return nil }
+
+        let network: PaymentNetwork = WalletEnvironment.isTestnet ? .testnet : .mainnet
+
+        // Best-effort input sender addresses from the SDK's consensus decoder
+        // (P2PKH scriptSig recovery). Optional — a decode failure only loses
+        // the sender annotations, not the inspector.
+        var decodedInputs: [DecodedTransaction.Input] = []
+        if let sdkNetwork = SwiftDashSDKHost.shared.runningNetwork,
+           let decoded = try? TransactionDecoder.decode(data, network: sdkNetwork) {
+            decodedInputs = decoded.inputs
+        }
+
+        // Wallet-owned spent TXOs, keyed by outpoint — the only source of
+        // input values (the raw tx carries none).
+        var ownedByOutpoint: [Data: PersistentTxo] = [:]
+        for txo in row.inputs {
+            ownedByOutpoint[txo.outpoint] = txo
+        }
+
+        let inputs = parsed.inputs.enumerated().map { index, input -> RawTransactionDetails.Input in
+            let outpoint = PersistentTxo.makeOutpoint(txid: input.prevTxid, vout: input.prevVout)
+            let owned = ownedByOutpoint[outpoint]
+            let decodedAddress = index < decodedInputs.count ? decodedInputs[index].address : nil
+            let isCoinbase = input.prevTxid.allSatisfy { $0 == 0 } && input.prevVout == UInt32.max
+            return RawTransactionDetails.Input(
+                index: index,
+                prevTxidDisplayHex: input.prevTxid.reversed().map { String(format: "%02x", $0) }.joined(),
+                prevVout: input.prevVout,
+                scriptSig: input.scriptSig,
+                sequence: input.sequence,
+                address: owned?.address.isEmpty == false ? owned?.address : decodedAddress,
+                amountDuffs: owned?.amount,
+                isCoinbase: isCoinbase)
+        }
+
+        let outputs = parsed.outputs.enumerated().map { index, output -> RawTransactionDetails.Output in
+            let kind: RawTransactionDetails.Output.Kind
+            if let opReturnData = Self.opReturnData(script: output.scriptPubKey) {
+                kind = .opReturn(data: opReturnData)
+            } else if let address = ScriptAddressCodec.address(forScript: output.scriptPubKey, network: network) {
+                kind = .standard(address: address)
+            } else {
+                kind = .nonStandard
+            }
+            return RawTransactionDetails.Output(
+                index: index,
+                valueDuffs: output.valueDuffs,
+                scriptPubKey: output.scriptPubKey,
+                kind: kind)
+        }
+
+        return RawTransactionDetails(
+            txidDisplayHex: row.txid.reversed().map { String(format: "%02x", $0) }.joined(),
+            version: parsed.version,
+            typeRaw: parsed.type,
+            typeName: Self.specialTypeName(parsed.type),
+            sizeBytes: data.count,
+            lockTime: parsed.lockTime,
+            inputs: inputs,
+            outputs: outputs,
+            extraPayload: parsed.extraPayload,
+            payloadFields: Self.parsePayloadFields(type: parsed.type, payload: parsed.extraPayload, network: network),
+            rawHex: data.map { String(format: "%02x", $0) }.joined(),
+            feeDuffs: row.fee,
+            blockHeight: row.blockHeight > 0 ? row.blockHeight : nil)
+    }
+
+    // MARK: - Script helpers
+
+    /// The concatenated data pushes of an OP_RETURN script, or nil when the
+    /// script isn't OP_RETURN-shaped.
+    static func opReturnData(script: Data) -> Data? {
+        let bytes = [UInt8](script)
+        guard bytes.first == 0x6a else { return nil }
+        var data = Data()
+        var i = 1
+        while i < bytes.count {
+            let op = bytes[i]
+            i += 1
+            let length: Int
+            switch op {
+            case 0x01...0x4b:
+                length = Int(op)
+            case 0x4c: // OP_PUSHDATA1
+                guard i < bytes.count else { return data }
+                length = Int(bytes[i]); i += 1
+            case 0x4d: // OP_PUSHDATA2
+                guard i + 1 < bytes.count else { return data }
+                length = Int(bytes[i]) | (Int(bytes[i + 1]) << 8); i += 2
+            case 0x00: // OP_0 pushes empty
+                continue
+            default:
+                // Non-push opcode after OP_RETURN — stop collecting.
+                return data
+            }
+            guard i + length <= bytes.count else { return data }
+            data.append(contentsOf: bytes[i ..< i + length])
+            i += length
+        }
+        return data
+    }
+
+    // MARK: - Special transaction payloads
+
+    /// DIP-2 special transaction names, keyed by the tx `type` field.
+    static func specialTypeName(_ type: UInt16) -> String? {
+        switch type {
+        case 0: return nil
+        case 1: return "Provider Registration (ProRegTx)"
+        case 2: return "Provider Update Service (ProUpServTx)"
+        case 3: return "Provider Update Registrar (ProUpRegTx)"
+        case 4: return "Provider Update Revocation (ProUpRevTx)"
+        case 5: return "Coinbase (CbTx)"
+        case 6: return "Quorum Commitment (QcTx)"
+        case 7: return "Masternode Hard Fork Signal (MnHfTx)"
+        case 8: return "Asset Lock"
+        case 9: return "Asset Unlock"
+        default: return String(format: NSLocalizedString("Unknown special type %d", comment: "Raw transaction inspector"), type)
+        }
+    }
+
+    /// Parsed fields for the payload types the app understands. Anything the
+    /// parser doesn't positively recognize contributes no fields — the UI
+    /// falls back to the payload hex rather than showing guessed values.
+    private static func parsePayloadFields(type: UInt16, payload: Data?, network: PaymentNetwork) -> [RawTransactionDetails.PayloadField] {
+        guard let payload, !payload.isEmpty else { return [] }
+        var fields: [RawTransactionDetails.PayloadField] = []
+
+        switch type {
+        case 5: // CbTx: u16 version, u32 height, 32B merkle root MN list, …
+            var reader = ByteReader(payload)
+            if let version = try? reader.readUInt16(),
+               let height = try? reader.readUInt32(),
+               let mnRoot = try? reader.readBytes(32) {
+                fields.append(.init(label: "Payload version", value: "\(version)"))
+                fields.append(.init(label: "Block height", value: "\(height)"))
+                fields.append(.init(label: "Masternode list merkle root", value: mnRoot.reversed().map { String(format: "%02x", $0) }.joined()))
+                if version >= 2, let quorumRoot = try? reader.readBytes(32) {
+                    fields.append(.init(label: "Quorums merkle root", value: quorumRoot.reversed().map { String(format: "%02x", $0) }.joined()))
+                }
+            }
+        case 8: // Asset lock: u8 version, varint count, credit outputs (TxOuts).
+            var reader = ByteReader(payload)
+            if let version = try? reader.readUInt8(),
+               let count = try? reader.readVarInt() {
+                fields.append(.init(label: "Payload version", value: "\(version)"))
+                fields.append(.init(label: "Credit outputs", value: "\(count)"))
+                for i in 0 ..< min(count, 16) {
+                    guard let value = try? reader.readUInt64(),
+                          let scriptLength = try? reader.readVarInt(),
+                          let script = try? reader.readBytes(Int(scriptLength)) else { break }
+                    let destination = ScriptAddressCodec.address(forScript: script, network: network)
+                        ?? script.map { String(format: "%02x", $0) }.joined()
+                    fields.append(.init(
+                        label: String(format: "Credit output %d", i),
+                        value: "\(value.formattedDashAmountWithoutCurrencySymbol) → \(destination)"))
+                }
+            }
+        default:
+            break
+        }
+        return fields
+    }
+}
+
+// MARK: - ParsedRawTransaction
+
+/// Minimal consensus parser for the structural fields the SDK decoder does
+/// not surface: version/type split, scriptSigs, sequences, locktime, and the
+/// DIP-2 extra payload. Throws on malformed bytes (including short reads) —
+/// the inspector shows an honest "can't decode" state instead of guessing.
+struct ParsedRawTransaction {
+    struct Input {
+        let prevTxid: Data
+        let prevVout: UInt32
+        let scriptSig: Data
+        let sequence: UInt32
+    }
+
+    struct Output {
+        let valueDuffs: UInt64
+        let scriptPubKey: Data
+    }
+
+    let version: UInt16
+    /// DIP-2 type (upper 16 bits of the 4-byte version field).
+    let type: UInt16
+    let inputs: [Input]
+    let outputs: [Output]
+    let lockTime: UInt32
+    let extraPayload: Data?
+
+    init(data: Data) throws {
+        var reader = ByteReader(data)
+
+        let versionField = try reader.readUInt32()
+        version = UInt16(versionField & 0xFFFF)
+        type = UInt16(versionField >> 16)
+
+        let inputCount = try reader.readVarInt()
+        guard inputCount <= 100_000 else { throw ByteReader.ReadError.malformed }
+        inputs = try (0 ..< inputCount).map { _ in
+            let prevTxid = try reader.readBytes(32)
+            let prevVout = try reader.readUInt32()
+            let scriptLength = try reader.readVarInt()
+            let scriptSig = try reader.readBytes(Int(scriptLength))
+            let sequence = try reader.readUInt32()
+            return Input(prevTxid: prevTxid, prevVout: prevVout, scriptSig: scriptSig, sequence: sequence)
+        }
+
+        let outputCount = try reader.readVarInt()
+        guard outputCount <= 100_000 else { throw ByteReader.ReadError.malformed }
+        outputs = try (0 ..< outputCount).map { _ in
+            let value = try reader.readUInt64()
+            let scriptLength = try reader.readVarInt()
+            let script = try reader.readBytes(Int(scriptLength))
+            return Output(valueDuffs: value, scriptPubKey: script)
+        }
+
+        lockTime = try reader.readUInt32()
+
+        if type > 0, reader.remaining > 0 {
+            let payloadLength = try reader.readVarInt()
+            extraPayload = try reader.readBytes(Int(payloadLength))
+        } else {
+            extraPayload = nil
+        }
+
+        // Trailing garbage means we mis-parsed somewhere — refuse rather
+        // than show wrong structure.
+        guard reader.remaining == 0 else { throw ByteReader.ReadError.malformed }
+    }
+}
+
+// MARK: - ByteReader
+
+/// Little-endian cursor over consensus-serialized bytes.
+private struct ByteReader {
+    enum ReadError: Error {
+        case outOfBounds
+        case malformed
+    }
+
+    private let bytes: [UInt8]
+    private var offset = 0
+
+    init(_ data: Data) {
+        bytes = [UInt8](data)
+    }
+
+    var remaining: Int { bytes.count - offset }
+
+    mutating func readUInt8() throws -> UInt8 {
+        guard offset + 1 <= bytes.count else { throw ReadError.outOfBounds }
+        defer { offset += 1 }
+        return bytes[offset]
+    }
+
+    mutating func readUInt16() throws -> UInt16 {
+        let b = try readBytes(2)
+        return UInt16(b[b.startIndex]) | (UInt16(b[b.startIndex + 1]) << 8)
+    }
+
+    mutating func readUInt32() throws -> UInt32 {
+        let b = try readBytes(4)
+        var value: UInt32 = 0
+        for i in (0 ..< 4).reversed() {
+            value = (value << 8) | UInt32(b[b.startIndex + i])
+        }
+        return value
+    }
+
+    mutating func readUInt64() throws -> UInt64 {
+        let b = try readBytes(8)
+        var value: UInt64 = 0
+        for i in (0 ..< 8).reversed() {
+            value = (value << 8) | UInt64(b[b.startIndex + i])
+        }
+        return value
+    }
+
+    /// Bitcoin-style CompactSize.
+    mutating func readVarInt() throws -> UInt64 {
+        let first = try readUInt8()
+        switch first {
+        case 0 ..< 0xfd: return UInt64(first)
+        case 0xfd: return UInt64(try readUInt16())
+        case 0xfe: return UInt64(try readUInt32())
+        default: return try readUInt64()
+        }
+    }
+
+    mutating func readBytes(_ count: Int) throws -> Data {
+        guard count >= 0, offset + count <= bytes.count else { throw ReadError.outOfBounds }
+        defer { offset += count }
+        return Data(bytes[offset ..< offset + count])
+    }
+}

--- a/DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift
+++ b/DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift
@@ -1,0 +1,338 @@
+//
+//  RawTransactionView.swift
+//  DashWallet
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - RawTransactionViewModel
+
+/// Loads and holds the consensus-decoded transaction for the inspector.
+@MainActor
+final class RawTransactionViewModel: ObservableObject {
+    enum State {
+        case loading
+        case loaded(RawTransactionDetails)
+        /// Row missing or bytes unparseable — shown honestly, never guessed.
+        case unavailable
+    }
+
+    @Published private(set) var state: State = .loading
+
+    private let txidWire: Data
+
+    init(txidWire: Data) {
+        self.txidWire = txidWire
+    }
+
+    func load() {
+        guard case .loading = state else { return }
+        if let details = RawTransactionInspector.load(txidWire: txidWire) {
+            state = .loaded(details)
+        } else {
+            state = .unavailable
+        }
+    }
+
+    func copyToPasteboard(_ value: String) {
+        UIPasteboard.general.string = value
+    }
+}
+
+// MARK: - RawTransactionView
+
+/// Full transaction inspector: every consensus field of the stored raw
+/// transaction — version/type, locktime, all inputs (outpoints, scriptSigs,
+/// sequences), all outputs (values, addresses, OP_RETURN contents, scripts),
+/// the DIP-2 special payload when present, and the raw hex. Every hex blob
+/// is tap-to-copy.
+struct RawTransactionView: View {
+    @StateObject private var viewModel: RawTransactionViewModel
+    @State private var copiedFeedback = false
+
+    init(txidWire: Data) {
+        _viewModel = StateObject(wrappedValue: RawTransactionViewModel(txidWire: txidWire))
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .loading:
+                SwiftUI.ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .unavailable:
+                unavailableBody
+            case .loaded(let details):
+                loadedBody(details)
+            }
+        }
+        .background(Color.primaryBackground)
+        .onAppear { viewModel.load() }
+        .overlay(alignment: .bottom) {
+            if copiedFeedback {
+                Text(NSLocalizedString("Copied", comment: ""))
+                    .font(.footnote.weight(.semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(Capsule().fill(Color.black.opacity(0.75)))
+                    .padding(.bottom, 24)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private var unavailableBody: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "doc.questionmark")
+                .font(.system(size: 34))
+                .foregroundColor(.secondary)
+            Text(NSLocalizedString("Raw transaction unavailable", comment: "Raw transaction inspector"))
+                .font(.subheadline)
+                .foregroundColor(.secondaryText)
+            Text(NSLocalizedString("This transaction's raw bytes are not stored on this device.", comment: "Raw transaction inspector"))
+                .font(.caption)
+                .foregroundColor(.tertiaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func loadedBody(_ details: RawTransactionDetails) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                overviewCard(details)
+
+                sectionHeader(String(format: NSLocalizedString("Inputs (%d)", comment: "Raw transaction inspector"), details.inputs.count))
+                ForEach(details.inputs, id: \.index) { input in
+                    inputCard(input)
+                }
+
+                sectionHeader(String(format: NSLocalizedString("Outputs (%d)", comment: "Raw transaction inspector"), details.outputs.count))
+                ForEach(details.outputs, id: \.index) { output in
+                    outputCard(output)
+                }
+
+                if let payload = details.extraPayload {
+                    sectionHeader(NSLocalizedString("Special payload", comment: "Raw transaction inspector"))
+                    payloadCard(details: details, payload: payload)
+                }
+
+                sectionHeader(NSLocalizedString("Raw transaction", comment: "Raw transaction inspector"))
+                hexCard(details.rawHex)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 24)
+        }
+    }
+
+    // MARK: - Cards
+
+    private func overviewCard(_ details: RawTransactionDetails) -> some View {
+        card {
+            copyableRow(label: NSLocalizedString("Transaction ID", comment: "Raw transaction inspector"), value: details.txidDisplayHex, monospaced: true)
+            divider
+            plainRow(label: NSLocalizedString("Version", comment: "Raw transaction inspector"), value: "\(details.version)")
+            if let typeName = details.typeName {
+                divider
+                plainRow(label: NSLocalizedString("Type", comment: "Raw transaction inspector"), value: "\(typeName) (\(details.typeRaw))")
+            }
+            divider
+            plainRow(label: NSLocalizedString("Size", comment: "Raw transaction inspector"),
+                     value: String(format: NSLocalizedString("%d bytes", comment: "Raw transaction inspector"), details.sizeBytes))
+            divider
+            plainRow(label: NSLocalizedString("Locktime", comment: "Raw transaction inspector"), value: "\(details.lockTime)")
+            if let height = details.blockHeight {
+                divider
+                plainRow(label: NSLocalizedString("Block height", comment: "Raw transaction inspector"), value: "\(height)")
+            }
+            if let fee = details.feeDuffs {
+                divider
+                plainRow(label: NSLocalizedString("Network fee", comment: ""), value: fee.formattedDashAmountWithoutCurrencySymbol)
+            }
+        }
+    }
+
+    private func inputCard(_ input: RawTransactionDetails.Input) -> some View {
+        card {
+            if input.isCoinbase {
+                plainRow(label: String(format: NSLocalizedString("Input %d", comment: "Raw transaction inspector"), input.index),
+                         value: NSLocalizedString("Coinbase (new coins)", comment: "Raw transaction inspector"))
+            } else {
+                copyableRow(
+                    label: String(format: NSLocalizedString("Input %d — outpoint", comment: "Raw transaction inspector"), input.index),
+                    value: "\(input.prevTxidDisplayHex):\(input.prevVout)",
+                    monospaced: true)
+            }
+            if let address = input.address {
+                divider
+                copyableRow(label: NSLocalizedString("Address", comment: ""), value: address, monospaced: true)
+            }
+            if let amount = input.amountDuffs {
+                divider
+                plainRow(label: NSLocalizedString("Amount", comment: ""), value: amount.formattedDashAmountWithoutCurrencySymbol)
+            }
+            divider
+            plainRow(label: NSLocalizedString("Sequence", comment: "Raw transaction inspector"),
+                     value: String(format: "0x%08x", input.sequence))
+            if !input.scriptSig.isEmpty {
+                divider
+                copyableRow(label: NSLocalizedString("Script signature", comment: "Raw transaction inspector"),
+                            value: input.scriptSig.map { String(format: "%02x", $0) }.joined(),
+                            monospaced: true)
+            }
+        }
+    }
+
+    private func outputCard(_ output: RawTransactionDetails.Output) -> some View {
+        card {
+            plainRow(label: String(format: NSLocalizedString("Output %d", comment: "Raw transaction inspector"), output.index),
+                     value: output.valueDuffs.formattedDashAmountWithoutCurrencySymbol)
+            switch output.kind {
+            case .standard(let address):
+                divider
+                copyableRow(label: NSLocalizedString("Address", comment: ""), value: address, monospaced: true)
+            case .opReturn(let data):
+                divider
+                copyableRow(label: "OP_RETURN",
+                            value: data.map { String(format: "%02x", $0) }.joined(),
+                            monospaced: true)
+                if let text = Self.printableASCII(data) {
+                    divider
+                    plainRow(label: NSLocalizedString("As text", comment: "Raw transaction inspector"), value: text)
+                }
+            case .nonStandard:
+                divider
+                plainRow(label: NSLocalizedString("Script type", comment: "Raw transaction inspector"),
+                         value: NSLocalizedString("Non-standard", comment: "Raw transaction inspector"))
+            }
+            divider
+            copyableRow(label: NSLocalizedString("Script", comment: "Raw transaction inspector"),
+                        value: output.scriptPubKey.map { String(format: "%02x", $0) }.joined(),
+                        monospaced: true)
+        }
+    }
+
+    private func payloadCard(details: RawTransactionDetails, payload: Data) -> some View {
+        card {
+            if let typeName = details.typeName {
+                plainRow(label: NSLocalizedString("Type", comment: "Raw transaction inspector"), value: typeName)
+                divider
+            }
+            plainRow(label: NSLocalizedString("Size", comment: "Raw transaction inspector"),
+                     value: String(format: NSLocalizedString("%d bytes", comment: "Raw transaction inspector"), payload.count))
+            ForEach(Array(details.payloadFields.enumerated()), id: \.offset) { _, field in
+                divider
+                plainRow(label: field.label, value: field.value)
+            }
+            divider
+            copyableRow(label: NSLocalizedString("Payload hex", comment: "Raw transaction inspector"),
+                        value: payload.map { String(format: "%02x", $0) }.joined(),
+                        monospaced: true)
+        }
+    }
+
+    private func hexCard(_ hex: String) -> some View {
+        card {
+            Button(action: { copy(hex) }) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(NSLocalizedString("Tap to copy", comment: ""))
+                            .font(.caption)
+                            .foregroundColor(.secondaryText)
+                        Spacer()
+                        Image(systemName: "doc.on.doc")
+                            .font(.caption)
+                            .foregroundColor(.dashBlue)
+                    }
+                    Text(hex)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.primaryText)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Row pieces
+
+    private func card(@ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color.gray300.opacity(0.3))
+            .frame(height: 1)
+    }
+
+    private func plainRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+            Text(value)
+                .font(.footnote)
+                .foregroundColor(.primaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func copyableRow(label: String, value: String, monospaced: Bool) -> some View {
+        Button(action: { copy(value) }) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundColor(.secondaryText)
+                    Spacer()
+                    Image(systemName: "doc.on.doc")
+                        .font(.system(size: 10))
+                        .foregroundColor(.dashBlue)
+                }
+                Text(value)
+                    .font(monospaced ? .system(size: 12, design: .monospaced) : .footnote)
+                    .foregroundColor(.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.footnote.weight(.semibold))
+            .foregroundColor(.secondaryText)
+            .padding(.top, 4)
+    }
+
+    // MARK: - Actions
+
+    private func copy(_ value: String) {
+        viewModel.copyToPasteboard(value)
+        withAnimation { copiedFeedback = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            withAnimation { copiedFeedback = false }
+        }
+    }
+
+    /// The data rendered as ASCII when every byte is printable — shown for
+    /// OP_RETURN payloads that are actually text. Nil otherwise (no lossy
+    /// best-effort rendering of binary data).
+    static func printableASCII(_ data: Data) -> String? {
+        guard !data.isEmpty, data.allSatisfy({ $0 >= 0x20 && $0 < 0x7f }) else { return nil }
+        return String(bytes: data, encoding: .ascii)
+    }
+}

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -112,6 +112,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case header
         case info
         case taxCategory
+        case rawTransaction
         case explorer
     }
 
@@ -125,6 +126,8 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case networkFee(DWTitleDetailItem)
         case date(DWTitleDetailItem)
         case taxCategory(DWTitleDetailItem)
+        case viewTransaction
+        case copyRawTransaction
         case explorer
 
         /// Per-case identity strings — the diffable-identifier content. The
@@ -143,6 +146,8 @@ class TXDetailViewController: BaseTxDetailsViewController {
             case .networkFee(let item): return ["NetworkFee"] + Self.identity(of: [item])
             case .date(let item): return ["Date"] + Self.identity(of: [item])
             case .taxCategory(let item): return ["TaxCategory"] + Self.identity(of: [item])
+            case .viewTransaction: return ["ViewTransaction"]
+            case .copyRawTransaction: return ["CopyRawTransaction"]
             case .explorer: return ["Explorer"]
             }
         }
@@ -214,6 +219,29 @@ extension TXDetailViewController {
         hostingController.setDetent(240)
         present(hostingController, animated: true, completion: nil)
     }
+
+    /// Full consensus-field inspector for this transaction's stored raw bytes.
+    private func viewRawTransaction() {
+        let sheet = BottomSheet(
+            title: NSLocalizedString("Transaction", comment: "Raw transaction inspector"),
+            showBackButton: Binding<Bool>.constant(false)
+        ) {
+            RawTransactionView(txidWire: self.model.transaction.txHashData)
+        }
+        let hostingController = UIHostingController(rootView: sheet)
+        present(hostingController, animated: true)
+    }
+
+    /// Copies the serialized transaction hex. A missing row (bytes not
+    /// stored on this device) reports itself rather than copying nothing.
+    private func copyRawTransaction() {
+        if let hex = RawTransactionInspector.rawHex(txidWire: model.transaction.txHashData) {
+            UIPasteboard.general.string = hex
+            view.dw_showInfoHUD(withText: NSLocalizedString("Copied", comment: ""))
+        } else {
+            view.dw_showInfoHUD(withText: NSLocalizedString("Raw transaction unavailable", comment: "Raw transaction inspector"))
+        }
+    }
 }
 
 extension TXDetailViewController {
@@ -250,6 +278,14 @@ extension TXDetailViewController {
                     cell.update(with: item)
                     return cell
 
+                case .rawTransaction:
+                    let cell = tableView.dequeueReusableCell(withIdentifier: TxDetailActionCell.reuseIdentifier,
+                                                             for: indexPath) as! TxDetailActionCell
+                    cell.titleLabel.text = item == .copyRawTransaction
+                        ? NSLocalizedString("Copy Raw Transaction", comment: "Raw transaction inspector")
+                        : NSLocalizedString("View Transaction", comment: "Raw transaction inspector")
+                    return cell
+
                 case .explorer:
                     let cell = tableView.dequeueReusableCell(withIdentifier: TxDetailActionCell.reuseIdentifier,
                                                              for: indexPath) as! TxDetailActionCell
@@ -265,7 +301,7 @@ extension TXDetailViewController {
         let taxCategory = model.taxCategory
 
         currentSnapshot = NSDiffableDataSourceSnapshot<Section, Item>()
-        currentSnapshot.appendSections([.header, .info, .taxCategory, .explorer])
+        currentSnapshot.appendSections([.header, .info, .taxCategory, .rawTransaction, .explorer])
         currentSnapshot.appendItems([.header], toSection: .header)
 
         // Empty address groups are skipped: SDK rows often carry no linked
@@ -307,6 +343,7 @@ extension TXDetailViewController {
 
         currentSnapshot.appendItems([.date(date)], toSection: .info)
         currentSnapshot.appendItems([.taxCategory(taxCategory)], toSection: .taxCategory)
+        currentSnapshot.appendItems([.viewTransaction, .copyRawTransaction], toSection: .rawTransaction)
         currentSnapshot.appendItems([.explorer], toSection: .explorer)
         dataSource.apply(currentSnapshot, animatingDifferences: false)
         dataSource.defaultRowAnimation = .none
@@ -326,6 +363,14 @@ extension TXDetailViewController {
             model.toggleTaxCategoryOnCurrentTransaction()
             reloadDataSource()
             break
+        case .rawTransaction:
+            if let item = dataSource.itemIdentifier(for: indexPath) {
+                switch item {
+                case .viewTransaction: viewRawTransaction()
+                case .copyRawTransaction: copyRawTransaction()
+                default: break
+                }
+            }
         case .explorer:
             viewInBlockExplorer()
         default:

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -58,6 +58,9 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
 /* Masternode keys overview */
 "%d key(s)" = "%d key(s)";
 
@@ -365,6 +368,9 @@
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
 
+/* Raw transaction inspector */
+"As text" = "As text";
+
 /* DashSpend */
 "at" = "at";
 
@@ -614,11 +620,17 @@
 /* No comment provided by engineer. */
 "Claimable balance" = "Claimable balance";
 
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (new coins)";
+
 /* Masternodes */
 "Collateral" = "Collateral";
 
 /* Balance info sheet section */
 "Cons" = "Cons";
+
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copy Raw Transaction";
 
 /* Masternodes */
 "Couldn't fetch the balance (network error). Try Refresh." = "Couldn't fetch the balance (network error). Try Refresh.";
@@ -1643,6 +1655,15 @@
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
 
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Inputs (%d)";
+
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
 
@@ -1898,6 +1919,9 @@
 
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -2232,6 +2256,9 @@
 /* SPV sync peer type */
 "Node" = "Node";
 
+/* Raw transaction inspector */
+"Non-standard" = "Non-standard";
+
 /* adjective, security level */
 "None" = "None";
 
@@ -2352,6 +2379,12 @@
 /* Masternodes */
 "Outpoint" = "Outpoint";
 
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Outputs (%d)";
+
 /* Masternodes */
 "Owner" = "Owner";
 
@@ -2369,6 +2402,9 @@
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
 
 /* Balance info sheet */
 "Payments confirm in seconds with InstantSend" = "Payments confirm in seconds with InstantSend";
@@ -2682,6 +2718,12 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Raw transaction";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Raw transaction unavailable";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead.";
 
@@ -2910,6 +2952,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Script signature";
+
+/* Raw transaction inspector */
+"Script type" = "Script type";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -3104,6 +3155,9 @@
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
 
@@ -3196,6 +3250,9 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Size";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
@@ -3225,6 +3282,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Special payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -3369,6 +3429,9 @@
 
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tap to copy";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -3598,6 +3661,9 @@
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
 
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "This transaction's raw bytes are not stored on this device.";
+
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
@@ -3660,6 +3726,9 @@
 
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaction ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3729,11 +3798,20 @@
 /* No comment provided by engineer. */
 "This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal.";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Unknown special type %d";
+
 /* Balance info sheet */
 "Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uses one of the most audited and tested zero-knowledge libraries (Orchard)";
 
+/* Raw transaction inspector */
+"Version" = "Version";
+
 /* Balance info sheet */
 "Very efficient with low fees" = "Very efficient with low fees";
+
+/* Raw transaction inspector */
+"View Transaction" = "View Transaction";
 
 /* Full-balance Platform → Transparent withdrawal */
 "Withdraws the entire balance" = "Withdraws the entire balance";


### PR DESCRIPTION
## What

Two new rows on the transaction detail sheet, above "View in Block Explorer":

- **View Transaction** — a full consensus-field inspector for the transaction's stored raw bytes:
  - *Overview*: txid, version, DIP-2 type (named: ProRegTx, CbTx, Asset Lock, …), size, locktime, block height, network fee.
  - *Inputs*: outpoint (`txid:vout`), best-effort sender address (SDK `TransactionDecoder` P2PKH scriptSig recovery), amount when the spent output is the wallet's own TXO (raw txs carry no input values), sequence, full scriptSig hex. Coinbase inputs labeled.
  - *Outputs*: value, P2PKH/P2SH address (shared `ScriptAddressCodec`), **OP_RETURN contents** (hex + ASCII when fully printable), non-standard scripts flagged, full scriptPubKey hex.
  - *Special payload*: type name, parsed fields for known types (CbTx version/height/merkle roots; Asset Lock credit outputs with amounts + destinations), full payload hex.
  - *Raw transaction*: complete serialized hex. Every value in the inspector is tap-to-copy with feedback.
- **Copy Raw Transaction** — copies the serialized tx hex to the pasteboard; reports "Raw transaction unavailable" if the row's bytes aren't stored rather than copying nothing.

## Implementation

- `RawTransactionInspector` (new, Models/Transactions/Model): fetches `PersistentTransaction.transactionData` from the wallet SwiftData store and consensus-parses it app-side (`ParsedRawTransaction`: version/type split, scriptSigs, sequences, locktime, DIP-2 extra payload; CompactSize reader; throws on malformed/trailing bytes — the UI shows an honest "unavailable" state instead of guessed structure). Input addresses merge from the SDK decoder; input values from the wallet's own TXO rows keyed by `PersistentTxo.makeOutpoint`.
- `RawTransactionView` (new, SwiftUI + `@MainActor` ViewModel) presented in the existing `BottomSheet` chrome from `TXDetailViewController`, which gains a `.rawTransaction` section with the two action rows.
- Display-only throughout — nothing here feeds signing or validation.

Note for reviewers: the repo `.gitignore` contains a bare `tx` pattern that (case-insensitively) swallows **new** files under `Sources/UI/Tx/` — `RawTransactionView.swift` is force-added. Possibly worth scoping that ignore pattern separately.

## Testing

Testnet smoke on QA-iPhone16 / iPhone 16 Pro sims: classic sends/receives (inputs, outputs, scripts), a Core→Shielded transfer (Asset Lock payload with decoded credit outputs), coinbase rewards (CbTx payload, coinbase input), copy actions. Unit-test target pre-existing-broken per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)