### PR TITLE
fix(ui): retire Join DashPay for synced-in identities; Core Sync Status label

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -395,6 +395,34 @@ public final class DWCurrentUserIdentityInfo: NSObject {
             username = Self.nilIfEmpty(DWGlobalOptions.sharedInstance().dashpayUsername)
         }
 
+        // Self-heal the DWGlobalOptions mirror. Registration completion
+        // and Find-identities adoption are the only writers, so an
+        // identity that arrived any other way (synced in after a
+        // reinstall, registered under an older build) leaves the mirror
+        // empty forever — and every mirror reader (the menu's Join
+        // DashPay banner, DWDashPayModel's registration status) then
+        // disagrees with the SDK truth rendered everywhere else. Only an
+        // SDK-sourced name qualifies (`usernames` — the fallback above
+        // IS the mirror), and the pending-contested filter has already
+        // run, so a deferred contested registration can't sneak in. The
+        // bridge notification is posted async: this runs lazily inside a
+        // property read, and DWDashPayModel re-posting the canonical
+        // status update reentrantly mid-read is the kind of surprise we
+        // don't need.
+        if let sdkUsername = usernames.first,
+           DWGlobalOptions.sharedInstance().dashpayUsername?.isEmpty != false {
+            let options = DWGlobalOptions.sharedInstance()
+            options.dashpayUsername = sdkUsername
+            options.dashpayRegistrationCompleted = true
+            Self.logger.info(
+                "🪪 IDENT-INFO :: backfilled username mirror from SDK: \(sdkUsername, privacy: .public)")
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(
+                    name: DWIdentityRegistrationBridge.stateChangedNotification,
+                    object: nil)
+            }
+        }
+
         Self.logger.debug(
             "🪪 IDENT-INFO :: snapshot username=\(username ?? "nil", privacy: .public) hasProfile=\(displayName != nil || avatarURL != nil, privacy: .public) id=\(hex.prefix(8), privacy: .public)…")
 

--- a/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
+++ b/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
@@ -69,12 +69,20 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
     }
 
     /// The menu's Join DashPay banner: only while synced AND not already
-    /// registered. A wallet whose identity owns a username (fresh
-    /// registration or an adopted discovered identity — both write the
-    /// `DWGlobalOptions.dashpayUsername` mirror) has nothing to join;
-    /// checking sync state alone kept the banner up forever.
+    /// registered. "Registered" is the SDK truth
+    /// (`DWCurrentUserIdentityInfo`, which also backfills the
+    /// `DWGlobalOptions.dashpayUsername` mirror when it finds a name the
+    /// mirror missed) OR the mirror itself — the mirror alone misses
+    /// identities that synced in without completing registration on this
+    /// install, which kept the banner up on a wallet that already has a
+    /// username.
     private func updateShowJoinDashpay() {
-        let hasUsername = DWGlobalOptions.sharedInstance().dashpayUsername?.isEmpty == false
+        var hasUsername = DWGlobalOptions.sharedInstance().dashpayUsername?.isEmpty == false
+        if !hasUsername {
+            hasUsername = MainActor.assumeIsolated {
+                DWCurrentUserIdentityInfo.shared.username?.isEmpty == false
+            }
+        }
         showJoinDashpay = model.state == .syncDone && !hasUsername
     }
     

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
@@ -91,7 +91,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
 
             // Header
             HStack {
-                Text("SwiftDashSDK SPV Status")
+                Text("Core Sync Status")
                     .font(.title)
                     .fontWeight(.bold)
                     .foregroundColor(.primaryText)

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SyncInfoMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SyncInfoMenuViewModel.swift
@@ -40,7 +40,7 @@ class SyncInfoMenuViewModel: ObservableObject {
     private func setupMenuItems() {
         items = [
             MenuItemModel(
-                title: "SwiftDashSDK SPV Status",
+                title: "Core Sync Status",
                 icon: .system("arrow.triangle.2.circlepath"),
                 action: { [weak self] in
                     self?.navigationDestination = .swiftDashSDKSPVStatus


### PR DESCRIPTION
## Problem

The More menu showed **Join DashPay — Request your username** on a device whose wallet already owns `Quantumtester2` (QA-iPhone16). #831 gated the banner on the `DWGlobalOptions.dashpayUsername` mirror, but the mirror is written only by an on-device registration completion or the explicit Find-identities adoption. An identity that arrived any other way — synced in from Platform after a reinstall, or registered under an earlier build — leaves the mirror empty forever, so every mirror reader disagrees with the SDK truth rendered everywhere else.

## Fix

- **Self-heal the mirror at the source.** `DWCurrentUserIdentityInfo.computeSnapshot` now backfills `dashpayUsername` + `dashpayRegistrationCompleted` whenever the SDK yields a real DPNS name and the mirror is empty, then posts the bridge state-change notification (async — the compute runs inside a lazy property read) so `DWDashPayModel` re-posts the canonical status update and every consumer re-keys. Only SDK-sourced names qualify (the mirror fallback can't feed itself), and the pending-contested filter has already run, so a deferred contested registration can't leak in. This fixes the whole class of stale-mirror bugs, not just this banner.
- **Gate reads SDK truth too.** `CurrentUserProfileModel.updateShowJoinDashpay` checks `DWCurrentUserIdentityInfo.shared.username` alongside the mirror — which both corrects the gate immediately and triggers the backfill the moment the More menu renders.

## Also

Sync Info's first row (and that screen's header) renamed **SwiftDashSDK SPV Status → Core Sync Status**, matching the Platform / DashPay / Shielded naming of its siblings.

## Test plan

- [x] dashpay arm64-sim build green; installed on QA-iPhone16
- [ ] Open More on the affected install → Join DashPay banner is gone (backfill log `IDENT-INFO :: backfilled username mirror` fires on first snapshot read)
- [ ] Sync Info → first row reads Core Sync Status; detail header matches
- [ ] Fresh wallet with no identity → banner still appears after sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)