### PR TITLE
feat(ui): observed incoming Platform-address payments in the home history

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -689,6 +689,10 @@
 		751C05DE2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */; };
 		5A1EC0FE2E29A10000000002 /* ShieldedActivityHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */; };
 		5A1EC0FE2E29A10000000003 /* ShieldedActivityHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */; };
+		5A1EC0FE2E29A20000000012 /* PlatformAddressActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A20000000011 /* PlatformAddressActivityStore.swift */; };
+		5A1EC0FE2E29A20000000013 /* PlatformAddressActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A20000000011 /* PlatformAddressActivityStore.swift */; };
+		5A1EC0FE2E29A20000000015 /* PlatformAddressHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A20000000014 /* PlatformAddressHistory.swift */; };
+		5A1EC0FE2E29A20000000016 /* PlatformAddressHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1EC0FE2E29A20000000014 /* PlatformAddressHistory.swift */; };
 		7527720D2AA9B2630066557E /* SupportedTopperAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527720C2AA9B2630066557E /* SupportedTopperAssets.swift */; };
 		7527720F2AA9F58E0066557E /* TopperViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527720E2AA9F58E0066557E /* TopperViewModel.swift */; };
 		752772122AAA1CE30066557E /* Coinbase-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 752772112AAA1CE30066557E /* Coinbase-Info.plist */; };
@@ -2892,6 +2896,8 @@
 		751C05DA2D3D0E7C00475E52 /* JoinDashPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinDashPayViewModel.swift; sourceTree = "<group>"; };
 		751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionListDataItem.swift; sourceTree = "<group>"; };
 		5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldedActivityHistory.swift; sourceTree = "<group>"; };
+		5A1EC0FE2E29A20000000011 /* PlatformAddressActivityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAddressActivityStore.swift; sourceTree = "<group>"; };
+		5A1EC0FE2E29A20000000014 /* PlatformAddressHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAddressHistory.swift; sourceTree = "<group>"; };
 		7527720C2AA9B2630066557E /* SupportedTopperAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedTopperAssets.swift; sourceTree = "<group>"; };
 		7527720E2AA9F58E0066557E /* TopperViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopperViewModel.swift; sourceTree = "<group>"; };
 		752772112AAA1CE30066557E /* Coinbase-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Coinbase-Info.plist"; sourceTree = "<group>"; };
@@ -4424,6 +4430,7 @@
 				754BEA112C0B6BD700E8C93C /* HomeViewModel.swift */,
 				751C05DC2D3E39A600475E52 /* TransactionListDataItem.swift */,
 				5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */,
+				5A1EC0FE2E29A20000000014 /* PlatformAddressHistory.swift */,
 				75D657662DF579F300ACE570 /* TransactionFilterDialog.swift */,
 			);
 			path = Views;
@@ -4629,6 +4636,7 @@
 				AA0020012FA0000000000001 /* Swap */,
 				7503643C2C89D4890029EC0D /* CoinJoin */,
 				75A8C1612AE571E30042256E /* Voting */,
+				5A1EC0FE2E29A20000000017 /* PlatformAddress */,
 				47081194298CF1E3003FCA3D /* Transactions */,
 				11BD737F28E7354200A34022 /* CrowdNode */,
 				479DBDDB2995167800F30AF1 /* Tx */,
@@ -6818,6 +6826,14 @@
 				B401E660599FEF6B18087F91 /* PaymentsLandingHostingController.swift */,
 			);
 			path = Landing;
+			sourceTree = "<group>";
+		};
+		5A1EC0FE2E29A20000000017 /* PlatformAddress */ = {
+			isa = PBXGroup;
+			children = (
+				5A1EC0FE2E29A20000000011 /* PlatformAddressActivityStore.swift */,
+			);
+			path = PlatformAddress;
 			sourceTree = "<group>";
 		};
 		7502A4852AE401DA00ACDDD3 /* Voting */ = {
@@ -9881,6 +9897,8 @@
 				470AE1882926600A001A0514 /* PaymentController.swift in Sources */,
 				751C05DE2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */,
 				5A1EC0FE2E29A10000000003 /* ShieldedActivityHistory.swift in Sources */,
+				5A1EC0FE2E29A20000000013 /* PlatformAddressActivityStore.swift in Sources */,
+				5A1EC0FE2E29A20000000016 /* PlatformAddressHistory.swift in Sources */,
 				2ADB396C242615C200A6F898 /* CALayer+MBAnimationPersistence.m in Sources */,
 				2A9FFDF42230FF1A00956D5F /* UIView+DWAnimations.m in Sources */,
 				114573A42949B221009DCF27 /* VerifiedSuccessfullyViewController.swift in Sources */,
@@ -10695,6 +10713,8 @@
 				C9D2C95E2A386D7E00D15901 /* DWBasePressableControl.m in Sources */,
 				751C05DD2D3E39A800475E52 /* TransactionListDataItem.swift in Sources */,
 				5A1EC0FE2E29A10000000002 /* ShieldedActivityHistory.swift in Sources */,
+				5A1EC0FE2E29A20000000012 /* PlatformAddressActivityStore.swift in Sources */,
+				5A1EC0FE2E29A20000000015 /* PlatformAddressHistory.swift in Sources */,
 				C9D2C70B2A320AA000D15901 /* DWDemoAppRootViewController.m in Sources */,
 				C9D2C70C2A320AA000D15901 /* DWUpholdLogoutTutorialViewController.m in Sources */,
 				75A8C1672AE5734A0042256E /* UsernameRequest.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
+++ b/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
@@ -76,7 +76,8 @@ extension DatabaseConnection {
             AddIconBitmapsTable(),
             AddProviderToGiftCardsTable(),
             AddRedeemUrlChallengeToGiftCardsTable(),
-            AddSwapOrdersTable()
+            AddSwapOrdersTable(),
+            AddPlatformAddressActivityTables()
         ]
     }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -928,6 +928,16 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             }
             platformBalance = rows.reduce(0) { $0 + $1.balance }
             activeAddressCount = rows.reduce(0) { $1.balance > 0 ? $0 + 1 : $0 }
+            // Observed-payment ledger: diff this snapshot against the
+            // persisted baseline and record unattributed increases as
+            // received activity for the home history.
+            if let network = runningNetwork {
+                PlatformAddressActivityRecorder.observe(
+                    addresses: derivedAddresses,
+                    walletId: walletId,
+                    network: network,
+                    container: container)
+            }
         } catch {
             Self.logger.warning("🛰️ PLATFORM-ADDR :: derived-address fetch failed: \(String(describing: error), privacy: .public)")
         }

--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -1,0 +1,328 @@
+//
+//  PlatformAddressActivityStore.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  App-owned ledger of observed incoming Platform-address payments.
+//
+//  Platform (DIP-17) address history has no SDK-persisted event stream:
+//  the BLAST sync surfaces only absolute per-address balances (and its
+//  per-pass sync event carries aggregate counters, no per-address
+//  entries). So a third party paying one of the wallet's Platform
+//  addresses changed the balance with NOTHING in the home history —
+//  confusing. This store closes that gap observationally: after every
+//  BLAST pass the recorder diffs per-address balances against a
+//  persisted baseline and records increases as "received" activity.
+//
+//  Honest limits, by design:
+//  - Rows are stamped with the OBSERVATION time (no block attribution
+//    is available), so history begins at install time and a payment
+//    that lands while the app is closed is recorded at next launch.
+//  - Increases caused by the wallet's own internal moves are
+//    suppressed so they don't double-show next to their existing
+//    history rows (shielded-unshield row / core top-up row). The
+//    unshield match is exact (destination address + net amount); the
+//    asset-lock top-up match is by recipient address hash. Anything
+//    not attributable to an own operation records as received.
+//
+
+import Foundation
+import SQLite
+import SQLiteMigrationManager
+import SwiftData
+import SwiftDashSDK
+
+extension Notification.Name {
+    /// Posted after the recorder inserts at least one received-activity
+    /// row; the home history reloads on it.
+    static let platformAddressActivityRecorded = Notification.Name("DWPlatformAddressActivityRecorded")
+}
+
+// MARK: - Record
+
+struct PlatformAddressActivityRecord: Identifiable {
+    let id: Int64
+    let walletId: Data
+    let networkRaw: Int64
+    let address: String
+    /// Observed balance increase, in duffs.
+    let amountDuffs: Int64
+    let balanceAfterDuffs: Int64
+    let observedAt: Date
+}
+
+// MARK: - Tables
+
+enum PlatformAddressActivitySchema {
+    /// Latest known per-address balance — the diff baseline. One row per
+    /// (wallet, network, address); silently updated for decreases and
+    /// own-operation increases so only genuine receives reach `activity`.
+    static let baseline = Table("platform_address_baseline")
+    /// Observed incoming payments (append-only).
+    static let activity = Table("platform_address_activity")
+
+    static let colId = SQLite.Expression<Int64>("id")
+    static let colWalletId = SQLite.Expression<Data>("wallet_id")
+    static let colNetwork = SQLite.Expression<Int64>("network")
+    static let colAddress = SQLite.Expression<String>("address")
+    static let colBalance = SQLite.Expression<Int64>("balance")
+    static let colAmount = SQLite.Expression<Int64>("amount")
+    static let colBalanceAfter = SQLite.Expression<Int64>("balance_after")
+    static let colObservedAt = SQLite.Expression<Double>("observed_at")
+    static let colUpdatedAt = SQLite.Expression<Double>("updated_at")
+}
+
+struct AddPlatformAddressActivityTables: Migration {
+    var version: Int64 = 20260717160000
+
+    func migrateDatabase(_ db: Connection) throws {
+        typealias S = PlatformAddressActivitySchema
+        try db.run(S.baseline.create(ifNotExists: true) { t in
+            t.column(S.colWalletId)
+            t.column(S.colNetwork)
+            t.column(S.colAddress)
+            t.column(S.colBalance)
+            t.column(S.colUpdatedAt)
+            t.unique(S.colWalletId, S.colNetwork, S.colAddress)
+        })
+        try db.run(S.activity.create(ifNotExists: true) { t in
+            t.column(S.colId, primaryKey: .autoincrement)
+            t.column(S.colWalletId)
+            t.column(S.colNetwork)
+            t.column(S.colAddress)
+            t.column(S.colAmount)
+            t.column(S.colBalanceAfter)
+            t.column(S.colObservedAt)
+        })
+        try db.run(S.activity.createIndex(S.colWalletId, S.colNetwork, ifNotExists: true))
+    }
+}
+
+// MARK: - DAO
+
+final class PlatformAddressActivityDAO {
+    static let shared = PlatformAddressActivityDAO()
+
+    private var db: Connection { DatabaseConnection.shared.db }
+
+    /// Baseline balances (duffs) per address for the wallet+network.
+    /// Empty means "never observed" — the recorder then seeds silently.
+    func baselineBalances(walletId: Data, networkRaw: Int64) -> [String: Int64] {
+        typealias S = PlatformAddressActivitySchema
+        var result: [String: Int64] = [:]
+        let query = S.baseline
+            .filter(S.colWalletId == walletId && S.colNetwork == networkRaw)
+        if let rows = try? db.prepare(query) {
+            for row in rows {
+                result[row[S.colAddress]] = row[S.colBalance]
+            }
+        }
+        return result
+    }
+
+    func upsertBaseline(walletId: Data, networkRaw: Int64, address: String, balanceDuffs: Int64) {
+        typealias S = PlatformAddressActivitySchema
+        _ = try? db.run(S.baseline.insert(
+            or: .replace,
+            S.colWalletId <- walletId,
+            S.colNetwork <- networkRaw,
+            S.colAddress <- address,
+            S.colBalance <- balanceDuffs,
+            S.colUpdatedAt <- Date().timeIntervalSince1970))
+    }
+
+    func insertActivity(
+        walletId: Data,
+        networkRaw: Int64,
+        address: String,
+        amountDuffs: Int64,
+        balanceAfterDuffs: Int64
+    ) {
+        typealias S = PlatformAddressActivitySchema
+        _ = try? db.run(S.activity.insert(
+            S.colWalletId <- walletId,
+            S.colNetwork <- networkRaw,
+            S.colAddress <- address,
+            S.colAmount <- amountDuffs,
+            S.colBalanceAfter <- balanceAfterDuffs,
+            S.colObservedAt <- Date().timeIntervalSince1970))
+    }
+
+    /// All received-activity rows for the wallet+network, newest first.
+    func activities(walletId: Data, networkRaw: Int64) -> [PlatformAddressActivityRecord] {
+        typealias S = PlatformAddressActivitySchema
+        let query = S.activity
+            .filter(S.colWalletId == walletId && S.colNetwork == networkRaw)
+            .order(S.colObservedAt.desc)
+        guard let rows = try? db.prepare(query) else { return [] }
+        return rows.map { row in
+            PlatformAddressActivityRecord(
+                id: row[S.colId],
+                walletId: row[S.colWalletId],
+                networkRaw: row[S.colNetwork],
+                address: row[S.colAddress],
+                amountDuffs: row[S.colAmount],
+                balanceAfterDuffs: row[S.colBalanceAfter],
+                observedAt: Date(timeIntervalSince1970: row[S.colObservedAt]))
+        }
+    }
+}
+
+// MARK: - Recorder
+
+/// Diffs each BLAST pass's per-address balances against the persisted
+/// baseline and records unattributed increases as received activity.
+/// Main-actor: called from `PlatformAddressSyncCoordinator` after its
+/// snapshot refresh; reads SwiftData through the host's main context.
+@MainActor
+enum PlatformAddressActivityRecorder {
+
+    /// Suppression window for matching an increase to an own operation.
+    /// Wide on purpose: an own unshield's credit may only be OBSERVED
+    /// many minutes after the operation (next full rescan).
+    private static let ownOperationWindow: TimeInterval = 6 * 60 * 60
+
+    static func observe(
+        addresses: [DerivedPlatformAddress],
+        walletId: Data,
+        network: Network,
+        container: ModelContainer
+    ) {
+        guard !addresses.isEmpty else { return }
+        let networkRaw = Int64(network.rawValue)
+        let dao = PlatformAddressActivityDAO.shared
+        let baseline = dao.baselineBalances(walletId: walletId, networkRaw: networkRaw)
+
+        // First observation of this wallet+network: seed the baseline
+        // silently. Recording the whole standing balance as "received
+        // today" would be fabricated history.
+        guard !baseline.isEmpty else {
+            for entry in addresses where entry.balance > 0 {
+                dao.upsertBaseline(
+                    walletId: walletId, networkRaw: networkRaw,
+                    address: entry.address, balanceDuffs: Int64(entry.balance))
+            }
+            return
+        }
+
+        var increases: [(address: String, delta: Int64, after: Int64)] = []
+        var netChange: Int64 = 0
+        for entry in addresses {
+            let after = Int64(entry.balance)
+            let before = baseline[entry.address] ?? 0
+            let delta = after - before
+            if delta == 0 { continue }
+            netChange += delta
+            if delta > 0 {
+                increases.append((entry.address, delta, after))
+            } else {
+                // Decrease: own spend (transfer/shield/withdrawal) — those
+                // flows have their own history representations. Baseline
+                // moves silently.
+                dao.upsertBaseline(
+                    walletId: walletId, networkRaw: networkRaw,
+                    address: entry.address, balanceDuffs: after)
+            }
+        }
+        guard !increases.isEmpty else { return }
+
+        // A pass whose deltas cancel out is an intra-wallet shuffle
+        // (own transfer between own addresses + change) — nothing was
+        // received.
+        let shuffleOnly = netChange == 0
+
+        var recorded = false
+        for increase in increases {
+            let internallyExplained = shuffleOnly
+                || matchesOwnUnshield(
+                    address: increase.address, deltaDuffs: increase.delta,
+                    walletId: walletId, network: network, container: container)
+                || matchesOwnAssetLockTopUp(
+                    address: increase.address, deltaDuffs: increase.delta,
+                    walletId: walletId, container: container)
+            if !internallyExplained {
+                dao.insertActivity(
+                    walletId: walletId, networkRaw: networkRaw,
+                    address: increase.address, amountDuffs: increase.delta,
+                    balanceAfterDuffs: increase.after)
+                recorded = true
+            }
+            dao.upsertBaseline(
+                walletId: walletId, networkRaw: networkRaw,
+                address: increase.address, balanceDuffs: increase.after)
+        }
+        if recorded {
+            NotificationCenter.default.post(name: .platformAddressActivityRecorded, object: nil)
+        }
+    }
+
+    /// Exact match against an own internal unshield: same destination
+    /// address, credited amount == entry.amount − fee (the recipient
+    /// receives the principal net of the pool fee).
+    private static func matchesOwnUnshield(
+        address: String,
+        deltaDuffs: Int64,
+        walletId: Data,
+        network: Network,
+        container: ModelContainer
+    ) -> Bool {
+        let cutoffMs = UInt64(max(0, Date().timeIntervalSince1970 - ownOperationWindow) * 1000)
+        let unshieldKind = 4
+        let descriptor = FetchDescriptor<PersistentShieldedActivity>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.kindTag == unshieldKind && $0.createdAtMs >= cutoffMs
+            })
+        guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
+        for row in rows {
+            guard row.counterparty.count == 21 else { continue }
+            let destination = AddressTransformer.formatAddress(
+                row.counterparty, asBech32m: true, isTestnet: network != .mainnet)
+            guard destination == address else { continue }
+            let creditedCredits = row.amount - (row.hasFee ? row.fee : 0)
+            if Int64(creditedCredits / 1000) == deltaDuffs {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Match against an own Transparent → Platform top-up: the asset
+    /// lock stores the recipient's 20-byte platform address hash, so the
+    /// address match is exact; the credited amount is the lock value
+    /// minus a small conversion fee, so the delta only has to fit under
+    /// the lock value.
+    private static func matchesOwnAssetLockTopUp(
+        address: String,
+        deltaDuffs: Int64,
+        walletId: Data,
+        container: ModelContainer
+    ) -> Bool {
+        guard let storageBytes = AddressTransformer.parseAddress(address),
+              storageBytes.count == 21 else { return false }
+        let addressHash = storageBytes.dropFirst()
+        let cutoff = Date().addingTimeInterval(-ownOperationWindow)
+        let topUpType = 4 // AssetLockAddressTopUp
+        let descriptor = FetchDescriptor<PersistentAssetLock>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.fundingTypeRaw == topUpType && $0.updatedAt >= cutoff
+            })
+        guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
+        return rows.contains { lock in
+            lock.recipientPlatformAddressHash == Data(addressHash)
+                && deltaDuffs <= lock.amountDuffs
+        }
+    }
+}

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -623,6 +623,21 @@ struct HomeViewContent<Content: View>: View {
                 self.selectedTxDataItem = txDataItem
             }
             .frame(minHeight: 66)
+
+        case .platformActivity(let item):
+            DashUIKit.TransactionView(
+                iconView: transferRouteIcon("creditcard.fill"),
+                secondaryIcon: DashIconSource.system("arrow.down"),
+                title: item.title,
+                subtitle: item.shortTimeString,
+                details: item.detailsText,
+                dashAmount: item.signedDashAmount,
+                amountSign: .always,
+                fiat: item.fiatAmount
+            ) {
+                self.selectedTxDataItem = txDataItem
+            }
+            .frame(minHeight: 66)
         }
     }
 }
@@ -839,6 +854,8 @@ struct TransactionDetailsSheet: View {
             TXDetailVCWrapper(tx: txItem, navigateBack: $backNavigationRequested)
         case .shieldedActivity(let item):
             ShieldedActivityDetailsView(item: item)
+        case .platformActivity(let item):
+            PlatformAddressActivityDetailsView(item: item)
         }
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -285,6 +285,16 @@ class HomeViewModel: ObservableObject {
             }
             .store(in: &cancellableBag)
 
+        // The platform-address recorder inserts into the app's SQLite —
+        // invisible to the SwiftData save trigger above — so it posts its
+        // own signal when a received row lands.
+        NotificationCenter.default.publisher(for: .platformAddressActivityRecorded)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.txReloadRequests.send()
+            }
+            .store(in: &cancellableBag)
+
         // Balance changes often indicate new transactions, so reload the full
         // transaction list, not just shortcuts. This ensures newly received or
         // sent transactions appear in the UI promptly.
@@ -385,6 +395,21 @@ class HomeViewModel: ObservableObject {
                     hasMasternodes: hasMasternodes)
                 else { continue }
                 items.append(.shieldedActivity(shielded))
+            }
+
+            // Observed incoming Platform-address payments (app-recorded —
+            // the SDK persists no per-payment platform history; see
+            // PlatformAddressActivityStore.swift). Received-only by
+            // construction, so they ride the .received filter category.
+            let platformItems = SwiftDashSDKWalletSource.fetchPlatformActivity()
+            for platform in platformItems {
+                guard self.passesCategoryFilter(
+                    categories: [.received],
+                    selected: self.selectedFilters,
+                    hasRewards: hasRewards,
+                    hasMasternodes: hasMasternodes)
+                else { continue }
+                items.append(.platformActivity(platform))
             }
 
             self.txByHash.removeAll()
@@ -820,6 +845,31 @@ extension HomeViewModel {
         hasRewards: Bool,
         hasMasternodes: Bool
     ) -> Bool {
+        var categories: Set<TransactionFilterCategory> = []
+        switch item.direction {
+        case .incoming:
+            categories.insert(.shieldedReceived)
+        case .outgoing:
+            categories.insert(.shieldedSent)
+        case .selfTransfer:
+            categories.formUnion([.shieldedSent, .shieldedReceived])
+        }
+        return passesCategoryFilter(
+            categories: categories,
+            selected: selected,
+            hasRewards: hasRewards,
+            hasMasternodes: hasMasternodes)
+    }
+
+    /// Shared filter check for non-Core history items with precomputed
+    /// categories — same "everything offered selected → show all" fast
+    /// path as `passesFilter(transaction:...)`.
+    private func passesCategoryFilter(
+        categories: Set<TransactionFilterCategory>,
+        selected: Set<TransactionFilterCategory>,
+        hasRewards: Bool,
+        hasMasternodes: Bool
+    ) -> Bool {
         var offered = Set(TransactionFilterCategory.allCases)
         if !hasRewards {
             offered.remove(.rewards)
@@ -829,15 +879,6 @@ extension HomeViewModel {
         }
         if selected.isSuperset(of: offered) {
             return true
-        }
-        var categories: Set<TransactionFilterCategory> = []
-        switch item.direction {
-        case .incoming:
-            categories.insert(.shieldedReceived)
-        case .outgoing:
-            categories.insert(.shieldedSent)
-        case .selfTransfer:
-            categories.formUnion([.shieldedSent, .shieldedReceived])
         }
         return !selected.isDisjoint(with: categories)
     }
@@ -1152,6 +1193,23 @@ class SwiftDashSDKWalletSource: TransactionSource {
             predicate: #Predicate { $0.address == address && $0.walletId == walletId })
         descriptor.fetchLimit = 1
         return ((try? context.fetch(descriptor)) ?? []).isEmpty == false
+    }
+
+    /// The active wallet's observed incoming Platform-address payments
+    /// (app-recorded ledger; see PlatformAddressActivityStore.swift).
+    /// Safe from any thread — the DAO's SQLite connection serializes.
+    static func fetchPlatformActivity() -> [PlatformAddressActivityItem] {
+        let handles: (walletId: Data, networkRaw: Int64)? = onMain {
+            guard let walletId = SwiftDashSDKHost.shared.wallet?.walletId,
+                  let network = SwiftDashSDKHost.shared.runningNetwork else {
+                return nil
+            }
+            return (walletId, Int64(network.rawValue))
+        }
+        guard let handles else { return [] }
+        return PlatformAddressActivityDAO.shared
+            .activities(walletId: handles.walletId, networkRaw: handles.networkRaw)
+            .map { PlatformAddressActivityItem(record: $0) }
     }
 
     /// Decode a withdrawal entry's counterparty (a Core scriptPubKey)

--- a/DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift
@@ -1,0 +1,180 @@
+//
+//  PlatformAddressHistory.swift
+//  DashWallet
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+//  Observed incoming Platform-address payments in the home history:
+//  the list item projected from `PlatformAddressActivityRecord`, and
+//  the detail sheet a tapped row opens. See
+//  `PlatformAddressActivityStore.swift` for what gets recorded (and
+//  the honest limits of observation-time attribution).
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - List item
+
+struct PlatformAddressActivityItem: Identifiable {
+    let recordId: Int64
+    let address: String
+    let amountDuffs: Int64
+    let balanceAfterDuffs: Int64
+    let date: Date
+
+    init(record: PlatformAddressActivityRecord) {
+        recordId = record.id
+        address = record.address
+        amountDuffs = record.amountDuffs
+        balanceAfterDuffs = record.balanceAfterDuffs
+        date = record.observedAt
+    }
+
+    var id: String { "platform-activity-\(recordId)" }
+
+    var title: String {
+        NSLocalizedString("Received", comment: "")
+    }
+
+    /// Row pill: the receiving address, shortened — mirrors the external
+    /// shielded rows.
+    var detailsText: String {
+        String(address.prefix(6)) + "…" + String(address.suffix(6))
+    }
+
+    var signedDashAmount: Int64 {
+        amountDuffs
+    }
+
+    var fiatAmount: String {
+        CurrencyExchanger.shared.fiatAmountString(for: UInt64(max(0, amountDuffs)).dashAmount)
+    }
+
+    var shortTimeString: String {
+        DWDateFormatter.sharedInstance.timeOnly(from: date)
+    }
+}
+
+// MARK: - Detail sheet
+
+/// Read-only detail for one observed Platform-address payment. There is
+/// deliberately little to show: Platform payments carry no sender, and
+/// the timestamp is when the wallet observed the balance change.
+struct PlatformAddressActivityDetailsView: View {
+    let item: PlatformAddressActivityItem
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .bottomTrailing) {
+                Image(systemName: "creditcard.fill")
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundColor(.dashBlue)
+                    .frame(width: 56, height: 56)
+                    .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                Image(systemName: "arrow.down")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(width: 20, height: 20)
+                    .background(Circle().fill(Color.dashBlue))
+                    .offset(x: 4, y: 4)
+            }
+            .padding(.top, 24)
+
+            Text(item.title)
+                .font(.headline)
+                .foregroundColor(.primaryText)
+                .padding(.top, 12)
+
+            DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: true)
+                .padding(.top, 4)
+            Text(item.fiatAmount)
+                .font(.footnote)
+                .foregroundColor(.tertiaryText)
+                .padding(.top, 2)
+
+            VStack(spacing: 0) {
+                infoRow(
+                    NSLocalizedString("Type", comment: ""),
+                    NSLocalizedString("Platform", comment: ""))
+                copyableRow(NSLocalizedString("To", comment: ""), item.address)
+                HStack(alignment: .firstTextBaseline) {
+                    Text(NSLocalizedString("Balance after", comment: "Platform address payment detail"))
+                        .font(.footnote)
+                        .foregroundColor(.tertiaryText)
+                    Spacer()
+                    DashAmount(amount: item.balanceAfterDuffs, font: .footnote, showDirection: false)
+                }
+                .padding(.vertical, 10)
+                infoRow(
+                    NSLocalizedString("Date", comment: ""),
+                    DWDateFormatter.sharedInstance.longString(from: item.date))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+            .background(Color.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+
+            Text(NSLocalizedString("Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier.", comment: "Platform address payment detail"))
+                .font(.caption)
+                .foregroundColor(.tertiaryText)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+                .padding(.top, 16)
+
+            Spacer(minLength: 24)
+        }
+    }
+
+    @ViewBuilder
+    private func infoRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.footnote)
+                .foregroundColor(.tertiaryText)
+            Spacer()
+            Text(value)
+                .font(.footnote)
+                .foregroundColor(.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private func copyableRow(_ label: String, _ value: String) -> some View {
+        Button {
+            UIPasteboard.general.string = value
+        } label: {
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                    .font(.footnote)
+                    .foregroundColor(.tertiaryText)
+                Spacer()
+                Text(value.prefix(8) + "…" + value.suffix(8))
+                    .font(.footnote)
+                    .monospaced()
+                    .foregroundColor(.primaryText)
+                Image(systemName: "doc.on.doc")
+                    .font(.caption2)
+                    .foregroundColor(.dashBlue)
+            }
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/DashWallet/Sources/UI/Home/Views/TransactionListDataItem.swift
+++ b/DashWallet/Sources/UI/Home/Views/TransactionListDataItem.swift
@@ -30,6 +30,7 @@ class TransactionGroup: Identifiable {
 enum TransactionListDataItem {
     case tx(Transaction, TxRowMetadata?)
     case shieldedActivity(ShieldedActivityItem)
+    case platformActivity(PlatformAddressActivityItem)
     case crowdnode(FullCrowdNodeSignUpTxSet)
     case coinjoin(CoinJoinMixingTxSet)
     case coinjoinWithdrawal(CoinJoinWithdrawalTxSet)
@@ -48,6 +49,8 @@ extension TransactionListDataItem: Identifiable {
             return tx.txHashHexString
         case .shieldedActivity(let item):
             return item.id
+        case .platformActivity(let item):
+            return item.id
         }
     }
 
@@ -62,6 +65,8 @@ extension TransactionListDataItem: Identifiable {
         case .tx(let tx, _):
             return tx.date
         case .shieldedActivity(let item):
+            return item.date
+        case .platformActivity(let item):
             return item.date
         }
     }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -449,6 +449,8 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+
+"Balance after" = "Balance after";
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
@@ -2608,6 +2610,8 @@
 "Platform Payment" = "Platform Payment";
 
 /* Masternodes */
+
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier.";
 "Platform SDK not ready" = "Platform SDK not ready";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
## Problem

When someone pays one of the wallet's Platform addresses, the balance changes but **nothing appears in the home history** — confusing ("where did this money come from?"). There's no SDK-persisted platform payment stream to render: the BLAST sync surfaces absolute per-address balances, and its per-pass event carries only aggregate counters.

## Approach — an observational ledger (honest v1)

App-side recording, no SDK/FFI changes ([PlatformAddressActivityStore.swift](DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift), new app-SQLite migration):

- **Baseline + ledger**: per-(wallet, network, address) balance baseline; after every BLAST pass the recorder diffs the fresh snapshot against it and records unattributed increases as received activity. Works with today's full-rescan syncing and gets sharper once platform #4142 (incremental recent-changes fix) deploys.
- **First observation seeds silently** — recording a standing balance as "received today" would be fabricated history.
- **Own internal moves don't double-show** next to their existing history rows:
  - net-zero passes → intra-wallet shuffle, baseline only;
  - internal unshields → exact match on decoded destination address + net amount (principal − fee);
  - Transparent→Platform top-ups → exact match on the asset lock's `recipientPlatformAddressHash`.
- Decreases move the baseline silently (own spends have their own representations).

## UI

- **Received** rows (creditcard icon + down-arrow badge, shortened address pill, live fiat) interleave by day with Core and shielded rows; they ride the **Received** filter category (shielded filtering refactored onto a shared `passesCategoryFilter`).
- Detail sheet: copyable address, balance after, date, and the honest caveats — Platform payments carry no sender, and the timestamp is when the wallet observed the change (a payment landing while the app is closed records at next launch).
- The recorder posts its own reload signal (SQLite inserts are invisible to the SwiftData-save trigger the rest of the history uses).

## Known limits (by design, documented in the store header)

- Observation-time attribution, no block heights; history starts at install.
- Two same-pass payments to one address record as one combined row.

## Test plan

- [x] dashpay arm64-sim build green (both targets); installed on QA-iPhone16 + iPhone 16 Pro; migration applied and baselines seeded silently on both (2 / 3 funded addresses, 0 activity rows — no fabricated history)
- [ ] Send tDASH from one device to the other's Platform address (`tdash1…`) → Received row appears on the receiver within a sync pass (full rescan until #4142 deploys), with correct amount/fiat and the address pill
- [ ] Internal transfer Shielded→Platform → NO duplicate Received row (only the Unshielded row)
- [ ] Internal transfer Transparent→Platform → NO duplicate Received row (only the Core transfer row)
- [ ] Filter → Received includes the platform rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)