### PR TITLE
feat(ui): DashPay model views in the storage explorer

### DIFF
--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
@@ -41,6 +41,27 @@ struct StorageExplorerView: View {
             modelRow("Keywords", icon: "tag", type: PersistentKeyword.self) {
                 KeywordStorageListView()
             }
+            modelRow("DPNS Names", icon: "at", type: PersistentDPNSName.self) {
+                DPNSNameStorageListView()
+            }
+            modelRow("DashPay Profiles", icon: "person.text.rectangle", type: PersistentDashpayProfile.self) {
+                DashpayProfileStorageListView()
+            }
+            modelRow("Contact Profiles", icon: "person.crop.circle", type: PersistentDashpayContactProfile.self) {
+                DashpayContactProfileStorageListView()
+            }
+            modelRow("Contact Requests", icon: "person.crop.circle.badge.plus", type: PersistentDashpayContactRequest.self) {
+                DashpayContactRequestStorageListView()
+            }
+            modelRow("DashPay Payments", icon: "arrow.left.arrow.right.circle", type: PersistentDashpayPayment.self) {
+                DashpayPaymentStorageListView()
+            }
+            modelRow("Sent Invitations", icon: "paperplane", type: PersistentInvitation.self) {
+                InvitationStorageListView()
+            }
+            modelRow("Ignored Senders", icon: "person.crop.circle.badge.xmark", type: PersistentDashpayIgnoredSender.self) {
+                DashpayIgnoredSenderStorageListView()
+            }
             modelCountRow(
                 "Platform Addresses",
                 icon: "creditcard",

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift
@@ -669,3 +669,233 @@ struct WalletManagerMetadataStorageListView: View {
         .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "gearshape.2") } }
     }
 }
+
+// MARK: - DashPay family (ported from SwiftExampleApp's storage explorer;
+// network filtering dropped — dashwallet's ModelContainer is per-network)
+
+/// "<first 4 hex>…<last 4 hex>" of a 32-byte id, keeping rows concise —
+/// the same truncation the example app's list views use.
+private func shortIdHex(_ data: Data) -> String {
+    guard data.count >= 8 else {
+        return data.map { String(format: "%02x", $0) }.joined()
+    }
+    let head = data.prefix(4).map { String(format: "%02x", $0) }.joined()
+    let tail = data.suffix(4).map { String(format: "%02x", $0) }.joined()
+    return "\(head)…\(tail)"
+}
+
+// MARK: - PersistentDPNSName
+
+struct DPNSNameStorageListView: View {
+    @Query(sort: \PersistentDPNSName.acquiredAt, order: .reverse)
+    private var records: [PersistentDPNSName]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: DPNSNameStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(record.label).\(record.parentDomainName)")
+                        .font(.body).lineLimit(1)
+                    Text(record.identity.identityIdBase58)
+                        .font(.caption).foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.middle)
+                }
+            }
+        }
+        .navigationTitle("DPNS Names (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "at") } }
+    }
+}
+
+// MARK: - PersistentDashpayProfile
+
+/// One row per (network, identity) — the wallet's own cached DashPay
+/// profiles. Newest profile update first.
+struct DashpayProfileStorageListView: View {
+    @Query(sort: \PersistentDashpayProfile.lastUpdated, order: .reverse)
+    private var records: [PersistentDashpayProfile]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: DashpayProfileStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(record.displayName ?? "(no display name)")
+                        .font(.body).lineLimit(1)
+                    Text(record.identity.identityIdBase58)
+                        .font(.caption).foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.middle)
+                }
+            }
+        }
+        .navigationTitle("DashPay Profiles (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "person.text.rectangle") } }
+    }
+}
+
+// MARK: - PersistentDashpayContactProfile
+
+/// Cached counterparty profiles, one row per (owner, contact).
+struct DashpayContactProfileStorageListView: View {
+    @Query(sort: \PersistentDashpayContactProfile.lastUpdated, order: .reverse)
+    private var records: [PersistentDashpayContactProfile]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: DashpayContactProfileStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(record.displayName ?? "(no display name)")
+                        .font(.body).lineLimit(1)
+                    Text(shortIdHex(record.contactIdentityId))
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Contact Profiles (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "person.crop.circle") } }
+    }
+}
+
+// MARK: - PersistentDashpayContactRequest
+
+/// Grouped by direction (Outgoing / Incoming) — the encrypted payload
+/// differs per direction, so the two directions are inherently distinct
+/// rows even for the same (owner, contact) pair. Newest first per section.
+struct DashpayContactRequestStorageListView: View {
+    @Query private var records: [PersistentDashpayContactRequest]
+
+    private var outgoing: [PersistentDashpayContactRequest] {
+        records.filter { $0.isOutgoing }
+            .sorted { $0.createdAtMillis > $1.createdAtMillis }
+    }
+
+    private var incoming: [PersistentDashpayContactRequest] {
+        records.filter { !$0.isOutgoing }
+            .sorted { $0.createdAtMillis > $1.createdAtMillis }
+    }
+
+    var body: some View {
+        List {
+            if !outgoing.isEmpty {
+                Section("Outgoing (\(outgoing.count))") {
+                    ForEach(outgoing) { record in
+                        contactRequestLink(record)
+                    }
+                }
+            }
+            if !incoming.isEmpty {
+                Section("Incoming (\(incoming.count))") {
+                    ForEach(incoming) { record in
+                        contactRequestLink(record)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Contact Requests (\(records.count))")
+        .overlay {
+            if records.isEmpty {
+                ContentUnavailableView("No Records", systemImage: "person.crop.circle.badge.plus")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contactRequestLink(_ record: PersistentDashpayContactRequest) -> some View {
+        NavigationLink(destination: DashpayContactRequestStorageDetailView(record: record)) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(shortIdHex(record.contactIdentityId))
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1).truncationMode(.middle)
+                Text("from \(shortIdHex(record.ownerIdentityId))")
+                    .font(.caption).foregroundColor(.secondary)
+                    .lineLimit(1).truncationMode(.middle)
+            }
+        }
+    }
+}
+
+// MARK: - PersistentDashpayPayment
+
+struct DashpayPaymentStorageListView: View {
+    @Query(sort: \PersistentDashpayPayment.createdAt, order: .reverse)
+    private var records: [PersistentDashpayPayment]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: DashpayPaymentStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(record.direction == .sent ? "Sent" : "Received")
+                            .font(.body)
+                        Spacer()
+                        Text(String(format: "%.8f DASH", Double(record.amountDuffs) / 100_000_000))
+                            .font(.system(.caption, design: .monospaced))
+                    }
+                    Text(record.txid)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1).truncationMode(.middle)
+                }
+            }
+        }
+        .navigationTitle("DashPay Payments (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "arrow.left.arrow.right.circle") } }
+    }
+}
+
+// MARK: - PersistentInvitation
+
+struct InvitationStorageListView: View {
+    @Query(sort: [SortDescriptor(\PersistentInvitation.createdAtSecs, order: .reverse)])
+    private var records: [PersistentInvitation]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: InvitationStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(record.outPointHex)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1).truncationMode(.middle)
+                    HStack(spacing: 8) {
+                        Text(invitationStatusLabel(record.statusRaw))
+                            .font(.caption2).foregroundColor(.secondary)
+                        Spacer()
+                        Text(String(format: "%.8f DASH", Double(record.amountDuffs) / 100_000_000))
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Sent Invitations (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Invitations", systemImage: "paperplane") } }
+    }
+}
+
+// MARK: - PersistentDashpayIgnoredSender
+
+struct DashpayIgnoredSenderStorageListView: View {
+    @Query(sort: \PersistentDashpayIgnoredSender.ignoredAt, order: .reverse)
+    private var records: [PersistentDashpayIgnoredSender]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: DashpayIgnoredSenderStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("ignored sender")
+                            .font(.body)
+                        Spacer()
+                        Text(record.ignoredAt, style: .date)
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    Text(shortIdHex(record.ignoredSenderId))
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .navigationTitle("Ignored Senders (\(records.count))")
+        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "person.crop.circle.badge.xmark") } }
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift
@@ -790,3 +790,272 @@ struct WalletManagerMetadataStorageDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 }
+
+// MARK: - DashPay family (ported from SwiftExampleApp's storage explorer)
+
+// MARK: - PersistentDPNSName
+
+struct DPNSNameStorageDetailView: View {
+    let record: PersistentDPNSName
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Label", value: record.label)
+                FieldRow(label: "Normalized Label", value: record.normalizedLabel)
+                FieldRow(label: "Parent Domain", value: record.parentDomainName)
+                FieldRow(label: "Normalized Parent Domain", value: record.normalizedParentDomainName)
+            }
+            Section("Status") {
+                // `acquiredAt` is Unix-millis from `DpnsNameInfo.acquired_at`;
+                // zero when the FFI changeset didn't carry a timestamp.
+                FieldRow(label: "Acquired At (ms)", value: record.acquiredAt == 0 ? "—" : "\(record.acquiredAt)")
+                if record.acquiredAt > 0 {
+                    let date = Date(timeIntervalSince1970: TimeInterval(record.acquiredAt) / 1000.0)
+                    FieldRow(label: "Acquired", value: dateString(date))
+                }
+            }
+            Section("Relationships") {
+                NavigationLink(destination: IdentityStorageDetailView(record: record.identity)) {
+                    FieldRow(label: "Owner Identity", value: record.identity.identityIdBase58)
+                }
+                FieldRow(label: "Owner ID (Hex)", value: record.identity.identityIdString)
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+                FieldRow(label: "Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("DPNS Name")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - PersistentDashpayProfile
+
+/// Every stored own-profile field; optional ones render as "—" so partial
+/// profiles are obvious rather than fields silently disappearing.
+struct DashpayProfileStorageDetailView: View {
+    let record: PersistentDashpayProfile
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Display Name", value: record.displayName ?? "—")
+                FieldRow(label: "Public Message", value: record.publicMessage ?? "—")
+                // Reserved for future DashPay contract revisions; v3 doesn't
+                // populate it — surfaced so it isn't invisible if lit up later.
+                FieldRow(label: "Bio", value: record.bio ?? "—")
+            }
+            Section("Avatar") {
+                FieldRow(label: "URL", value: record.avatarUrl ?? "—")
+                FieldRow(label: "Hash (32 B)", value: record.avatarHash.map { hexString($0) } ?? "—")
+                FieldRow(label: "Fingerprint (8 B)", value: record.avatarFingerprint.map { hexString($0) } ?? "—")
+            }
+            Section("Relationships") {
+                NavigationLink(destination: IdentityStorageDetailView(record: record.identity)) {
+                    FieldRow(label: "Owner Identity", value: record.identity.identityIdBase58)
+                }
+                FieldRow(label: "Owner ID (Hex)", value: record.identity.identityIdString)
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+                FieldRow(label: "Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("DashPay Profile")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - PersistentDashpayContactProfile
+
+/// A counterparty's DashPay profile as seen by an owner identity — one
+/// row per (owner, contact).
+struct DashpayContactProfileStorageDetailView: View {
+    let record: PersistentDashpayContactProfile
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Display Name", value: record.displayName ?? "—")
+                FieldRow(label: "Public Message", value: record.publicMessage ?? "—")
+                FieldRow(label: "Bio", value: record.bio ?? "—")
+            }
+            Section("Avatar") {
+                FieldRow(label: "URL", value: record.avatarUrl ?? "—")
+                FieldRow(label: "Hash (32 B)", value: record.avatarHash.map { hexString($0) } ?? "—")
+                FieldRow(label: "Fingerprint (8 B)", value: record.avatarFingerprint.map { hexString($0) } ?? "—")
+            }
+            Section("Relationships") {
+                NavigationLink(destination: IdentityStorageDetailView(record: record.owner)) {
+                    FieldRow(label: "Owner Identity", value: record.owner.identityIdBase58)
+                }
+                FieldRow(label: "Owner ID (Hex)", value: hexString(record.ownerIdentityId))
+                FieldRow(label: "Contact ID (Hex)", value: hexString(record.contactIdentityId))
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Checked At (ms)", value: String(record.checkedAtMs))
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+                FieldRow(label: "Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("Contact Profile")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - PersistentDashpayContactRequest
+
+/// Every payload field plus the relationship pair. The `ownerIdentityId`
+/// denorm shadow is redundant with `owner.identityId` but query-friendly.
+/// The owner-private alias/note (decrypted contact meta) are included —
+/// they back the contacts list titles and the payment-row aliases.
+struct DashpayContactRequestStorageDetailView: View {
+    let record: PersistentDashpayContactRequest
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Direction", value: record.isOutgoing ? "Outgoing" : "Incoming")
+                FieldRow(label: "Sender Key Index", value: "\(record.senderKeyIndex)")
+                FieldRow(label: "Recipient Key Index", value: "\(record.recipientKeyIndex)")
+                FieldRow(label: "Account Reference", value: "\(record.accountReference)")
+                FieldRow(label: "Core Height Created At", value: "\(record.coreHeightCreatedAt)")
+                FieldRow(label: "Created At (ms)", value: record.createdAtMillis == 0 ? "—" : "\(record.createdAtMillis)")
+            }
+            Section("Payload") {
+                FieldRow(label: "Encrypted Public Key", value: "\(record.encryptedPublicKey.count) bytes")
+                FieldRow(label: "Encrypted Account Label", value: record.encryptedAccountLabel.map { "\($0.count) bytes" } ?? "—")
+                FieldRow(label: "Account Label (decrypted)", value: record.contactAccountLabel ?? "—")
+                FieldRow(label: "Auto-Accept Proof", value: record.autoAcceptProof.map { "\($0.count) bytes" } ?? "—")
+                FieldRow(label: "Alias (owner-private)", value: record.contactAlias ?? "—")
+                FieldRow(label: "Note (owner-private)", value: record.contactNote ?? "—")
+            }
+            Section("Relationships") {
+                NavigationLink(destination: IdentityStorageDetailView(record: record.owner)) {
+                    FieldRow(label: "Owner Identity", value: record.owner.identityIdBase58)
+                }
+                FieldRow(label: "Owner ID (Hex, denorm)", value: hexString(record.ownerIdentityId))
+                FieldRow(label: "Contact ID (Hex)", value: hexString(record.contactIdentityId))
+            }
+            Section("Timestamps") {
+                if record.createdAtMillis > 0 {
+                    let date = Date(timeIntervalSince1970: TimeInterval(record.createdAtMillis) / 1000.0)
+                    FieldRow(label: "Document Created", value: dateString(date))
+                }
+                FieldRow(label: "Row Created", value: dateString(record.createdAt))
+                FieldRow(label: "Row Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("Contact Request")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - PersistentDashpayPayment
+
+struct DashpayPaymentStorageDetailView: View {
+    let record: PersistentDashpayPayment
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Direction", value: record.direction == .sent ? "Sent" : "Received")
+                FieldRow(label: "Status", value: statusText)
+                FieldRow(label: "Amount", value: String(format: "%.8f DASH", Double(record.amountDuffs) / 100_000_000))
+                FieldRow(label: "Amount (duffs)", value: "\(record.amountDuffs)")
+                FieldRow(label: "Memo", value: record.memo ?? "—")
+            }
+            Section("Transaction") {
+                FieldRow(label: "Txid", value: record.txid)
+            }
+            Section("Identities") {
+                FieldRow(label: "Owner", value: hexString(record.ownerIdentityId))
+                FieldRow(label: "Counterparty", value: hexString(record.counterpartyIdentityId))
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+                FieldRow(label: "Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("DashPay Payment")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var statusText: String {
+        switch record.status {
+        case .pending: return "Pending"
+        case .confirmed: return "Confirmed"
+        case .failed: return "Failed"
+        }
+    }
+}
+
+// MARK: - PersistentInvitation
+
+/// Human label for a `PersistentInvitation.statusRaw` discriminant
+/// (0 = Created, 1 = Claimed, 2 = Reclaimed). Shared with the list view;
+/// an unmapped value renders as "Unknown (n)" rather than being hidden.
+func invitationStatusLabel(_ raw: Int) -> String {
+    switch raw {
+    case 0: return "Created"
+    case 1: return "Claimed"
+    case 2: return "Reclaimed"
+    default: return "Unknown (\(raw))"
+    }
+}
+
+/// One created DashPay invitation (DIP-13). No secret column — the
+/// one-time voucher key is never stored.
+struct InvitationStorageDetailView: View {
+    let record: PersistentInvitation
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Status", value: invitationStatusLabel(record.statusRaw))
+                FieldRow(label: "Amount", value: String(format: "%.8f DASH", Double(record.amountDuffs) / 100_000_000))
+                FieldRow(label: "Amount (duffs)", value: "\(record.amountDuffs)")
+                FieldRow(label: "Funding index", value: "\(record.fundingIndexRaw)")
+                FieldRow(label: "Has inviter", value: record.hasInviter ? "Yes" : "No")
+            }
+            Section("Outpoint") {
+                FieldRow(label: "Outpoint", value: record.outPointHex)
+                FieldRow(label: "Raw outpoint", value: hexString(record.rawOutPoint))
+            }
+            Section("Wallet") {
+                FieldRow(label: "Wallet id", value: hexString(record.walletId))
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Expiry (unix)", value: "\(record.expiryUnix)")
+                FieldRow(label: "Created (unix)", value: "\(record.createdAtSecs)")
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+                FieldRow(label: "Updated", value: dateString(record.updatedAt))
+            }
+        }
+        .navigationTitle("Invitation")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - PersistentDashpayIgnoredSender
+
+/// One DashPay ignored sender (per-sender mute, local-only).
+struct DashpayIgnoredSenderStorageDetailView: View {
+    let record: PersistentDashpayIgnoredSender
+
+    var body: some View {
+        Form {
+            Section("Suppression key") {
+                FieldRow(label: "Owner", value: hexString(record.ownerIdentityId))
+                FieldRow(label: "Ignored sender", value: hexString(record.ignoredSenderId))
+            }
+            Section("Audit") {
+                FieldRow(label: "Ignored", value: dateString(record.ignoredAt))
+            }
+        }
+        .navigationTitle("Ignored Sender")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}


### PR DESCRIPTION
## Summary

The storage explorer covered 19 of the SDK's 34 SwiftData models — and none of the DashPay family. This ports the example app's views for the missing DashPay models:

| Model | Explorer row |
|---|---|
| `PersistentDPNSName` | DPNS Names |
| `PersistentDashpayProfile` | DashPay Profiles |
| `PersistentDashpayContactProfile` | Contact Profiles |
| `PersistentDashpayContactRequest` | Contact Requests (grouped Outgoing / Incoming) |
| `PersistentDashpayPayment` | DashPay Payments |
| `PersistentInvitation` | Sent Invitations |
| `PersistentDashpayIgnoredSender` | Ignored Senders |

Each gets a list view + full field-dump detail view (copyable rows), matching the existing explorer conventions. Adaptations from the example app: per-network filtering dropped (dashwallet's `ModelContainer` is per-network already), `AppDate` → the local `dateString` helper, and the contact-request detail additionally surfaces the owner-private **alias/note** meta that backs the contacts list titles and payment-row aliases.

### Second commit — full parity
The remaining example-app views are ported too: **Pending Inputs**, **Asset Locks** (linked-identity resolution; recipient platform address encoded via the app's shared `Bech32m` instead of the example's private encoder; `statusLabel` extension added since the SDK doesn't ship it), **Masternodes**, **Shielded Notes** (All/Unspent/Spent filter), **Shielded Sent Notes**, **Shielded Activity**, **Shielded Sync State**, **Shielded Viewing Keys**. Every SDK SwiftData model (34/34) is now browsable.

~~**Still unported**~~ (done in the second commit) (follow-up material if wanted): asset locks, pending inputs, masternodes, and the five shielded views.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] Tools → Storage Explorer shows the seven new rows with live counts; contact request / payment / profile drill-downs render the QA wallet's real rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
