### PR TITLE
fix(gitignore): root-anchor the Transifex CLI `tx` ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,9 @@ TODO.md
 *.db-shm
 *.db-wal
 
-# Transifex CLI binary
-tx
+# Transifex CLI binary (repo root only; a bare `tx` also matched
+# DashWallet/Sources/UI/Tx/ on case-insensitive filesystems)
+/tx
 DashWalletScreenshotsUITests/refund-addresses.csv
 
 


### PR DESCRIPTION
## Problem

`.gitignore` line 57 was a bare `tx` pattern, added in 2e34e82be ("chore: add Transifex CLI binary to .gitignore") to keep a locally downloaded Transifex CLI binary out of the repo.

Because macOS repos default to `core.ignorecase=true`, the unanchored pattern also matched the tracked source directories `DashWallet/Sources/UI/Tx/` and `DashWallet/Sources/Models/Tx/`. Existing tracked files were unaffected, but any **new** file created under those directories was silently invisible to `git status` / `git add` — this bit #824, where `RawTransactionView.swift` had to be force-added.

## Fix

Anchor the pattern to the repo root (`/tx`), which is where the CLI binary lands, and note the hazard in the comment.

## Verification

- `git check-ignore DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift` no longer matches (exit 1)
- A probe file created under `Sources/UI/Tx/` now appears in `git status` as untracked
- A root-level `tx` file is still ignored (`.gitignore:58:/tx`)
- `git status` otherwise clean; `find` shows no other `tx`-named paths in the tree that relied on the broad pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)