### PR TITLE
docs(dashsync): bump the platform pin to v4.1-dev tip b889e05a1e

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -45,17 +45,19 @@ included.
 ## Platform pin
 
 The app builds against sibling `../platform` on **`v4.1-dev`** (verified
-2026-07-15: dashpay arm64-sim build green at app tip `5d90bac08` against
-`origin/v4.1-dev` tip `dc1d645df4` with a freshly rebuilt sim-slice
-xcframework; the seedless-shielded-bind API drift —
-`shieldedWithdraw`/`shieldedUnshield` gaining a per-operation
-`resolver:` — is adapted in `ShieldedTransferCoordinator`, and the tip's
-breaking managed-identity-top-up change (#4093) removed only legacy
-`SDK.identityTopUp`/`topUpIdentity` surfaces the app never called). Every app-required surface is upstream:
-tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay fee threading,
-`RawKeySigner` (#4097), the testnet faucet client (#4098), classified SPV peers,
-and the filter-rescan FFI (#4099). The `local/tx-decode-plus-v4.1-dev-dashwallet`
-integration branch is retired.
+2026-07-17: dashpay arm64-sim build green at app tip `1f195c6fb` against
+`origin/v4.1-dev` tip `b889e05a1e`; the tip's breaking change — platform
+#4140 removing `EstablishedContact`'s clone-mutating setters, which never
+wrote real state — requires app tip ≥ #834, where contact alias/note/hidden
+write through `setDashPayContactInfo` instead. Earlier drift notes (the
+seedless-shielded-bind `resolver:` parameter, the #4093 managed-identity-
+top-up removal) remain adapted as before). Every app-required surface is
+upstream: tx decoding (`TransactionDecoder`, key-wallet-ffi route), DashPay
+fee threading, `RawKeySigner` (#4097), the testnet faucet client (#4098),
+classified SPV peers, the filter-rescan FFI (#4099), and the
+partial-amount platform address withdrawal wrapper (#4139). The
+`local/tx-decode-plus-v4.1-dev-dashwallet` integration branch and the
+`v4.1-dev-local` sidecar are retired.
 
 No open nuances: the verified tip includes
 [platform #4049](https://github.com/dashpay/platform/pull/4049) (merged as


### PR DESCRIPTION
## Summary

Updates `DASHSYNC_MIGRATION.md`'s platform-pin record to today's verified pairing:

- **App tip `1f195c6fb`** (post-#834) against **`origin/v4.1-dev` tip `b889e05a1e`** — dashpay arm64-sim build green, 2026-07-17.
- Picks up [platform#4139](https://github.com/dashpay/platform/pull/4139) (partial-amount platform address withdrawal wrapper — the last app-required surface that previously lived only on a local sidecar branch) and [platform#4140](https://github.com/dashpay/platform/pull/4140) (removal of `EstablishedContact`'s clone-mutating setters).
- Records the new compatibility floor: platform tips ≥ #4140 require app tips ≥ [#834](https://github.com/dashpay/dashwallet-ios/pull/834) (contact meta writes through `setDashPayContactInfo`).
- Retires the `v4.1-dev-local` sidecar branch note — everything is upstream now; teammates should build against plain `v4.1-dev` plus the usual xcframework rebuild.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)