### PR TITLE
feat(wallet): Max fills the fee-aware maxSendable

### DIFF
--- a/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
@@ -76,7 +76,10 @@ class SendAmountModel: BaseAmountModel {
     }
 
     internal func selectAllFundsWithoutAuth() {
-        let allAvailableFunds = SwiftDashSDKWalletState.shared.balance?.spendable ?? 0
+        // Fee-aware max: spendable minus the send fee reserve (the app-wide
+        // WalletBalance.maxSendable contract), not raw spendable — the latter
+        // leaves no room for the fee, so the send fails to build.
+        let allAvailableFunds = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
 
         if allAvailableFunds > 0 {
             updateCurrentAmountObject(with: allAvailableFunds)

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -509,7 +509,10 @@ final class InternalTransferViewModel: ObservableObject {
         let sourceDuffs: UInt64
         switch route {
         case .coreToShielded, .coreToPlatform:
-            sourceDuffs = coreBalanceDuffs
+            // Fee-aware max: spendable minus the send fee reserve (mirrors
+            // DSAccount.maxOutputAmount), never the raw total — the asset-lock
+            // spends core UTXOs and still needs room for the L1 fee.
+            sourceDuffs = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
         case .platformToShielded:
             // Reserve the fee the SDK charges on top of the amount so Max
             // stays sendable (credits → duffs: integer divide by 1000).

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -528,7 +528,10 @@ final class SendViewModel: ObservableObject {
         let sourceDuffs: UInt64
         switch route {
         case .coreToCore, .coreToShielded, nil:
-            sourceDuffs = coreBalanceDuffs
+            // Fee-aware max: spendable minus the send fee reserve (mirrors
+            // DSAccount.maxOutputAmount), never the raw total — which would
+            // include unconfirmed/immature funds and leave no room for the fee.
+            sourceDuffs = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
         case .platformToPlatform:
             sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
         case .platformToCore:


### PR DESCRIPTION
## Issue being fixed or feature implemented
The "Max" buttons in the Send and Internal-transfer flows filled the raw balance, leaving no room for the transaction fee — and for the `total`-based ones, even including unconfirmed/immature funds that can't be spent. The resulting amount was not actually sendable, so the send failed to build or showed insufficient funds.

## What was done?
Routed all three Max fills through `WalletBalance.maxSendable` (spendable minus the send fee reserve — the SwiftDashSDK replacement for `DSAccount.maxOutputAmount` that the rest of the app already caps Max at, e.g. `ContactProfileSheet`, `BuyCreditsViewController`, `DashSpendPayViewModel`, `CrowdNode`, and the `WalletSendService` "callers cap input at maxSendable" contract):

- `SendViewModel.fillMaxFromWallet` (Core legs) — was `balance.total`
- `SendAmountModel.selectAllFundsWithoutAuth` (classic amount screen) — was `balance.spendable`
- `InternalTransferViewModel.fillMaxFromWallet` (Core legs) — was `balance.total`

Only the Max fills changed; balance-card display and affordability checks that legitimately use `total` are untouched.

## How Has This Been Tested?
Clean `dashpay` build (`xcodebuild ... -scheme dashpay -sdk iphonesimulator ARCHS=arm64 build`). Not yet smoke-tested on testnet — worth confirming that tapping Max then Send actually broadcasts for a Transparent send and a Core→Shielded internal transfer.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone