### PR TITLE
fix(dashpay): don't carry the identity across a network switch

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -168,6 +168,16 @@ public final class DWCurrentUserIdentityInfo: NSObject {
             selector: #selector(handleInvalidationNotification(_:)),
             name: SwiftDashSDKWalletState.activeWalletDidChangeNotification,
             object: nil)
+        // A network switch rebinds the host to the destination network's
+        // container, whose identity set is entirely different (or empty) —
+        // the walletId can be identical across networks (same seed), so the
+        // active-wallet notification alone doesn't cover it. Without this
+        // the testnet identity kept rendering on mainnet.
+        center.addObserver(
+            self,
+            selector: #selector(handleInvalidationNotification(_:)),
+            name: NSNotification.Name.DWCurrentNetworkDidChange,
+            object: nil)
     }
 
     // MARK: - Obj-C / Swift read API

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletEnvironment.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletEnvironment.swift
@@ -114,6 +114,17 @@ public final class WalletEnvironment: NSObject {
             return false
         }
 
+        // The DashPay mirror (username + registration flag) is a single
+        // global slot while identities are per-network — without this, a
+        // testnet-registered username keeps rendering after switching to
+        // mainnet (avatar, menu, Join DashPay gating all read the mirror).
+        // Clearing is safe: re-entering a network that has a registered
+        // identity re-backfills the mirror from the SDK's
+        // `PersistentIdentity` rows on the next read
+        // (`DWCurrentUserIdentityInfo`'s self-heal).
+        DWGlobalOptions.sharedInstance().dashpayUsername = nil
+        DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = false
+
         UserDefaults.standard.set(kind.rawValue, forKey: currentChainTypeKey)
         NotificationCenter.default.post(name: NSNotification.Name.DWCurrentNetworkDidChange, object: nil)
         return true


### PR DESCRIPTION
## What

Switching testnet → mainnet kept rendering the testnet identity (username, avatar, registered state) even though the destination network has no identity. Two root causes, both fixed:

1. **Global mirror, per-network identities**: `DWGlobalOptions.dashpayUsername` / `dashpayRegistrationCompleted` are single global UserDefaults slots, and they're the values `DWDashPayModel.username` / `registrationCompleted` / `hasIdentity` terminate on — driving the home avatar, menu state, and Join DashPay gating. `WalletEnvironment.switchToNetwork` now clears both before posting `DWCurrentNetworkDidChange`. Clearing is safe: `DWCurrentUserIdentityInfo`'s existing self-heal re-backfills the mirror from the destination network's `PersistentIdentity` rows on the next read, so switching back to a network with a registered identity restores it automatically.
2. **Stale snapshot cache**: `DWCurrentUserIdentityInfo` invalidates on registration events and active-wallet changes — but a network switch fires neither (the walletId is identical across networks, same seed), so the cached testnet snapshot kept being served after the host rebound to mainnet's container. It now also invalidates on `DWCurrentNetworkDidChange`; the rebuild reads the newly-bound per-network container, which is authoritative.

## Testing

Testnet smoke on QA-iPhone16 (wallet with a registered testnet identity): switch to mainnet → avatar/username gone, Join DashPay banner returns; switch back to testnet → identity reappears after the SDK rows re-read. Build green on the dashpay scheme; unit-test target pre-existing-broken per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)