### PR TITLE
fix(ui): register the ported explorer models in loadCounts

### DIFF
--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
@@ -169,6 +169,24 @@ struct StorageExplorerView: View {
         count(PersistentTransaction.self)
         count(PersistentTxo.self)
         count(PersistentWalletManagerMetadata.self)
+        // DashPay family + asset locks / masternodes / shielded (the
+        // ported list views) — a row whose model isn't counted here
+        // shows a misleading 0 next to a non-empty list.
+        count(PersistentDPNSName.self)
+        count(PersistentDashpayProfile.self)
+        count(PersistentDashpayContactProfile.self)
+        count(PersistentDashpayContactRequest.self)
+        count(PersistentDashpayPayment.self)
+        count(PersistentInvitation.self)
+        count(PersistentDashpayIgnoredSender.self)
+        count(PersistentPendingInput.self)
+        count(PersistentAssetLock.self)
+        count(PersistentMasternode.self)
+        count(PersistentShieldedNote.self)
+        count(PersistentShieldedOutgoingNote.self)
+        count(PersistentShieldedActivity.self)
+        count(PersistentShieldedSyncState.self)
+        count(PersistentShieldedViewingKey.self)
         // Core and Platform address rows live in separate models now
         // (PersistentCoreAddress vs PersistentPlatformAddress), so
         // counting them is a plain `fetchCount` per model.


### PR DESCRIPTION
## Summary

Follow-up to #832: the new explorer rows read their count badge from the `counts` dictionary, but `loadCounts()` was never taught about the ported models — so every new row showed **0** while its drill-in `@Query` list rendered the real records (QA repro: "Contact Requests 0" on the root list, 4 rows inside).

Registers all fifteen ported models (DashPay family ×7, pending inputs, asset locks, masternodes, shielded ×5) in `loadCounts()`.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] Explorer root badges match the drill-in list counts (Contact Requests 4, Contact Profiles 1, DashPay Payments 3, Asset Locks 4, shielded rows non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)