### PR TITLE
feat(ui): shielded operations in the home transaction history

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -687,6 +687,8 @@
 		751C05DB2D3D0E8C00475E52 /* JoinDashPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751C05DA2D3D0E7C00475E52 /* JoinDashPayViewModel.swift */; };
 		751C05DD2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */; };
 		751C05DE2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */; };
+		5A1EC0FE2E29A10000000002 /* ShieldedActivityHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */; };
+		5A1EC0FE2E29A10000000003 /* ShieldedActivityHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */; };
 		7527720D2AA9B2630066557E /* SupportedTopperAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527720C2AA9B2630066557E /* SupportedTopperAssets.swift */; };
 		7527720F2AA9F58E0066557E /* TopperViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527720E2AA9F58E0066557E /* TopperViewModel.swift */; };
 		752772122AAA1CE30066557E /* Coinbase-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 752772112AAA1CE30066557E /* Coinbase-Info.plist */; };
@@ -2889,6 +2891,7 @@
 		751C05D82D3BB6A200475E52 /* CurrentUserProfileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserProfileModel.swift; sourceTree = "<group>"; };
 		751C05DA2D3D0E7C00475E52 /* JoinDashPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinDashPayViewModel.swift; sourceTree = "<group>"; };
 		751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListDataItem.swift; sourceTree = "<group>"; };
+		5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldedActivityHistory.swift; sourceTree = "<group>"; };
 		7527720C2AA9B2630066557E /* SupportedTopperAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedTopperAssets.swift; sourceTree = "<group>"; };
 		7527720E2AA9F58E0066557E /* TopperViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopperViewModel.swift; sourceTree = "<group>"; };
 		752772112AAA1CE30066557E /* Coinbase-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Coinbase-Info.plist"; sourceTree = "<group>"; };
@@ -4420,6 +4423,7 @@
 				C9F452002A0CE6C900825057 /* HomeView.swift */,
 				754BEA112C0B6BD700E8C93C /* HomeViewModel.swift */,
 				751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */,
+				5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */,
 				75D657662DF579F300ACE570 /* TransactionFilterDialog.swift */,
 			);
 			path = Views;
@@ -9876,6 +9880,7 @@
 				752F81AA2E323FDB00ADA76D /* ToolsMenuViewModel.swift in Sources */,
 				470AE1882926600A001A0514 /* PaymentController.swift in Sources */,
 				751C05DE2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */,
+				5A1EC0FE2E29A10000000003 /* ShieldedActivityHistory.swift in Sources */,
 				2ADB396C242615C200A6F898 /* CALayer+MBAnimationPersistence.m in Sources */,
 				2A9FFDF42230FF1A00956D5F /* UIView+DWAnimations.m in Sources */,
 				114573A42949B221009DCF27 /* VerifiedSuccessfullyViewController.swift in Sources */,
@@ -10689,6 +10694,7 @@
 				C9D2C70A2A320AA000D15901 /* CoinsToAddressTxFilter.swift in Sources */,
 				C9D2C95E2A386D7E00D15901 /* DWBasePressableControl.m in Sources */,
 				751C05DD2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */,
+				5A1EC0FE2E29A10000000002 /* ShieldedActivityHistory.swift in Sources */,
 				C9D2C70B2A320AA000D15901 /* DWDemoAppRootViewController.m in Sources */,
 				C9D2C70C2A320AA000D15901 /* DWUpholdLogoutTutorialViewController.m in Sources */,
 				75A8C1672AE5734A0042256E /* UsernameRequest.swift in Sources */,

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -616,7 +616,7 @@ struct HomeViewContent<Content: View>: View {
                 subtitle: item.shortTimeString,
                 details: item.detailsText,
                 dashAmount: item.signedDashAmount,
-                amountSign: item.direction == .selfTransfer ? .none : .always,
+                amountSign: item.showsDirectionSign ? .always : .none,
                 fiat: item.fiatAmount,
                 trailingStatusText: item.trailingStatusText
             ) {

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -607,6 +607,22 @@ struct HomeViewContent<Content: View>: View {
                 }
             }
             .frame(minHeight: 66)
+
+        case .shieldedActivity(let item):
+            DashUIKit.TransactionView(
+                iconView: transferRouteIcon("shield.fill"),
+                secondaryIcon: item.secondarySystemIcon.map { DashIconSource.system($0) },
+                title: item.title,
+                subtitle: item.shortTimeString,
+                details: item.detailsText,
+                dashAmount: item.signedDashAmount,
+                amountSign: item.direction == .selfTransfer ? .none : .always,
+                fiat: item.fiatAmount,
+                trailingStatusText: item.trailingStatusText
+            ) {
+                self.selectedTxDataItem = txDataItem
+            }
+            .frame(minHeight: 66)
         }
     }
 }
@@ -821,6 +837,8 @@ struct TransactionDetailsSheet: View {
             )
         case .tx(let txItem, _):
             TXDetailVCWrapper(tx: txItem, navigateBack: $backNavigationRequested)
+        case .shieldedActivity(let item):
+            ShieldedActivityDetailsView(item: item)
         }
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -372,6 +372,21 @@ class HomeViewModel: ObservableObject {
                 return .tx(wrappedTx, self.resolveMetadata(for: wrappedTx.txHashData, in: metadataSnapshots))
             }
 
+            // Interleave the shielded operations (private receives/sends,
+            // Platform↔Shielded moves, shielded identity fundings) — the
+            // Core rows above only cover operations with an L1 leg. The
+            // day-grouping sort below merges the two timelines.
+            let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity()
+            for shielded in shieldedItems {
+                guard self.passesShieldedFilter(
+                    item: shielded,
+                    selected: self.selectedFilters,
+                    hasRewards: hasRewards,
+                    hasMasternodes: hasMasternodes)
+                else { continue }
+                items.append(.shieldedActivity(shielded))
+            }
+
             self.txByHash.removeAll()
             items.forEach { item in
                 self.txByHash[item.id] = item
@@ -794,6 +809,39 @@ extension HomeViewModel {
         return !selected.isDisjoint(with: categories(of: transaction, giftCardTxIds: giftCardTxIds))
     }
 
+    /// Filter check for a pure-shielded history item — the counterpart of
+    /// `passesFilter(transaction:...)` with the same "everything offered
+    /// selected → show all" fast path. Direction maps to the dedicated
+    /// shielded categories only (never plain sent/received: those mean
+    /// on-chain transparent movements).
+    private func passesShieldedFilter(
+        item: ShieldedActivityItem,
+        selected: Set<TransactionFilterCategory>,
+        hasRewards: Bool,
+        hasMasternodes: Bool
+    ) -> Bool {
+        var offered = Set(TransactionFilterCategory.allCases)
+        if !hasRewards {
+            offered.remove(.rewards)
+        }
+        if !hasMasternodes {
+            offered.remove(.masternode)
+        }
+        if selected.isSuperset(of: offered) {
+            return true
+        }
+        var categories: Set<TransactionFilterCategory> = []
+        switch item.direction {
+        case .incoming:
+            categories.insert(.shieldedReceived)
+        case .outgoing:
+            categories.insert(.shieldedSent)
+        case .selfTransfer:
+            categories.formUnion([.shieldedSent, .shieldedReceived])
+        }
+        return !selected.isDisjoint(with: categories)
+    }
+
     /// Categories a transaction belongs to. Overlaps are allowed (a gift-card
     /// purchase is also a sent tx); rewards and shielded receipts are carved
     /// out of received, mirroring how the old single-select filter separated
@@ -1003,6 +1051,44 @@ class SwiftDashSDKWalletSource: TransactionSource {
     static func fetch(txid: Data) -> Transaction? {
         guard let (container, walletId) = hostHandles() else { return nil }
         return fetchOne(txid: txid, in: ModelContext(container), walletId: walletId)
+    }
+
+    /// The active wallet's shielded operations as history items, for
+    /// interleaving with the Core rows. Safe from any thread.
+    ///
+    /// Two reductions happen here rather than in the view model:
+    /// - Kinds whose Core leg already renders as a history row are
+    ///   dropped — ShieldFromAssetLock (`Transaction.isShieldedTransfer`)
+    ///   and Withdrawal (`Transaction.isShieldedWithdrawalReceipt`) —
+    ///   so one user action never shows as two rows.
+    /// - Rows are deduped by `entryId`: an intra-wallet transfer writes
+    ///   a Sent row on the sending account and a Received row on the
+    ///   receiving account for the same operation; the outgoing
+    ///   (initiating) side wins.
+    static func fetchShieldedActivity() -> [ShieldedActivityItem] {
+        guard let (container, walletId) = hostHandles() else { return [] }
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<PersistentShieldedActivity>(
+            predicate: #Predicate { $0.walletId == walletId })
+        guard let rows = try? context.fetch(descriptor) else { return [] }
+
+        let coreLegKinds = [
+            ShieldedActivityItem.Kind.shieldFromAssetLock.rawValue,
+            ShieldedActivityItem.Kind.withdrawal.rawValue,
+        ]
+        var byEntry: [Data: PersistentShieldedActivity] = [:]
+        for row in rows where !coreLegKinds.contains(row.kindTag) {
+            if let existing = byEntry[row.entryId] {
+                let existingOutgoing = existing.direction == ShieldedActivityItem.Direction.outgoing.rawValue
+                let rowOutgoing = row.direction == ShieldedActivityItem.Direction.outgoing.rawValue
+                if !existingOutgoing && rowOutgoing {
+                    byEntry[row.entryId] = row
+                }
+            } else {
+                byEntry[row.entryId] = row
+            }
+        }
+        return byEntry.values.map { ShieldedActivityItem(row: $0) }
     }
 
     /// The host is `@MainActor`-isolated; grab its container + active-wallet

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1056,11 +1056,16 @@ class SwiftDashSDKWalletSource: TransactionSource {
     /// The active wallet's shielded operations as history items, for
     /// interleaving with the Core rows. Safe from any thread.
     ///
-    /// Two reductions happen here rather than in the view model:
-    /// - Kinds whose Core leg already renders as a history row are
-    ///   dropped — ShieldFromAssetLock (`Transaction.isShieldedTransfer`)
-    ///   and Withdrawal (`Transaction.isShieldedWithdrawalReceipt`) —
-    ///   so one user action never shows as two rows.
+    /// Three reductions happen here rather than in the view model:
+    /// - ShieldFromAssetLock entries are dropped: their Core asset-lock
+    ///   spend always renders as a history row already
+    ///   (`Transaction.isShieldedTransfer`).
+    /// - Withdrawal entries are dropped ONLY when the destination script
+    ///   is one of the active wallet's own Core addresses — that's the
+    ///   internal Shielded→Transparent transfer, whose Core receipt
+    ///   renders via `Transaction.isShieldedWithdrawalReceipt`. A
+    ///   withdrawal to an EXTERNAL Core address produces no wallet-side
+    ///   Core transaction at all, so it stays and renders as a Sent row.
     /// - Rows are deduped by `entryId`: an intra-wallet transfer writes
     ///   a Sent row on the sending account and a Received row on the
     ///   receiving account for the same operation; the outgoing
@@ -1072,12 +1077,8 @@ class SwiftDashSDKWalletSource: TransactionSource {
             predicate: #Predicate { $0.walletId == walletId })
         guard let rows = try? context.fetch(descriptor) else { return [] }
 
-        let coreLegKinds = [
-            ShieldedActivityItem.Kind.shieldFromAssetLock.rawValue,
-            ShieldedActivityItem.Kind.withdrawal.rawValue,
-        ]
         var byEntry: [Data: PersistentShieldedActivity] = [:]
-        for row in rows where !coreLegKinds.contains(row.kindTag) {
+        for row in rows where row.kindTag != ShieldedActivityItem.Kind.shieldFromAssetLock.rawValue {
             if let existing = byEntry[row.entryId] {
                 let existingOutgoing = existing.direction == ShieldedActivityItem.Direction.outgoing.rawValue
                 let rowOutgoing = row.direction == ShieldedActivityItem.Direction.outgoing.rawValue
@@ -1088,7 +1089,49 @@ class SwiftDashSDKWalletSource: TransactionSource {
                 byEntry[row.entryId] = row
             }
         }
-        return byEntry.values.map { ShieldedActivityItem(row: $0) }
+
+        var items: [ShieldedActivityItem] = []
+        for row in byEntry.values {
+            if row.kindTag == ShieldedActivityItem.Kind.withdrawal.rawValue {
+                let address = withdrawalDestinationAddress(counterparty: row.counterparty)
+                if let address, isActiveWalletCoreAddress(address, walletId: walletId, in: context) {
+                    // Internal Shielded→Transparent transfer — the Core
+                    // receipt row represents it.
+                    continue
+                }
+                // External (or undecodable-script) withdrawal: nothing
+                // else in the history covers it — hiding it would make
+                // funds silently vanish from the timeline.
+                items.append(ShieldedActivityItem(row: row, externalWithdrawalAddress: address))
+            } else {
+                items.append(ShieldedActivityItem(row: row))
+            }
+        }
+        return items
+    }
+
+    /// Decode a withdrawal entry's counterparty (a Core scriptPubKey)
+    /// to a Base58Check address. Nil for empty / non-P2PKH/P2SH scripts.
+    private static func withdrawalDestinationAddress(counterparty: Data) -> String? {
+        guard !counterparty.isEmpty else { return nil }
+        let network: PaymentNetwork = WalletEnvironment.isTestnet ? .testnet : .mainnet
+        return ScriptAddressCodec.address(forScript: counterparty, network: network)
+    }
+
+    /// True when `address` belongs to the ACTIVE wallet's Core address
+    /// pools. Scoped to the active wallet on purpose: a withdrawal to
+    /// another on-device wallet's address is still external from this
+    /// wallet's perspective (this wallet gets no Core receipt row).
+    private static func isActiveWalletCoreAddress(
+        _ address: String,
+        walletId: Data,
+        in context: ModelContext
+    ) -> Bool {
+        var descriptor = FetchDescriptor<PersistentCoreAddress>(
+            predicate: #Predicate { $0.address == address })
+        descriptor.fetchLimit = 1
+        guard let row = (try? context.fetch(descriptor))?.first else { return false }
+        return row.account?.wallet.walletId == walletId
     }
 
     /// The host is `@MainActor`-isolated; grab its container + active-wallet

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -1,0 +1,316 @@
+//
+//  ShieldedActivityHistory.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Shielded operations in the home transaction history. The SDK's
+//  shielded persister writes one `PersistentShieldedActivity` row per
+//  operation (live-recorded on execution, or scan-derived on restore);
+//  this file projects those rows into immutable list items that the
+//  home history interleaves with the Core transaction rows, plus the
+//  detail sheet a tapped row opens.
+//
+//  Kinds whose Core leg is already a history row are NOT projected —
+//  ShieldFromAssetLock (the Core asset-lock spend renders via
+//  `Transaction.isShieldedTransfer`) and Withdrawal (the Core receipt
+//  renders via `Transaction.isShieldedWithdrawalReceipt`). Projecting
+//  them too would show one user action as two rows. There is no txid
+//  on the activity entry to dedupe by, so the exclusion is by kind —
+//  guaranteed-correct for live-recorded entries because those two
+//  kinds have a Core transaction by construction.
+//
+
+import Foundation
+import SwiftData
+import SwiftDashSDK
+import SwiftUI
+
+// MARK: - List item
+
+/// Immutable projection of one `PersistentShieldedActivity` row,
+/// captured at reload time so the list never holds live `@Model`
+/// references (same contract as the `Transaction` snapshot wrapper).
+struct ShieldedActivityItem: Identifiable {
+
+    enum Kind: Int {
+        case shield = 0              // platform transparent → shielded
+        case shieldFromAssetLock = 1 // Core L1 → shielded (Core leg shown instead)
+        case received = 2
+        case sent = 3
+        case unshield = 4            // shielded → platform transparent
+        case withdrawal = 5          // shielded → Core L1 (Core leg shown instead)
+        case identityCreate = 6
+        case shieldedSpend = 7       // restore-path residual
+    }
+
+    enum Direction: Int {
+        case incoming = 0
+        case outgoing = 1
+        case selfTransfer = 2
+    }
+
+    enum Status: Int {
+        case pending = 0
+        case confirmed = 1
+        case failed = 2
+    }
+
+    let entryId: Data
+    let accountIndex: UInt32
+    let kind: Kind
+    let direction: Direction
+    let status: Status
+    /// Principal in duffs (the store keeps credits; 1000 credits = 1 duff).
+    let amountDuffs: UInt64
+    /// Exact fee in duffs, when the entry recorded one.
+    let feeDuffs: UInt64?
+    let blockHeight: UInt64?
+    let date: Date
+    /// Decoded UTF-8 text memo, when the 36-byte Dash memo is kind-1 text.
+    let memoText: String?
+    /// Created identity id (hex) for `identityCreate` entries.
+    let createdIdentityIdHex: String?
+
+    var id: String {
+        "shielded-" + entryId.map { String(format: "%02x", $0) }.joined() + "-\(accountIndex)"
+    }
+
+    init(row: PersistentShieldedActivity) {
+        entryId = row.entryId
+        accountIndex = row.accountIndex
+        kind = Kind(rawValue: row.kindTag) ?? .shieldedSpend
+        direction = Direction(rawValue: row.direction) ?? .selfTransfer
+        status = Status(rawValue: row.status) ?? .confirmed
+        amountDuffs = row.amount / 1000
+        feeDuffs = row.hasFee ? row.fee / 1000 : nil
+        blockHeight = row.hasBlockHeight ? row.blockHeight : nil
+        date = Date(timeIntervalSince1970: Double(row.createdAtMs) / 1000.0)
+        memoText = Self.decodeTextMemo(row.memo)
+        createdIdentityIdHex = row.kindTag == Kind.identityCreate.rawValue && row.identityId.count == 32
+            ? row.identityId.map { String(format: "%02x", $0) }.joined()
+            : nil
+    }
+
+    // MARK: Display
+
+    var title: String {
+        switch kind {
+        case .shield, .shieldFromAssetLock:
+            return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
+        case .received:
+            return NSLocalizedString("Received", comment: "")
+        case .sent:
+            return NSLocalizedString("Sent", comment: "")
+        case .unshield, .withdrawal:
+            return NSLocalizedString("Unshielded", comment: "Shielded activity: funds moved out of the private shielded balance")
+        case .identityCreate:
+            return NSLocalizedString("Identity registration", comment: "Asset lock funding a DashPay identity registration")
+        case .shieldedSpend:
+            return NSLocalizedString("Shielded Spend", comment: "Shielded activity: a spend restored from on-chain data whose exact type is unknown")
+        }
+    }
+
+    /// Route/context pill under the time — mirrors the Core internal-
+    /// transfer rows' "Transparent → Shielded" wording. The memo wins
+    /// when present (it's the sender's message, strictly more useful).
+    var detailsText: String? {
+        if let memoText { return memoText }
+        switch kind {
+        case .shield, .shieldFromAssetLock:
+            return NSLocalizedString("Platform → Shielded", comment: "Transfer of own funds from the Platform balance into the private shielded balance")
+        case .unshield, .withdrawal:
+            return NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
+        case .received, .sent, .identityCreate, .shieldedSpend:
+            return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
+        }
+    }
+
+    /// Corner-badge SF symbol next to the shield primary icon; nil keeps
+    /// the plain shield (the details pill already carries the route).
+    var secondarySystemIcon: String? {
+        switch kind {
+        case .received: return "arrow.down"
+        case .sent: return "arrow.up"
+        case .identityCreate: return "person.crop.circle.fill"
+        case .shieldedSpend: return "questionmark"
+        case .shield, .shieldFromAssetLock, .unshield, .withdrawal: return nil
+        }
+    }
+
+    /// Signed duffs for the row amount label. Self-transfers stay
+    /// positive and render with no sign (own funds moved, not gained
+    /// or lost).
+    var signedDashAmount: Int64 {
+        let magnitude = amountDuffs > UInt64(Int64.max) ? Int64.max : Int64(amountDuffs)
+        return direction == .outgoing ? -magnitude : magnitude
+    }
+
+    var fiatAmount: String {
+        CurrencyExchanger.shared.fiatAmountString(for: amountDuffs.dashAmount)
+    }
+
+    var trailingStatusText: String? {
+        switch status {
+        case .pending: return NSLocalizedString("Pending", comment: "")
+        case .failed: return NSLocalizedString("Failed", comment: "")
+        case .confirmed: return nil
+        }
+    }
+
+    var shortTimeString: String {
+        DWDateFormatter.sharedInstance.timeOnly(from: date)
+    }
+
+    /// Decode the 36-byte Dash memo when it is kind-1 UTF-8 text:
+    /// 4-byte LE kind tag == 1, then up to 32 bytes of UTF-8 with
+    /// trailing zeros trimmed. Nil for empty / non-text memos.
+    private static func decodeTextMemo(_ memo: Data) -> String? {
+        guard memo.count >= 4 else { return nil }
+        let bytes = [UInt8](memo)
+        let kind = UInt32(bytes[0]) | (UInt32(bytes[1]) << 8)
+            | (UInt32(bytes[2]) << 16) | (UInt32(bytes[3]) << 24)
+        guard kind == 1 else { return nil }
+        let payload = bytes[4...].prefix(while: { $0 != 0 })
+        guard !payload.isEmpty else { return nil }
+        return String(bytes: payload, encoding: .utf8)
+    }
+}
+
+// MARK: - Detail sheet
+
+/// Read-only detail for one shielded activity entry, presented from the
+/// history list inside the standard `BottomSheet`. Deliberately simpler
+/// than `TXDetailVC`: a shielded entry has no inputs/outputs/addresses
+/// to enumerate — its whole point is that those stay private.
+struct ShieldedActivityDetailsView: View {
+    let item: ShieldedActivityItem
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .bottomTrailing) {
+                Image(systemName: "shield.fill")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundColor(.dashBlue)
+                    .frame(width: 56, height: 56)
+                    .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                if let badge = item.secondarySystemIcon {
+                    Image(systemName: badge)
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Color.dashBlue))
+                        .offset(x: 4, y: 4)
+                }
+            }
+            .padding(.top, 24)
+
+            Text(item.title)
+                .font(.headline)
+                .foregroundColor(.primaryText)
+                .padding(.top, 12)
+
+            DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: item.direction != .selfTransfer)
+                .padding(.top, 4)
+            Text(item.fiatAmount)
+                .font(.footnote)
+                .foregroundColor(.tertiaryText)
+                .padding(.top, 2)
+
+            VStack(spacing: 0) {
+                if let details = item.detailsText {
+                    infoRow(NSLocalizedString("Type", comment: ""), details)
+                }
+                infoRow(
+                    NSLocalizedString("Status", comment: ""),
+                    item.trailingStatusText ?? NSLocalizedString("Confirmed", comment: ""))
+                if let height = item.blockHeight {
+                    infoRow(NSLocalizedString("Block", comment: "Block height of a confirmed shielded operation"), "\(height)")
+                }
+                if let fee = item.feeDuffs, fee > 0 {
+                    HStack {
+                        Text(NSLocalizedString("Network fee", comment: ""))
+                            .font(.footnote)
+                            .foregroundColor(.tertiaryText)
+                        Spacer()
+                        DashAmount(amount: Int64(fee), font: .footnote, showDirection: false)
+                    }
+                    .padding(.vertical, 10)
+                }
+                if let identityId = item.createdIdentityIdHex {
+                    copyableRow(NSLocalizedString("Identity ID", comment: "Identities"), identityId)
+                }
+                infoRow(
+                    NSLocalizedString("Date", comment: ""),
+                    DWDateFormatter.sharedInstance.longString(from: item.date))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+            .background(Color.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+
+            if item.kind == .shieldedSpend {
+                Text(NSLocalizedString("Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data.", comment: "Shielded activity"))
+                    .font(.caption)
+                    .foregroundColor(.tertiaryText)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+                    .padding(.top, 16)
+            }
+
+            Spacer(minLength: 24)
+        }
+    }
+
+    @ViewBuilder
+    private func infoRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.footnote)
+                .foregroundColor(.tertiaryText)
+            Spacer()
+            Text(value)
+                .font(.footnote)
+                .foregroundColor(.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func copyableRow(_ label: String, _ value: String) -> some View {
+        Button {
+            UIPasteboard.general.string = value
+        } label: {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                    .font(.footnote)
+                    .foregroundColor(.tertiaryText)
+                Spacer()
+                Text(value.prefix(8) + "…" + value.suffix(8))
+                    .font(.footnote)
+                    .monospaced()
+                    .foregroundColor(.primaryText)
+                Image(systemName: "doc.on.doc")
+                    .font(.caption2)
+                    .foregroundColor(.dashBlue)
+            }
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -168,6 +168,21 @@ struct ShieldedActivityItem: Identifiable {
         !isInternalMove && direction != .selfTransfer
     }
 
+    /// From/To wording for an internal move's detail sheet; nil for
+    /// non-internal kinds.
+    var internalMoveRoute: (source: String, destination: String)? {
+        let platform = NSLocalizedString("Your Platform balance", comment: "Shielded activity: source/destination of an internal move")
+        let shielded = NSLocalizedString("Your Shielded balance", comment: "Shielded activity: source/destination of an internal move")
+        let transparent = NSLocalizedString("Your Transparent balance", comment: "Shielded activity: source/destination of an internal move")
+        switch kind {
+        case .shield: return (platform, shielded)
+        case .shieldFromAssetLock: return (transparent, shielded)
+        case .unshield: return (shielded, platform)
+        case .withdrawal: return (shielded, transparent)
+        case .received, .sent, .identityCreate, .shieldedSpend: return nil
+        }
+    }
+
     /// Signed duffs for the row amount label. Internal moves and
     /// self-transfers stay positive (and render signless via
     /// `showsDirectionSign`) — own funds moved, not gained or lost.
@@ -250,6 +265,16 @@ struct ShieldedActivityDetailsView: View {
             VStack(spacing: 0) {
                 if let details = item.detailsText {
                     infoRow(NSLocalizedString("Type", comment: ""), details)
+                }
+                // Internal moves are self-originated BY CONSTRUCTION: the
+                // shield/unshield kinds are only ever live-recorded for
+                // this wallet's own operation (the restore-path scan can't
+                // prove origin, so it never labels anything a shield —
+                // an old own-shield resurfaces as plain "Received").
+                // Saying From/To here is therefore a guarantee, not a guess.
+                if let route = item.internalMoveRoute {
+                    infoRow(NSLocalizedString("From", comment: ""), route.source)
+                    infoRow(NSLocalizedString("To", comment: ""), route.destination)
                 }
                 infoRow(
                     NSLocalizedString("Status", comment: ""),

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -150,12 +150,30 @@ struct ShieldedActivityItem: Identifiable {
         }
     }
 
-    /// Signed duffs for the row amount label. Self-transfers stay
-    /// positive and render with no sign (own funds moved, not gained
-    /// or lost).
+    /// Internal moves between the user's own balances (Platform ↔
+    /// Shielded). The recorded direction reflects the shielded pool's
+    /// perspective (a shield is "incoming"), but no funds were gained
+    /// or lost — these render signless, like self-transfers.
+    var isInternalMove: Bool {
+        switch kind {
+        case .shield, .shieldFromAssetLock, .unshield, .withdrawal:
+            return true
+        case .received, .sent, .identityCreate, .shieldedSpend:
+            return false
+        }
+    }
+
+    /// Whether the amount renders with a +/− direction sign.
+    var showsDirectionSign: Bool {
+        !isInternalMove && direction != .selfTransfer
+    }
+
+    /// Signed duffs for the row amount label. Internal moves and
+    /// self-transfers stay positive (and render signless via
+    /// `showsDirectionSign`) — own funds moved, not gained or lost.
     var signedDashAmount: Int64 {
         let magnitude = amountDuffs > UInt64(Int64.max) ? Int64.max : Int64(amountDuffs)
-        return direction == .outgoing ? -magnitude : magnitude
+        return direction == .outgoing && showsDirectionSign ? -magnitude : magnitude
     }
 
     var fiatAmount: String {
@@ -222,7 +240,7 @@ struct ShieldedActivityDetailsView: View {
                 .foregroundColor(.primaryText)
                 .padding(.top, 12)
 
-            DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: item.direction != .selfTransfer)
+            DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: item.showsDirectionSign)
                 .padding(.top, 4)
             Text(item.fiatAmount)
                 .font(.footnote)

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -83,12 +83,19 @@ struct ShieldedActivityItem: Identifiable {
     let memoText: String?
     /// Created identity id (hex) for `identityCreate` entries.
     let createdIdentityIdHex: String?
+    /// Destination Core address for a withdrawal that did NOT go to one
+    /// of the active wallet's own addresses (external withdrawals are
+    /// the only `withdrawal` entries projected into the history — the
+    /// internal ones render as their Core receipt row instead). Nil for
+    /// every other kind, and for the rare undecodable-script external.
+    let externalWithdrawalAddress: String?
 
     var id: String {
         "shielded-" + entryId.map { String(format: "%02x", $0) }.joined() + "-\(accountIndex)"
     }
 
-    init(row: PersistentShieldedActivity) {
+    init(row: PersistentShieldedActivity, externalWithdrawalAddress: String? = nil) {
+        self.externalWithdrawalAddress = externalWithdrawalAddress
         entryId = row.entryId
         accountIndex = row.accountIndex
         kind = Kind(rawValue: row.kindTag) ?? .shieldedSpend
@@ -114,6 +121,8 @@ struct ShieldedActivityItem: Identifiable {
             return NSLocalizedString("Received", comment: "")
         case .sent:
             return NSLocalizedString("Sent", comment: "")
+        case .withdrawal where isExternalWithdrawal:
+            return NSLocalizedString("Sent", comment: "")
         case .unshield, .withdrawal:
             return NSLocalizedString("Unshielded", comment: "Shielded activity: funds moved out of the private shielded balance")
         case .identityCreate:
@@ -131,6 +140,13 @@ struct ShieldedActivityItem: Identifiable {
         switch kind {
         case .shield, .shieldFromAssetLock:
             return NSLocalizedString("Platform → Shielded", comment: "Transfer of own funds from the Platform balance into the private shielded balance")
+        case .withdrawal where isExternalWithdrawal:
+            // External withdrawal: show where the money went, shortened
+            // to row-pill size (the detail sheet carries the full address).
+            if let address = externalWithdrawalAddress {
+                return String(address.prefix(6)) + "…" + String(address.suffix(6))
+            }
+            return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
         case .unshield, .withdrawal:
             return NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
         case .received, .sent, .identityCreate, .shieldedSpend:
@@ -144,20 +160,33 @@ struct ShieldedActivityItem: Identifiable {
         switch kind {
         case .received: return "arrow.down"
         case .sent: return "arrow.up"
+        case .withdrawal: return isExternalWithdrawal ? "arrow.up" : nil
         case .identityCreate: return "person.crop.circle.fill"
         case .shieldedSpend: return "questionmark"
-        case .shield, .shieldFromAssetLock, .unshield, .withdrawal: return nil
+        case .shield, .shieldFromAssetLock, .unshield: return nil
         }
+    }
+
+    /// A withdrawal item in the history is external by construction —
+    /// internal ones (destination = own Core address) are dropped at
+    /// fetch time in favor of their Core receipt row. Kept as a named
+    /// predicate so the display code reads as intent, not coincidence.
+    var isExternalWithdrawal: Bool {
+        kind == .withdrawal
     }
 
     /// Internal moves between the user's own balances (Platform ↔
     /// Shielded). The recorded direction reflects the shielded pool's
     /// perspective (a shield is "incoming"), but no funds were gained
-    /// or lost — these render signless, like self-transfers.
+    /// or lost — these render signless, like self-transfers. An
+    /// external withdrawal is real money leaving the wallet, so it is
+    /// NOT internal despite its kind being an own-initiated one.
     var isInternalMove: Bool {
         switch kind {
-        case .shield, .shieldFromAssetLock, .unshield, .withdrawal:
+        case .shield, .shieldFromAssetLock, .unshield:
             return true
+        case .withdrawal:
+            return !isExternalWithdrawal
         case .received, .sent, .identityCreate, .shieldedSpend:
             return false
         }
@@ -168,8 +197,9 @@ struct ShieldedActivityItem: Identifiable {
         !isInternalMove && direction != .selfTransfer
     }
 
-    /// From/To wording for an internal move's detail sheet; nil for
-    /// non-internal kinds.
+    /// From/To wording for the detail sheet. Internal moves name the
+    /// user's own balances on both sides (a guarantee — see the fetch
+    /// doc); an external withdrawal names the destination address.
     var internalMoveRoute: (source: String, destination: String)? {
         let platform = NSLocalizedString("Your Platform balance", comment: "Shielded activity: source/destination of an internal move")
         let shielded = NSLocalizedString("Your Shielded balance", comment: "Shielded activity: source/destination of an internal move")
@@ -178,7 +208,11 @@ struct ShieldedActivityItem: Identifiable {
         case .shield: return (platform, shielded)
         case .shieldFromAssetLock: return (transparent, shielded)
         case .unshield: return (shielded, platform)
-        case .withdrawal: return (shielded, transparent)
+        case .withdrawal:
+            if let address = externalWithdrawalAddress {
+                return (shielded, address)
+            }
+            return isExternalWithdrawal ? (shielded, transparent) : nil
         case .received, .sent, .identityCreate, .shieldedSpend: return nil
         }
     }

--- a/DashWallet/Sources/UI/Home/Views/TransactionListDataItem.swift
+++ b/DashWallet/Sources/UI/Home/Views/TransactionListDataItem.swift
@@ -29,6 +29,7 @@ class TransactionGroup: Identifiable {
 
 enum TransactionListDataItem {
     case tx(Transaction, TxRowMetadata?)
+    case shieldedActivity(ShieldedActivityItem)
     case crowdnode(FullCrowdNodeSignUpTxSet)
     case coinjoin(CoinJoinMixingTxSet)
     case coinjoinWithdrawal(CoinJoinWithdrawalTxSet)
@@ -45,9 +46,11 @@ extension TransactionListDataItem: Identifiable {
             return set.id
         case .tx(let tx, _):
             return tx.txHashHexString
+        case .shieldedActivity(let item):
+            return item.id
         }
     }
-    
+
     var date: Date {
         switch self {
         case .crowdnode(let set):
@@ -58,6 +61,8 @@ extension TransactionListDataItem: Identifiable {
             return set.groupDay
         case .tx(let tx, _):
             return tx.date
+        case .shieldedActivity(let item):
+            return item.date
         }
     }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -695,6 +695,8 @@
 "Confirm Platform Send" = "Confirm Platform Send";
 
 /* SPV diagnostics */
+
+"Confirmed" = "Confirmed";
 "Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start.";
 
 /* ZenLedger */
@@ -1233,6 +1235,8 @@
 "Face ID limit" = "Face ID limit";
 
 /* No comment provided by engineer. */
+
+"Failed" = "Failed";
 "Failed to load barcode" = "Failed to load barcode";
 
 /* Coinbase */
@@ -2614,6 +2618,8 @@
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
 
 /* Coinbase/Buy Dash */
+
+"Platform → Shielded" = "Platform → Shielded";
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
 
 /* Network Unavailable */
@@ -2947,6 +2953,8 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data.";
 "Restricted" = "Restricted";
 
 /* Usernames */
@@ -3272,9 +3280,13 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+
+"Shielded Spend" = "Shielded Spend";
 "Shielded wallet starting…" = "Shielded wallet starting…";
 
 /* Transfer of own funds from the private shielded balance back to the transparent wallet */
+
+"Shielded → Platform" = "Shielded → Platform";
 "Shielded → Transparent" = "Shielded → Transparent";
 
 /* Explore Dash */
@@ -3985,6 +3997,8 @@
 "Unknown Balance" = "Unknown Balance";
 
 /* No comment provided by engineer. */
+
+"Unshielded" = "Unshielded";
 "Unsupported URL" = "Unsupported URL";
 
 /* No comment provided by engineer. */

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -4597,6 +4597,8 @@
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
 
 /* Maya/SwapKit */
+
+"Your Platform balance" = "Your Platform balance";
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
 
 /* CrowdNode */
@@ -4612,6 +4614,8 @@
 "Your session expired" = "Your session expired";
 
 /* Usernames */
+
+"Your Shielded balance" = "Your Shielded balance";
 "Your Shielded balance is almost ready — you can register privately around %@." = "Your Shielded balance is almost ready — you can register privately around %@.";
 
 /* Usernames */
@@ -4639,6 +4643,8 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+
+"Your Transparent balance" = "Your Transparent balance";
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
## Problem

The home history reads only the Core SwiftData rows, so purely shielded operations were invisible. Private receives, private sends, Platform → Shielded moves, and shielded identity fundings never appeared — the list showed at most the L1 legs of shielded flows.

## What this does

Merges the SDK's `PersistentShieldedActivity` timeline (live-recorded per operation, scan-derived on restore) into the same day-grouped history list as the Core rows.

- **`ShieldedActivityItem`** ([ShieldedActivityHistory.swift](DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift)): immutable projection of one activity row — credits→duffs, kind/direction/status, decoded 36-byte text memo — plus row display: kind title, route pill ("Platform → Shielded" / "Shielded → Platform" / "Shielded", memo wins when present), shield icon with a per-kind corner badge, signed amount, live fiat, Pending/Failed trailing status.
- **No double rows**: kinds whose Core leg already renders are not projected — ShieldFromAssetLock (shows as the Core asset-lock row via `Transaction.isShieldedTransfer`), and Withdrawal only when its destination script is one of the active wallet's own Core addresses (the Core receipt via `isShieldedWithdrawalReceipt`). A withdrawal to an EXTERNAL Core address produces no wallet-side Core transaction, so it stays in the merged list as a signed Sent row with the destination address (shortened in the row pill, full in the detail sheet). Entries are also deduped by `entryId` across accounts (an intra-wallet transfer writes Sent + Received rows for one operation; the initiating side wins).
- **Pipeline**: new `TransactionListDataItem.shieldedActivity` case flows through the existing filter → sort → day-group pipeline. The `NSManagedObjectContextDidSave` reload trigger already fires on the shielded persister's saves, so rows appear live.
- **Filters**: the existing "Shielded sent" / "Shielded received" filter categories now match these rows (previously they only matched Core legs).
- **Detail**: tapping opens `ShieldedActivityDetailsView` in the standard bottom sheet — type, status, block, exact fee when recorded, copyable created-identity id, date, and the honest restore-path footnote for unclassifiable `ShieldedSpend` residuals. Deliberately simpler than `TXDetailVC`: a shielded entry has no addresses or inputs/outputs to enumerate — that's the point of it.

## Test plan

- [x] dashpay arm64-sim build green; installed on QA-iPhone16 (whose store holds 1 shielded receive, 2 Platform→Shielded moves, 3 private sends, and 2 asset-lock entries that correctly stay represented by their Core rows)
- [ ] Home history shows the shielded rows interleaved by day; asset-lock shieldings/withdrawals appear once (as their Core rows), not twice
- [ ] Filter → Shielded sent / Shielded received matches the new rows
- [ ] Tap a shielded row → detail sheet; identity-funding entry shows the copyable identity id

🤖 Generated with [Claude Code](https://claude.com/claude-code)
