### PR TITLE
feat(ui): Identities screen on the main menu under Wallets

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -542,6 +542,8 @@
 		4AC8F492DD74101C71A5EA5E /* PlatformSendExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */; };
 		4B8A9492829B622FCDAF4F19 /* SecureTimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47594B5DDCF9D335C0C7AB7 /* SecureTimeService.swift */; };
 		4DB882B7974693571FD16952 /* WalletsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F134B2E67D68A97892FD760 /* WalletsScreen.swift */; };
+		71F8642520D4DD9E5F0B0181 /* IdentitiesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AB2C7C555FB7DC14FD5E17 /* IdentitiesViewModel.swift */; };
+		9E39B6CDE39A9CA4E74ADF3B /* IdentitiesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528594007157A56ABDEAD552 /* IdentitiesScreen.swift */; };
 		9A891339E42C1BE3AED09CBB /* WalletAccountDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */; };
 		7190FF8B29307603641F6B5A /* WalletAccountDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */; };
 		DE146DFF383C96BD9DDD692A /* WalletAccountDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */; };
@@ -951,6 +953,8 @@
 		8FCE113ECEA4B9781B24922C /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE3302C1C5DF898D1A0F915 /* AuthenticationService.swift */; };
 		908AB7EFCC69D3828BBD70A8 /* PaymentsLandingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B401E660599FEF6B18087F91 /* PaymentsLandingHostingController.swift */; };
 		90BCB843A2C5965C115C04CC /* WalletsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F134B2E67D68A97892FD760 /* WalletsScreen.swift */; };
+		756F67E27604B9C680848733 /* IdentitiesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AB2C7C555FB7DC14FD5E17 /* IdentitiesViewModel.swift */; };
+		8E3AF21ED19AEC0FD89A63FC /* IdentitiesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528594007157A56ABDEAD552 /* IdentitiesScreen.swift */; };
 		915115B56A2B097590AE3797 /* SwiftDashSDKHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E181EB71C8803101EA789AA4 /* SwiftDashSDKHost.swift */; };
 		91F0B8B92F3FAB7C00E713AE /* KeysOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0B8B82F3FAB7C00E713AE /* KeysOverviewView.swift */; };
 		91F0B8BA2F3FAB7C00E713AE /* KeysOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0B8B82F3FAB7C00E713AE /* KeysOverviewView.swift */; };
@@ -2583,6 +2587,8 @@
 		2DCBA057E553F81F54ACE6E1 /* StorageRecordDetailViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageRecordDetailViews.swift; sourceTree = "<group>"; };
 		2E7EE6B2E027DC4062E9983E /* ContactProfileSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactProfileSheet.swift; sourceTree = "<group>"; };
 		2F134B2E67D68A97892FD760 /* WalletsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletsScreen.swift; sourceTree = "<group>"; };
+		76AB2C7C555FB7DC14FD5E17 /* IdentitiesViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IdentitiesViewModel.swift; sourceTree = "<group>"; };
+		528594007157A56ABDEAD552 /* IdentitiesScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IdentitiesScreen.swift; sourceTree = "<group>"; };
 		F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailScreen.swift; sourceTree = "<group>"; };
 		BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailViewModel.swift; sourceTree = "<group>"; };
 		285B961142AB3AFF2442F4EB /* WalletAccountsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountsScreen.swift; sourceTree = "<group>"; };
@@ -8804,6 +8810,8 @@
 				F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */,
 				BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */,
 				2F134B2E67D68A97892FD760 /* WalletsScreen.swift */,
+				76AB2C7C555FB7DC14FD5E17 /* IdentitiesViewModel.swift */,
+				528594007157A56ABDEAD552 /* IdentitiesScreen.swift */,
 				76AB0835FF44EA88F36991E0 /* WalletsViewModel.swift */,
 			);
 			path = Wallets;
@@ -10406,6 +10414,8 @@
 				2AB76051F87248AC36AED99B /* NetworkReachability.swift in Sources */,
 				A92AEDB6AD391E61F696809C /* MasternodeAPYCalculator.swift in Sources */,
 				4DB882B7974693571FD16952 /* WalletsScreen.swift in Sources */,
+				71F8642520D4DD9E5F0B0181 /* IdentitiesViewModel.swift in Sources */,
+				9E39B6CDE39A9CA4E74ADF3B /* IdentitiesScreen.swift in Sources */,
 				9A891339E42C1BE3AED09CBB /* WalletAccountDetailScreen.swift in Sources */,
 				DE146DFF383C96BD9DDD692A /* WalletAccountDetailViewModel.swift in Sources */,
 				45EAD8E50593EE5158E92E9B /* WalletAccountsScreen.swift in Sources */,
@@ -11350,6 +11360,8 @@
 				C20BF8237F3E1009AD3B7716 /* DarkCoinMessageFraming.swift in Sources */,
 				8DD6758D2AC6F5BB23D5504D /* WalletSendService.swift in Sources */,
 				90BCB843A2C5965C115C04CC /* WalletsScreen.swift in Sources */,
+				756F67E27604B9C680848733 /* IdentitiesViewModel.swift in Sources */,
+				8E3AF21ED19AEC0FD89A63FC /* IdentitiesScreen.swift in Sources */,
 				7190FF8B29307603641F6B5A /* WalletAccountDetailScreen.swift in Sources */,
 				2AD2319F6C528CF6E17656F9 /* WalletAccountDetailViewModel.swift in Sources */,
 				22B03841025A55A573432CC9 /* WalletAccountsScreen.swift in Sources */,

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -153,6 +153,7 @@ struct MainMenuScreen: View {
     @State private var showTools: Bool = false
     @State private var showSyncInfo: Bool = false
     @State private var showWallets: Bool = false
+    @State private var showIdentities: Bool = false
     @State private var showSecurity: Bool = false
     @State private var showDashPayInfo: Bool = false
     @State private var showCreditsPurchasedToast: Bool = false
@@ -354,6 +355,13 @@ struct MainMenuScreen: View {
             }
 
             NavigationLink(
+                destination: IdentitiesScreen(vc: vc),
+                isActive: $showIdentities
+            ) {
+                EmptyView()
+            }
+
+            NavigationLink(
                 destination: SecurityMenuScreen(vc: vc, wipeDelegate: delegateInternal.wipeDelegate),
                 isActive: $showSecurity
             ) {
@@ -431,6 +439,8 @@ struct MainMenuScreen: View {
             showSyncInfo = true
         case .wallets:
             showWallets = true
+        case .identities:
+            showIdentities = true
         case .security:
             showSecurity = true
         case .settings:

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -23,6 +23,7 @@ enum MainMenuNavigationDestination {
     case explore
     case syncInfo
     case wallets
+    case identities
     case security
     case settings
     case tools
@@ -114,6 +115,15 @@ class MainMenuViewModel: ObservableObject {
             icon: .custom("image.wallets", maxHeight: 30),
             action: { [weak self] in
                 self?.navigationDestination = .wallets
+            }
+        ))
+
+        // Identities — the device's Dash Platform identities (under Wallets)
+        allItems.append(MenuItemModel(
+            title: NSLocalizedString("Identities", comment: "Identities"),
+            icon: .system("person.crop.circle"),
+            action: { [weak self] in
+                self?.navigationDestination = .identities
             }
         ))
 

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -89,6 +89,17 @@ struct IdentitiesScreen: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
+        // Find-identities outcome ("Found N new identities" / none found).
+        .alert(
+            NSLocalizedString("Find identities", comment: "Identities"),
+            isPresented: Binding(
+                get: { viewModel.infoMessage != nil },
+                set: { if !$0 { viewModel.infoMessage = nil } })
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(viewModel.infoMessage ?? "")
+        }
     }
 
     // MARK: - Subviews
@@ -104,6 +115,24 @@ struct IdentitiesScreen: View {
                         .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
                 }
                 Spacer()
+                // Explicit Find-identities command: DIP-9 scan of the active
+                // wallet against Platform — discovers identities the store
+                // has never seen (reinstall / imported phrase / other device).
+                Button(action: { Task { await viewModel.discoverIdentities() } }) {
+                    if viewModel.isDiscovering {
+                        SwiftUI.ProgressView()
+                            .frame(width: 36, height: 36)
+                    } else {
+                        Image(systemName: "person.crop.circle.badge.questionmark")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(.primary)
+                            .frame(width: 36, height: 36)
+                            .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                    }
+                }
+                .disabled(viewModel.isDiscovering || viewModel.isRefreshing)
+                .accessibilityLabel(NSLocalizedString("Find identities", comment: "Identities"))
+
                 Button(action: { Task { await viewModel.refreshFromNetwork() } }) {
                     if viewModel.isRefreshing {
                         SwiftUI.ProgressView()
@@ -116,7 +145,7 @@ struct IdentitiesScreen: View {
                             .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
                     }
                 }
-                .disabled(viewModel.isRefreshing)
+                .disabled(viewModel.isRefreshing || viewModel.isDiscovering)
                 .accessibilityLabel(NSLocalizedString("Refresh", comment: ""))
             }
             .padding(.horizontal, 5)
@@ -153,6 +182,27 @@ struct IdentitiesScreen: View {
                 .foregroundColor(.secondaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 40)
+
+            // Restored/imported wallet: the identity may already exist on
+            // Platform even though this device has never seen it.
+            Button(action: { Task { await viewModel.discoverIdentities() } }) {
+                HStack(spacing: 6) {
+                    if viewModel.isDiscovering {
+                        SwiftUI.ProgressView()
+                    } else {
+                        Image(systemName: "person.crop.circle.badge.questionmark")
+                    }
+                    Text(NSLocalizedString("Find identities", comment: "Identities"))
+                }
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.dashBlue)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color.dashBlue.opacity(0.1))
+                .clipShape(Capsule())
+            }
+            .disabled(viewModel.isDiscovering)
+            .padding(.top, 8)
             Spacer()
         }
         .frame(maxWidth: .infinity)

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -1,0 +1,397 @@
+//
+//  IdentitiesScreen.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  "Identities" screen (main menu, under Wallets). Lists the Platform
+//  identities known to this device for the current network — modeled on
+//  the SwiftExampleApp's Identities tab (name + star for the pinned main
+//  DPNS name, balance, truncated id, type/local badges), rendered in the
+//  WalletsScreen card style. Tapping a row opens a compact detail sheet
+//  with the copyable full id. Pull down to refresh balances/names from
+//  Platform. All data access lives in `IdentitiesViewModel`.
+//
+
+import SwiftUI
+import SwiftDashSDK
+import UIKit
+
+struct IdentitiesScreen: View {
+    private let vc: UINavigationController
+
+    @StateObject private var viewModel = IdentitiesViewModel()
+    @State private var detailRow: IdentityRowModel? = nil
+
+    init(vc: UINavigationController) {
+        self.vc = vc
+    }
+
+    var body: some View {
+        ZStack {
+            Color.primaryBackground.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 0) {
+                header
+
+                if viewModel.rows.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            ForEach(viewModel.rows) { row in
+                                IdentityRowView(row: row)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture { detailRow = row }
+                                if row.id != viewModel.rows.last?.id {
+                                    Divider().padding(.leading, 16)
+                                }
+                            }
+                        }
+                        .background(Color.secondaryBackground)
+                        .cornerRadius(12)
+                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 4)
+                    }
+                    .refreshable {
+                        await viewModel.refreshFromNetwork()
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .navigationBarHidden(true)
+        .onAppear { viewModel.reload() }
+        .sheet(item: $detailRow) { row in
+            IdentityDetailSheet(row: row)
+        }
+        .alert(
+            NSLocalizedString("Error", comment: ""),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } })
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Button(action: { vc.popViewController(animated: true) }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.primary)
+                        .frame(width: 36, height: 36)
+                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                }
+                Spacer()
+                Button(action: { Task { await viewModel.refreshFromNetwork() } }) {
+                    if viewModel.isRefreshing {
+                        SwiftUI.ProgressView()
+                            .frame(width: 36, height: 36)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(.primary)
+                            .frame(width: 36, height: 36)
+                            .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                    }
+                }
+                .disabled(viewModel.isRefreshing)
+                .accessibilityLabel(NSLocalizedString("Refresh", comment: ""))
+            }
+            .padding(.horizontal, 5)
+            .padding(.top, 10)
+
+            HStack {
+                Text(NSLocalizedString("Identities", comment: "Identities"))
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primaryText)
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 30)
+            .padding(.bottom, 10)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer(minLength: 40)
+            Image(systemName: "person.crop.circle.badge.plus")
+                .font(.system(size: 40))
+                .foregroundColor(.secondaryText)
+
+            Text(NSLocalizedString("No Identities", comment: "Identities"))
+                .font(.headline)
+                .foregroundColor(.primaryText)
+
+            Text(NSLocalizedString(
+                "Your Dash Platform identity appears here once you register a username.",
+                comment: "Identities"))
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Row
+
+private struct IdentityRowView: View {
+    let row: IdentityRowModel
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 4) {
+                    Text(row.title)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(row.hasName ? .dashBlue : .primaryText)
+                        .lineLimit(1)
+                    if row.isMainName {
+                        Image(systemName: "star.fill")
+                            .font(.caption)
+                            .foregroundColor(.yellow)
+                    }
+                }
+                if let subtitle = row.subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 13))
+                        .foregroundColor(.secondaryText)
+                        .lineLimit(1)
+                }
+                Text(row.idBase58)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundColor(.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                badges
+            }
+            Spacer(minLength: 8)
+            TransferSourceRow.dashBalanceTrailing(row.balanceText)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.secondaryText)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(minHeight: 60)
+    }
+
+    @ViewBuilder
+    private var badges: some View {
+        HStack(spacing: 6) {
+            if row.type == .masternode {
+                IdentityBadge(
+                    text: NSLocalizedString("Masternode", comment: "Identities"),
+                    icon: "server.rack",
+                    color: .purple)
+            } else if row.type == .evonode {
+                IdentityBadge(
+                    text: NSLocalizedString("Evonode", comment: "Identities"),
+                    icon: "server.rack",
+                    color: .indigo)
+            }
+            if row.isLocal {
+                IdentityBadge(
+                    text: NSLocalizedString("Local Only", comment: "Identities"),
+                    icon: "location",
+                    color: .orange)
+            }
+        }
+    }
+}
+
+/// Compact colored capsule badge — same affordance as the example app's
+/// identity row badges.
+private struct IdentityBadge: View {
+    let text: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: icon)
+            Text(text)
+        }
+        .font(.caption2)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(color.opacity(0.15))
+        .foregroundColor(color)
+        .cornerRadius(4)
+    }
+}
+
+// MARK: - Detail sheet
+
+/// Compact identity detail: full copyable id, balance, type, network
+/// status, owning wallet, key count, and every owned DPNS name.
+private struct IdentityDetailSheet: View {
+    let row: IdentityRowModel
+
+    @State private var copied = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.primaryBackground.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 14) {
+                        idCard
+                        infoCard
+                        if !row.dpnsNames.isEmpty {
+                            namesCard
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+            .navigationTitle(row.title)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var idCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("Identity ID", comment: "Identities"))
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+            Text(row.idBase58)
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundColor(.primaryText)
+                .textSelection(.enabled)
+
+            Button(action: copyId) {
+                HStack(spacing: 6) {
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    Text(copied
+                        ? NSLocalizedString("Copied", comment: "")
+                        : NSLocalizedString("Copy", comment: ""))
+                }
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.dashBlue)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    private var infoCard: some View {
+        VStack(spacing: 0) {
+            detailRow(
+                label: NSLocalizedString("Balance", comment: ""),
+                value: row.balanceDetailText)
+            divider
+            detailRow(
+                label: NSLocalizedString("Type", comment: "Identities"),
+                value: typeName)
+            divider
+            detailRow(
+                label: NSLocalizedString("Status", comment: ""),
+                value: row.isLocal
+                    ? NSLocalizedString("Local Only", comment: "Identities")
+                    : NSLocalizedString("On Network", comment: "Identities"))
+            if let walletName = row.walletName {
+                divider
+                detailRow(
+                    label: NSLocalizedString("Wallet", comment: "Identities"),
+                    value: walletName)
+            }
+            divider
+            detailRow(
+                label: NSLocalizedString("Identity index", comment: "Identities"),
+                value: "#\(row.identityIndex)")
+            divider
+            detailRow(
+                label: NSLocalizedString("Public keys", comment: "Identities"),
+                value: "\(row.publicKeyCount)")
+        }
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    private var namesCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("Usernames", comment: "Identities"))
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+            ForEach(row.dpnsNames, id: \.self) { name in
+                Text(name)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.primaryText)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
+    }
+
+    private var typeName: String {
+        switch row.type {
+        case .user: return NSLocalizedString("User", comment: "Identities")
+        case .masternode: return NSLocalizedString("Masternode", comment: "Identities")
+        case .evonode: return NSLocalizedString("Evonode", comment: "Identities")
+        }
+    }
+
+    private func detailRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 14))
+                .foregroundColor(.secondaryText)
+            Spacer()
+            Text(value)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color.gray300.opacity(0.3))
+            .frame(height: 1)
+            .padding(.horizontal, 14)
+    }
+
+    private func copyId() {
+        UIPasteboard.general.string = row.idBase58
+        copied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            copied = false
+        }
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -163,13 +163,53 @@ final class IdentitiesViewModel: ObservableObject {
                     : String(
                         format: NSLocalizedString("Found %d new identities", comment: "Identities"),
                         found.count)
-                // Backfill balances / usernames for the fresh rows.
+                // Backfill balances / usernames for the fresh rows, THEN
+                // adopt — the discovered row usually arrives nameless and
+                // the DPNS backfill supplies the username adoption needs.
                 reload()
                 await refreshFromNetwork()
+                adoptActiveWalletIdentityIfNeeded()
             }
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    /// A discovery that surfaced the ACTIVE wallet's pinned identity
+    /// (index 0) flips the app into DashPay mode — the same
+    /// `DWGlobalOptions` mirror + notification chain a fresh registration
+    /// performs on `.completed` — provided the identity already owns a
+    /// DPNS username. A nameless identity stays list-only: Join DashPay
+    /// later completes the name (the coordinator skips IdentityCreate for
+    /// an existing identity at the pinned slot). No-op when the mirror is
+    /// already set, so re-running Find can't clobber live state.
+    private func adoptActiveWalletIdentityIfNeeded() {
+        let options = DWGlobalOptions.sharedInstance()
+        guard options.dashpayUsername?.isEmpty != false else { return }
+        guard let container = SwiftDashSDKHost.shared.modelContainer,
+              let activeWalletId = SwiftDashSDKHost.shared.wallet?.walletId else { return }
+
+        var descriptor = FetchDescriptor<PersistentIdentity>(
+            predicate: #Predicate { identity in
+                identity.wallet?.walletId == activeWalletId && identity.identityIndex == 0
+            })
+        descriptor.fetchLimit = 1
+        guard let identity = try? container.mainContext.fetch(descriptor).first else { return }
+        let username = [identity.mainDpnsName, identity.dpnsName]
+            .compactMap { $0?.nonEmptyString }
+            .first
+        guard let username else { return }
+
+        options.dashpayUsername = username
+        options.dashpayRegistrationCompleted = true
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+        // Internal bridge notification: DWDashPayModel observes it, rebuilds
+        // its state, and posts the canonical
+        // DWDashPayRegistrationStatusUpdatedNotification for the wider UI —
+        // same ordering as a registration completion.
+        NotificationCenter.default.post(
+            name: DWIdentityRegistrationBridge.stateChangedNotification,
+            object: nil)
     }
 
     // MARK: - Mapping

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -1,0 +1,167 @@
+//
+//  IdentitiesViewModel.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Backs the "Identities" screen (main menu, under Wallets). Reads the
+//  SwiftDashSDK `PersistentIdentity` rows for the current network — the
+//  same store the SwiftExampleApp's Identities tab renders — and refreshes
+//  balance/DPNS from Platform on pull. All SDK access lives here
+//  (SwiftUI-first guardrail); the screen only renders row models.
+//
+
+import Combine
+import Foundation
+import SwiftData
+import SwiftDashSDK
+
+/// Immutable per-row projection of a `PersistentIdentity`, captured at
+/// reload time so the view never holds live `@Model` references.
+struct IdentityRowModel: Identifiable {
+    let identityId: Data
+    /// `alias → mainDpnsName → dpnsName → truncated id` (the SDK model's
+    /// `displayName` priority).
+    let title: String
+    /// True when the title is a DPNS name / alias rather than the id.
+    let hasName: Bool
+    /// True when the user pinned a main DPNS name (star affordance,
+    /// mirrors the example app's row).
+    let isMainName: Bool
+    /// Alias shown as subtitle when the title is a DPNS name.
+    let subtitle: String?
+    let idBase58: String
+    /// Balance formatted as a plain DASH decimal (no symbol).
+    let balanceText: String
+    /// Full-precision balance line for the detail sheet.
+    let balanceDetailText: String
+    let type: IdentityType
+    let isLocal: Bool
+    let walletName: String?
+    let identityIndex: UInt32
+    let publicKeyCount: Int
+    /// Every DPNS label owned by this identity (detail sheet list).
+    let dpnsNames: [String]
+
+    var id: Data { identityId }
+}
+
+@MainActor
+final class IdentitiesViewModel: ObservableObject {
+
+    @Published private(set) var rows: [IdentityRowModel] = []
+    @Published private(set) var isRefreshing = false
+    @Published var errorMessage: String?
+
+    /// Reload the row models from SwiftData. Cheap; called on appear and
+    /// after every network refresh.
+    func reload() {
+        guard let container = SwiftDashSDKHost.shared.modelContainer,
+              let network = SwiftDashSDKHost.shared.runningNetwork else {
+            rows = []
+            return
+        }
+        let descriptor = FetchDescriptor<PersistentIdentity>(
+            predicate: PersistentIdentity.predicate(network: network),
+            sortBy: [SortDescriptor(\.identityIndex, order: .forward)])
+        let identities = (try? container.mainContext.fetch(descriptor)) ?? []
+        rows = identities.map(Self.rowModel(for:))
+    }
+
+    /// One-shot Platform refresh, pull-to-refresh style: re-fetch each
+    /// identity's balance, and backfill a DPNS name for rows that have
+    /// none (silent — not every identity has a name). Mirrors the example
+    /// app's `IdentityRow.refreshBalance`, batched over the whole list.
+    func refreshFromNetwork() async {
+        guard !isRefreshing else { return }
+        guard let sdk = SwiftDashSDKHost.shared.sdk,
+              let container = SwiftDashSDKHost.shared.modelContainer else { return }
+        isRefreshing = true
+        defer {
+            isRefreshing = false
+            reload()
+        }
+
+        var failures = 0
+        for row in rows where !row.isLocal {
+            do {
+                let fetched = try await sdk.identityGet(identityId: row.idBase58)
+                if let balance = Self.uint64(from: fetched["balance"]) {
+                    PersistentIdentity.updateBalance(
+                        in: container.mainContext,
+                        identityId: row.identityId,
+                        balance: balance)
+                }
+                if !row.hasName,
+                   let usernames = try? await sdk.dpnsGetUsername(identityId: row.idBase58, limit: 1),
+                   let label = usernames.first?["label"] as? String {
+                    PersistentIdentity.updateDpnsName(
+                        in: container.mainContext,
+                        identityId: row.identityId,
+                        dpnsName: label)
+                }
+            } catch {
+                failures += 1
+            }
+        }
+        try? container.mainContext.save()
+
+        if failures > 0 {
+            errorMessage = String(
+                format: NSLocalizedString("Could not refresh %d identities", comment: "Identities"),
+                failures)
+        }
+    }
+
+    // MARK: - Mapping
+
+    private static func rowModel(for identity: PersistentIdentity) -> IdentityRowModel {
+        let hasName = (identity.alias?.isEmpty == false)
+            || (identity.mainDpnsName?.isEmpty == false)
+            || (identity.dpnsName?.isEmpty == false)
+        // Balance is stored as Int64 bit-pattern of the UInt64 credits.
+        let credits = UInt64(bitPattern: identity.balance)
+        return IdentityRowModel(
+            identityId: identity.identityId,
+            title: identity.displayName,
+            hasName: hasName,
+            isMainName: identity.mainDpnsName?.isEmpty == false,
+            subtitle: hasName ? identity.alias?.nonEmptyString : nil,
+            idBase58: identity.identityIdBase58,
+            balanceText: InternalTransferViewModel.cardBalanceString(duffs: credits / 1000),
+            balanceDetailText: identity.formattedBalance,
+            type: identity.identityTypeEnum,
+            isLocal: identity.isLocal,
+            walletName: identity.wallet?.label.nonEmptyString,
+            identityIndex: identity.identityIndex,
+            publicKeyCount: identity.publicKeys.count,
+            dpnsNames: identity.dpnsNames.map(\.label))
+    }
+
+    private static func uint64(from value: Any?) -> UInt64? {
+        if let number = value as? NSNumber {
+            return number.uint64Value
+        }
+        if let string = value as? String, let parsed = UInt64(string) {
+            return parsed
+        }
+        return nil
+    }
+}
+
+private extension String {
+    /// Self when non-empty, else nil.
+    var nonEmptyString: String? { isEmpty ? nil : self }
+}

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -63,7 +63,11 @@ final class IdentitiesViewModel: ObservableObject {
 
     @Published private(set) var rows: [IdentityRowModel] = []
     @Published private(set) var isRefreshing = false
+    @Published private(set) var isDiscovering = false
     @Published var errorMessage: String?
+    /// Outcome of the explicit Find-identities scan ("Found 2 new
+    /// identities" / none found) — presented as an informational alert.
+    @Published var infoMessage: String?
 
     /// Reload the row models from SwiftData. Cheap; called on appear and
     /// after every network refresh.
@@ -122,6 +126,49 @@ final class IdentitiesViewModel: ObservableObject {
             errorMessage = String(
                 format: NSLocalizedString("Could not refresh %d identities", comment: "Identities"),
                 failures)
+        }
+    }
+
+    /// Explicit "Find identities" command — the example app's
+    /// "Re-scan for Identities": a DIP-9 gap-limit scan of the ACTIVE
+    /// wallet's identity-authentication derivation tree against Platform
+    /// (`ManagedPlatformWallet.discoverIdentities`). Unlike the refresh,
+    /// this DISCOVERS identities the local store has never seen — after a
+    /// reinstall, an imported recovery phrase, or a registration made on
+    /// another device with the same seed. Discoveries are persisted by
+    /// the SDK's identity persister; `startIndex: 0` forces a full
+    /// re-walk rather than resuming from the cached scan watermark.
+    /// Scans only the loaded (active) wallet — other on-device wallets
+    /// would each need their own loaded handle.
+    func discoverIdentities() async {
+        guard !isDiscovering else { return }
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            errorMessage = NSLocalizedString("Wallet is not ready", comment: "Identities")
+            return
+        }
+        isDiscovering = true
+        defer {
+            isDiscovering = false
+            reload()
+        }
+        do {
+            let found = try await wallet.discoverIdentities(startIndex: 0)
+            if found.isEmpty {
+                infoMessage = NSLocalizedString(
+                    "No new identities were found for this wallet",
+                    comment: "Identities")
+            } else {
+                infoMessage = found.count == 1
+                    ? NSLocalizedString("Found 1 new identity", comment: "Identities")
+                    : String(
+                        format: NSLocalizedString("Found %d new identities", comment: "Identities"),
+                        found.count)
+                // Backfill balances / usernames for the fresh rows.
+                reload()
+                await refreshFromNetwork()
+            }
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -638,6 +638,9 @@
 /* Raw transaction inspector */
 "Copy Raw Transaction" = "Copy Raw Transaction";
 
+/* Identities */
+"Could not refresh %d identities" = "Could not refresh %d identities";
+
 /* Masternodes */
 "Couldn't fetch the balance (network error). Try Refresh." = "Couldn't fetch the balance (network error). Try Refresh.";
 
@@ -1568,11 +1571,17 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identities";
+
 /* Voting */
 "Identity" = "Identity";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
+
+/* Identities */
+"Identity index" = "Identity index";
 
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
@@ -1917,6 +1926,9 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Local Only";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
@@ -2220,6 +2232,9 @@
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
 
+/* Identities */
+"No Identities" = "No Identities";
+
 /* No connection */
 "No internet connection" = "No internet connection";
 
@@ -2330,6 +2345,9 @@
 
 /* Voting */
 "Old to new" = "Old to new";
+
+/* Identities */
+"On Network" = "On Network";
 
 /* Once <username> accepts your request... */
 "Once %@ accepts your request you can Pay Directly to Username" = "Once %@ accepts your request you can Pay Directly to Username";
@@ -2699,6 +2717,9 @@
 
 /* Masternode keys */
 "Public key (legacy)" = "Public key (legacy)";
+
+/* Identities */
+"Public keys" = "Public keys";
 
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
@@ -3816,6 +3837,9 @@
 /* Raw transaction inspector */
 "Unknown special type %d" = "Unknown special type %d";
 
+/* Identities */
+"Usernames" = "Usernames";
+
 /* Balance info sheet */
 "Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uses one of the most audited and tested zero-knowledge libraries (Orchard)";
 
@@ -4461,6 +4485,9 @@
 
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
+
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Your Dash Platform identity appears here once you register a username.";
 
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1304,6 +1304,9 @@
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
 
+/* Identities */
+"Find identities" = "Find identities";
+
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
 
@@ -1351,6 +1354,12 @@
 
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
+
+/* Identities */
+"Found %d new identities" = "Found %d new identities";
+
+/* Identities */
+"Found 1 new identity" = "Found 1 new identity";
 
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
@@ -2255,6 +2264,9 @@
 "No masternodes yet" = "No masternodes yet";
 
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+/* Identities */
+"No new identities were found for this wallet" = "No new identities were found for this wallet";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";


### PR DESCRIPTION
## Summary

Adds an **Identities** entry to the More menu, directly under **Wallets**, showing the device's Dash Platform identities for the current network. Heavily modeled on the SwiftExampleApp's Identities tab, adapted to dashwallet's menu/screen conventions.

### List
- Reads the SwiftDashSDK `PersistentIdentity` store (network-scoped via `PersistentIdentity.predicate(network:)`, ordered by identity index) — the same rows the example app renders.
- Each row: display name (alias → main DPNS name → DPNS name → truncated id) with a ⭐ for the pinned main name, alias subtitle, truncated base58 id, credits balance with the Dash glyph, and Masternode / Evonode / Local-Only badges.
- Empty state explains identities appear after username registration (dashwallet's create-identity path is the existing Join DashPay flow — deliberately not duplicated here).

### Detail sheet
Tap a row → compact sheet: full **copyable** identity id, balance (full precision), type, Local Only / On Network status, owning wallet, identity index, public-key count, and every owned username.

### Refresh
Pull-to-refresh or the header button: per identity, `sdk.identityGet` refreshes the balance and `dpnsGetUsername` backfills a missing DPNS name (silent 404s, mirroring the example app), then persists via the SDK's `updateBalance`/`updateDpnsName` mutators.

### Find identities (explicit command)
The refresh only polishes known rows — it can't discover an identity this device has never seen. A header button (and an empty-state button, where the restored-wallet case lives) runs the example app's "Re-scan for Identities": `ManagedPlatformWallet.discoverIdentities(startIndex: 0)`, the DIP-9 gap-limit scan of the active wallet's identity-authentication tree against Platform. Discoveries persist via the SDK persister; on a hit the list reloads and the balance/username refresh backfills the new rows. Outcome reported in an alert.

When the scan surfaces the **active wallet's pinned identity (index 0) with a username**, the app adopts it into DashPay mode — the same `DWGlobalOptions` mirror writes + notification chain a finished registration performs (avatar appears, Join banner retires). Nameless identities stay list-only until Join DashPay completes the name.

### Notes
- MVVM per the SwiftUI-first guardrail — all SDK/SwiftData access in `IdentitiesViewModel`; the screen renders row models only.
- No create/load/remove flows from the example app: creation belongs to the Join DashPay flow, and local identity removal has different keychain semantics in dashwallet.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] More → Identities shows the registered identity with DPNS name and balance; refresh updates after a top-up
- [ ] Empty state on a wallet with no identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)


