### PR TITLE
feat(ui): TESTNET badge on the home balance header

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
@@ -25,6 +25,10 @@ final class BalanceModel: ObservableObject {
     
     @Published private(set) var state = SyncingActivityMonitor.shared.state
     @Published private(set) var value: UInt64 = 0
+    /// True while the wallet runs on testnet — drives the home header's
+    /// TESTNET badge so test funds can't be mistaken for real Dash
+    /// (fresh installs currently default to testnet by design).
+    @Published private(set) var isTestnet = WalletEnvironment.isTestnet
     @Published var isBalanceHidden: Bool {
         didSet {
             DWGlobalOptions.sharedInstance().balanceHidden = isBalanceHidden
@@ -52,6 +56,13 @@ final class BalanceModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.reloadBalance()
+            }
+            .store(in: &cancellableBag)
+
+        NotificationCenter.default.publisher(for: NSNotification.Name.DWCurrentNetworkDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.isTestnet = WalletEnvironment.isTestnet
             }
             .store(in: &cancellableBag)
 

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
@@ -49,6 +49,10 @@ struct HomeBalanceView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            if viewModel.isTestnet {
+                testnetBadge
+            }
+
             ZStack {
                 if !viewModel.isBalanceHidden && viewModel.state == .syncing {
                     Text(NSLocalizedString("Syncing Balance", comment: ""))
@@ -150,6 +154,18 @@ struct HomeBalanceView: View {
         .padding(.horizontal, 12)
         .background(Color.white.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// Unmissable "these are not real funds" marker while the wallet runs
+    /// on testnet.
+    private var testnetBadge: some View {
+        Text(NSLocalizedString("TESTNET", comment: "Badge on the home balance while the wallet runs on testnet"))
+            .font(.system(size: 11, weight: .bold))
+            .kerning(1.2)
+            .foregroundColor(.white)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Color.orange.opacity(0.9)))
     }
 
     private var rowDivider: some View {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -3544,6 +3544,9 @@
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
 
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
+
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
 


### PR DESCRIPTION
## What

An orange **TESTNET** capsule at the top of the home balance header whenever the wallet runs on testnet, so test funds can't be mistaken for real Dash. Especially relevant while fresh installs deliberately default to testnet during the migration (`WalletEnvironment.networkKind`'s missing-key default, owner decision 2026-07-03).

- Driven by a `@Published isTestnet` on `BalanceModel`, re-evaluated on `DWCurrentNetworkDidChange` — the badge appears/disappears live when using the switch-network shortcuts.
- Renders nothing on mainnet.

## Testing

Testnet smoke on QA-iPhone16 / iPhone 16 Pro sims (both run testnet): badge visible above the balance; balance hide/show, sync label, and breakdown card layout unaffected. Unit-test target pre-existing-broken per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)