### PR TITLE
fix(dashpay): write contact alias/note/hidden through setDashPayContactInfo

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -530,84 +530,52 @@ final class SwiftDashSDKContactsService: ObservableObject {
         }
     }
 
-    /// Set / clear the owner-private alias on an established contact.
-    /// Local-only state (no on-chain artifact, no auth gate); durably
-    /// persisted via `flushPersist`.
-    func setAlias(_ alias: String?, for contactId: Data) async throws {
-        try await mutateEstablishedContact(contactId) { contact in
-            if let alias, !alias.isEmpty {
-                try contact.setAlias(alias)
-            } else {
-                try contact.clearAlias()
-            }
-        }
-    }
+    /// Write the owner-private contact metadata (alias / note / hidden)
+    /// for an established contact. One combined write: the SDK's
+    /// `setDashPayContactInfo` updates the wallet manager's REAL contact
+    /// state, persists it (feeds the SwiftData mirror the contacts list
+    /// and payment rows read), and publishes the self-encrypted DIP-15
+    /// `contactInfo` document to Platform — the "remote wins" convergence
+    /// that makes the alias roam across devices.
+    ///
+    /// The publish signs a Platform document with the identity key, so
+    /// this is PIN/biometric-gated like every other document write.
+    /// Empty strings clear their field. Returns the publish outcome —
+    /// local state is saved even when the document publish was deferred
+    /// (DIP-15 defers until ≥ 2 established contacts) or skipped
+    /// (watch-only identity).
+    ///
+    /// Replaces the deprecated `EstablishedContact.setAlias/setNote/hide`
+    /// path, which mutated a detached FFI handle clone — nothing it wrote
+    /// ever reached wallet state, disk, or Platform (platform PR #4140).
+    @discardableResult
+    func setContactMeta(
+        alias: String?,
+        note: String?,
+        hidden: Bool,
+        for contactId: Data
+    ) async throws -> ManagedPlatformWallet.ContactInfoPublishOutcome {
+        let (wallet, modelContainer, ownerId) = try requireContext()
 
-    /// Set / clear the owner-private note on an established contact.
-    func setNote(_ note: String?, for contactId: Data) async throws {
-        try await mutateEstablishedContact(contactId) { contact in
-            if let note, !note.isEmpty {
-                try contact.setNote(note)
-            } else {
-                try contact.clearNote()
-            }
-        }
-    }
+        try await authorize()
 
-    /// Hide / unhide an established contact (moves it to the Hidden
-    /// section of the contacts list).
-    func setHidden(_ hidden: Bool, for contactId: Data) async throws {
-        try await mutateEstablishedContact(contactId) { contact in
-            hidden ? try contact.hide() : try contact.unhide()
-        }
-    }
-
-    /// One in-memory lookup of an established contact — split out so the
-    /// mutation path can retry it after a resync.
-    private func establishedContactHandle(
-        wallet: ManagedPlatformWallet,
-        ownerId: Data,
-        contactId: Data
-    ) throws -> EstablishedContact? {
-        let identity = try wallet.managedIdentity(identityId: ownerId)
-        return try identity.getEstablishedContact(contactId: contactId)
-    }
-
-    private func mutateEstablishedContact(
-        _ contactId: Data,
-        _ mutate: (EstablishedContact) throws -> Void
-    ) async throws {
-        let (wallet, _, ownerId) = try requireContext()
+        let signer = KeychainSigner(modelContainer: modelContainer)
+        let outcome: ManagedPlatformWallet.ContactInfoPublishOutcome
         do {
-            // The SDK's in-memory contact state is PER-SESSION while the
-            // rows the UI acted on persist across sessions — same trap as
-            // `acceptContactRequest`. A miss doesn't mean the contact is
-            // gone: resync and look again before failing (setting an alias
-            // right after launch used to die here with the bogus
-            // "Contact request not found").
-            let contact: EstablishedContact
-            if let live = try establishedContactHandle(wallet: wallet, ownerId: ownerId, contactId: contactId) {
-                contact = live
-            } else {
-                Self.logger.info("👥 CONTACTS :: established contact not in memory — resyncing before mutation")
-                await syncNow()
-                guard let retried = try establishedContactHandle(wallet: wallet, ownerId: ownerId, contactId: contactId) else {
-                    throw ServiceError.requestNotFound
-                }
-                contact = retried
-            }
-            try mutate(contact)
-            // Durability: the setters mutate in-memory Rust state; the
-            // flush lands the change in SwiftData via the persister,
-            // which also triggers the debounced snapshot refresh.
-            try wallet.flushPersist()
-        } catch let error as ServiceError {
-            throw error
+            outcome = try await wallet.setDashPayContactInfo(
+                identityId: ownerId,
+                contactId: contactId,
+                alias: alias?.isEmpty == false ? alias : nil,
+                note: note?.isEmpty == false ? note : nil,
+                hidden: hidden,
+                signer: signer)
         } catch {
-            Self.logger.error("👥 CONTACTS :: contact-meta mutation failed: \(String(describing: error), privacy: .public)")
+            Self.logger.error("👥 CONTACTS :: contact-meta write failed: \(String(describing: error), privacy: .public)")
             throw ServiceError.sdk(error)
         }
+        Self.logger.info("👥 CONTACTS :: contact meta saved — outcome \(String(describing: outcome), privacy: .public)")
         refresh()
+        return outcome
     }
 
     // MARK: - Contact-request eligibility

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -337,13 +337,19 @@ struct ContactProfileSheet: View {
     private func saveMeta() {
         Task { @MainActor in
             do {
-                try await service.setAlias(aliasText.trimmingCharacters(in: .whitespaces), for: contact.contactIdentityId)
-                try await service.setNote(noteText.trimmingCharacters(in: .whitespaces), for: contact.contactIdentityId)
+                // Combined write — the contactInfo document carries
+                // alias + note + hidden together, so every save sends the
+                // sheet's full current state.
+                try await service.setContactMeta(
+                    alias: aliasText.trimmingCharacters(in: .whitespaces),
+                    note: noteText.trimmingCharacters(in: .whitespaces),
+                    hidden: isHidden,
+                    for: contact.contactIdentityId)
                 withAnimation { metaSavedToast = true }
                 try? await Task.sleep(nanoseconds: 1_200_000_000)
                 withAnimation { metaSavedToast = false }
             } catch {
-                errorMessage = error.localizedDescription
+                errorMessage = errorMessageIfNotCancelled(error)
             }
         }
     }
@@ -351,12 +357,25 @@ struct ContactProfileSheet: View {
     private func toggleHidden() {
         Task { @MainActor in
             do {
-                try await service.setHidden(!isHidden, for: contact.contactIdentityId)
+                try await service.setContactMeta(
+                    alias: aliasText.trimmingCharacters(in: .whitespaces),
+                    note: noteText.trimmingCharacters(in: .whitespaces),
+                    hidden: !isHidden,
+                    for: contact.contactIdentityId)
                 isHidden.toggle()
             } catch {
-                errorMessage = error.localizedDescription
+                errorMessage = errorMessageIfNotCancelled(error)
             }
         }
+    }
+
+    /// A cancelled PIN/biometric prompt is a user action, not an error —
+    /// stay silent instead of popping the error alert.
+    private func errorMessageIfNotCancelled(_ error: Error) -> String? {
+        if case SwiftDashSDKContactsService.ServiceError.authCancelled = error {
+            return nil
+        }
+        return error.localizedDescription
     }
 
     // MARK: Payments between us — history card


### PR DESCRIPTION
## Summary

Saving a contact's alias/note (or hiding a contact) was a **complete no-op behind a "Saved" toast**. QA evidence: after saving an alias, the `contactAlias`/`contactNote` mirror columns in SwiftData stayed empty.

**Root cause (SDK-side):** the sheet was wired to `EstablishedContact.setAlias/setNote/hide`, which mutate a **detached FFI clone** — `managed_identity_get_established_contact` inserts a `.cloned()` copy into the handle table, so the mutation never reaches the wallet manager's contact state, is never persisted, and is lost when the handle is freed. (The earlier resync-retry fix on this path cured the *lookup* failure but couldn't cure the phantom write.)

**Fix:** rewire to the SDK's real write path — `ManagedPlatformWallet.setDashPayContactInfo` → `set_contact_info_with_external_signer`, which:
1. updates the wallet manager's real contact state (local first, works offline),
2. persists it — feeding the SwiftData mirror that the contacts list, payment-row aliases, and storage explorer read,
3. publishes the self-encrypted DIP-15 `contactInfo` document so alias/note/hidden **roam across devices** (outcome: published / deferred-until-2-contacts / skipped-watch-only).

Changes:
- One combined `setContactMeta(alias:note:hidden:for:)` replaces the three per-field setters (the document carries all three together; the sheet sends its full current state on every save).
- **Now PIN/biometric-gated** — the publish signs a Platform document with the identity key, same as every other document write. A cancelled prompt is silent, not an error alert.
- The clone-mutating path (`mutateEstablishedContact` + resync-retry) is deleted.

Companion: [platform#4140](https://github.com/dashpay/platform/pull/4140) deprecates the clone setters SDK-side so they can't be re-wired.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] Set an alias on a contact → PIN prompt → Saved; `contactAlias` mirror column non-empty (storage explorer → Contact Requests → detail) and payment rows read "Sent to <alias>"
- [ ] Relaunch → alias survives
- [ ] Hide/unhide round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)