### PR TITLE
feat(ui): main-identity selection and a pushed identity detail page

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -66,6 +66,47 @@ public final class DWCurrentUserIdentityInfo: NSObject {
     /// `DWIdentityRegistrationCoordinator.pinnedIdentityIndex`.
     private static let pinnedIdentityIndex: UInt32 = 0
 
+    // MARK: - Main identity (per-wallet pick)
+
+    /// The SDK deliberately leaves primary-identity selection to the app
+    /// layer (`InMemoryWalletSummary.primaryIdentityId` is always nil
+    /// Rust-side), so the pick lives here: one UserDefaults slot per
+    /// wallet, holding the chosen identity's 32-byte id as hex. `nil` =
+    /// no explicit pick; the snapshot then falls back to identity index
+    /// 0, then the lowest registered index.
+    private static func mainIdentityDefaultsKey(walletId: Data) -> String {
+        "DWMainIdentityId." + walletId.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The stored main-identity pick for `walletId`, or nil.
+    static func mainIdentityId(walletId: Data) -> Data? {
+        guard let hex = UserDefaults.standard.string(forKey: mainIdentityDefaultsKey(walletId: walletId)),
+              hex.count == 64 else { return nil }
+        var bytes = Data(capacity: 32)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        return bytes
+    }
+
+    /// Store (or clear, with nil) the main-identity pick for `walletId`.
+    /// Storage only — callers drive the refresh/notification cascade so
+    /// DashPay surfaces re-key (see `IdentitiesViewModel.setMainIdentity`).
+    static func setMainIdentityId(_ identityId: Data?, walletId: Data) {
+        let key = mainIdentityDefaultsKey(walletId: walletId)
+        if let identityId {
+            UserDefaults.standard.set(
+                identityId.map { String(format: "%02x", $0) }.joined(),
+                forKey: key)
+        } else {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
     // MARK: - Snapshot
 
     /// Cached read of the SDK's current identity info. Rebuilt lazily
@@ -290,8 +331,19 @@ public final class DWCurrentUserIdentityInfo: NSObject {
             predicate: #Predicate { $0.walletId == walletId }
         )
         walletDescriptor.fetchLimit = 1
-        guard let persistedWallet = try? context.fetch(walletDescriptor).first,
-              let persisted = persistedWallet.identities.first(where: { $0.identityIndex == pinnedIndex })
+        guard let persistedWallet = try? context.fetch(walletDescriptor).first else {
+            return .empty
+        }
+        // Resolution order: the user's stored main-identity pick (when it
+        // still names one of this wallet's identities), then the pinned
+        // registration slot (index 0), then the lowest registered index —
+        // so a wallet whose only identity was discovered at a higher slot
+        // still resolves instead of reading as unregistered.
+        let identities = persistedWallet.identities
+        let mainPick = Self.mainIdentityId(walletId: walletId)
+        guard let persisted = identities.first(where: { mainPick != nil && $0.identityId == mainPick })
+            ?? identities.first(where: { $0.identityIndex == pinnedIndex })
+            ?? identities.min(by: { $0.identityIndex < $1.identityIndex })
         else {
             return .empty
         }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -33,7 +33,6 @@ struct IdentitiesScreen: View {
     private let vc: UINavigationController
 
     @StateObject private var viewModel = IdentitiesViewModel()
-    @State private var detailRow: IdentityRowModel? = nil
 
     init(vc: UINavigationController) {
         self.vc = vc
@@ -54,7 +53,7 @@ struct IdentitiesScreen: View {
                             ForEach(viewModel.rows) { row in
                                 IdentityRowView(row: row)
                                     .contentShape(Rectangle())
-                                    .onTapGesture { detailRow = row }
+                                    .onTapGesture { showDetail(row) }
                                 if row.id != viewModel.rows.last?.id {
                                     Divider().padding(.leading, 16)
                                 }
@@ -76,9 +75,6 @@ struct IdentitiesScreen: View {
         }
         .navigationBarHidden(true)
         .onAppear { viewModel.reload() }
-        .sheet(item: $detailRow) { row in
-            IdentityDetailSheet(row: row)
-        }
         .alert(
             NSLocalizedString("Error", comment: ""),
             isPresented: Binding(
@@ -100,6 +96,18 @@ struct IdentitiesScreen: View {
         } message: {
             Text(viewModel.infoMessage ?? "")
         }
+    }
+
+    // MARK: - Navigation
+
+    /// Push the identity's full detail page (WalletsScreen → accounts
+    /// pattern). A page, not a sheet: the detail carries actions
+    /// (set-main) and grows with future identity features.
+    private func showDetail(_ row: IdentityRowModel) {
+        let controller = UIHostingController(
+            rootView: IdentityDetailScreen(row: row, vc: vc, viewModel: viewModel))
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
     }
 
     // MARK: - Subviews
@@ -227,6 +235,12 @@ private struct IdentityRowView: View {
                             .font(.caption)
                             .foregroundColor(.yellow)
                     }
+                    if row.isMainIdentity {
+                        IdentityBadge(
+                            text: NSLocalizedString("Main", comment: "Identities — the wallet's main identity"),
+                            icon: "checkmark.seal.fill",
+                            color: .dashBlue)
+                    }
                 }
                 if let subtitle = row.subtitle {
                     Text(subtitle)
@@ -298,19 +312,44 @@ private struct IdentityBadge: View {
     }
 }
 
-// MARK: - Detail sheet
+// MARK: - Detail page
 
-/// Compact identity detail: full copyable id, balance, type, network
-/// status, owning wallet, key count, and every owned DPNS name.
-private struct IdentityDetailSheet: View {
+/// Full identity detail page (pushed, not a sheet): copyable id,
+/// balance, type, network status, owning wallet, key count, every owned
+/// DPNS name — and the main-identity control. The main identity is the
+/// one every DashPay surface keys on (username, avatar, contacts).
+struct IdentityDetailScreen: View {
     let row: IdentityRowModel
+    private let vc: UINavigationController
+    @ObservedObject private var viewModel: IdentitiesViewModel
 
     @State private var copied = false
+    /// Local main-state so the page reflects the change immediately;
+    /// seeded from the row, flipped on a successful set-main.
+    @State private var isMain: Bool
+    @State private var confirmSetMain = false
+
+    init(row: IdentityRowModel, vc: UINavigationController, viewModel: IdentitiesViewModel) {
+        self.row = row
+        self.vc = vc
+        self.viewModel = viewModel
+        _isMain = State(initialValue: row.isMainIdentity)
+    }
+
+    /// Only identities of the active wallet can become main — the pick
+    /// re-keys the live DashPay surfaces, which follow the active wallet.
+    private var canBecomeMain: Bool {
+        !isMain && row.walletId != nil
+            && row.walletId == SwiftDashSDKHost.shared.wallet?.walletId
+    }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+        ZStack {
+            Color.primaryBackground.ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 0) {
+                pageHeader
+
                 ScrollView {
                     VStack(alignment: .leading, spacing: 14) {
                         idCard
@@ -318,15 +357,118 @@ private struct IdentityDetailSheet: View {
                         if !row.dpnsNames.isEmpty {
                             namesCard
                         }
+                        mainIdentityCard
                     }
                     .padding(20)
                 }
             }
-            .navigationTitle(row.title)
-            .navigationBarTitleDisplayMode(.inline)
         }
-        .presentationDetents([.medium, .large])
-        .presentationDragIndicator(.visible)
+        .navigationBarHidden(true)
+        .alert(
+            NSLocalizedString("Set as Main Identity", comment: "Identities"),
+            isPresented: $confirmSetMain
+        ) {
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
+            Button(NSLocalizedString("Set as Main", comment: "Identities")) {
+                viewModel.setMainIdentity(row)
+                if viewModel.errorMessage == nil {
+                    isMain = true
+                }
+            }
+        } message: {
+            Text(NSLocalizedString(
+                "Your username, profile, and contacts will follow this identity.",
+                comment: "Identities"))
+        }
+        .alert(
+            NSLocalizedString("Error", comment: ""),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } })
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    private var pageHeader: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Button(action: { vc.popViewController(animated: true) }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundColor(.primary)
+                        .frame(width: 36, height: 36)
+                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 5)
+            .padding(.top, 10)
+
+            HStack(spacing: 6) {
+                Text(row.title)
+                    .font(.title)
+                    .fontWeight(.bold)
+                    .foregroundColor(.primaryText)
+                    .lineLimit(1)
+                if isMain {
+                    Image(systemName: "checkmark.seal.fill")
+                        .font(.system(size: 20))
+                        .foregroundColor(.dashBlue)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 6)
+        }
+    }
+
+    /// Main-identity control: a checked state when this IS the main,
+    /// a Set button when it can become it, and an explanatory line when
+    /// it can't (other wallet's identity).
+    private var mainIdentityCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if isMain {
+                HStack(spacing: 8) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundColor(.dashBlue)
+                    Text(NSLocalizedString("This is your main identity", comment: "Identities"))
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundColor(.primaryText)
+                }
+                Text(NSLocalizedString(
+                    "Your username, profile, and contacts follow this identity.",
+                    comment: "Identities"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondaryText)
+            } else if canBecomeMain {
+                Button(action: { confirmSetMain = true }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.seal")
+                        Text(NSLocalizedString("Set as Main Identity", comment: "Identities"))
+                    }
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color.dashBlue)
+                    .cornerRadius(12)
+                }
+            } else {
+                Text(NSLocalizedString(
+                    "The main identity can only be chosen from the active wallet",
+                    comment: "Identities"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.secondaryText)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color.secondaryBackground)
+        .cornerRadius(12)
     }
 
     private var idCard: some View {

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -50,10 +50,18 @@ struct IdentityRowModel: Identifiable {
     let type: IdentityType
     let isLocal: Bool
     let walletName: String?
+    /// Owning wallet id — main-identity selection is scoped to the
+    /// active wallet, so the detail page needs this to offer it.
+    let walletId: Data?
     let identityIndex: UInt32
     let publicKeyCount: Int
     /// Every DPNS label owned by this identity (detail sheet list).
     let dpnsNames: [String]
+    /// True when this identity is the wallet's resolved MAIN identity —
+    /// the one `DWCurrentUserIdentityInfo` reads, i.e. the owner of
+    /// DashPay mode (username, avatar, contacts). Resolution = stored
+    /// pick → index 0 → lowest index.
+    let isMainIdentity: Bool
 
     var id: Data { identityId }
 }
@@ -81,7 +89,46 @@ final class IdentitiesViewModel: ObservableObject {
             predicate: PersistentIdentity.predicate(network: network),
             sortBy: [SortDescriptor(\.identityIndex, order: .forward)])
         let identities = (try? container.mainContext.fetch(descriptor)) ?? []
-        rows = identities.map(Self.rowModel(for:))
+        // The RESOLVED main identity (stored pick → index 0 → lowest) —
+        // read from the same source every DashPay surface reads, so the
+        // star can't disagree with actual behavior.
+        let mainIdentityId = DWCurrentUserIdentityInfo.shared.identityId
+        rows = identities.map { Self.rowModel(for: $0, mainIdentityId: mainIdentityId) }
+    }
+
+    /// Make `row` the wallet's main identity: the one every DashPay
+    /// surface keys on (username, avatar, contacts owner). Stores the
+    /// per-wallet pick, then drives the same refresh cascade a
+    /// registration completion does so the app re-keys live: identity
+    /// snapshot, DWGlobalOptions username mirror (the new main's name,
+    /// or cleared when it has none — the Join banner then honestly
+    /// returns), the registration-status notification chain, and the
+    /// contacts snapshots.
+    func setMainIdentity(_ row: IdentityRowModel) {
+        guard let activeWalletId = SwiftDashSDKHost.shared.wallet?.walletId else {
+            errorMessage = NSLocalizedString("Wallet is not ready", comment: "Identities")
+            return
+        }
+        guard row.walletId == activeWalletId else {
+            errorMessage = NSLocalizedString(
+                "The main identity can only be chosen from the active wallet",
+                comment: "Identities")
+            return
+        }
+
+        DWCurrentUserIdentityInfo.setMainIdentityId(row.identityId, walletId: activeWalletId)
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+
+        let options = DWGlobalOptions.sharedInstance()
+        let username = DWCurrentUserIdentityInfo.shared.username
+        options.dashpayUsername = username
+        options.dashpayRegistrationCompleted = username?.isEmpty == false
+
+        NotificationCenter.default.post(
+            name: DWIdentityRegistrationBridge.stateChangedNotification,
+            object: nil)
+        SwiftDashSDKContactsService.shared.refresh()
+        reload()
     }
 
     /// One-shot Platform refresh, pull-to-refresh style: re-fetch each
@@ -214,7 +261,7 @@ final class IdentitiesViewModel: ObservableObject {
 
     // MARK: - Mapping
 
-    private static func rowModel(for identity: PersistentIdentity) -> IdentityRowModel {
+    private static func rowModel(for identity: PersistentIdentity, mainIdentityId: Data?) -> IdentityRowModel {
         let hasName = (identity.alias?.isEmpty == false)
             || (identity.mainDpnsName?.isEmpty == false)
             || (identity.dpnsName?.isEmpty == false)
@@ -232,9 +279,11 @@ final class IdentitiesViewModel: ObservableObject {
             type: identity.identityTypeEnum,
             isLocal: identity.isLocal,
             walletName: identity.wallet?.label.nonEmptyString,
+            walletId: identity.wallet?.walletId,
             identityIndex: identity.identityIndex,
             publicKeyCount: identity.publicKeys.count,
-            dpnsNames: identity.dpnsNames.map(\.label))
+            dpnsNames: identity.dpnsNames.map(\.label),
+            isMainIdentity: mainIdentityId != nil && identity.identityId == mainIdentityId)
     }
 
     private static func uint64(from value: Any?) -> UInt64? {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2016,6 +2016,9 @@
 /* Voting */
 "Low to high" = "Low to high";
 
+/* Identities — the wallet's main identity */
+"Main" = "Main";
+
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
 
@@ -3221,6 +3224,12 @@
 /* Masternodes */
 "Service" = "Service";
 
+/* Identities */
+"Set as Main" = "Set as Main";
+
+/* Identities */
+"Set as Main Identity" = "Set as Main Identity";
+
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
 
@@ -3571,6 +3580,9 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "The main identity can only be chosen from the active wallet";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
@@ -3654,6 +3666,9 @@
 
 /* Send screen */
 "This is not a valid Dash address for this network" = "This is not a valid Dash address for this network";
+
+/* Identities */
+"This is your main identity" = "This is your main identity";
 
 /* Masternodes */
 "This masternode has no Platform identity yet." = "This masternode has no Platform identity yet.";
@@ -4620,6 +4635,12 @@
 
 /* Usernames */
 "Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Your username, profile, and contacts follow this identity.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Your username, profile, and contacts will follow this identity.";
 
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";


### PR DESCRIPTION
## Summary

Two changes to the Identities screen (More → Identities):

### Pushed detail page
Tapping an identity now pushes a full page (same pattern as Wallets → accounts) instead of the compact modal sheet. Same content — copyable id card, info card, owned usernames — plus the new main-identity control, with room to grow.

### Set your main identity
The SDK deliberately leaves primary-identity selection to the app layer (`InMemoryWalletSummary.primaryIdentityId` is always nil Rust-side, "source the user's pick from app state"). So:

- The pick is stored app-side, **per wallet** (`UserDefaults`, `DWMainIdentityId.<walletIdHex>`).
- `DWCurrentUserIdentityInfo` resolves the current identity as **stored pick → identity index 0 → lowest registered index**. The new last fallback also fixes a latent gap: a wallet whose only identity was discovered at a higher slot used to read as unregistered.
- Setting main runs the registration-completion cascade so everything re-keys live: identity snapshot, the `DWGlobalOptions` username mirror (re-pointed at the new main's name, or cleared — the Join banner then honestly returns), the registration-status notification chain, and the contacts snapshots.
- Scoped to the **active wallet** (DashPay surfaces follow it); identities of other wallets get an explanatory line instead of the button. Confirmation alert states the consequence ("Your username, profile, and contacts will follow this identity").
- The resolved main is badged with a seal on the list row and the page header — read from the same resolution every DashPay surface uses, so the badge can't disagree with behavior.

## Test plan
- [x] Clean `dashpay` simulator build (arm64); installed on QA-iPhone16
- [ ] Tap identity → detail page pushes (no sheet); back chevron pops
- [ ] Single-identity wallet: row and page show the Main seal (index-0 fallback)
- [ ] With a second identity (e.g. via Find on a multi-slot seed): Set as Main → confirm → home avatar/username and Contacts owner follow the pick; survives relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)