### PR TITLE
fix(ui): retire the menu's Join DashPay banner once a username exists

### DIFF
--- a/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
+++ b/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
@@ -46,14 +46,36 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
     override init() {
         updateModel = DWDPUpdateProfileModel()
         super.init()
-        
+
         model.$state
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                self?.showJoinDashpay = self?.model.state == .syncDone
+            .sink { [weak self] _ in
+                self?.updateShowJoinDashpay()
             }
             .store(in: &cancellableBag)
+
+        // Registration (or the Identities screen adopting a discovered
+        // identity) retires the banner live — both paths post the
+        // registration-status update after writing the username mirror.
+        NotificationCenter.default.publisher(for: .DWDashPayRegistrationStatusUpdated)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateShowJoinDashpay()
+            }
+            .store(in: &cancellableBag)
+
+        updateShowJoinDashpay()
+    }
+
+    /// The menu's Join DashPay banner: only while synced AND not already
+    /// registered. A wallet whose identity owns a username (fresh
+    /// registration or an adopted discovered identity — both write the
+    /// `DWGlobalOptions.dashpayUsername` mirror) has nothing to join;
+    /// checking sync state alone kept the banner up forever.
+    private func updateShowJoinDashpay() {
+        let hasUsername = DWGlobalOptions.sharedInstance().dashpayUsername?.isEmpty == false
+        showJoinDashpay = model.state == .syncDone && !hasUsername
     }
     
     @objc func update() {


### PR DESCRIPTION
## Summary

The More menu kept showing **"Join DashPay — Request your username"** on a wallet that already has a registered username (QA repro after registering + paying contacts).

**Root cause:** `CurrentUserProfileModel.showJoinDashpay` was derived from sync state alone (`model.state == .syncDone`) — it never checked whether the user is already registered, so once synced the banner showed forever. The home screen's banner does this correctly (`joinDashPayState != .registered`); the menu model predates that check.

**Fix:** gate the banner on the `DWGlobalOptions.dashpayUsername` mirror as well (written by registration completion and by the Identities screen's discovered-identity adoption), and re-evaluate on `DWDashPayRegistrationStatusUpdated` so it retires live when registration finishes while the menu is open.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] Registered wallet: More menu shows no Join DashPay banner
- [ ] Unregistered wallet: banner still appears once synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)