### PR TITLE
feat(wallet): fix Verify Recovery Phrase crash from removed shuffledArray

### DIFF
--- a/DashWallet/Sources/UI/Setup/SecureWallet/Seed/Views/SeedPhrase/DWSeedPhraseModel.m
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/Seed/Views/SeedPhrase/DWSeedPhraseModel.m
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
             [words addObject:newWord];
         }
 
-        _words = [words shuffledArray];
+        _words = [[GKRandomSource sharedRandom] arrayByShufflingObjectsInArray:words];
     }
     return self;
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Reported via TestFlight (9.0.0 build 9) — the app crashes the moment the user reaches the **Verify Recovery Phrase** screen (Backup / Show Recovery Phrase flow):

```
-[__NSArrayM shuffledArray]: unrecognized selector sent to instance
```

The seed-phrase verification step shuffled the words via `-[NSArray shuffledArray]`, a category method formerly provided by DashSync's `NSArray+Dash`. That method was dropped during the DashSync teardown, so at runtime the selector no longer resolves and the app aborts. This is deterministic — it affects every user who reaches the verification step, which is exactly the "make sure you've backed up your wallet" flow called out in the beta release notes.

## What was done?
Shuffle in-place with GameplayKit's `GKRandomSource` instead — the header already imports GameplayKit (which the old category wrapped), so this drops the last dependency on the removed category with no behavior change.

`DWSeedPhraseModel.m:68`
```objc
- _words = [words shuffledArray];
+ _words = [[GKRandomSource sharedRandom] arrayByShufflingObjectsInArray:words];
```

This was the only remaining call site of `shuffledArray` in the codebase.

## How Has This Been Tested?
- Root-caused from the TestFlight crash log; call chain confirmed:
  `BackupSeedPhraseViewController.actionButtonAction` → `DWVerifySeedPhraseViewController controllerWithSeedPhrase:` → `DWVerifySeedPhraseModel initWithSeedPhrase:` → `DWSeedPhraseModel initByShufflingSeedPhrase:`.
- Verified `shuffledArray` is not defined anywhere reachable (removed from `NSArray+Dash`), and this is its only caller.
- Manual smoke pending on device/testnet via Backup → **Verify Recovery Phrase** (word re-ordering step). Change is a 1-line drop-in using an already-imported API.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone