### PR TITLE
feat(wallet): block Core-funded sends until the chain has synced

### DIFF
--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -147,8 +147,26 @@ final class WalletSendService: NSObject {
         super.init()
     }
 
+    /// Core sends are blocked until the L1 chain sync completes: before
+    /// `.syncDone` the persisted UTXO set can be stale (already-spent inputs,
+    /// missing recent funds), so a built tx could be rejected — or worse,
+    /// double-spend a UTXO consumed while offline. Gate on
+    /// `SyncingActivityMonitor` per the repo guardrail (never raw SPV state).
+    /// UI entry points disable Continue with the same message; this is the
+    /// boundary backstop for programmatic callers.
+    private static func ensureChainSynced() throws {
+        guard SyncingActivityMonitor.shared.state == .syncDone else {
+            throw Self.makeError(
+                code: .chainNotSynced,
+                description: NSLocalizedString(
+                    "Your wallet is still syncing with the Dash network. Sending will be available once syncing completes.",
+                    comment: "Core send blocked until chain sync completes"))
+        }
+    }
+
     func prepareStandardSendForConfirmation(address: String, amount: UInt64, sessionAuthSufficient: Bool = false) async throws -> PreparedStandardSend {
         Self.logger.info("💸 TXSEND :: preparing standard send")
+        try Self.ensureChainSynced()
         try await sendAuthorizer.authorizeSend(spendAmount: amount, sessionAuthSufficient: sessionAuthSufficient)
         let prepared = try buildPreparedStandardSend(address: address, amount: amount)
         Self.logger.info("💸 TXSEND :: standard send prepared")
@@ -164,6 +182,7 @@ final class WalletSendService: NSObject {
         adjustAmountDownwards: Bool = false,
         sessionAuthSufficient: Bool = false
     ) async throws -> Data {
+        try Self.ensureChainSynced()
         if let inputSelector {
             Self.logger.info("💸 TXSEND :: routing to selected-input (SwiftDashSDK) path")
             try await sendAuthorizer.authorizeSend(spendAmount: amount, sessionAuthSufficient: sessionAuthSufficient)
@@ -285,6 +304,7 @@ final class WalletSendService: NSObject {
         memo: String? = nil
     ) async throws -> (txid: Data, feeDuffs: UInt64) {
         Self.logger.info("💸 TXSEND :: pay-to-contact starting — \(amount, privacy: .public) duffs")
+        try Self.ensureChainSynced()
         // spendAmount engages the biometric spending limit (C7.4) —
         // without it the gate is non-monetary and Face ID alone would
         // authorize a contact payment of any size.
@@ -469,6 +489,7 @@ private extension WalletSendService {
         case coinJoinSweepUnavailable = 4
         case alreadyBroadcast = 5
         case dashPayPaymentUnavailable = 6
+        case chainNotSynced = 7
     }
 
     static let errorDomain = "org.dashfoundation.dash.wallet-send-service"

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -55,6 +55,11 @@ struct InternalTransferScreen: View {
                     directionCards
                         .padding(.horizontal, 20)
 
+                    if viewModel.isBlockedBySync {
+                        SyncGateNote()
+                            .padding(.horizontal, 20)
+                    }
+
                     if viewModel.canContinue {
                         transferPreview
                             .padding(.horizontal, 20)

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -238,9 +238,22 @@ final class InternalTransferViewModel: ObservableObject {
     /// the manual `syncShieldedNow()` kick after a successful transfer.
     @Published private(set) var shieldedBalance: UInt64 = 0
 
+    /// True once the L1 chain sync completed (`SyncingActivityMonitor`
+    /// `.syncDone`). Core-funded routes (asset locks spend BIP44 UTXOs)
+    /// can't Continue before that — the UTXO set may be stale. Mirrors
+    /// `SendViewModel.isChainSynced`; `WalletSendService` guards the
+    /// classic path at the boundary.
+    @Published private(set) var isChainSynced = SyncingActivityMonitor.shared.state == .syncDone
+
     private var cancellables = Set<AnyCancellable>()
 
+    deinit {
+        // The monitor holds observers strongly — remove or leak the VM.
+        SyncingActivityMonitor.shared.remove(observer: self)
+    }
+
     init() {
+        SyncingActivityMonitor.shared.add(observer: self)
         coreBalanceDuffs = SwiftDashSDKWalletState.shared.balance?.total ?? 0
         platformCredits = PlatformAddressSyncCoordinator.shared.platformBalance
 
@@ -304,12 +317,24 @@ final class InternalTransferViewModel: ObservableObject {
     /// currently-selected source bucket. Each route has its own balance
     /// envelope — asset-lock spends BIP44 duffs, transparent shield spends
     /// DIP-17 credits.
+    /// True when the picked route spends Core UTXOs but the chain hasn't
+    /// finished syncing — Continue stays disabled and the screen explains
+    /// why (a stale UTXO set can't safely fund an asset lock).
+    var isBlockedBySync: Bool {
+        switch route {
+        case .coreToShielded, .coreToPlatform:
+            return !isChainSynced
+        default:
+            return false
+        }
+    }
+
     var canContinue: Bool {
         // Gate on duffs, not raw DASH: a sub-duff amount (e.g. 1e-9 DASH)
         // renders as 0 in the confirm sheet, so it must not enable Continue —
         // otherwise the credit routes would submit a nonzero amount while the
         // UI shows 0.
-        guard dashDuffsUnsigned > 0 else { return false }
+        guard dashDuffsUnsigned > 0, !isBlockedBySync else { return false }
         switch route {
         case .coreToShielded, .coreToPlatform:
             // Asset-lock routes: the pool/processing fee is carved from the
@@ -552,5 +577,19 @@ final class InternalTransferViewModel: ObservableObject {
         formatter.decimalSeparator = "."
         let rounded = NSDecimalNumber(decimal: value)
         return formatter.string(from: rounded) ?? "\(value)"
+    }
+}
+
+
+// MARK: - SyncingActivityMonitorObserver
+
+extension InternalTransferViewModel: SyncingActivityMonitorObserver {
+    nonisolated func syncingActivityMonitorProgressDidChange(_ progress: Double) {}
+
+    nonisolated func syncingActivityMonitorStateDidChange(previousState: SyncingActivityMonitor.State,
+                                                          state: SyncingActivityMonitor.State) {
+        Task { @MainActor in
+            self.isChainSynced = state == .syncDone
+        }
     }
 }

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -58,6 +58,11 @@ struct SendScreen: View {
                     if viewModel.destination != nil {
                         sourceCards
 
+                        if viewModel.isBlockedBySync {
+                            SyncGateNote()
+                                .padding(.horizontal, 20)
+                        }
+
                         TransferAmountRow(
                             unit: $viewModel.unit,
                             amountText: viewModel.amountText,
@@ -825,5 +830,30 @@ struct SendConfirmSheet: View {
         }
         coordinator.reset()
         confirm()
+    }
+}
+
+
+/// Inline explanation for a Continue disabled by the chain-sync gate:
+/// Core-funded sends stay off until `SyncingActivityMonitor` reports
+/// `.syncDone` (a stale UTXO set can't safely fund a spend). Shared by
+/// the Send and Internal transfer screens.
+struct SyncGateNote: View {
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 13))
+                .foregroundColor(.orange)
+            Text(NSLocalizedString(
+                "Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes.",
+                comment: "Core send blocked until chain sync completes"))
+                .font(.caption)
+                .foregroundColor(.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color.orange.opacity(0.08))
+        .cornerRadius(10)
     }
 }

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -74,6 +74,12 @@ final class SendViewModel: ObservableObject {
     @Published private(set) var withdrawalPreflight: ManagedPlatformAddressWallet.WithdrawalPreflight?
     private var preflightTask: Task<Void, Never>?
 
+    /// True once the L1 chain sync completed (`SyncingActivityMonitor`
+    /// `.syncDone`). Core-funded routes can't Continue before that — the
+    /// UTXO set may be stale (see `WalletSendService.ensureChainSynced`,
+    /// the boundary backstop behind this UI gate).
+    @Published private(set) var isChainSynced = SyncingActivityMonitor.shared.state == .syncDone
+
     private var cancellables = Set<AnyCancellable>()
 
     /// Set by the balance-row send sheet: the source is fixed to the tapped
@@ -82,12 +88,19 @@ final class SendViewModel: ObservableObject {
     /// rather than silently re-picking the source.
     let pinnedSource: ChainNetwork?
 
+    deinit {
+        // The monitor holds observers strongly — without this the VM (and
+        // its Combine pipelines) outlive the screen.
+        SyncingActivityMonitor.shared.remove(observer: self)
+    }
+
     init(pinnedSource: ChainNetwork? = nil) {
         self.pinnedSource = pinnedSource
         if let pinnedSource {
             source = pinnedSource
         }
         refreshClipboardSuggestion()
+        SyncingActivityMonitor.shared.add(observer: self)
 
         NotificationCenter.default.publisher(for: UIPasteboard.changedNotification)
             .receive(on: RunLoop.main)
@@ -468,8 +481,21 @@ final class SendViewModel: ObservableObject {
             && dashDuffsUnsigned == platformWithdrawableDuffs
     }
 
+    /// True when the picked route spends Core UTXOs but the chain hasn't
+    /// finished syncing — Continue stays disabled and the screen explains
+    /// why (a stale UTXO set can't safely fund a send).
+    var isBlockedBySync: Bool {
+        guard let route else { return false }
+        switch route {
+        case .coreToCore, .coreToShielded:
+            return !isChainSynced
+        default:
+            return false
+        }
+    }
+
     var canContinue: Bool {
-        guard dashDuffsUnsigned > 0, let route else { return false }
+        guard dashDuffsUnsigned > 0, let route, !isBlockedBySync else { return false }
         switch route {
         case .coreToCore:
             // The L1 fee rides on top; the payment processor rejects an
@@ -547,6 +573,20 @@ final class SendViewModel: ObservableObject {
             }
         } catch {
             // Rate fetch failed — leave `amountText` as-is so the user can re-type.
+        }
+    }
+}
+
+
+// MARK: - SyncingActivityMonitorObserver
+
+extension SendViewModel: SyncingActivityMonitorObserver {
+    nonisolated func syncingActivityMonitorProgressDidChange(_ progress: Double) {}
+
+    nonisolated func syncingActivityMonitorStateDidChange(previousState: SyncingActivityMonitor.State,
+                                                          state: SyncingActivityMonitor.State) {
+        Task { @MainActor in
+            self.isChainSynced = state == .syncDone
         }
     }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -4677,6 +4677,12 @@
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
 
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Your wallet is still syncing with the Dash network. Sending will be available once syncing completes.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes.";
+
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
 


### PR DESCRIPTION
## What

Core-funded sends are now blocked until the L1 chain sync completes. Before `SyncingActivityMonitor` reports `.syncDone`, the persisted UTXO set can be stale — already-spent inputs or missing recent funds — so a built transaction could be rejected or, worse, double-spend a UTXO consumed while the wallet was offline.

- **Boundary guard** (`WalletSendService.ensureChainSynced()`): `prepareStandardSendForConfirmation`, `send(...)`, and `sendToContact` throw a localized `chainNotSynced` error while unsynced — covering every programmatic path (payment processor, scan-QR pay flow, DashPay contact payments). CoinJoin sweep is deliberately not gated (recovery to the wallet's own address).
- **UI gates**: `SendViewModel` and `InternalTransferViewModel` observe the monitor; Continue is disabled for any route that spends Core UTXOs — `coreToCore`, `coreToShielded`, `coreToPlatform`, including the balance-row sheets' pinned variants.
- **Honest affordance**: a shared `SyncGateNote` banner on the Send and Internal transfer screens explains why Continue is disabled ("Your wallet is still syncing…") instead of leaving a dead button.

Platform- and Shielded-funded routes (platform→platform/core/shielded, shielded→anything) stay available during sync — their balances come from the Platform-side syncs, not the L1 UTXO set.

Per the repo guardrail, gating is on `SyncingActivityMonitor` (`.syncDone`), never raw SPV state (dash-spv's synced steady state is `waitForEvents`).

## Implementation notes

- The monitor's observer array holds strongly, so both VMs remove themselves in `deinit` (same pattern as `SyncingAlertViewModel`).
- Observer callbacks hop to the main actor before touching `@Published` state.

## Testing

Testnet smoke on QA-iPhone16 / iPhone 16 Pro sims: fresh launch mid-sync shows the banner and a disabled Continue on Send (Core destination) and on Transparent-funded internal transfers, while Shielded→Core stays enabled; once the monitor flips to synced the banner disappears and sends work; scan-QR pay during sync surfaces the localized error instead of building a tx. Unit-test target pre-existing-broken per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)