### PR TITLE
fix(ui): Platform Sync Clear actually forces a full trunk/branch resync

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -52,6 +52,9 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     @Published public private(set) var runningNetwork: Network? = nil
 
     @Published public private(set) var isSyncing: Bool = false
+    /// True for the whole Clear sequence (Rust reset → SwiftData zeroing
+    /// → display wipe → loop re-arm); gates the Sync Now / Clear buttons.
+    @Published public private(set) var isClearing: Bool = false
     @Published public private(set) var lastSyncTime: Date? = nil
     @Published public private(set) var lastError: String? = nil
 
@@ -465,6 +468,83 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         let recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient(
             addressType: 0, hash: parsed.hash, credits: nil)
         return (addressWallet, container, recipient, target.accountIndex)
+    }
+
+    /// Full local wipe of the platform-address sync state — the Sync Info
+    /// screen's "Clear" button. Ported from the SwiftExampleApp
+    /// `PlatformBalanceSyncService.clearLocalState` contract:
+    ///
+    /// 1. Reset the Rust-owned incremental-sync watermark FIRST
+    ///    (`resetPlatformAddressSyncState`) — without this, the in-memory
+    ///    watermark survives and the next Sync Now resumes incrementally
+    ///    (Recent queries only) instead of the full trunk/branch rescan.
+    ///    Fail closed: on error, surface it and keep the current display
+    ///    rather than showing a false "cleared" state.
+    /// 2. Zero the volatile balance/sync fields of this network's
+    ///    `PersistentPlatformAddress` rows IN PLACE — never delete them:
+    ///    they are durable derivation state the rescan upserts against
+    ///    (the balance callback skips rows it can't find, and no
+    ///    in-session sync re-emits them).
+    /// 3. Delete the network's `PersistentPlatformAddressesSyncState`
+    ///    watermark rows outright — pure volatile state, recreated by
+    ///    the next sync.
+    /// 4. Clear the published display, then re-arm the background loop
+    ///    (the Rust reset deliberately leaves it stopped).
+    public func clearLocalState() async {
+        guard !isClearing else { return }
+        guard let manager = walletManager else {
+            // BLAST never started — nothing Rust-side or persisted to
+            // reset; wiping the display is the whole job.
+            clearDisplay()
+            return
+        }
+        isClearing = true
+        defer { isClearing = false }
+
+        do {
+            try await manager.resetPlatformAddressSyncState()
+        } catch {
+            lastError = "Failed to reset platform-address sync state: \(error.localizedDescription)"
+            Self.logger.error("🛰️ PLATFORM-ADDR :: clear reset failed: \(String(describing: error), privacy: .public)")
+            return
+        }
+
+        if let container = modelContainer, let network = runningNetwork {
+            do {
+                let context = container.mainContext
+                let networkRaw = network.rawValue
+                let wallets = try context.fetch(FetchDescriptor<PersistentWallet>(
+                    predicate: #Predicate { $0.networkRaw == networkRaw }))
+                let walletIds = Set(wallets.map(\.walletId))
+                let addresses = try context.fetch(FetchDescriptor<PersistentPlatformAddress>())
+                for row in addresses where walletIds.contains(row.walletId) {
+                    row.balance = 0
+                    row.nonce = 0
+                    row.isUsed = false
+                    row.firstSeenHeight = 0
+                    row.lastSeenHeight = 0
+                    row.lastUpdated = Date()
+                }
+                let syncStates = try context.fetch(FetchDescriptor<PersistentPlatformAddressesSyncState>())
+                for row in syncStates where row.networkRaw == networkRaw {
+                    context.delete(row)
+                }
+                try context.save()
+            } catch {
+                lastError = "Failed to clear persisted platform-address state: \(error.localizedDescription)"
+                Self.logger.error("🛰️ PLATFORM-ADDR :: clear persist failed: \(String(describing: error), privacy: .public)")
+                return
+            }
+        }
+
+        clearDisplay()
+
+        do {
+            try manager.startPlatformAddressSync()
+        } catch {
+            lastError = "startPlatformAddressSync failed after clear: \(error.localizedDescription)"
+            Self.logger.error("🛰️ PLATFORM-ADDR :: post-clear restart failed: \(String(describing: error), privacy: .public)")
+        }
     }
 
     /// Clear the UI counters/display without tearing down the sync loop.

--- a/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
@@ -268,23 +268,27 @@ struct PlatformSyncStatusScreen: View {
                 .font(.system(size: 14, weight: .semibold))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .background(coordinator.isSyncing ? Color.gray300.opacity(0.3) : Color.blue.opacity(0.15))
-                .foregroundColor(coordinator.isSyncing ? .secondary : .blue)
+                .background(coordinator.isSyncing || coordinator.isClearing ? Color.gray300.opacity(0.3) : Color.blue.opacity(0.15))
+                .foregroundColor(coordinator.isSyncing || coordinator.isClearing ? .secondary : .blue)
                 .cornerRadius(8)
             }
-            .disabled(coordinator.isSyncing)
+            .disabled(coordinator.isSyncing || coordinator.isClearing)
 
             Button(action: {
-                coordinator.clearDisplay()
+                // Full local wipe (Rust watermark + persisted balances +
+                // display), so the next Sync Now does the complete
+                // trunk/branch rescan — not just a display reset.
+                Task { await coordinator.clearLocalState() }
             }) {
                 Text("Clear")
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                     .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(coordinator.isClearing ? .secondary : .primaryText)
                     .cornerRadius(8)
             }
+            .disabled(coordinator.isClearing || coordinator.isSyncing)
 
             Button(action: {
                 PlatformAddressSyncCoordinator.stop()


### PR DESCRIPTION
## Problem

On the Platform Sync Status screen, Clear + Sync Now looked like a from-scratch resync but wasn't one: Clear only called `clearDisplay()` (a published-counter wipe). The Rust-owned BLAST incremental-sync watermark survived, so the next Sync Now resumed from the checkpoint — Recent queries only, no trunk/branch walk — under a zeroed UI that implied a full rescan. Exactly the "I feel like it isn't really resyncing" QA observation.

## Fix

`PlatformAddressSyncCoordinator.clearLocalState()`, ported from the SwiftExampleApp `PlatformBalanceSyncService` contract:

1. **`resetPlatformAddressSyncState()` first** — drains the in-flight pass and drops the Rust watermark, which is what actually forces the full trunk/branch rescan. Fail closed: on error the display keeps its real state rather than showing a false "cleared".
2. **Zero (never delete) the network's `PersistentPlatformAddress` volatile fields** — the rows are durable derivation state the rescan upserts against; deleting them would strand balances until an app relaunch re-seeds them.
3. **Delete the `PersistentPlatformAddressesSyncState` watermark rows** — pure volatile state, recreated by the next sync.
4. **Clear the display, then re-arm the background loop** — the Rust reset deliberately leaves it stopped.

The screen's Clear button now runs this sequence; Sync Now / Clear are gated on the new `isClearing` flag for its duration.

## Test plan

- [x] dashpay arm64-sim build green; installed on QA-iPhone16
- [ ] Platform Sync Status → Clear → Sync Now: Queries card shows non-zero Trunk/Branch counts (full walk), balances repopulate
- [ ] Clear while offline → error surfaces in Last Error, display NOT falsely zeroed

🤖 Generated with [Claude Code](https://claude.com/claude-code)