### PR TITLE
feat(ui): migrate SwiftUI views to DashUIKit color tokens for dark mode

### DIFF
--- a/DashWallet/Sources/UI/Auth/PinPromptView.swift
+++ b/DashWallet/Sources/UI/Auth/PinPromptView.swift
@@ -15,6 +15,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - Result
 
@@ -190,7 +191,7 @@ struct PinPromptView: View {
     var body: some View {
         ZStack {
             // Dimmed pass-through backdrop (the send screen shows through).
-            Color.black.opacity(0.5)
+            Color.dash.backgroundOverlay
                 .ignoresSafeArea()
 
             card
@@ -226,7 +227,7 @@ struct PinPromptView: View {
             VStack(spacing: 16) {
                 Text(viewModel.titleMessage)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 dots
                     .modifier(ShakeEffect(animatableData: CGFloat(viewModel.shakeToken)))
@@ -234,14 +235,14 @@ struct PinPromptView: View {
                 if let subtitle = viewModel.subtitleMessage, viewModel.lockoutMessage == nil {
                     Text(subtitle)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .multilineTextAlignment(.center)
                 }
 
                 if let lockout = viewModel.lockoutMessage {
                     Text(lockout)
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.systemRed)
+                        .foregroundColor(.dash.red)
                         .multilineTextAlignment(.center)
                 }
             }
@@ -254,7 +255,7 @@ struct PinPromptView: View {
             Button(action: viewModel.cancel) {
                 Text(NSLocalizedString("Cancel", comment: ""))
                     .font(.system(size: 17))
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
                     .frame(maxWidth: .infinity)
                     .frame(height: 52)
             }
@@ -274,7 +275,7 @@ struct PinPromptView: View {
                 .disabled(viewModel.isLockedOut)
                 .id(viewModel.fieldGeneration)
         )
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .cornerRadius(14)
     }
 
@@ -288,7 +289,7 @@ struct PinPromptView: View {
                     .frame(width: 60, height: 60)
                     .overlay(
                         Circle()
-                            .fill(Color.primaryText)
+                            .fill(Color.dash.primaryText)
                             .frame(width: 14, height: 14)
                             .opacity(index < viewModel.enteredPin.count ? 1 : 0)
                     )

--- a/DashWallet/Sources/UI/Buy Sell/BuySellPortalScreen.swift
+++ b/DashWallet/Sources/UI/Buy Sell/BuySellPortalScreen.swift
@@ -16,14 +16,15 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 private struct MenuCardStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
             .padding(.horizontal, 20)
     }
 }
@@ -84,11 +85,11 @@ struct BuySellPortalScreen: View {
                             .frame(width: 18, height: 18)
                         Text(NSLocalizedString("Powered by Uphold", comment: "Buy Sell Dash"))
                             .font(.caption)
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)
-                    .background(colorScheme == .dark ? Color.whiteAlpha5 : Color.primaryBackground)
+                    .background(colorScheme == .dark ? Color.dash.whiteAlpha5 : Color.dash.primaryBackground)
                     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                 }
                 .modifier(MenuCardStyle())
@@ -122,7 +123,7 @@ struct BuySellPortalScreen: View {
 
             Spacer()
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
     }
 
@@ -162,11 +163,11 @@ struct BuySellPortalScreen: View {
                         .scaledToFit()
                         .frame(width: 12)
                 }
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 if let fiat = item.fiatBalanceFormatted, (item.dashBalance ?? 0) > 0 {
                     Text(fiat)
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
         )

--- a/DashWallet/Sources/UI/Buy Sell/BuySellPortalView.swift
+++ b/DashWallet/Sources/UI/Buy Sell/BuySellPortalView.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - MenuItemButtonStyle
 
@@ -36,7 +37,7 @@ private struct MenuCardStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(.rect(cornerRadius: 20))
             .shadow(color: .shadow, radius: 10, x: 0, y: 5)
     }
@@ -89,7 +90,7 @@ struct BuySellPortalView: View {
                 .padding(.horizontal, 20)
             }
         }
-        .background(Color.primaryBackground.ignoresSafeArea())
+        .background(Color.dash.primaryBackground.ignoresSafeArea())
     }
 
     // MARK: - Cards
@@ -140,11 +141,11 @@ struct BuySellPortalView: View {
 
             Text(NSLocalizedString("Powered by Uphold", comment: "Buy Sell Portal"))
                 .font(.caption1)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 5)
-        .background(Color.gray300Alpha10)
+        .background(Color.dash.gray300Alpha10)
         .clipShape(.rect(cornerRadius: 14))
     }
 

--- a/DashWallet/Sources/UI/Buy Sell/Model/VO/ServiceItem.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Model/VO/ServiceItem.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import Foundation
 
 extension ServiceItem {
@@ -124,4 +123,3 @@ extension Status {
         }
     }
 }
-

--- a/DashWallet/Sources/UI/Buy Sell/Model/VO/ServiceItem.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Model/VO/ServiceItem.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import Foundation
 
 extension ServiceItem {

--- a/DashWallet/Sources/UI/Buy Sell/Views/BuySellServiceItemCell.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Views/BuySellServiceItemCell.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import UIKit
 
 class BuySellServiceItemCell: UICollectionViewCell {

--- a/DashWallet/Sources/UI/Buy Sell/Views/BuySellServiceItemCell.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Views/BuySellServiceItemCell.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import UIKit
 
 class BuySellServiceItemCell: UICollectionViewCell {

--- a/DashWallet/Sources/UI/Coinbase/Buy Dash/BuyDashViewController.swift
+++ b/DashWallet/Sources/UI/Coinbase/Buy Dash/BuyDashViewController.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import Combine
 import UIKit
 

--- a/DashWallet/Sources/UI/Coinbase/Buy Dash/BuyDashViewController.swift
+++ b/DashWallet/Sources/UI/Coinbase/Buy Dash/BuyDashViewController.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import Combine
 import UIKit
 

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountView.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountView.swift
@@ -110,9 +110,9 @@ struct TransferAmountView<ViewModel: TransferAmountViewModelProtocol>: View {
             actionHandler: { viewModel.transfer() }
         )
         .frame(maxWidth: .infinity, maxHeight: 320)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .clipShape(.rect(cornerRadius: 20))
-        .background(Color.secondaryBackground, ignoresSafeAreaEdges: .bottom)
+        .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
     }
 }
 
@@ -192,12 +192,12 @@ final class MockTransferAmountViewModel: TransferAmountViewModelProtocol {
 
 #Preview("Online") {
     TransferAmountView(viewModel: MockTransferAmountViewModel())
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 #Preview("Offline") {
     TransferAmountView(viewModel: MockTransferAmountViewModel(isNetworkOnline: false))
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 #Preview("Error") {
@@ -207,6 +207,6 @@ final class MockTransferAmountViewModel: TransferAmountViewModelProtocol {
             errorMessage: NSLocalizedString("Amount too low", comment: "")
         )
     )
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }
 #endif

--- a/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountConfirmationController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountConfirmationController.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import Combine
 
 // MARK: - OnlineAccountConfirmationController

--- a/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountConfirmationController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountConfirmationController.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import Combine
 
 // MARK: - OnlineAccountConfirmationController

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import Combine
 import Foundation
 

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodeTransferViewController.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import Combine
 import Foundation
 

--- a/DashWallet/Sources/UI/CrowdNode/Portal/WithdrawalLimitsController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/WithdrawalLimitsController.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import UIKit
 
 // MARK: - WithdrawalLimitDialogModel
@@ -226,4 +225,3 @@ extension WithdrawalLimitsController {
         return limitLabel
     }
 }
-

--- a/DashWallet/Sources/UI/CrowdNode/Portal/WithdrawalLimitsController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/WithdrawalLimitsController.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import UIKit
 
 // MARK: - WithdrawalLimitDialogModel

--- a/DashWallet/Sources/UI/CrowdNode/Tx Details/GroupedTransactionsScreen.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Tx Details/GroupedTransactionsScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GroupedTransactionsScreen: View {
     @State private var currentTag: String?
@@ -40,13 +41,13 @@ struct GroupedTransactionsScreen: View {
                             Text(model.fiatAmount)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .font(.caption)
-                                .foregroundColor(.tertiaryText)
+                                .foregroundColor(.dash.tertiaryText)
 
                             if let summary = model.summaryText {
                                 Text(summary)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                                     .font(.caption)
-                                    .foregroundColor(.tertiaryText)
+                                    .foregroundColor(.dash.tertiaryText)
                                     .padding(.top, 2)
                             }
                         }
@@ -57,7 +58,7 @@ struct GroupedTransactionsScreen: View {
                         Icon(name: .custom(model.iconName))
                             .padding(10)
                             .frame(width: 50, height: 50)
-                            .background(Color.secondaryBackground)
+                            .background(Color.dash.secondaryBackground)
                             .clipShape(.circle)
                     }
                     .padding(.horizontal, 25)
@@ -69,17 +70,17 @@ struct GroupedTransactionsScreen: View {
                         Text(NSLocalizedString("Why do I see all these transactions?", comment: "Grouped Transactions"))
                             .font(.footnote)
                             .fontWeight(.medium)
-                            .foregroundStyle(Color.tertiaryText)
+                            .foregroundStyle(Color.dash.tertiaryText)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             
                         Text(model.infoText)
                             .font(.subheadline)
-                            .foregroundColor(Color.primaryText)
+                            .foregroundColor(Color.dash.primaryText)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding(15)
                     .frame(maxWidth: .infinity)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(10)
                     .padding()
                 }
@@ -118,7 +119,7 @@ struct GroupedTransactionsScreen: View {
                         }
                     }
                     .padding(5)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(10)
                     .padding(.horizontal, 15)
                     .shadow(color: .shadow, radius: 10, x: 0, y: 5)
@@ -126,6 +127,6 @@ struct GroupedTransactionsScreen: View {
             }
         }
         .frame(maxHeight: .infinity)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -14,6 +14,7 @@
 
 import SwiftDashSDK
 import SwiftUI
+import DashUIKit
 
 struct AddContactScreen: View {
     @Environment(\.dismiss) private var dismiss
@@ -42,7 +43,7 @@ struct AddContactScreen: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 VStack(spacing: 0) {
                     header
                     ContactsSearchField(
@@ -58,7 +59,7 @@ struct AddContactScreen: View {
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(NSLocalizedString("Cancel", comment: "")) { dismiss() }
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
             }
             .onChange(of: query) { _, _ in
@@ -101,14 +102,14 @@ struct AddContactScreen: View {
         VStack(spacing: 6) {
             Image(systemName: "person.crop.circle.badge.plus")
                 .font(.system(size: 56, weight: .light))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .padding(.bottom, 14)
             Text(NSLocalizedString("Add a New Contact", comment: "DashPay Contacts"))
                 .font(.system(size: 20, weight: .bold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Text(NSLocalizedString("Find a User", comment: "DashPay Contacts"))
                 .font(.system(size: 16))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .padding(.top, 28)
     }
@@ -123,19 +124,19 @@ struct AddContactScreen: View {
                 } else if results.isEmpty && trimmedQuery.count >= 2 {
                     Text(NSLocalizedString("No usernames found", comment: "DashPay Contacts"))
                         .font(.system(size: 14))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .padding(.top, 32)
                 } else if trimmedQuery.count < 2 && !trimmedQuery.isEmpty {
                     Text(NSLocalizedString("Type at least 2 characters to search usernames", comment: "DashPay Contacts"))
                         .font(.system(size: 14))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .padding(.top, 32)
                 }
                 ForEach(results) { result in
                     resultRow(result)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.secondaryBackground))
+                                .fill(Color.dash.secondaryBackground))
                         .contentShape(Rectangle())
                         .onTapGesture { previewTarget = result }
                         .onAppear { checkEligibilityIfNeeded(result) }
@@ -193,12 +194,12 @@ struct AddContactScreen: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(result.fullName.withoutDashSuffix)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 if let hint = collisionText(state) {
                     Text(hint)
                         .font(.system(size: 12))
-                        .foregroundColor(state == .alreadyRequested ? .dashGolden : .tertiaryText)
+                        .foregroundColor(state == .alreadyRequested ? .dashGolden : .dash.tertiaryText)
                 }
             }
             Spacer()
@@ -230,11 +231,11 @@ struct AddContactScreen: View {
                     previewTarget = result
                 } label: {
                     Image(systemName: "person.badge.plus")
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                         .frame(width: 30, height: 30)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.dashBlue.opacity(0.1)))
+                                .fill(Color.dash.blue.opacity(0.1)))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(NSLocalizedString("Send Contact Request", comment: "DashPay Contacts"))
@@ -250,7 +251,7 @@ struct AddContactScreen: View {
                 EmptyView()
             case .missingDashPayKeys:
                 Image(systemName: "lock.slash")
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
             }
         }
     }
@@ -378,7 +379,7 @@ struct AddContactPreviewSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 VStack(spacing: 12) {
                     ContactAvatarView(
                         title: title,
@@ -388,23 +389,23 @@ struct AddContactPreviewSheet: View {
                         .padding(.top, 28)
                     Text(title)
                         .font(.system(size: 22, weight: .bold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                     if username != title {
                         Text(username)
                             .font(.system(size: 14))
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                     }
                     if let message = contact?.publicMessage, !message.isEmpty {
                         Text(message)
                             .font(.system(size: 14))
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 32)
                             .padding(.top, 2)
                     }
                     Text(rationale)
                         .font(.system(size: 14))
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 28)
                         .padding(.top, 4)
@@ -418,7 +419,7 @@ struct AddContactPreviewSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(NSLocalizedString("Close", comment: "")) { dismiss() }
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
             }
         }
@@ -451,7 +452,7 @@ struct AddContactPreviewSheet: View {
     private var cta: some View {
         switch collision {
         case .none:
-            primaryButton(NSLocalizedString("Send Contact Request", comment: "DashPay Contacts"), color: .dashBlue) {
+            primaryButton(NSLocalizedString("Send Contact Request", comment: "DashPay Contacts"), color: .dash.blue) {
                 onSend()
                 dismiss()
             }
@@ -467,7 +468,7 @@ struct AddContactPreviewSheet: View {
         case .isSelf:
             EmptyView()
         case .missingDashPayKeys:
-            statusLabel(NSLocalizedString("Can't receive contact requests", comment: "DashPay Contacts"), systemImage: "lock.slash", color: .tertiaryText)
+            statusLabel(NSLocalizedString("Can't receive contact requests", comment: "DashPay Contacts"), systemImage: "lock.slash", color: .dash.tertiaryText)
         }
     }
 
@@ -475,7 +476,7 @@ struct AddContactPreviewSheet: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(Color.dash.whiteText)
                 .frame(maxWidth: .infinity)
                 .frame(height: 48)
                 .background(RoundedRectangle(cornerRadius: 8, style: .continuous).fill(color))

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - Design tokens (Android parity)
 
@@ -55,7 +56,7 @@ struct ContactAvatarView: View {
             Circle().fill(backgroundColor)
             Text(initial)
                 .font(.system(size: size * 0.5, weight: .regular))
-                .foregroundColor(.white)
+                .foregroundColor(Color.dash.whiteText)
         }
     }
 
@@ -93,12 +94,12 @@ struct AcceptPillButton: View {
         Button(action: action) {
             Text(NSLocalizedString("Accept", comment: "DashPay Contacts"))
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .frame(minWidth: 64)
                 .frame(height: 30)
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color.dashBlue.opacity(0.1)))
+                        .fill(Color.dash.blue.opacity(0.1)))
         }
         .buttonStyle(.plain)
     }
@@ -113,9 +114,9 @@ struct IgnoreCircleButton: View {
         Button(action: action) {
             Image(systemName: "xmark")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .frame(width: 30, height: 30)
-                .background(Circle().fill(Color.gray300Alpha10))
+                .background(Circle().fill(Color.dash.gray300Alpha10))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(NSLocalizedString("Ignore", comment: "DashPay Contacts"))
@@ -132,7 +133,7 @@ struct ContactsSearchField: View {
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             TextField(placeholder, text: $text)
                 .font(.system(size: 15))
                 .autocorrectionDisabled()
@@ -142,7 +143,7 @@ struct ContactsSearchField: View {
                     text = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                 }
                 .buttonStyle(.plain)
             }
@@ -151,7 +152,7 @@ struct ContactsSearchField: View {
         .frame(height: height)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.secondaryBackground)
+                .fill(Color.dash.secondaryBackground)
                 .shadow(color: .shadow, radius: 4, y: 1))
     }
 }
@@ -164,6 +165,6 @@ struct ContactsCard<Content: View>: View {
         VStack(spacing: 0) { content }
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.secondaryBackground))
+                    .fill(Color.dash.secondaryBackground))
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -12,6 +12,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ContactProfileSheet: View {
     let contact: ContactItem
@@ -49,14 +50,14 @@ struct ContactProfileSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 ScrollView {
                     VStack(spacing: 20) {
                         header
                         if let message = contact.publicMessage, !message.isEmpty {
                             Text(message)
                                 .font(.system(size: 14))
-                                .foregroundColor(.secondaryText)
+                                .foregroundColor(.dash.secondaryText)
                                 .multilineTextAlignment(.center)
                                 .padding(.horizontal, 32)
                         }
@@ -81,7 +82,7 @@ struct ContactProfileSheet: View {
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(NSLocalizedString("Done", comment: "")) { dismiss() }
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
             }
             .alert(
@@ -138,20 +139,20 @@ struct ContactProfileSheet: View {
                 size: 88)
             Text(contact.displayTitle)
                 .font(.system(size: 20, weight: .bold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             if let username = contact.username?.withoutDashSuffix,
                !username.isEmpty,
                username != contact.displayTitle {
                 Text(username)
                     .font(.system(size: 14))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             if contact.relationship == .established {
                 // Disclosure hint: tapping the header toggles the
                 // Contact settings card below.
                 Image(systemName: "chevron.down")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                     .rotationEffect(.degrees(showContactSettings ? 180 : 0))
                     .padding(.top, 2)
             }
@@ -176,7 +177,7 @@ struct ContactProfileSheet: View {
                     format: NSLocalizedString("%@ has requested to be your contact", comment: "DashPay Contacts"),
                     contact.displayTitle))
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .multilineTextAlignment(.center)
                 if isProcessing {
                     SwiftUI.ProgressView()
@@ -187,7 +188,7 @@ struct ContactProfileSheet: View {
                         } label: {
                             Text(NSLocalizedString("Accept", comment: "DashPay Contacts"))
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.dash.whiteText)
                                 .frame(width: 120, height: 39)
                                 .background(
                                     RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -200,11 +201,11 @@ struct ContactProfileSheet: View {
                         } label: {
                             Text(NSLocalizedString("Ignore", comment: "DashPay Contacts"))
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                                 .frame(width: 120, height: 39)
                                 .background(
                                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                        .fill(Color.gray300Alpha10))
+                                        .fill(Color.dash.gray300Alpha10))
                         }
                         .buttonStyle(.plain)
                     }
@@ -240,12 +241,12 @@ struct ContactProfileSheet: View {
                         NSLocalizedString("Pay", comment: "DashPay Contacts"),
                         systemImage: "arrow.up.circle.fill")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .frame(maxWidth: .infinity)
                         .frame(height: 46)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.dashBlue))
+                                .fill(Color.dash.blue))
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 32)
@@ -261,12 +262,12 @@ struct ContactProfileSheet: View {
                             : NSLocalizedString("Hide Contact", comment: "DashPay Contacts"),
                         systemImage: isHidden ? "eye" : "eye.slash")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .frame(maxWidth: .infinity)
                         .frame(height: 42)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.gray300Alpha10))
+                                .fill(Color.dash.gray300Alpha10))
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 15)
@@ -280,10 +281,10 @@ struct ContactProfileSheet: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(NSLocalizedString("Contact settings", comment: "DashPay Contacts"))
                 .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Text(NSLocalizedString("Only visible to you", comment: "DashPay Contacts"))
                 .font(.system(size: 12))
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             TextField(
                 NSLocalizedString("Alias", comment: "DashPay Contacts"),
                 text: $aliasText)
@@ -292,7 +293,7 @@ struct ContactProfileSheet: View {
                 .frame(height: 44)
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color.primaryBackground))
+                        .fill(Color.dash.primaryBackground))
                 .onSubmit { saveMeta() }
             TextField(
                 NSLocalizedString("Note", comment: "DashPay Contacts"),
@@ -304,7 +305,7 @@ struct ContactProfileSheet: View {
                 .padding(.vertical, 12)
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color.primaryBackground))
+                        .fill(Color.dash.primaryBackground))
                 .onSubmit { saveMeta() }
             if metaChanged {
                 Button {
@@ -312,12 +313,12 @@ struct ContactProfileSheet: View {
                 } label: {
                     Text(NSLocalizedString("Save", comment: ""))
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                         .frame(height: 30)
                         .padding(.horizontal, 14)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.dashBlue.opacity(0.1)))
+                                .fill(Color.dash.blue.opacity(0.1)))
                 }
                 .buttonStyle(.plain)
             }
@@ -326,7 +327,7 @@ struct ContactProfileSheet: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.secondaryBackground))
+                .fill(Color.dash.secondaryBackground))
         .padding(.horizontal, 15)
     }
 
@@ -384,17 +385,17 @@ struct ContactProfileSheet: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("Payments", comment: "DashPay Contacts"))
                 .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             // Legacy profile's info tooltip, inlined: only payments
             // that flowed through the DashPay contact channel appear
             // here — direct-to-address sends are not retained.
             Text(NSLocalizedString("Payments made directly to an address aren't retained here.", comment: "DashPay Contacts"))
                 .font(.system(size: 12))
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             if payments.isEmpty {
                 Text(NSLocalizedString("No payments with this contact yet", comment: "DashPay Contacts"))
                     .font(.system(size: 14))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .padding(.top, 2)
             } else {
                 ForEach(payments) { payment in
@@ -406,7 +407,7 @@ struct ContactProfileSheet: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.secondaryBackground))
+                .fill(Color.dash.secondaryBackground))
         .padding(.horizontal, 15)
     }
 
@@ -419,31 +420,31 @@ struct ContactProfileSheet: View {
         HStack(spacing: 10) {
             Image(systemName: payment.direction == .sent
                 ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
-                .foregroundColor(payment.direction == .sent ? .dashBlue : .dashGreen)
+                .foregroundColor(payment.direction == .sent ? .dash.blue : .dashGreen)
             VStack(alignment: .leading, spacing: 2) {
                 Text("\(payment.direction == .sent ? "-" : "+")\(Self.dashString(duffs: payment.amountDuffs)) DASH")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 if let fiat = payment.fiatString {
                     Text(fiat)
                         .font(.system(size: 12))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
                 if let memo = payment.memo, !memo.isEmpty {
                     Text(memo)
                         .font(.system(size: 12))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .lineLimit(1)
                 }
             }
             Spacer()
             Text(payment.date.formatted(date: .abbreviated, time: .omitted))
                 .font(.system(size: 12))
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             if resolvedTx != nil {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
             }
         }
         .padding(.vertical, 6)
@@ -532,7 +533,7 @@ struct PayContactSheet: View {
                     Button(NSLocalizedString(sentTxid == nil ? "Cancel" : "Done", comment: "")) {
                         dismiss()
                     }
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
                 }
             }
             .alert(
@@ -560,7 +561,7 @@ struct PayContactSheet: View {
                 .onAppear { amountFocused = true }
             Text("DASH")
                 .font(.system(size: 17, weight: .bold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .padding(.top, 12)
 
@@ -568,11 +569,11 @@ struct PayContactSheet: View {
             format: NSLocalizedString("Available: %@ DASH", comment: "DashPay Contacts"),
             Self.dashString(duffs: maxSendable)))
             .font(.system(size: 13))
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
 
         Text(NSLocalizedString("A network fee will be added on top of the amount.", comment: "DashPay Contacts"))
             .font(.system(size: 12))
-            .foregroundColor(.tertiaryText)
+            .foregroundColor(.dash.tertiaryText)
 
         if isSending {
             SwiftUI.ProgressView()
@@ -583,12 +584,12 @@ struct PayContactSheet: View {
             } label: {
                 Text(NSLocalizedString("Pay", comment: "DashPay Contacts"))
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .frame(maxWidth: .infinity)
                     .frame(height: 46)
                     .background(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(parsedDuffs == nil ? Color.gray300 : Color.dashBlue))
+                            .fill(parsedDuffs == nil ? Color.dash.gray300 : Color.dash.blue))
             }
             .buttonStyle(.plain)
             .disabled(parsedDuffs == nil)
@@ -602,18 +603,18 @@ struct PayContactSheet: View {
                 .foregroundColor(.dashGreen)
             Text(NSLocalizedString("Payment Sent", comment: "DashPay Contacts"))
                 .font(.system(size: 17, weight: .bold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Text(String(
                 format: NSLocalizedString("%@ DASH sent to %@", comment: "DashPay Contacts"),
                 amountText, contact.displayTitle))
                 .font(.system(size: 14))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             if let fee = sentFeeDuffs {
                 Text(String(
                     format: NSLocalizedString("Network fee: %@ DASH", comment: "DashPay Contacts"),
                     Self.dashString(duffs: fee)))
                     .font(.system(size: 12))
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
             }
         }
         .padding(.top, 24)

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -14,6 +14,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - ContactsViewModel
 
@@ -99,7 +100,7 @@ struct ContactsScreen: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 content
             }
             .navigationTitle(NSLocalizedString("Contacts", comment: "DashPay Contacts"))
@@ -109,7 +110,7 @@ struct ContactsScreen: View {
                         showingAddContact = true
                     } label: {
                         Image(systemName: "person.badge.plus")
-                            .foregroundColor(.dashBlue)
+                            .foregroundColor(.dash.blue)
                     }
                     .accessibilityLabel(NSLocalizedString("Add a New Contact", comment: "DashPay Contacts"))
                 }
@@ -213,7 +214,7 @@ struct ContactsScreen: View {
         HStack {
             Text(text)
                 .font(.system(size: size, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
         }
         .padding(.horizontal, 15)
@@ -225,7 +226,7 @@ struct ContactsScreen: View {
         content()
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.secondaryBackground))
+                    .fill(Color.dash.secondaryBackground))
             .padding(.horizontal, 15)
             .padding(.vertical, 3)
             .contentShape(Rectangle())
@@ -238,14 +239,14 @@ struct ContactsScreen: View {
             Spacer()
             Image(systemName: "person.crop.circle.badge.plus")
                 .font(.system(size: 72, weight: .light))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .padding(.bottom, 12)
             Text(NSLocalizedString("Add a New Contact", comment: "DashPay Contacts"))
                 .font(.system(size: 20, weight: .bold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Text(NSLocalizedString("Find a user and add them to your contacts.", comment: "DashPay Contacts"))
                 .font(.system(size: 16))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
             Button {
@@ -255,12 +256,12 @@ struct ContactsScreen: View {
                     NSLocalizedString("Search for a User", comment: "DashPay Contacts"),
                     systemImage: "magnifyingglass")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .frame(maxWidth: .infinity)
                     .frame(height: 46)
                     .background(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(Color.dashBlue))
+                            .fill(Color.dash.blue))
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 32)
@@ -301,12 +302,12 @@ struct ContactRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.displayTitle)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 if let secondary = secondaryLine {
                     Text(secondary)
                         .font(.system(size: 12))
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .lineLimit(1)
                 }
             }
@@ -347,12 +348,12 @@ struct IncomingRequestRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.displayTitle)
                     .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 if let username = item.username?.withoutDashSuffix, !username.isEmpty, username != item.displayTitle {
                     Text(username)
                         .font(.system(size: 12))
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .lineLimit(1)
                 }
             }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
@@ -15,6 +15,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct NotificationsScreen: View {
     @StateObject private var viewModel = ContactsViewModel()
@@ -27,7 +28,7 @@ struct NotificationsScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
             content
         }
         .navigationTitle(NSLocalizedString("Notifications", comment: "DashPay Notifications"))
@@ -97,10 +98,10 @@ struct NotificationsScreen: View {
             VStack(spacing: 12) {
                 Image(systemName: "bell")
                     .font(.system(size: 44, weight: .light))
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                 Text(NSLocalizedString("You have no notifications", comment: "DashPay Notifications"))
                     .font(.system(size: 14))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
@@ -124,7 +125,7 @@ struct NotificationsScreen: View {
     private func sectionHeader(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 15, weight: .semibold))
-            .foregroundColor(.primaryText)
+            .foregroundColor(.dash.primaryText)
             .padding(.horizontal, 20)
             .padding(.top, 18)
             .padding(.bottom, 6)
@@ -142,7 +143,7 @@ struct NotificationsScreen: View {
         }
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.secondaryBackground))
+                .fill(Color.dash.secondaryBackground))
         .padding(.horizontal, 15)
     }
 
@@ -225,11 +226,11 @@ struct NotificationsScreen: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(text)
                     .font(.system(size: 14))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(2)
                 Text(Self.timestampFormatter.string(from: event.date))
                     .font(.system(size: 11))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             Spacer()
             accessory()

--- a/DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 /// Push-based navigation glue shared by every redeem entry (deep link,
@@ -121,11 +122,11 @@ struct ClaimInvitationScreen: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(NSLocalizedString("Claim your invitation", comment: "DashPay Invitations"))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .font(.title1)
                 .padding(.top, 12)
             Text(NSLocalizedString("Paste the invitation link you received, or scan its QR code. It funds your username registration.", comment: "DashPay Invitations"))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .font(.system(size: 14))
                 .padding(.top, 4)
 
@@ -140,7 +141,7 @@ struct ClaimInvitationScreen: View {
             .lineLimit(2...5)
             .focused($isInputFocused)
             .padding(12)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.top, 20)
 
@@ -214,7 +215,7 @@ struct ClaimInvitationScreen: View {
         case .valid:
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: "envelope.open")
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
                     .font(.system(size: 20))
                 VStack(alignment: .leading, spacing: 4) {
                     if let inviter = viewModel.inviterUsername {
@@ -222,24 +223,24 @@ struct ClaimInvitationScreen: View {
                             NSLocalizedString("Invitation from %@", comment: "DashPay Invitations"),
                             inviter))
                             .font(.subheadline.bold())
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                     } else {
                         Text(NSLocalizedString("Valid invitation", comment: "DashPay Invitations"))
                             .font(.subheadline.bold())
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                     }
                     // The voucher amount is not in the link — it is read
                     // from the funding transaction during the claim — so
                     // no amount is shown here.
                     Text(NSLocalizedString("Continue to pick your username. The invitation pays the registration fee.", comment: "DashPay Invitations"))
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.dashBlue.opacity(0.08))
+            .background(Color.dash.blue.opacity(0.08))
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -19,6 +19,7 @@
 import SwiftData
 import SwiftDashSDK
 import SwiftUI
+import DashUIKit
 
 struct SDKIdentityProfileSheet: View {
     @Environment(\.dismiss) private var dismiss
@@ -56,7 +57,7 @@ struct SDKIdentityProfileSheet: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 24)
             }
-            .background(Color.primaryBackground)
+            .background(Color.dash.primaryBackground)
             .navigationTitle(NSLocalizedString("My Profile", comment: "SDK identity profile sheet — title"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -70,10 +71,10 @@ struct SDKIdentityProfileSheet: View {
                 if let toast = copyToast {
                     Text(toast)
                         .font(.subheadline)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 10)
-                        .background(Color.black.opacity(0.8))
+                        .background(Color.dash.backgroundOverlay)
                         .clipShape(Capsule())
                         .padding(.bottom, 32)
                         .transition(.opacity)
@@ -101,10 +102,10 @@ struct SDKIdentityProfileSheet: View {
             Text(NSLocalizedString("Edit Profile", comment: "SDK identity profile sheet — edit button"))
                 .font(.body)
                 .fontWeight(.semibold)
-                .foregroundColor(.white)
+                .foregroundColor(Color.dash.whiteText)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
-                .background(Color.dashBlue)
+                .background(Color.dash.blue)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
@@ -115,16 +116,16 @@ struct SDKIdentityProfileSheet: View {
         VStack(spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 96, height: 96)
                 Text(initial)
                     .font(.system(size: 40, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
             Text(username)
                 .font(.title2)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
         }
         .frame(maxWidth: .infinity)
     }
@@ -158,20 +159,20 @@ struct SDKIdentityProfileSheet: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("DPNS Names", comment: "SDK identity profile sheet — usernames list"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(Array(dpnsNames.enumerated()), id: \.offset) { index, name in
                     HStack {
                         Text(name)
                             .font(.body)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                         Spacer()
                         Button {
                             UIPasteboard.general.string = name
                             showCopyToast()
                         } label: {
                             Image(systemName: "doc.on.doc")
-                                .foregroundColor(.secondaryText)
+                                .foregroundColor(.dash.secondaryText)
                         }
                         .buttonStyle(.plain)
                     }
@@ -182,7 +183,7 @@ struct SDKIdentityProfileSheet: View {
                 }
             }
             .padding(.horizontal, 12)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
@@ -191,11 +192,11 @@ struct SDKIdentityProfileSheet: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title)
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             HStack(alignment: .top, spacing: 8) {
                 Text(value)
                     .font(monospaced ? .system(.body, design: .monospaced) : .body)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if copyable {
@@ -204,7 +205,7 @@ struct SDKIdentityProfileSheet: View {
                         showCopyToast()
                     } label: {
                         Image(systemName: "doc.on.doc")
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                     }
                     .buttonStyle(.plain)
                 }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import SwiftUI
+import DashUIKit
 
 class CreateUsernameViewController: UIViewController {
     @objc var completionHandler: ((Bool) -> ())?
@@ -124,11 +125,11 @@ struct CreateUsernameView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(NSLocalizedString("Create your username", comment: "Usernames"))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .font(.title1)
                 .padding(.top, 12)
             Text(NSLocalizedString("Please note that you will not be able to change it in future", comment: "Usernames"))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .font(.system(size: 14))
             TextInput(label: "Username", text: $viewModel.username, isEnabled: !screenLockedAfterAuth)
                 .padding(.top, 20)
@@ -201,7 +202,7 @@ struct CreateUsernameView: View {
             if !viewModel.isInvitationMode, viableFundingSources.count >= 2 {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(NSLocalizedString("Pay with", comment: "Usernames"))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .font(.caption)
                     Picker("", selection: userFundingSourceBinding) {
                         ForEach(viableFundingSources, id: \.rawValue) { source in
@@ -356,13 +357,13 @@ struct CreateUsernameView: View {
                         .foregroundColor(.blue)
                     Text(shieldedHintText(for: snapshot))
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .padding(12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.blue.opacity(0.08))
+            .background(Color.dash.blue.opacity(0.08))
             .clipShape(RoundedRectangle(cornerRadius: 8))
             .padding(.top, 20)
         }
@@ -406,7 +407,7 @@ struct CreateUsernameView: View {
                     "This name requires a masternode vote.",
                     comment: "Usernames"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
         }
         .padding(12)
@@ -426,16 +427,16 @@ struct CreateUsernameView: View {
     private var invitationFundingBanner: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: "envelope.open")
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .font(.system(size: 20))
             Text(NSLocalizedString("Your invitation pays the registration fee for this username.", comment: "DashPay Invitations"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.dashBlue.opacity(0.08))
+        .background(Color.dash.blue.opacity(0.08))
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
@@ -536,7 +537,7 @@ struct CreateUsernameView: View {
             ? NSLocalizedString("Funded from your Shielded balance — your username can't be linked to your other Dash.", comment: "Usernames")
             : NSLocalizedString("Transparent funding publicly links your username to these funds.", comment: "Usernames"))
             .font(.caption2)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
             .fixedSize(horizontal: false, vertical: true)
     }
 

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
@@ -19,6 +19,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct JoinDashPayReadinessScreen: View {
     @ObservedObject private var readiness = ShieldedIdentityFundingReadiness.shared
@@ -47,12 +48,12 @@ struct JoinDashPayReadinessScreen: View {
         VStack(alignment: .leading, spacing: 0) {
             Text(NSLocalizedString("Get ready to join DashPay", comment: "Usernames"))
                 .font(.title1)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 12)
 
             Text(NSLocalizedString("Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.", comment: "Usernames"))
                 .font(.system(size: 14))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 8)
 
@@ -63,7 +64,7 @@ struct JoinDashPayReadinessScreen: View {
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.top, 24)
 
@@ -80,7 +81,7 @@ struct JoinDashPayReadinessScreen: View {
                 Button(action: onProceed) {
                     Text(NSLocalizedString("Use transparent balance instead", comment: "Usernames"))
                         .font(.footnote)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .frame(maxWidth: .infinity)
                 }
                 .padding(.top, 12)
@@ -89,7 +90,7 @@ struct JoinDashPayReadinessScreen: View {
         .padding(.horizontal, 20)
         .padding(.bottom, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(Color.primaryBackground.ignoresSafeArea())
+        .background(Color.dash.primaryBackground.ignoresSafeArea())
         .onAppear {
             readiness.refresh()
             // Pull fresh notes + the pool count so the checklist isn't
@@ -198,17 +199,17 @@ struct JoinDashPayReadinessScreen: View {
         HStack(alignment: .top, spacing: 14) {
             Image(systemName: met ? "checkmark.circle.fill" : pendingIcon)
                 .font(.system(size: 20, weight: .semibold))
-                .foregroundColor(met ? .green : .gray300)
+                .foregroundColor(met ? .green : .dash.gray300)
                 .frame(width: 24, height: 24)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .fixedSize(horizontal: false, vertical: true)
                 Text(subtitle)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -217,10 +218,10 @@ struct JoinDashPayReadinessScreen: View {
                 Button(action: action) {
                     Text(label)
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 7)
-                        .background(Color.dashBlue)
+                        .background(Color.dash.blue)
                         .clipShape(Capsule())
                 }
             }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 public struct JoinDashPayScreen: View {
     @StateObject private var viewModel = CreateUsernameViewModel.shared
@@ -56,7 +57,7 @@ public struct JoinDashPayScreen: View {
                     Button(action: onClaimInvitation) {
                         Text(NSLocalizedString("Have an invitation?", comment: "DashPay Invitations"))
                             .font(.subheadline)
-                            .foregroundColor(.dashBlue)
+                            .foregroundColor(.dash.blue)
                     }
                     .padding(.bottom, 12)
                 }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 enum JoinDashPayState {
     case none
@@ -57,13 +58,13 @@ struct JoinDashPayView: View {
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .fixedSize(horizontal: false, vertical: true)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .multilineTextAlignment(.leading)
                     
                     if viewModel.state != .registered {
                         Text(subtitleText)
                             .font(.footnote)
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                             .fixedSize(horizontal: false, vertical: true)
                             .multilineTextAlignment(.leading)
                             .padding(.top, 2)
@@ -95,7 +96,7 @@ struct JoinDashPayView: View {
         .background(
             GeometryReader { geometry in
                 onSizeChange?(geometry.size)
-                return Color.secondaryBackground
+                return Color.dash.secondaryBackground
             }
         )
         .cornerRadius(8)

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/VerifyIdentityScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/VerifyIdentityScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 public struct VerifyIdentityScreen: View {
     @State private var link: String = ""
@@ -35,13 +36,13 @@ public struct VerifyIdentityScreen: View {
                     .font(.title1)
                     .multilineTextAlignment(.leading)
                     .lineSpacing(3)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
               
                 Text(NSLocalizedString("The link you send will be visible only to the network owners", comment: "Usernames"))
                     .font(.subhead)
                     .multilineTextAlignment(.leading)
                     .lineSpacing(3)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
 
                 HStack(spacing: 0) {
                     let text = String.localizedStringWithFormat(NSLocalizedString("Please vote to approve my requested Dash username - %@", comment: "Usernames"), viewModel.username)
@@ -49,7 +50,7 @@ public struct VerifyIdentityScreen: View {
                     VStack(alignment: .leading, spacing: 0) {
                         Text(NSLocalizedString("Copy text", comment: ""))
                             .font(.footnote)
-                            .foregroundStyle(Color.secondaryText)
+                            .foregroundStyle(Color.dash.secondaryText)
                         
                         Text(text)
                             .font(.subhead)
@@ -67,14 +68,14 @@ public struct VerifyIdentityScreen: View {
                         }
                     }) {
                         Image("icon_copy_outline")
-                            .foregroundStyle(Color.primaryText)
+                            .foregroundStyle(Color.dash.primaryText)
                             .frame(width: 40, height: 40)
                             .scaledToFit()
                     }
                     .padding(.trailing, 10)
                 }
                 .frame(maxWidth: .infinity)
-                .background(Color.gray400.opacity(0.13))
+                .background(Color.dash.gray400.opacity(0.13))
                 .cornerRadius(10)
                 .padding(.vertical, 20)
                 
@@ -82,14 +83,14 @@ public struct VerifyIdentityScreen: View {
                     .font(.calloutMedium)
                     .multilineTextAlignment(.leading)
                     .lineSpacing(3)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .padding(.top, 8)
               
                 Text(NSLocalizedString("Make a post with the text above on a well known social media or messaging platform to verify that you are the original owner of the requested username and paste the link bellow", comment: "Usernames"))
                     .font(.subhead)
                     .multilineTextAlignment(.leading)
                     .lineSpacing(3)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .padding(.top, 1)
                 
                 TextInput(
@@ -101,7 +102,7 @@ public struct VerifyIdentityScreen: View {
                 if isInputError {
                     Text(errorText)
                         .font(.footnote)
-                        .foregroundColor(.systemRed)
+                        .foregroundColor(.dash.red)
                         .padding(.leading, 4)
                 }
                 

--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct ExploreMenuScreen: View {
@@ -100,7 +101,7 @@ struct ExploreMenuScreen: View {
                         subtitleView: AnyView(
                             Text(NSLocalizedString("Easily stake Dash and earn passive income with a few simple clicks", comment: ""))
                                 .font(.footnote)
-                                .foregroundColor(.tertiaryText)
+                                .foregroundColor(.dash.tertiaryText)
                                 .multilineTextAlignment(.leading)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         ),
@@ -112,9 +113,9 @@ struct ExploreMenuScreen: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
             .padding(.horizontal, 20)
 
             if balanceReminder.shouldShowOnExplore {
@@ -127,7 +128,7 @@ struct ExploreMenuScreen: View {
 
             Spacer()
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .alert(NSLocalizedString("The chain is syncing…", comment: ""), isPresented: $showSyncingAlert) {
             Button(NSLocalizedString("Go to CrowdNode website", comment: "")) {
@@ -144,7 +145,7 @@ struct ExploreMenuScreen: View {
         VStack(alignment: .leading, spacing: 11) {
             Text(NSLocalizedString("Easily stake Dash and earn passive income with a few simple clicks", comment: ""))
                 .font(.footnote)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .multilineTextAlignment(.leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
@@ -70,7 +70,7 @@ struct POIDetailsView: View {
                     }
                 }
                 .padding(20)
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
                 .cornerRadius(12)
 
                 // Location and contact info card
@@ -89,7 +89,7 @@ struct POIDetailsView: View {
                         }
                     }
                     .padding(10)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(12)
                     .padding(.top, 16)
                 }
@@ -131,12 +131,12 @@ struct POIDetailsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(merchant.title ?? "")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 
                 if let subtitle = merchant.subtitle {
                     Text(subtitle)
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
             
@@ -155,26 +155,26 @@ struct POIDetailsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(NSLocalizedString("Address", comment: "Explore Dash"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
 
                 if merchant.address1?.isEmpty == false {
                     Text(merchant.address1 ?? "")
                         .font(.subhead)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if merchant.address2?.isEmpty == false {
                     Text(merchant.address2 ?? "")
                         .font(.subhead)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if merchant.address3?.isEmpty == false {
                     Text(merchant.address3 ?? "")
                         .font(.subhead)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
@@ -183,14 +183,14 @@ struct POIDetailsView: View {
                 if !cityAndTerritory.isEmpty {
                     Text(cityAndTerritory)
                         .font(.subhead)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if let distanceText = viewModel.distanceText {
                     Text(distanceText)
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
             
@@ -200,7 +200,7 @@ struct POIDetailsView: View {
                 Button(action: directionAction) {
                     Image(systemName: "arrow.triangle.turn.up.right.circle.fill")
                         .font(.system(size: 22))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
             }
         }
@@ -214,11 +214,11 @@ struct POIDetailsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("Phone", comment: ""))
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                     
                     Text(viewModel.formattedPhoneNumber ?? merchant.phone ?? "")
                         .font(.subhead)
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
                 
                 Spacer()
@@ -235,11 +235,11 @@ struct POIDetailsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("Website", comment: ""))
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                             
                     Text(merchant.website ?? "merchant.com")
                         .font(.subhead)
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
@@ -259,19 +259,19 @@ struct POIDetailsView: View {
             HStack {
                 Text(viewModel.locationCount > 0 ? "\(NSLocalizedString("Show all locations", comment: "Explore Dash")) (\(viewModel.locationCount))" : NSLocalizedString("Show all locations", comment: "Explore Dash"))
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 Spacer()
 
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 20)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
-            .shadow(color: Color.black.opacity(0.05), radius: 10, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 10, x: 0, y: 5)
             .contentShape(.rect)
         }
         .buttonStyle(PlainButtonStyle())
@@ -284,7 +284,7 @@ struct POIDetailsView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(NSLocalizedString("Select gift card provider", comment: "DashSpend"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .padding(.horizontal, 16)
             
             VStack(spacing: 8) {
@@ -293,7 +293,7 @@ struct POIDetailsView: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
         }
     }
@@ -304,13 +304,13 @@ struct POIDetailsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(viewModel.selectedProvider?.displayName ?? "")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 if let selectedProvider = viewModel.selectedProvider,
                    let providerData = viewModel.supportedProviders[selectedProvider] {
                     Text(providerStatusText(for: selectedProvider, isFixed: providerData.isFixed))
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
 
@@ -321,7 +321,7 @@ struct POIDetailsView: View {
                providerData.discount > 0 {
                 Text(formatDiscount(providerData.discount))
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
         }
         .padding(.horizontal, 16)
@@ -346,10 +346,10 @@ struct POIDetailsView: View {
         ) {
             viewModel.selectProvider(provider)
         }
-        .background(viewModel.selectedProvider == provider ? Color.dashBlue.opacity(0.05) : Color.clear)
+        .background(viewModel.selectedProvider == provider ? Color.dash.blue.opacity(0.05) : Color.clear)
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(viewModel.selectedProvider == provider ? Color.dashBlue : Color.secondaryText.opacity(0.2), lineWidth: 1)
+                .stroke(viewModel.selectedProvider == provider ? Color.dash.blue : Color.dash.secondaryText.opacity(0.2), lineWidth: 1)
         )
         .cornerRadius(12)
     }
@@ -372,7 +372,7 @@ struct POIDetailsView: View {
         if case .merchant(let m) = merchant.category, m.paymentMethod == .giftCard {
             Text(NSLocalizedString("This card works only in the United States.", comment: "DashSpend"))
                 .font(.system(size: 13))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 8)
         }
@@ -402,7 +402,7 @@ struct POIDetailsView: View {
             HStack(spacing: 6) {
                 Text(providerLoginText)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .lineLimit(1)
                     .truncationMode(.head)
                 
@@ -413,7 +413,7 @@ struct POIDetailsView: View {
                 }) {
                     Text(NSLocalizedString("Log Out", comment: "Log out button"))
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .underline()
                 }
             }
@@ -455,9 +455,9 @@ struct POIDetailsView: View {
     
     private var buttonTintColor: Color {
         if case .merchant(let m) = merchant.category, m.paymentMethod == .giftCard {
-            return Color(UIColor.dw_orange())
+            return Color.dash.orange
         } else {
-            return .dashBlue
+            return .dash.blue
         }
     }
     
@@ -546,7 +546,7 @@ struct POIDetailsView: View {
                 size: .large,
                 action: payAction
             )
-            .overrideBackgroundColor(Color(red: 0.235, green: 0.722, blue: 0.471))
+            .overrideBackgroundColor(Color.dash.green)
             
             if case .atm(let atm) = merchant.category, 
                atm.type == .buySell || atm.type == .sell {
@@ -570,7 +570,7 @@ struct POIDetailsView: View {
 
     private var separatorView: some View {
         Rectangle()
-            .fill(Color.black.opacity(0.3))
+            .fill(Color.dash.black.opacity(0.3))
             .frame(height: 1/UIScreen.main.scale)
     }
 }
@@ -624,6 +624,6 @@ extension ExplorePointOfUse {
 
 #Preview("Merchant details") {
     POIDetailsView(merchant: .previewBurgerKing())
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 #endif

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
@@ -570,7 +570,7 @@ struct POIDetailsView: View {
 
     private var separatorView: some View {
         Rectangle()
-            .fill(Color.dash.black.opacity(0.3))
+            .fill(Color.dash.primaryText.opacity(0.3))
             .frame(height: 1/UIScreen.main.scale)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
@@ -18,6 +18,7 @@
 import CoreLocation
 import SDWebImageSwiftUI
 import SwiftUI
+import DashUIKit
 
 private enum Layout {
     static let contentSpacing: CGFloat = 20
@@ -78,13 +79,13 @@ struct AllMerchantLocationsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(20)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .clipShape(.rect(cornerRadius: 20))
         .padding(.horizontal, Layout.contentInsets)
         .padding(.top, Layout.topInset)
         .padding(.bottom, Layout.bottomInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear {
             viewModel.onItemsUpdated = onItemsUpdated
             onItemsUpdated?(viewModel.items)
@@ -120,12 +121,12 @@ private struct MerchantHeaderView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(pointOfUse.name)
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 if let subtitle = pointOfUse.subtitle {
                     Text(subtitle)
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
 
@@ -150,7 +151,7 @@ private struct LocationsSection: View {
             HStack(spacing: 8) {
                 Text(NSLocalizedString("Select location", comment: "Explore Dash"))
                     .font(.footnoteMedium)
-                    .foregroundStyle(Color.primaryText)
+                    .foregroundStyle(Color.dash.primaryText)
 
                 if isLoading && !items.isEmpty {
                     SwiftUI.ProgressView()
@@ -211,7 +212,7 @@ private struct LocationsSection: View {
             Spacer()
             Text(NSLocalizedString("No locations found.", comment: "Explore Dash"))
                 .font(.subhead)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
             Spacer()
         }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/Components/MerchantCellRow.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/Components/MerchantCellRow.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct MerchantCellRow: View {
     let pointOfUse: ExplorePointOfUse
@@ -46,7 +47,7 @@ struct MerchantCellRow: View {
             chevron
         }
         .padding(Layout.contentPadding)
-        .background(Color.gray300Alpha10)
+        .background(Color.dash.gray300Alpha10)
         .clipShape(.rect(cornerRadius: Layout.cornerRadius))
     }
 
@@ -64,7 +65,7 @@ struct MerchantCellRow: View {
                 Icon(name: .custom(Asset.distanceIcon, maxHeight: Layout.distanceIconHeight))
                 Text(distanceText)
                     .font(.footnote)
-                    .foregroundStyle(Color.gray500)
+                    .foregroundStyle(Color.dash.gray500)
             }
         }
     }
@@ -72,7 +73,7 @@ struct MerchantCellRow: View {
     private var addressLabel: some View {
         Text(pointOfUse.address)
             .font(.subhead)
-            .foregroundStyle(Color.primaryText)
+            .foregroundStyle(Color.dash.primaryText)
             .lineLimit(Layout.addressLineLimit)
             .fixedSize(horizontal: false, vertical: true)
     }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift
@@ -200,7 +200,7 @@ struct MerchantFiltersView: View {
                             Text(NSLocalizedString("Reset Filters", comment: "Explore Dash"))
                                 .font(.subheadline)
                                 .fontWeight(.medium)
-                                .foregroundColor(viewModel.canReset ? .red : Color.tertiaryText)
+                                .foregroundColor(viewModel.canReset ? .red : Color.dash.tertiaryText)
                                 .padding()
                                 .frame(maxWidth: .infinity, alignment: .center)
                         }
@@ -221,21 +221,21 @@ struct MerchantFiltersView: View {
                 EmptyView()
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarTitle(NSLocalizedString("Filters", comment: "Explore Dash"), displayMode: .inline)
         .navigationBarItems(
             leading: Button(NSLocalizedString("Close", comment: "")) {
                 presentationMode.wrappedValue.dismiss()
             }
             .font(.system(size: 15, weight: .medium))
-            .foregroundColor(.dashBlue),
+            .foregroundColor(.dash.blue),
             trailing: Button(NSLocalizedString("Apply", comment: "")) {
                 let filters = viewModel.buildFilters()
                 onApplyFilters(filters)
                 presentationMode.wrappedValue.dismiss()
             }
             .font(.system(size: 15, weight: .medium))
-            .foregroundColor(viewModel.canApply ? .dashBlue : Color.tertiaryText)
+            .foregroundColor(viewModel.canApply ? .dash.blue : Color.dash.tertiaryText)
             .disabled(!viewModel.canApply)
         )
     }
@@ -253,7 +253,7 @@ private struct FilterSection<Content: View>: View {
                 Text(title)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .padding(.leading, 15)
                     .padding(.vertical, 12)
             }
@@ -262,7 +262,7 @@ private struct FilterSection<Content: View>: View {
                 content()
             }
             .padding(.vertical, 6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedShape(corners: .allCorners, radii: 12))
             .padding(.bottom, 20)
         }
@@ -284,12 +284,12 @@ private struct FilterDisclosureItem: View {
             Text(title)
                 .font(.subhead)
                 .fontWeight(.medium)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             
             Spacer()
             
             Image(systemName: "chevron.right")
-                .foregroundColor(.gray)
+                .foregroundColor(Color.dash.gray500)
                 .imageScale(.small)
         }
         .padding(.horizontal, 16)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift
@@ -289,7 +289,7 @@ private struct FilterDisclosureItem: View {
             Spacer()
             
             Image(systemName: "chevron.right")
-                .foregroundColor(Color.dash.gray500)
+                .foregroundColor(Color.dash.tertiaryText)
                 .imageScale(.small)
         }
         .padding(.horizontal, 16)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift
@@ -45,14 +45,14 @@ struct TerritoryPickerView: View {
                 // Search Bar
                 HStack {
                     Image(systemName: "magnifyingglass")
-                        .foregroundColor(.gray)
+                        .foregroundColor(Color.dash.gray500)
                     
                     TextField(NSLocalizedString("Search territories", comment: ""), text: $searchText)
                         .textFieldStyle(PlainTextFieldStyle())
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 12)
-                .background(Color.gray400.opacity(0.1))
+                .background(Color.dash.gray400.opacity(0.1))
                 .cornerRadius(10)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
@@ -75,7 +75,7 @@ struct TerritoryPickerView: View {
                                     onTerritorySelected(nil)
                                     presentationMode.wrappedValue.dismiss()
                                 }
-                                .background(Color.secondaryBackground)
+                                .background(Color.dash.secondaryBackground)
                                 .clipShape(RoundedShape(corners: .allCorners, radii: 12))
                                 .padding(.horizontal, 20)
                                 .padding(.bottom, 8)
@@ -94,7 +94,7 @@ struct TerritoryPickerView: View {
                                         .id(territory)
                                     }
                                 }
-                                .background(Color.secondaryBackground)
+                                .background(Color.dash.secondaryBackground)
                                 .clipShape(RoundedShape(corners: .allCorners, radii: 12))
                                 .padding(.horizontal, 20)
                             }
@@ -114,7 +114,7 @@ struct TerritoryPickerView: View {
                     }
                 }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationTitle(NSLocalizedString("Location", comment: ""))
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
@@ -125,7 +125,7 @@ struct TerritoryPickerView: View {
                 }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                 }
             }
         }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift
@@ -45,7 +45,7 @@ struct TerritoryPickerView: View {
                 // Search Bar
                 HStack {
                     Image(systemName: "magnifyingglass")
-                        .foregroundColor(Color.dash.gray500)
+                        .foregroundColor(Color.dash.tertiaryText)
                     
                     TextField(NSLocalizedString("Search territories", comment: ""), text: $searchText)
                         .textFieldStyle(PlainTextFieldStyle())
@@ -153,4 +153,3 @@ struct TerritoryPickerView: View {
         }
     }
 }
-

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -19,6 +19,7 @@ import CoreLocation
 import MapKit
 import UIKit
 import SwiftUI
+import DashUIKit
 
 // MARK: - MerchantsListSegment
 
@@ -455,6 +456,6 @@ private struct MerchantListNavBar: View {
             central: { Text(title).font(.subheadMedium) },
             trailing: { NavigationBarElement.info.button(action: onInfo) }
         )
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendDenominationRow.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendDenominationRow.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashSpendDenominationRow: View {
     let denomination: Decimal
@@ -36,7 +37,7 @@ struct DashSpendDenominationRow: View {
                 Text(fiatFormatter.string(from: NSDecimalNumber(decimal: denomination)) ?? "")
                     .font(.headline)
                     .fontWeight(.semibold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -52,7 +53,7 @@ struct DashSpendDenominationRow: View {
         DashSpendDenominationRowPreview(denomination: 100)
     }
     .padding(20)
-    .background(Color.secondaryBackground)
+    .background(Color.dash.secondaryBackground)
     .cornerRadius(20)
     .padding(20)
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFixedContent.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFixedContent.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashSpendFixedContent: View {
     @ObservedObject var viewModel: DashSpendPayViewModel
@@ -83,7 +84,7 @@ struct DashSpendFixedContent: View {
 
 #Preview {
     DashSpendFixedContentPreview()
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 private struct DashSpendFixedContentPreview: View {

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFlexibleContent.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFlexibleContent.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 enum DashSpendMode: CaseIterable, Hashable {
     case single
@@ -251,7 +252,7 @@ struct DashSpendFlexibleContent: View {
 
 #Preview("Single / Keyboard") {
     DashSpendFlexibleContentPreview()
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 private struct DashSpendFlexibleContentPreview: View {

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendMultiplePanel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendMultiplePanel.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashSpendMultiplePanel: View {
     let denominations: [Decimal]
@@ -54,10 +55,10 @@ struct DashSpendMultiplePanel: View {
                 if let warning = inventoryWarning {
                     Text(warning)
                         .font(.caption)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
-                        .background(Color(red: 10/255, green: 11/255, blue: 13/255).opacity(0.7))
+                        .background(Color.dash.black1000Alpha70)
                         .cornerRadius(10)
                         .offset(y: 20)
                 }
@@ -69,7 +70,7 @@ struct DashSpendMultiplePanel: View {
                 if let error = error {
                     Text(error.localizedDescription)
                         .font(.caption)
-                        .foregroundColor(Color.systemRed)
+                        .foregroundColor(Color.dash.red)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity)
@@ -77,7 +78,7 @@ struct DashSpendMultiplePanel: View {
                 } else if showCost {
                     Text(costMessage)
                         .font(.subhead)
-                        .foregroundColor(Color.primaryText)
+                        .foregroundColor(Color.dash.primaryText)
                         .multilineTextAlignment(.center)
                         .frame(maxWidth: .infinity)
                         .padding(.bottom, 4)
@@ -129,14 +130,14 @@ private struct DenominationCard: View {
                         size: .extraSmall,
                         action: onReset
                     )
-                    .overrideForegroundColor(.primaryText)
-                    .overrideBackgroundColor(.gray300Alpha10)
+                    .overrideForegroundColor(.dash.primaryText)
+                    .overrideBackgroundColor(.dash.gray300Alpha10)
                     .frame(maxWidth: 126, alignment: .trailing)
                 }
             }
         }
         .padding(20)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(20)
     }
 }
@@ -150,7 +151,7 @@ private struct DashSpendMultiplePanelPreview: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             DashSpendMultiplePanel(
                 denominations: [5, 10, 50, 100],

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
@@ -17,6 +17,7 @@
 
 
 import SwiftUI
+import DashUIKit
 import SDWebImageSwiftUI
 
 struct DashSpendPayIntro: View {
@@ -49,7 +50,7 @@ struct DashSpendPayIntro: View {
         } placeholder: {
             // No icon yet (missing URL or still loading): show a grey circle of the same size.
             Circle()
-                .fill(Color.gray300Alpha50)
+                .fill(Color.dash.gray300Alpha50)
         }
         .frame(width: Layout.merchantIconSize, height: Layout.merchantIconSize)
     }
@@ -57,15 +58,15 @@ struct DashSpendPayIntro: View {
     private var eyeIcon: some View {
         ZStack {
             Circle()
-                .fill(Color.gray300Alpha10)
+                .fill(Color.dash.gray300Alpha10)
                 .frame(width: Layout.eyeCircleSize, height: Layout.eyeCircleSize)
 
             Icon(name: .custom("eye_opened-icon", maxHeight: Layout.eyeIconSize))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .opacity(balanceHidden ? 1 : 0)
 
             Icon(name: .custom("eye_closed-icon", maxHeight: Layout.eyeIconSize))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .opacity(balanceHidden ? 0 : 1)
         }
         .compositingGroup()
@@ -100,7 +101,7 @@ struct DashSpendPayIntro: View {
                 }
             }
             .font(.subheadline)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -111,13 +112,13 @@ struct DashSpendPayIntro: View {
 
         Text(text ?? NSLocalizedString("Not available", comment: ""))
             .font(.subheadline)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
     }
 }
 
 #Preview("DashSpendPayIntro") {
     VStack(spacing: 20) {
-        Text("DashSpendPayIntro").font(.caption).foregroundColor(.secondary)
+        Text("DashSpendPayIntro").font(.caption).foregroundColor(Color.dash.secondaryText)
         DashSpendPayIntro(
             merchantIconUrl: "",
             merchantTitle: "Amazon",
@@ -125,7 +126,7 @@ struct DashSpendPayIntro: View {
             dashBalance: 555566
         )
         Divider()
-        Text("SendIntro (reference)").font(.caption).foregroundColor(.secondary)
+        Text("SendIntro (reference)").font(.caption).foregroundColor(Color.dash.secondaryText)
         SendIntro(
             title: "Buy gift card",
             preposition: "at",

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendSinglePanel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendSinglePanel.swift
@@ -22,7 +22,7 @@ extension View {
     func bottomPanelStyle() -> some View {
         self
             .padding(.horizontal, 20)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
 //            .padding(.bottom, 30)
             .cornerRadius(20)
     }
@@ -66,7 +66,7 @@ struct DashSpendSinglePanel: View {
         if showCost {
             Text(costMessage)
                 .font(.subhead)
-                .foregroundColor(Color.primaryText)
+                .foregroundColor(Color.dash.primaryText)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
                 .padding(.top, 12)
@@ -78,7 +78,7 @@ struct DashSpendSinglePanel: View {
         if let error = error {
             Text(error.localizedDescription)
                 .font(.caption)
-                .foregroundColor(Color.systemRed)
+                .foregroundColor(Color.dash.red)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 12)
@@ -87,11 +87,11 @@ struct DashSpendSinglePanel: View {
             HStack {
                 Text(minimumLimitMessage)
                     .font(.caption)
-                    .foregroundColor(amount > 0 && amount < minimumAmount ? Color.systemRed : Color.tertiaryText)
+                    .foregroundColor(amount > 0 && amount < minimumAmount ? Color.dash.red : Color.dash.tertiaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text(maximumLimitMessage)
                     .font(.caption)
-                    .foregroundColor(amount > maximumAmount ? Color.systemRed : Color.tertiaryText)
+                    .foregroundColor(amount > maximumAmount ? Color.dash.red : Color.dash.tertiaryText)
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
             .padding(.top, 12)
@@ -102,7 +102,7 @@ struct DashSpendSinglePanel: View {
         VStack(spacing: 20) {
             Text(NSLocalizedString("Loading gift card options...", comment: "DashSpend"))
                 .font(.subhead)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -142,7 +142,7 @@ struct DashSpendSinglePanel: View {
             )
             .frame(maxWidth: .infinity)
             .bottomPanelStyle()
-            .background(Color.secondaryBackground, ignoresSafeAreaEdges: .bottom)
+            .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
         }
 
     }
@@ -205,7 +205,7 @@ private struct DashSpendSinglePanelKeyboardPreview: View {
             onDenominationSelected: { _ in },
             onAction: {}
         )
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }
 
@@ -234,6 +234,6 @@ private struct DashSpendSinglePanelDenominationsPreview: View {
             onDenominationSelected: { selected = $0 },
             onAction: {}
         )
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import SDWebImageSwiftUI
 
 struct DashSpendConfirmationDialog: View {
@@ -54,14 +55,14 @@ struct DashSpendConfirmationDialog: View {
     var body: some View {
         VStack(spacing: 0) {
             Capsule()
-                .fill(Color(red: 0.69, green: 0.71, blue: 0.74).opacity(0.5))
+                .fill(Color.dash.grabberFill)
                 .frame(width: 36, height: 5)
                 .padding(.top, 6)
                 .padding(.bottom, 13)
 
             Text(NSLocalizedString("Confirm", comment: "DashSpend"))
                 .font(.calloutMedium)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .frame(height: 44)
 
             VStack(spacing: 20) {
@@ -80,7 +81,7 @@ struct DashSpendConfirmationDialog: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 7))
                             Text(NSLocalizedString("Dash Wallet", comment: "DashSpend"))
                                 .font(.subhead)
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                         }
                     }
 
@@ -95,14 +96,14 @@ struct DashSpendConfirmationDialog: View {
                                 .clipShape(RoundedRectangle(cornerRadius: 7))
                             Text(merchantName)
                                 .font(.subhead)
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                         }
                     }
 
                     detailsRow(title: NSLocalizedString("Gift card", comment: "DashSpend")) {
                         Text(fiatFormatter.string(from: NSDecimalNumber(decimal: originalPrice)) ?? "")
                             .font(.subhead)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                     }
 
                     if !quantityLines.isEmpty {
@@ -111,7 +112,7 @@ struct DashSpendConfirmationDialog: View {
                                 ForEach(quantityLines, id: \.self) { line in
                                     Text(line)
                                         .font(.subhead)
-                                        .foregroundColor(.primaryText)
+                                        .foregroundColor(.dash.primaryText)
                                 }
                             }
                         }
@@ -120,27 +121,27 @@ struct DashSpendConfirmationDialog: View {
                     detailsRow(title: NSLocalizedString("Discount", comment: "DashSpend")) {
                         Text(PercentageFormatter.format(percent: NSDecimalNumber(decimal: discount * 100).doubleValue))
                             .font(.subhead)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                     }
 
                     detailsRow(title: NSLocalizedString("You pay", comment: "DashSpend")) {
                         Text(fiatFormatter.string(from: NSDecimalNumber(decimal: youPayAmount)) ?? "")
                             .font(.subhead)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                     }
                 }
                 .padding(6)
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
                 .cornerRadius(20)
-                .shadow(color: Color(red: 0.72, green: 0.76, blue: 0.8).opacity(0.1), radius: 20, x: 0, y: 5)
+                .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
 
                 HStack(spacing: 20) {
                     DashButton(
                         text: NSLocalizedString("Cancel", comment: "DashSpend"),
                         action: onCancel
                     )
-                    .overrideForegroundColor(.primaryText)
-                    .overrideBackgroundColor(.gray300Alpha10)
+                    .overrideForegroundColor(.dash.primaryText)
+                    .overrideBackgroundColor(.dash.gray300Alpha10)
 
                     DashButton(
                         text: NSLocalizedString("Confirm", comment: "DashSpend"),
@@ -173,7 +174,7 @@ struct DashSpendConfirmationDialog: View {
             Text(title)
                 .font(.subhead)
                 .fontWeight(.medium)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
 
             Spacer()
 
@@ -215,7 +216,7 @@ private struct DashSpendConfirmationDialogPreview: View {
 
             if #available(iOS 16.4, *) {
                 content
-                    .presentationBackground(Color.primaryBackground)
+                    .presentationBackground(Color.dash.primaryBackground)
                     .selfSizingSheet()
                     .presentationCornerRadius(32)
                     .presentationDragIndicator(.hidden)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import SDWebImageSwiftUI
 
 struct DashSpendPayScreen: View {
@@ -99,7 +100,7 @@ struct DashSpendPayScreen: View {
             }
             overlays
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear {
             viewModel.subscribeToUpdates()
 
@@ -162,7 +163,7 @@ struct DashSpendPayScreen: View {
                 positiveButtonAction: { showErrorDialog = false }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.black.opacity(0.7))
+            .background(Color.dash.backgroundOverlay)
             .edgesIgnoringSafeArea(.all)
         }
 
@@ -181,7 +182,7 @@ struct DashSpendPayScreen: View {
                 }
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.black.opacity(0.7))
+            .background(Color.dash.backgroundOverlay)
             .edgesIgnoringSafeArea(.all)
         }
     }
@@ -266,7 +267,7 @@ private struct DashSpendPayConfirmationSheet: View {
 
         if #available(iOS 16.4, *) {
             dialog
-                .presentationBackground(Color.primaryBackground)
+                .presentationBackground(Color.dash.primaryBackground)
                 .selfSizingSheet(fallback: 500)
                 .presentationCornerRadius(32)
                 .presentationDragIndicator(.hidden)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashSpendTermsScreen: View {
     @Environment(\.presentationMode) private var presentationMode
@@ -38,7 +39,7 @@ struct DashSpendTermsScreen: View {
                     }) {
                         Image(systemName: "xmark")
                             .font(.system(size: 18, weight: .semibold))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                             .padding(10)
                     }
                 }
@@ -78,22 +79,22 @@ struct DashSpendTermsScreen: View {
                         ZStack {
                             if isTermsAccepted {
                                 RoundedRectangle(cornerRadius: 6)
-                                    .fill(Color.dashBlue)
+                                    .fill(Color.dash.blue)
                                     .frame(width: 22, height: 22)
                                 
                                 Image(systemName: "checkmark")
                                     .font(.system(size: 14, weight: .bold))
-                                    .foregroundColor(.white)
+                                    .foregroundColor(Color.dash.whiteText)
                             } else {
                                 RoundedRectangle(cornerRadius: 6)
-                                    .strokeBorder(Color.gray300, lineWidth: 1.5)
+                                    .strokeBorder(Color.dash.gray300, lineWidth: 1.5)
                                     .frame(width: 22, height: 22)
                             }
                         }
                         
                         Text(String(format: NSLocalizedString("I accept %@ terms and conditions", comment: "Accept terms checkbox"), provider.displayName))
                             .font(.system(size: 14))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                             
                         Spacer()
                     }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift
@@ -83,7 +83,7 @@ struct DashSpendUserAuthScreen: View {
                     }) {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 18, weight: .semibold))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                             .padding(10)
                     }
                     
@@ -91,7 +91,7 @@ struct DashSpendUserAuthScreen: View {
                     
                     Text("DashSpend")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .frame(maxWidth: .infinity)
                     
                     Spacer()
@@ -109,11 +109,11 @@ struct DashSpendUserAuthScreen: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(authType.screenTitle)
                             .font(.system(size: 24, weight: .bold))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                         
                         Text(authType.screenSubtitle)
                             .font(.system(size: 13))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                             .lineSpacing(4)
                     }
                     .padding(.horizontal, 20)
@@ -133,7 +133,7 @@ struct DashSpendUserAuthScreen: View {
                         if viewModel.showError {
                             Text(viewModel.errorMessage)
                                 .font(.footnote)
-                                .foregroundColor(.systemRed)
+                                .foregroundColor(.dash.red)
                                 .padding(.horizontal, 8)
                         }
                     }
@@ -175,7 +175,7 @@ struct DashSpendUserAuthScreen: View {
                     
                     if viewModel.isLoading {
                         SwiftUI.ProgressView()
-                            .tint(.white)
+                            .tint(Color.dash.whiteText)
                     }
                 }
                 .padding(.bottom, 20)
@@ -192,7 +192,7 @@ struct DashSpendUserAuthScreen: View {
                 EmptyView()
             }
         }
-        .background(Color.secondaryBackground.ignoresSafeArea(edges: .top))
+        .background(Color.dash.secondaryBackground.ignoresSafeArea(edges: .top))
         .navigationBarHidden(true)
         .navigationBarBackButtonHidden(true)
         .onAppear {

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsHowToUseSection.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsHowToUseSection.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardDetailsHowToUseSection: View {
     var body: some View {
@@ -23,7 +24,7 @@ struct GiftCardDetailsHowToUseSection: View {
             Text(NSLocalizedString("How to use your gift card", comment: "DashSpend"))
                 .font(.subhead)
                 .fontWeight(.medium)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             FeatureSingleItem(
@@ -45,7 +46,7 @@ struct GiftCardDetailsHowToUseSection: View {
             )
         }
         .padding(20)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(20)
     }
 }
@@ -53,5 +54,5 @@ struct GiftCardDetailsHowToUseSection: View {
 #Preview {
     GiftCardDetailsHowToUseSection()
         .padding()
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsInfoCard.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsInfoCard.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardDetailsInfoCard: View {
     let formattedPrice: String
@@ -33,7 +34,7 @@ struct GiftCardDetailsInfoCard: View {
             barcodeSection
             detailsRowsSection
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(20)
     }
 
@@ -57,7 +58,7 @@ struct GiftCardDetailsInfoCard: View {
                     if hasBeenPollingForLongTime {
                         Text(NSLocalizedString("As soon as your code is generated, it will be displayed here", comment: "DashSpend"))
                             .font(.footnote)
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 50)
                     } else {
@@ -68,7 +69,7 @@ struct GiftCardDetailsInfoCard: View {
                 } else if loadingError != nil {
                     Text(NSLocalizedString("Failed to load barcode", comment: "DashSpend"))
                         .font(.footnote)
-                        .foregroundColor(.systemRed)
+                        .foregroundColor(.dash.red)
                 }
             }
             .padding(.horizontal, 6)
@@ -155,21 +156,21 @@ struct GiftCardDetailsInfoCard: View {
         HStack(alignment: .top, spacing: 0) {
             Text(title)
                 .font(.subheadMedium)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
 
             Spacer()
 
             VStack(alignment: .trailing, spacing: 0) {
                 Text(value)
                     .font(.subhead)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 if let actionConfig {
                     Button(action: actionConfig.action) {
                         Text(actionConfig.actionName)
                             .font(.footnote)
                             .fontWeight(.medium)
-                            .foregroundColor(.dashBlue)
+                            .foregroundColor(.dash.blue)
                             .padding(.vertical, 4)
                     }
                     .buttonStyle(.plain)
@@ -184,18 +185,18 @@ struct GiftCardDetailsInfoCard: View {
         HStack(alignment: .center) {
             Text(title)
                 .font(.subheadMedium)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
 
             Spacer()
 
             HStack(spacing: 6) {
                 Text(value)
                     .font(.subheadline)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 Button(action: onCopy) {
                     Icon(name: .custom("icon_copy_outline", maxHeight: 14))
-                        .tint(.primaryText)
+                        .tint(.dash.primaryText)
                 }
             }
         }
@@ -207,11 +208,11 @@ struct GiftCardDetailsInfoCard: View {
             Text(title)
                 .font(.subheadline)
                 .fontWeight(.medium)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
 
             Text(value)
                 .font(.subheadline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 12)
@@ -238,7 +239,7 @@ struct GiftCardDetailsInfoCard: View {
         onCopy: { _ in }
     )
     .padding()
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }
 
 #Preview("Claim Link") {
@@ -260,7 +261,7 @@ struct GiftCardDetailsInfoCard: View {
         onCopy: { _ in }
     )
     .padding()
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }
 
 #Preview("Loading") {
@@ -274,5 +275,5 @@ struct GiftCardDetailsInfoCard: View {
         onCopy: { _ in }
     )
     .padding()
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardDetailsMerchantHeader: View {
     let merchantIcon: UIImage?
@@ -45,7 +46,7 @@ struct GiftCardDetailsMerchantHeader: View {
                         .scaledToFit()
                         .frame(width: 20, height: 20)
                         .frame(width: 23, height: 23)
-                        .background(Circle().fill(Color.secondaryBackground))
+                        .background(Circle().fill(Color.dash.secondaryBackground))
                         .offset(x: 2, y: 2)
                 }
             }
@@ -54,12 +55,12 @@ struct GiftCardDetailsMerchantHeader: View {
                 Text(merchantName)
                     .font(.subhead)
                     .fontWeight(.medium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 if let purchaseDateText = purchaseDateText {
                     Text(purchaseDateText)
                         .font(.footnote)
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -74,7 +75,7 @@ struct GiftCardDetailsMerchantHeader: View {
         purchaseDateText: "May 04, 2026 at 5:35 PM"
     )
     .padding()
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }
 
 #Preview("No Icon") {
@@ -84,5 +85,5 @@ struct GiftCardDetailsMerchantHeader: View {
         purchaseDateText: "May 04, 2026 at 3:10 PM"
     )
     .padding()
-    .background(Color.primaryBackground)
+    .background(Color.dash.primaryBackground)
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsPoweredBySection.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsPoweredBySection.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardDetailsPoweredBySection: View {
     let provider: String?
@@ -24,7 +25,7 @@ struct GiftCardDetailsPoweredBySection: View {
         VStack(spacing: 5) {
             Text(NSLocalizedString("Powered by", comment: "DashSpend"))
                 .font(.caption)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
 
             if provider == "PiggyCards" {
                 Image("piggycards.logo")
@@ -45,11 +46,11 @@ struct GiftCardDetailsPoweredBySection: View {
 #Preview("CTX") {
     GiftCardDetailsPoweredBySection(provider: "CTX")
         .padding()
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 #Preview("PiggyCards") {
     GiftCardDetailsPoweredBySection(provider: "PiggyCards")
         .padding()
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardPurchaseSelectionSheet.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardPurchaseSelectionSheet.swift
@@ -3,6 +3,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardPurchaseSelectionSheet: View {
     let merchantIcon: UIImage?
@@ -31,7 +32,7 @@ struct GiftCardPurchaseSelectionSheet: View {
             .padding(.top, 12)
             .padding(.bottom, 30)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 
     @ViewBuilder
@@ -52,18 +53,18 @@ struct GiftCardPurchaseSelectionSheet: View {
             } else if hasBeenPollingForLongTime {
                 Text(NSLocalizedString("As soon as your code is generated, it will be displayed here", comment: "DashSpend"))
                     .font(.footnote)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 24)
             } else {
                 Text(NSLocalizedString("Gift card is being prepared", comment: "DashSpend"))
                     .font(.subheadline)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
             }
         }
         .frame(maxWidth: .infinity)
         .frame(height: 120)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(20)
     }
 
@@ -79,7 +80,7 @@ struct GiftCardPurchaseSelectionSheet: View {
                                 Text("\(index + 1)")
                                     .font(.caption1.weight(.medium))
                                     .padding(.horizontal, 4)
-                                    .background(Color.gray50)
+                                    .background(Color.dash.gray50)
                                     .clipShape(.rect(cornerRadius: 5))
                             }
 
@@ -93,7 +94,7 @@ struct GiftCardPurchaseSelectionSheet: View {
                             Text(card.formattedPrice)
                                 .font(.title3)
                                 .fontWeight(.semibold)
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -107,7 +108,7 @@ struct GiftCardPurchaseSelectionSheet: View {
             }
         }
         .padding(20)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(20)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/GiftCardDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/GiftCardDetailsView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct GiftCardDetailsView: View {
     @StateObject private var viewModel: GiftCardDetailsViewModel
@@ -79,7 +80,7 @@ struct GiftCardDetailsView: View {
             poweredBySection
         }
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear {
             guard !isPreview else { return }
             if shouldObserve {
@@ -131,7 +132,7 @@ struct GiftCardDetailsView: View {
             HStack {
                 Text(NSLocalizedString("View transaction details", comment: "DashSpend"))
                     .font(.subheadMedium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 Spacer()
 
@@ -143,7 +144,7 @@ struct GiftCardDetailsView: View {
             .frame(height: 46)
             .padding(6)
             .padding(.horizontal, 14)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(.rect(cornerRadius: 20))
         }
     }
@@ -159,7 +160,7 @@ struct GiftCardDetailsView: View {
                 }) {
                     Text(NSLocalizedString("See how to use this gift card", comment: "DashSpend"))
                         .font(.subheadMedium)
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
                 .padding(.horizontal, 16)
             } else {

--- a/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
@@ -18,6 +18,7 @@
 import UIKit
 import SafariServices
 import SwiftUI
+import DashUIKit
 import SwiftDashSDK
 
 extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
@@ -454,7 +455,7 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
             return AnyView(
                 sheet
                     .presentationDetents([.large])
-                    .presentationBackground(Color.primaryBackground)
+                    .presentationBackground(Color.dash.primaryBackground)
                     .presentationCornerRadius(32)
                     .presentationDragIndicator(.hidden)
             )

--- a/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertView.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertView.swift
@@ -12,6 +12,7 @@
 import Combine
 import SwiftDashSDK
 import SwiftUI
+import DashUIKit
 
 // MARK: - SyncingAlertViewModel
 
@@ -144,7 +145,7 @@ struct SyncingAlertView: View {
 
             Text(title)
                 .font(.title3)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.center)
                 .padding(.top, 16)
 
@@ -201,7 +202,7 @@ struct SyncingAlertView: View {
                             viewModel.snapshot.lastSyncBlockHeight,
                             viewModel.snapshot.estimatedBlockHeight))
                     .font(.footnote)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             } else {
                 VStack(spacing: 14) {
                     ForEach(Array(viewModel.snapshot.phases.enumerated()), id: \.offset) { _, phase in
@@ -220,7 +221,7 @@ struct SyncingAlertView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(label(for: phase.kind))
                     .font(.footnote)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer(minLength: 12)
                 if phase.isComplete {
                     Image(systemName: "checkmark.circle.fill")
@@ -229,14 +230,14 @@ struct SyncingAlertView: View {
                 } else {
                     Text("\(formattedHeight(phase.current)) / \(formattedHeight(phase.target))")
                         .font(.footnote.monospacedDigit())
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
             // Fully qualified: the app declares its own `ProgressView`
             // type, which shadows SwiftUI's in this scope.
             SwiftUI.ProgressView(value: fraction(of: phase))
                 .progressViewStyle(.linear)
-                .tint(phase.isComplete ? .green : .dashBlue)
+                .tint(phase.isComplete ? .green : .dash.blue)
         }
     }
 
@@ -245,11 +246,11 @@ struct SyncingAlertView: View {
             HStack {
                 Text(NSLocalizedString("Connected peers", comment: "SPV sync"))
                     .font(.footnote.weight(.semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text("\(viewModel.peers.count)")
                     .font(.footnote.monospacedDigit().weight(.semibold))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             ForEach(viewModel.peers) { peer in
                 HStack {
@@ -258,12 +259,12 @@ struct SyncingAlertView: View {
                         .frame(width: 6, height: 6)
                     Text(peer.address)
                         .font(.caption.monospaced())
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .lineLimit(1)
                     Spacer()
                     Text(label(for: peer.nodeType))
                         .font(.caption)
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                 }
             }
         }
@@ -273,7 +274,7 @@ struct SyncingAlertView: View {
         HStack(spacing: 8) {
             Text(NSLocalizedString("Sync too slow?", comment: "SPV sync"))
                 .font(.footnote)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Button {
                 viewModel.rotatePeers()
             } label: {
@@ -283,7 +284,7 @@ struct SyncingAlertView: View {
                 } else {
                     Text(NSLocalizedString("Change peers", comment: "SPV sync"))
                         .font(.footnote.weight(.semibold))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
             }
             .disabled(viewModel.isRotatingPeers)
@@ -293,7 +294,7 @@ struct SyncingAlertView: View {
     private func color(for nodeType: PlatformSpvPeerNodeType) -> Color {
         switch nodeType {
         case .evonode: return .purple
-        case .masternode: return .dashBlue
+        case .masternode: return .dash.blue
         case .normal: return .green
         case .unknown: return .gray
         }

--- a/DashWallet/Sources/UI/Home/Views/Cells/SyncingHeaderView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Cells/SyncingHeaderView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - SyncingHeaderView
 
@@ -28,7 +29,7 @@ struct SyncingHeaderView: View {
         HStack {
             Text(NSLocalizedString("History", comment: ""))
                 .font(.subheadline)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             
             Spacer()
             
@@ -44,7 +45,7 @@ struct SyncingHeaderView: View {
                                 .fontWeight(.medium)
                         }
                     }
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 }
             }
             
@@ -55,10 +56,10 @@ struct SyncingHeaderView: View {
                 size: .small,
                 stretch: false,
                 action: onFilterTap
-            ).overrideForegroundColor(.dashBlue)
+            ).overrideForegroundColor(.dash.blue)
         }
         .padding(.leading, 16)
         .padding(.trailing, 10)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift
@@ -24,7 +24,7 @@ struct BalanceInfoSheet: View {
 
                     Text(info.summary)
                         .font(.subheadline)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -53,21 +53,21 @@ struct BalanceInfoSheet: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 16)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 
     private var header: some View {
         VStack(spacing: 12) {
             Image(systemName: info.iconSystemName)
                 .font(.system(size: 26, weight: .semibold))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .frame(width: 56, height: 56)
-                .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                .background(Circle().fill(Color.dash.blue.opacity(0.08)))
 
             Text(info.title)
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
         }
     }
 
@@ -75,7 +75,7 @@ struct BalanceInfoSheet: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(title)
                 .font(.footnote.weight(.semibold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
 
             ForEach(points, id: \.self) { point in
                 HStack(alignment: .firstTextBaseline, spacing: 10) {
@@ -84,14 +84,14 @@ struct BalanceInfoSheet: View {
                         .foregroundColor(tint)
                     Text(point)
                         .font(.subheadline)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - HomeBalanceViewState
 
@@ -57,7 +58,7 @@ struct HomeBalanceView: View {
                 if !viewModel.isBalanceHidden && viewModel.state == .syncing {
                     Text(NSLocalizedString("Syncing Balance", comment: ""))
                         .font(.caption)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .opacity(opacity)
                         .onAppear {
                             withAnimation(
@@ -74,20 +75,20 @@ struct HomeBalanceView: View {
             ZStack {
                 if viewModel.isBalanceHidden {
                     Image(systemName: "eye.slash.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .padding(10)
                         .background(
                             Circle()
-                                .fill(Color.black.opacity(0.2))
+                                .fill(Color.dash.black.opacity(0.2))
                         )
                         .frame(width: 58, height: 58)
                 } else {
                     VStack(spacing: 0) {
                         DashAmount(amount: Int64(totalDuffs), font: .largeTitle, dashSymbolFactor: 0.7, showDirection: false)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
                         Text(viewModel.fiatString(forDuffs: totalDuffs))
                             .font(.subhead)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
 
                         ZStack {
                             if viewModel.shouldShowTapToHideBalance {
@@ -152,7 +153,7 @@ struct HomeBalanceView: View {
                 outAction: { onSend(.shielded) })
         }
         .padding(.horizontal, 12)
-        .background(Color.white.opacity(0.12))
+        .background(Color.dash.white.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -162,7 +163,7 @@ struct HomeBalanceView: View {
         Text(NSLocalizedString("TESTNET", comment: "Badge on the home balance while the wallet runs on testnet"))
             .font(.system(size: 11, weight: .bold))
             .kerning(1.2)
-            .foregroundColor(.white)
+            .foregroundColor(Color.dash.whiteText)
             .padding(.horizontal, 10)
             .padding(.vertical, 3)
             .background(Capsule().fill(Color.orange.opacity(0.9)))
@@ -170,7 +171,7 @@ struct HomeBalanceView: View {
 
     private var rowDivider: some View {
         Rectangle()
-            .fill(Color.white.opacity(0.18))
+            .fill(Color.dash.white.opacity(0.18))
             .frame(height: 0.5)
     }
 
@@ -188,20 +189,20 @@ struct HomeBalanceView: View {
             HStack(spacing: 8) {
                 Image(systemName: icon)
                     .font(.system(size: 15))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .frame(width: 20)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(title)
                         .font(.footnote)
                         .fontWeight(.medium)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                     Text(viewModel.fiatString(forDuffs: duffs))
                         .font(.caption2)
                         .foregroundColor(.white.opacity(0.7))
                 }
                 Spacer(minLength: 8)
                 DashAmount(amount: Int64(duffs), font: .footnote, dashSymbolFactor: 0.8, showDirection: false)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
             .contentShape(Rectangle())
             .onTapGesture { infoAction() }
@@ -224,9 +225,9 @@ struct HomeBalanceView: View {
         Button(action: action) {
             Image(systemName: systemName)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(Color.dash.whiteText)
                 .frame(width: 28, height: 28)
-                .background(Circle().fill(Color.white.opacity(0.18)))
+                .background(Circle().fill(Color.dash.white.opacity(0.18)))
                 // Keep the visual small but the tap target comfortable.
                 .contentShape(Rectangle().inset(by: -8))
         }

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -312,7 +312,7 @@ struct HomeViewContent<Content: View>: View {
                                     }
                                 }
                                 .padding(.bottom, 4)
-                                .background(Color.secondaryBackground)
+                                .background(Color.dash.secondaryBackground)
                                 .clipShape(RoundedShape(corners: [.bottomLeft, .bottomRight], radii: 10))
                                 .padding(15)
                                 .shadow(color: .shadow, radius: 10, x: 0, y: 5)
@@ -428,14 +428,14 @@ struct HomeViewContent<Content: View>: View {
                 
                 Text(DWDateFormatter.sharedInstance.dayOfWeek(from: date))
                     .font(.footnote)
-                    .foregroundStyle(Color.tertiaryText)
+                    .foregroundStyle(Color.dash.tertiaryText)
                     .padding(.trailing, 15)
             }
             .padding(.bottom, 6)
         }
         .frame(height: 38)
         .frame(maxWidth: .infinity)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .clipShape(RoundedShape(corners: [.topLeft, .topRight], radii: 10))
         .padding(.horizontal, 15)
     }
@@ -502,9 +502,9 @@ struct HomeViewContent<Content: View>: View {
         AnyView(
             Image(systemName: systemName)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .frame(width: 30, height: 30)
-                .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                .background(Circle().fill(Color.dash.blue.opacity(0.08)))
         )
     }
 
@@ -710,13 +710,13 @@ struct GiftCardDetailsSheet: View {
             if #available(iOS 16.4, *) {
                 if showsTxDetailRoute {
                     dialog
-                        .presentationBackground(Color.primaryBackground)
+                        .presentationBackground(Color.dash.primaryBackground)
                         .presentationDetents([.large])
                         .presentationCornerRadius(32)
                         .presentationDragIndicator(.hidden)
                 } else {
                     dialog
-                        .presentationBackground(Color.primaryBackground)
+                        .presentationBackground(Color.dash.primaryBackground)
                         .selfSizingSheet(fallback: calculatedSelectionSheetHeight)
                         .presentationCornerRadius(32)
                         .presentationDragIndicator(.hidden)
@@ -733,7 +733,7 @@ struct GiftCardDetailsSheet: View {
                 dialog
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear {
             viewModel.startObserving()
             showBackButton = shouldShowBackButton
@@ -818,7 +818,7 @@ struct TransactionDetailsSheet: View {
         }) {
             TxDetailsDestination(from: item)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
     
     @ViewBuilder

--- a/DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift
@@ -25,6 +25,7 @@
 
 import Foundation
 import SwiftUI
+import DashUIKit
 
 // MARK: - List item
 
@@ -81,28 +82,28 @@ struct PlatformAddressActivityDetailsView: View {
             ZStack(alignment: .bottomTrailing) {
                 Image(systemName: "creditcard.fill")
                     .font(.system(size: 24, weight: .semibold))
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
                     .frame(width: 56, height: 56)
-                    .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                    .background(Circle().fill(Color.dash.blue.opacity(0.08)))
                 Image(systemName: "arrow.down")
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .frame(width: 20, height: 20)
-                    .background(Circle().fill(Color.dashBlue))
+                    .background(Circle().fill(Color.dash.blue))
                     .offset(x: 4, y: 4)
             }
             .padding(.top, 24)
 
             Text(item.title)
                 .font(.headline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 12)
 
             DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: true)
                 .padding(.top, 4)
             Text(item.fiatAmount)
                 .font(.footnote)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .padding(.top, 2)
 
             VStack(spacing: 0) {
@@ -113,7 +114,7 @@ struct PlatformAddressActivityDetailsView: View {
                 HStack(alignment: .firstTextBaseline) {
                     Text(NSLocalizedString("Balance after", comment: "Platform address payment detail"))
                         .font(.footnote)
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                     Spacer()
                     DashAmount(amount: item.balanceAfterDuffs, font: .footnote, showDirection: false)
                 }
@@ -124,14 +125,14 @@ struct PlatformAddressActivityDetailsView: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 20)
             .padding(.top, 24)
 
             Text(NSLocalizedString("Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier.", comment: "Platform address payment detail"))
                 .font(.caption)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
                 .padding(.top, 16)
@@ -145,11 +146,11 @@ struct PlatformAddressActivityDetailsView: View {
         HStack(alignment: .firstTextBaseline) {
             Text(label)
                 .font(.footnote)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             Spacer()
             Text(value)
                 .font(.footnote)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.trailing)
         }
         .padding(.vertical, 10)
@@ -163,15 +164,15 @@ struct PlatformAddressActivityDetailsView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(label)
                     .font(.footnote)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                 Spacer()
                 Text(value.prefix(8) + "…" + value.suffix(8))
                     .font(.footnote)
                     .monospaced()
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Image(systemName: "doc.on.doc")
                     .font(.caption2)
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
             }
             .padding(.vertical, 10)
         }

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -37,6 +37,7 @@ import Foundation
 import SwiftData
 import SwiftDashSDK
 import SwiftUI
+import DashUIKit
 
 // MARK: - List item
 
@@ -277,15 +278,15 @@ struct ShieldedActivityDetailsView: View {
             ZStack(alignment: .bottomTrailing) {
                 Image(systemName: "shield.fill")
                     .font(.system(size: 26, weight: .semibold))
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
                     .frame(width: 56, height: 56)
-                    .background(Circle().fill(Color.dashBlue.opacity(0.08)))
+                    .background(Circle().fill(Color.dash.blue.opacity(0.08)))
                 if let badge = item.secondarySystemIcon {
                     Image(systemName: badge)
                         .font(.system(size: 11, weight: .bold))
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .frame(width: 20, height: 20)
-                        .background(Circle().fill(Color.dashBlue))
+                        .background(Circle().fill(Color.dash.blue))
                         .offset(x: 4, y: 4)
                 }
             }
@@ -293,14 +294,14 @@ struct ShieldedActivityDetailsView: View {
 
             Text(item.title)
                 .font(.headline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 12)
 
             DashAmount(amount: item.signedDashAmount, font: .title2, showDirection: item.showsDirectionSign)
                 .padding(.top, 4)
             Text(item.fiatAmount)
                 .font(.footnote)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .padding(.top, 2)
 
             VStack(spacing: 0) {
@@ -337,7 +338,7 @@ struct ShieldedActivityDetailsView: View {
                     HStack {
                         Text(NSLocalizedString("Network fee", comment: ""))
                             .font(.footnote)
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                         Spacer()
                         DashAmount(amount: Int64(fee), font: .footnote, showDirection: false)
                     }
@@ -352,7 +353,7 @@ struct ShieldedActivityDetailsView: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal, 20)
             .padding(.top, 24)
@@ -360,7 +361,7 @@ struct ShieldedActivityDetailsView: View {
             if item.kind == .shieldedSpend {
                 Text(NSLocalizedString("Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data.", comment: "Shielded activity"))
                     .font(.caption)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
                     .padding(.top, 16)
@@ -375,11 +376,11 @@ struct ShieldedActivityDetailsView: View {
         HStack(alignment: .firstTextBaseline) {
             Text(label)
                 .font(.footnote)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
             Spacer()
             Text(value)
                 .font(.footnote)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.trailing)
         }
         .padding(.vertical, 10)
@@ -393,15 +394,15 @@ struct ShieldedActivityDetailsView: View {
             HStack(alignment: .firstTextBaseline) {
                 Text(label)
                     .font(.footnote)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                 Spacer()
                 Text(value.prefix(8) + "…" + value.suffix(8))
                     .font(.footnote)
                     .monospaced()
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Image(systemName: "doc.on.doc")
                     .font(.caption2)
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
             }
             .padding(.vertical, 10)
         }

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift
@@ -41,7 +41,7 @@ struct ShortcutCustomizeBannerView: View {
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(Color(.dw_secondaryText()))
+                    .foregroundColor(Color.dash.secondaryText)
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
@@ -50,7 +50,7 @@ struct ShortcutCustomizeBannerView: View {
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 12)
-        .background(Color.dash.white)
+        .background(Color.dash.secondaryBackground)
         .clipShape(.rect(cornerRadius: 20))
         .shadow(color: Color.dash.shadow, radius: 10, x: 0, y: 5)
     }

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ShortcutCustomizeBannerView: View {
     let onDismiss: () -> Void
@@ -28,11 +29,11 @@ struct ShortcutCustomizeBannerView: View {
             VStack(alignment: .leading, spacing: 1) {
                 Text(NSLocalizedString("Customize shortcut bar", comment: "Shortcut banner"))
                     .font(.footnoteMedium)
-                    .foregroundStyle(Color.primaryText)
+                    .foregroundStyle(Color.dash.primaryText)
 
                 Text(NSLocalizedString("Hold any button above to replace it with the function you need", comment: "Shortcut banner"))
                     .font(.footnote)
-                    .foregroundStyle(Color.gray500)
+                    .foregroundStyle(Color.dash.gray500)
             }
 
             Spacer(minLength: 0)
@@ -49,9 +50,9 @@ struct ShortcutCustomizeBannerView: View {
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 12)
-        .background(Color.white)
+        .background(Color.dash.white)
         .clipShape(.rect(cornerRadius: 20))
-        .shadow(color: Color.shadow, radius: 10, x: 0, y: 5)
+        .shadow(color: Color.dash.shadow, radius: 10, x: 0, y: 5)
     }
 }
 
@@ -61,7 +62,7 @@ private func bannerPreview() -> some View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.vertical, 20)
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 
 #Preview("Light") {

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutItemView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutItemView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct ShortcutItemView: View {
@@ -40,7 +41,7 @@ struct ShortcutItemView: View {
 
             Text(title)
                 .font(.caption2.weight(.semibold))
-                .foregroundStyle(Color.primaryText)
+                .foregroundStyle(Color.dash.primaryText)
                 .multilineTextAlignment(.center)
                 .lineLimit(2)
                 .padding(.horizontal, 8)
@@ -65,7 +66,7 @@ private func shortcutItemGrid() -> some View {
         )
     }
     .padding(8)
-    .background(Color.secondaryBackground)
+    .background(Color.dash.secondaryBackground)
 }
 
 #Preview("Enabled") {

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutSelectionView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutSelectionView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ShortcutSelectionView: View {
     let usedTypes: Set<ShortcutActionType>
@@ -33,7 +34,7 @@ struct ShortcutSelectionView: View {
                 if availableActions.isEmpty {
                     Text(NSLocalizedString("All shortcuts are already in use", comment: "Shortcut selection empty state"))
                         .font(.subheadline)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .padding(.vertical, 16)
                 } else {
                     ForEach(availableActions, id: \.rawValue) { actionType in
@@ -49,7 +50,7 @@ struct ShortcutSelectionView: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(.rect(cornerRadius: 20))
             .padding(.top, 10)
             .padding(.horizontal, 20)
@@ -72,7 +73,7 @@ struct ShortcutSelectionView: View {
 
 #Preview("Bottom sheet") {
     VStack {
-        Color.secondaryBackground.ignoresSafeArea()
+        Color.dash.secondaryBackground.ignoresSafeArea()
             .sheet(isPresented: .constant(true)) {
                 let sheet = BottomSheet(title: NSLocalizedString("Select option", comment: ""), showBackButton: .constant(false)) {
                     ShortcutSelectionView(usedTypes: [.receive, .send, .spend]) { _ in }
@@ -81,7 +82,7 @@ struct ShortcutSelectionView: View {
                 if #available(iOS 16.4, *) {
                     sheet
                         .presentationDetents([.large])
-                        .presentationBackground(Color.primaryBackground)
+                        .presentationBackground(Color.dash.primaryBackground)
                         .presentationCornerRadius(32)
                         .presentationDragIndicator(.hidden)
                 } else {

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutsBarView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutsBarView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // NOTE: `ShortcutsActionDelegate` is still declared in the legacy `ShortcutsView.swift` (same
 // module), so this bar reuses it for now. When `ShortcutsView.swift` is deleted, move the
@@ -27,10 +28,10 @@ import SwiftUI
 /// (`ShortcutsView.swift` + `ShortcutsView.xib`). Always shows one row of 4 shortcut buttons.
 ///
 /// Layered back-to-front, matching the old xib:
-///   1. grey content background  (`Color.primaryBackground`, #F7F7F7),
+///   1. grey content background  (`Color.dash.primaryBackground`, #F7F7F7),
 ///   2. a 30pt blue strip at the top (`Color.navigationBarColor`) so the navigation-bar blue
 ///      continues down behind the top of the card and merges with the balance view above,
-///   3. a white rounded card (`Color.secondaryBackground`, #FFFFFF) inset 20pt on the sides,
+///   3. a white rounded card (`Color.dash.secondaryBackground`, #FFFFFF) inset 20pt on the sides,
 ///      holding the 4 evenly-spaced shortcut buttons.
 ///
 /// Data comes straight from `HomeViewModel.shortcutItems` (`@Published`), so the bar updates
@@ -50,7 +51,7 @@ struct ShortcutsBarView: View {
     var body: some View {
         ZStack(alignment: .top) {
             // 1. Grey content background, full bleed.
-            Color.primaryBackground
+            Color.dash.primaryBackground
 
             // 2. Blue fills the top half of the block, reaching the vertical middle of the card
             //    (the card is centred by its equal 4pt top/bottom insets). The card's upper half
@@ -78,7 +79,7 @@ struct ShortcutsBarView: View {
             }
         }
         .padding(4)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .clipShape(.rect(cornerRadius: cardCornerRadius))
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift
@@ -10,6 +10,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct WalletSwitchDialog: View {
     let rows: [WalletRow]
@@ -34,25 +35,25 @@ struct WalletSwitchDialog: View {
                                 Text(row.displayName)
                                     .font(.subhead)
                                     .fontWeight(.medium)
-                                    .foregroundColor(.primaryText)
+                                    .foregroundColor(.dash.primaryText)
                                     .lineLimit(1)
                                 if let username = row.username {
                                     Text("@\(username)")
                                         .font(.caption)
-                                        .foregroundColor(.dashBlue)
+                                        .foregroundColor(.dash.blue)
                                         .lineLimit(1)
                                 }
                                 if let balance = row.balanceText {
                                     Text(balance)
                                         .font(.caption)
-                                        .foregroundColor(.secondaryText)
+                                        .foregroundColor(.dash.secondaryText)
                                         .lineLimit(1)
                                 }
                             }
                             Spacer(minLength: 8)
                             Image(systemName: "chevron.right")
                                 .font(.system(size: 14, weight: .semibold))
-                                .foregroundColor(.secondaryText)
+                                .foregroundColor(.dash.secondaryText)
                         }
                         .padding(.horizontal, 16)
                         .contentShape(Rectangle())
@@ -62,11 +63,11 @@ struct WalletSwitchDialog: View {
                 }
             }
             .padding(.vertical, 6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedShape(corners: .allCorners, radii: 12))
             .padding(.horizontal, 20)
             .padding(.top, 25)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
+++ b/DashWallet/Sources/UI/Home/Views/TransactionFilterDialog.swift
@@ -77,12 +77,12 @@ struct TransactionFilterDialog: View {
                 }
             }
             .padding(.vertical, 6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedShape(corners: .allCorners, radii: 12))
             .padding(.horizontal, 20)
             .padding(.top, 25)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 
     private func toggle(_ category: TransactionFilterCategory) {
@@ -116,7 +116,7 @@ private struct FilterCheckboxRow: View {
                 Text(title)
                     .font(.subhead)
                     .fontWeight(.medium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 Spacer()
 
@@ -125,7 +125,7 @@ private struct FilterCheckboxRow: View {
                         Text(NSLocalizedString("Only", comment: "Transaction filter"))
                             .font(.subhead)
                             .fontWeight(.medium)
-                            .foregroundColor(.dashBlue)
+                            .foregroundColor(.dash.blue)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 4)
                             .contentShape(Rectangle())

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import SwiftUI
+import DashUIKit
 import MessageUI
 
 
@@ -258,9 +259,9 @@ struct MainMenuScreen: View {
                             }
                         }
                         .padding(6)
-                        .background(Color.secondaryBackground)
+                        .background(Color.dash.secondaryBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                     }
 
                     // Menu list - second group (remaining items)
@@ -278,9 +279,9 @@ struct MainMenuScreen: View {
                             }
                         }
                         .padding(6)
-                        .background(Color.secondaryBackground)
+                        .background(Color.dash.secondaryBackground)
                         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                     }
                 }
                 .padding(.horizontal, 20)
@@ -318,7 +319,7 @@ struct MainMenuScreen: View {
                     negativeButtonText: NSLocalizedString("Maybe later", comment: "")
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color.black.opacity(0.7))
+                .background(Color.dash.backgroundOverlay)
                 .edgesIgnoringSafeArea(.all)
             }
             #endif
@@ -368,7 +369,7 @@ struct MainMenuScreen: View {
                 EmptyView()
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear {
             viewModel.buildMenuSections()
         }

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct SecurityMenuScreen: View {
@@ -63,14 +64,14 @@ struct SecurityMenuScreen: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
             .padding(.horizontal, 20)
 
             Spacer()
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .onReceive(viewModel.$navigationDestination) { destination in
             handleNavigation(destination)

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -26,6 +26,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import SwiftDashSDK
 import UIKit
 
@@ -40,7 +41,7 @@ struct IdentitiesScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -59,9 +60,9 @@ struct IdentitiesScreen: View {
                                 }
                             }
                         }
-                        .background(Color.secondaryBackground)
+                        .background(Color.dash.secondaryBackground)
                         .cornerRadius(12)
-                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                         .padding(.horizontal, 20)
                         .padding(.top, 4)
                     }
@@ -118,9 +119,9 @@ struct IdentitiesScreen: View {
                 Button(action: { vc.popViewController(animated: true) }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
                 Spacer()
                 // Explicit Find-identities command: DIP-9 scan of the active
@@ -133,9 +134,9 @@ struct IdentitiesScreen: View {
                     } else {
                         Image(systemName: "person.crop.circle.badge.questionmark")
                             .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(.primary)
+                            .foregroundColor(Color.dash.primaryText)
                             .frame(width: 36, height: 36)
-                            .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                            .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                     }
                 }
                 .disabled(viewModel.isDiscovering || viewModel.isRefreshing)
@@ -148,9 +149,9 @@ struct IdentitiesScreen: View {
                     } else {
                         Image(systemName: "arrow.clockwise")
                             .font(.system(size: 16, weight: .medium))
-                            .foregroundColor(.primary)
+                            .foregroundColor(Color.dash.primaryText)
                             .frame(width: 36, height: 36)
-                            .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                            .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                     }
                 }
                 .disabled(viewModel.isRefreshing || viewModel.isDiscovering)
@@ -163,7 +164,7 @@ struct IdentitiesScreen: View {
                 Text(NSLocalizedString("Identities", comment: "Identities"))
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.horizontal, 20)
@@ -177,17 +178,17 @@ struct IdentitiesScreen: View {
             Spacer(minLength: 40)
             Image(systemName: "person.crop.circle.badge.plus")
                 .font(.system(size: 40))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
 
             Text(NSLocalizedString("No Identities", comment: "Identities"))
                 .font(.headline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             Text(NSLocalizedString(
                 "Your Dash Platform identity appears here once you register a username.",
                 comment: "Identities"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 40)
 
@@ -203,10 +204,10 @@ struct IdentitiesScreen: View {
                     Text(NSLocalizedString("Find identities", comment: "Identities"))
                 }
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
-                .background(Color.dashBlue.opacity(0.1))
+                .background(Color.dash.blue.opacity(0.1))
                 .clipShape(Capsule())
             }
             .disabled(viewModel.isDiscovering)
@@ -228,7 +229,7 @@ private struct IdentityRowView: View {
                 HStack(spacing: 4) {
                     Text(row.title)
                         .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(row.hasName ? .dashBlue : .primaryText)
+                        .foregroundColor(row.hasName ? .dash.blue : .dash.primaryText)
                         .lineLimit(1)
                     if row.isMainName {
                         Image(systemName: "star.fill")
@@ -239,18 +240,18 @@ private struct IdentityRowView: View {
                         IdentityBadge(
                             text: NSLocalizedString("Main", comment: "Identities — the wallet's main identity"),
                             icon: "checkmark.seal.fill",
-                            color: .dashBlue)
+                            color: .dash.blue)
                     }
                 }
                 if let subtitle = row.subtitle {
                     Text(subtitle)
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .lineLimit(1)
                 }
                 Text(row.idBase58)
                     .font(.system(.caption, design: .monospaced))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .lineLimit(1)
                     .truncationMode(.middle)
 
@@ -260,7 +261,7 @@ private struct IdentityRowView: View {
             TransferSourceRow.dashBalanceTrailing(row.balanceText)
             Image(systemName: "chevron.right")
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
@@ -345,7 +346,7 @@ struct IdentityDetailScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {
                 pageHeader
@@ -398,9 +399,9 @@ struct IdentityDetailScreen: View {
                 Button(action: { vc.popViewController(animated: true) }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
                 Spacer()
             }
@@ -411,12 +412,12 @@ struct IdentityDetailScreen: View {
                 Text(row.title)
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 if isMain {
                     Image(systemName: "checkmark.seal.fill")
                         .font(.system(size: 20))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
                 Spacer()
             }
@@ -434,16 +435,16 @@ struct IdentityDetailScreen: View {
             if isMain {
                 HStack(spacing: 8) {
                     Image(systemName: "checkmark.seal.fill")
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                     Text(NSLocalizedString("This is your main identity", comment: "Identities"))
                         .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                 }
                 Text(NSLocalizedString(
                     "Your username, profile, and contacts follow this identity.",
                     comment: "Identities"))
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             } else if canBecomeMain {
                 Button(action: { confirmSetMain = true }) {
                     HStack(spacing: 8) {
@@ -451,10 +452,10 @@ struct IdentityDetailScreen: View {
                         Text(NSLocalizedString("Set as Main Identity", comment: "Identities"))
                     }
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(Color.dashBlue)
+                    .background(Color.dash.blue)
                     .cornerRadius(12)
                 }
             } else {
@@ -462,12 +463,12 @@ struct IdentityDetailScreen: View {
                     "The main identity can only be chosen from the active wallet",
                     comment: "Identities"))
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -475,10 +476,10 @@ struct IdentityDetailScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("Identity ID", comment: "Identities"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Text(row.idBase58)
                 .font(.system(.footnote, design: .monospaced))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .textSelection(.enabled)
 
             Button(action: copyId) {
@@ -489,12 +490,12 @@ struct IdentityDetailScreen: View {
                         : NSLocalizedString("Copy", comment: ""))
                 }
                 .font(.system(size: 14, weight: .medium))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -528,7 +529,7 @@ struct IdentityDetailScreen: View {
                 label: NSLocalizedString("Public keys", comment: "Identities"),
                 value: "\(row.publicKeyCount)")
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -536,16 +537,16 @@ struct IdentityDetailScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("Usernames", comment: "Identities"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             ForEach(row.dpnsNames, id: \.self) { name in
                 Text(name)
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -561,11 +562,11 @@ struct IdentityDetailScreen: View {
         HStack {
             Text(label)
                 .font(.system(size: 14))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.trailing)
         }
         .padding(.horizontal, 14)
@@ -574,7 +575,7 @@ struct IdentityDetailScreen: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(Color.gray300.opacity(0.3))
+            .fill(Color.dash.gray300.opacity(0.3))
             .frame(height: 1)
             .padding(.horizontal, 14)
     }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift
@@ -25,6 +25,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct WalletAccountDetailScreen: View {
@@ -42,7 +43,7 @@ struct WalletAccountDetailScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -94,9 +95,9 @@ struct WalletAccountDetailScreen: View {
                 Button(action: { vc.popViewController(animated: true) }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
                 Spacer()
             }
@@ -107,11 +108,11 @@ struct WalletAccountDetailScreen: View {
                 Text(viewModel.detail?.typeName ?? NSLocalizedString("Account", comment: "Wallet accounts"))
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 if let detail = viewModel.detail, detail.showsBalance {
                     Text("#\(detail.accountIndex)")
                         .font(.subheadline)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                 }
             }
             .padding(.horizontal, 20)
@@ -155,11 +156,11 @@ struct WalletAccountDetailScreen: View {
                 HStack {
                     Text(NSLocalizedString("Total Balance", comment: "Wallet accounts"))
                         .font(.footnote)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                     Spacer()
                     Text((detail.confirmed + detail.unconfirmed).formattedDashAmount)
                         .font(.system(size: 15, weight: .bold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                 }
             }
         }
@@ -220,7 +221,7 @@ struct WalletAccountDetailScreen: View {
                     .font(.system(.caption, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 HStack(spacing: 6) {
                     Text("#\(item.index)")
                     if item.isUsed {
@@ -233,7 +234,7 @@ struct WalletAccountDetailScreen: View {
                     }
                 }
                 .font(.caption2)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             }
             Spacer()
             if copiedAddress == item.address {
@@ -243,7 +244,7 @@ struct WalletAccountDetailScreen: View {
             } else {
                 Image(systemName: "doc.on.doc")
                     .font(.caption2)
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
             }
         }
         .padding(.vertical, 4)
@@ -265,17 +266,17 @@ struct WalletAccountDetailScreen: View {
                     "This account derives masternode keys. It has no on-chain addresses or balance.",
                     comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                 Text(hex)
                     .font(.system(.caption2, design: .monospaced))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .textSelection(.enabled)
             } else {
                 Text(NSLocalizedString(
                     "No extended public key has been persisted for this account yet.",
                     comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
         }
     }
@@ -290,27 +291,27 @@ struct WalletAccountDetailScreen: View {
         VStack(alignment: .leading, spacing: 10) {
             Label(title, systemImage: systemImage)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Divider()
             content()
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
-        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+        .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
     }
 
     private func infoRow(_ label: String, _ value: String, monospaced: Bool = false) -> some View {
         HStack {
             Text(label)
                 .font(.footnote)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Spacer()
             Text(value)
                 .font(monospaced ? .system(.footnote, design: .monospaced) : .system(.footnote))
                 .fontWeight(.medium)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.trailing)
         }
     }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift
@@ -25,6 +25,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct WalletAccountsScreen: View {
@@ -42,7 +43,7 @@ struct WalletAccountsScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -66,9 +67,9 @@ struct WalletAccountsScreen: View {
                                 }
                             }
                         }
-                        .background(Color.secondaryBackground)
+                        .background(Color.dash.secondaryBackground)
                         .cornerRadius(12)
-                        .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                        .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                         .padding(.horizontal, 20)
                         .padding(.top, 4)
                     }
@@ -96,7 +97,7 @@ struct WalletAccountsScreen: View {
                 central: {
                     Text(viewModel.walletName)
                         .font(.headline)
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .lineLimit(1)
                         .padding(.horizontal, 60)
                 }
@@ -106,7 +107,7 @@ struct WalletAccountsScreen: View {
                 Text(NSLocalizedString("Accounts", comment: "Wallet accounts"))
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.horizontal, 20)
@@ -180,7 +181,7 @@ private struct AccountRowView: View {
 
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
 
             if row.isPlatformPayment {
@@ -190,7 +191,7 @@ private struct AccountRowView: View {
             } else {
                 Text(NSLocalizedString("Special Purpose Account", comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .italic()
             }
 
@@ -205,18 +206,18 @@ private struct AccountRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(NSLocalizedString("Confirmed", comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                 Text(row.confirmed.formattedDashAmount)
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
 
             if row.unconfirmed > 0 {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("Pending", comment: "Wallet accounts"))
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                     Text(row.unconfirmed.formattedDashAmount)
                         .font(.subheadline)
                         .fontWeight(.medium)
@@ -229,7 +230,7 @@ private struct AccountRowView: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(NSLocalizedString("Total", comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                 Text((row.confirmed + row.unconfirmed).formattedDashAmount)
                     .font(.subheadline)
                     .fontWeight(.semibold)
@@ -245,7 +246,7 @@ private struct AccountRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(NSLocalizedString("Balance", comment: "Wallet accounts"))
                     .font(.caption)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                 Text(Self.formatCredits(row.platformCredits))
                     .font(.subheadline)
                     .fontWeight(.medium)
@@ -269,7 +270,7 @@ private struct AccountRowView: View {
                 Spacer()
             }
             .font(.caption)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
         } else if row.receiveAddressCount > 0 || row.changeAddressCount > 0 {
             HStack(spacing: 16) {
                 if row.receiveAddressCount > 0 {
@@ -285,7 +286,7 @@ private struct AccountRowView: View {
                 Spacer()
             }
             .font(.caption)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
         }
     }
 

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
@@ -24,6 +24,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct WalletsScreen: View {
@@ -49,7 +50,7 @@ struct WalletsScreen: View {
 
     var body: some View {
         ZStack {
-            Color.primaryBackground.ignoresSafeArea()
+            Color.dash.primaryBackground.ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 0) {
                 header
@@ -92,9 +93,9 @@ struct WalletsScreen: View {
                             }
                         }
                     }
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(12)
-                    .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                    .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                     .padding(.horizontal, 20)
                     .padding(.top, 4)
                 }
@@ -183,17 +184,17 @@ struct WalletsScreen: View {
                 Button(action: { vc.popViewController(animated: true) }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
                 Spacer()
                 Button(action: { showAddWallet = true }) {
                     Image(systemName: "plus")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
                 .accessibilityLabel(NSLocalizedString("Add Wallet", comment: "Wallets"))
             }
@@ -204,7 +205,7 @@ struct WalletsScreen: View {
                 Text(NSLocalizedString("Wallets", comment: "Wallets"))
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.horizontal, 20)
@@ -215,18 +216,18 @@ struct WalletsScreen: View {
 
     private var progressOverlay: some View {
         ZStack {
-            Color.black.opacity(0.35).ignoresSafeArea()
+            Color.dash.backgroundOverlay.ignoresSafeArea()
             VStack(spacing: 14) {
                 // Fully qualified: the app has a UIKit `ProgressView: UIView`
                 // that otherwise shadows SwiftUI's.
                 SwiftUI.ProgressView()
-                    .tint(.white)
+                    .tint(Color.dash.whiteText)
                 Text(NSLocalizedString("Switching wallet…", comment: "Wallets"))
                     .font(.subheadline)
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
             .padding(24)
-            .background(Color.black.opacity(0.6))
+            .background(Color.dash.backgroundOverlay)
             .cornerRadius(14)
         }
     }
@@ -270,18 +271,18 @@ private struct WalletRowView: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(row.displayName)
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 if let username = row.username {
                     Text("@\(username)")
                         .font(.system(size: 13))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                         .lineLimit(1)
                 }
                 if let balance = row.balanceText {
                     Text(balance)
                         .font(.system(size: 13))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .lineLimit(1)
                 }
             }
@@ -289,7 +290,7 @@ private struct WalletRowView: View {
             if row.isActive {
                 Image(systemName: "checkmark")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
             }
             // Visible entry point for switch/rename/remove — the long-press
             // context menu duplicates these but is undiscoverable on its own.
@@ -314,13 +315,13 @@ private struct WalletRowView: View {
             } label: {
                 Image(systemName: "ellipsis")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .frame(width: 32, height: 32)
                     .contentShape(Rectangle())
             }
             Image(systemName: "chevron.right")
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
@@ -346,31 +347,31 @@ private struct RemoveWalletSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
                         Text(String(
                             format: NSLocalizedString("Remove \"%@\"", comment: "Wallets"),
                             row.displayName))
                             .font(.title2).fontWeight(.bold)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
 
                         Text(NSLocalizedString(
                             "This removes this device's copy of the wallet, including its keys and synced data. Your funds are NOT deleted — they remain on the Dash network and can only be recovered with this wallet's recovery phrase. If you have not backed up the phrase, you will lose access to these funds.",
                             comment: "Wallets"))
                             .font(.subheadline)
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
 
                         Text(NSLocalizedString(
                             "Type this wallet's recovery phrase to confirm.",
                             comment: "Wallets"))
                             .font(.system(size: 15, weight: .medium))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
 
                         TextEditor(text: $phrase)
                             .frame(minHeight: 100)
                             .padding(8)
-                            .background(Color.secondaryBackground)
+                            .background(Color.dash.secondaryBackground)
                             .cornerRadius(10)
                             .autocorrectionDisabled(true)
                             .textInputAutocapitalization(.never)
@@ -380,16 +381,16 @@ private struct RemoveWalletSheet: View {
                                 "That is not this wallet's recovery phrase.",
                                 comment: "Wallets"))
                                 .font(.footnote)
-                                .foregroundColor(.systemRed)
+                                .foregroundColor(.dash.red)
                         }
 
                         Button(action: confirm) {
                             Text(NSLocalizedString("Remove Wallet", comment: "Wallets"))
                                 .font(.system(size: 16, weight: .semibold))
-                                .foregroundColor(.white)
+                                .foregroundColor(Color.dash.whiteText)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 14)
-                                .background(canConfirm ? Color.systemRed : Color.systemRed.opacity(0.4))
+                                .background(canConfirm ? Color.dash.red : Color.dash.red.opacity(0.4))
                                 .cornerRadius(12)
                         }
                         .disabled(!canConfirm)
@@ -446,7 +447,7 @@ private struct AddWalletSheet: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                Color.primaryBackground.ignoresSafeArea()
+                Color.dash.primaryBackground.ignoresSafeArea()
                 content
             }
             .navigationTitle(navigationTitle)
@@ -493,7 +494,7 @@ private struct AddWalletSheet: View {
                 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.",
                 comment: "Wallets"))
                 .font(.subheadline)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 24)
 
@@ -518,23 +519,23 @@ private struct AddWalletSheet: View {
         HStack(spacing: 14) {
             Image(systemName: systemImage)
                 .font(.system(size: 22))
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .frame(width: 32)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Text(subtitle)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             Spacer()
             Image(systemName: "chevron.right")
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 }
@@ -561,29 +562,29 @@ private struct CreateWalletView: View {
                     "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.",
                     comment: "Wallets"))
                     .font(.subheadline)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
 
                 phraseGrid
 
                 Toggle(isOn: $confirmedWrittenDown) {
                     Text(NSLocalizedString("I have written down my recovery phrase.", comment: "Wallets"))
                         .font(.system(size: 15))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                 }
                 .disabled(mnemonic == nil || viewModel.addInProgress || viewModel.switchInProgress)
 
                 Button(action: create) {
                     HStack {
                         if viewModel.addInProgress || viewModel.switchInProgress {
-                            SwiftUI.ProgressView().tint(.white)
+                            SwiftUI.ProgressView().tint(Color.dash.whiteText)
                         }
                         Text(NSLocalizedString("Create Wallet", comment: "Wallets"))
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(canCreate ? Color.dashBlue : Color.dashBlue.opacity(0.4))
+                    .background(canCreate ? Color.dash.blue : Color.dash.blue.opacity(0.4))
                     .cornerRadius(12)
                 }
                 .disabled(!canCreate)
@@ -604,16 +605,16 @@ private struct CreateWalletView: View {
                 HStack(spacing: 8) {
                     Text("\(index + 1)")
                         .font(.system(size: 13, design: .monospaced))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .frame(width: 22, alignment: .trailing)
                     Text(word)
                         .font(.system(size: 15, weight: .medium))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                     Spacer(minLength: 0)
                 }
                 .padding(.vertical, 10)
                 .padding(.horizontal, 12)
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
                 .cornerRadius(10)
             }
         }
@@ -654,12 +655,12 @@ private struct ImportWalletView: View {
                     "Enter the recovery phrase of the wallet you want to add.",
                     comment: "Wallets"))
                     .font(.subheadline)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
 
                 TextEditor(text: $phrase)
                     .frame(minHeight: 120)
                     .padding(8)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(10)
                     .autocorrectionDisabled(true)
                     .textInputAutocapitalization(.never)
@@ -671,27 +672,27 @@ private struct ImportWalletView: View {
                             "This wallet is already on this device.",
                             comment: "Wallets"))
                             .font(.footnote)
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                         Button(NSLocalizedString("Switch to it", comment: "Wallets")) {
                             onSwitchToExisting(existingWalletId)
                         }
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                     }
                 }
 
                 Button(action: importWallet) {
                     HStack {
                         if viewModel.addInProgress || viewModel.switchInProgress {
-                            SwiftUI.ProgressView().tint(.white)
+                            SwiftUI.ProgressView().tint(Color.dash.whiteText)
                         }
                         Text(NSLocalizedString("Import Wallet", comment: "Wallets"))
                             .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(canImport ? Color.dashBlue : Color.dashBlue.opacity(0.4))
+                    .background(canImport ? Color.dash.blue : Color.dash.blue.opacity(0.4))
                     .cornerRadius(12)
                 }
                 .disabled(!canImport)

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/Cells/LocalCurrencyCellView.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/Cells/LocalCurrencyCellView.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct LocalCurrencyCellView: View {
 
@@ -53,7 +54,7 @@ struct LocalCurrencyCellView: View {
                     .resizable()
                     .scaledToFill()
             } else {
-                Color.gray200
+                Color.dash.gray200
             }
         }
         .frame(width: Layout.flagSize, height: Layout.flagSize)
@@ -64,13 +65,13 @@ struct LocalCurrencyCellView: View {
         VStack(alignment: .leading, spacing: Layout.infoSpacing) {
             highlightedText(item.name, query: searchQuery)
                 .font(.subhead.weight(.medium))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .lineLimit(1)
 
             if let priceString = item.priceString {
                 Text(priceString)
                     .font(.footnote)
-                    .foregroundColor(.tertiaryText)
+                    .foregroundColor(.dash.tertiaryText)
                     .lineLimit(1)
             }
         }
@@ -88,14 +89,14 @@ struct LocalCurrencyCellView: View {
     private var currencyCodeView: some View {
         highlightedText(item.code, query: searchQuery)
             .font(.caption1)
-            .foregroundColor(.tertiaryText)
+            .foregroundColor(.dash.tertiaryText)
             .lineLimit(1)
     }
 
     private var checkboxView: some View {
         Circle()
             .strokeBorder(
-                isSelected ? Color.dashBlue : Color.gray300,
+                isSelected ? Color.dash.blue : Color.dash.gray300,
                 lineWidth: isSelected ? Layout.checkboxSelectedBorderWidth : Layout.checkboxDefaultBorderWidth
             )
             .frame(width: Layout.checkboxSize, height: Layout.checkboxSize)
@@ -112,7 +113,7 @@ struct LocalCurrencyCellView: View {
         let match  = String(text[range])
         let after  = String(text[range.upperBound...])
 
-        return Text("\(before)\(Text(match).foregroundColor(.dashBlue))\(after)")
+        return Text("\(before)\(Text(match).foregroundColor(.dash.blue))\(after)")
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/LocalCurrencyView.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/LocalCurrencyView.swift
@@ -71,7 +71,7 @@ struct LocalCurrencyView: View {
     }
 
     private var background: some View {
-        Color.primaryBackground
+        Color.dash.primaryBackground
     }
 }
 
@@ -108,12 +108,12 @@ private struct LocalCurrencyScrollContentView: View {
         VStack {
             Text(noResultsText)
                 .font(.footnote)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
         }
         .frame(maxWidth: .infinity, minHeight: Layout.noResultsMinHeight, alignment: .center)
         .background(
             RoundedRectangle(cornerRadius: Layout.containerCornerRadius)
-                .fill(Color.secondaryBackground)
+                .fill(Color.dash.secondaryBackground)
         )
     }
 
@@ -137,7 +137,7 @@ private struct LocalCurrencyScrollContentView: View {
             .padding(filteredItems.isEmpty ? 0 : 6)
             .background(
                 RoundedRectangle(cornerRadius: Layout.containerCornerRadius)
-                    .fill(Color.secondaryBackground)
+                    .fill(Color.dash.secondaryBackground)
             )
         }
     }
@@ -189,7 +189,7 @@ private struct LocalCurrencyTopOverlayView: View {
                 Text(NSLocalizedString("Local Currency", comment: "Settings"))
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
         }
     }
@@ -198,11 +198,11 @@ private struct LocalCurrencyTopOverlayView: View {
         ZStack(alignment: .bottom) {
             Rectangle()
                 .fill(.clear)
-                .background(Color.primaryBackground)
+                .background(Color.dash.primaryBackground)
                 .ignoresSafeArea()
 
             Divider()
-                .background(Color(red: 176 / 255, green: 182 / 255, blue: 188 / 255, opacity: 0.15))
+                .background(Color.dash.gray400Alpha13)
                 .opacity(scrollOffset < -20 ? 1 : 0)
         }
     }

--- a/DashWallet/Sources/UI/Menu/Settings/SettingsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/SettingsScreen.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import SwiftUI
+import DashUIKit
 import Combine
 import MessageUI
 
@@ -66,14 +67,14 @@ struct SettingsScreen: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
             .padding(.horizontal, 20)
 
             Spacer()
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .onReceive(viewModel.$navigationDestination) { destination in
             handleNavigation(destination)

--- a/DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift
@@ -19,6 +19,7 @@ import Combine
 import OSLog
 import SwiftDashSDK
 import SwiftUI
+import DashUIKit
 import UIKit
 
 // MARK: - ViewModel
@@ -145,10 +146,10 @@ struct DashPaySyncInfoScreen: View {
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
                         .overlay(
-                            Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1)
+                            Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1)
                         )
                 }
                 Spacer()
@@ -161,7 +162,7 @@ struct DashPaySyncInfoScreen: View {
                 Text("DashPay Sync Info")
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.top, 30)
@@ -182,7 +183,7 @@ struct DashPaySyncInfoScreen: View {
             }
         }
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .onAppear {
             viewModel.refresh()
@@ -198,24 +199,24 @@ struct DashPaySyncInfoScreen: View {
                     .foregroundColor(.orange)
                 Text("Platform sync is not running")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             } else if viewModel.isSyncing {
                 SwiftUI.ProgressView().scaleEffect(0.7)
                 Text("Syncing…")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else if let lastSync = viewModel.lastSync {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.green)
                 Text("Last sync: \(lastSync, style: .relative) ago")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else {
                 Image(systemName: "circle.dashed")
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                 Text("Not synced yet")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             Spacer()
             if let running = viewModel.isLoopRunning {
@@ -225,7 +226,7 @@ struct DashPaySyncInfoScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -234,14 +235,14 @@ struct DashPaySyncInfoScreen: View {
             HStack {
                 Text("Last Manual Pass")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             row(title: "Wallets Synced", value: "\(summary.success)")
             row(title: "Wallets Failed", value: "\(summary.errors)")
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -272,7 +273,7 @@ struct DashPaySyncInfoScreen: View {
             .font(.system(size: 14, weight: .semibold))
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
-            .background(syncNowDisabled ? Color.gray300.opacity(0.3) : Color.blue.opacity(0.15))
+            .background(syncNowDisabled ? Color.dash.gray300.opacity(0.3) : Color.dash.blue.opacity(0.15))
             .foregroundColor(syncNowDisabled ? .secondary : .blue)
             .cornerRadius(8)
         }
@@ -289,11 +290,11 @@ struct DashPaySyncInfoScreen: View {
         HStack {
             Text(title)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .monospacedDigit()
         }
     }

--- a/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
@@ -15,6 +15,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct PlatformSyncStatusScreen: View {
@@ -35,10 +36,10 @@ struct PlatformSyncStatusScreen: View {
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
                         .overlay(
-                            Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1)
+                            Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1)
                         )
                 }
                 Spacer()
@@ -51,7 +52,7 @@ struct PlatformSyncStatusScreen: View {
                 Text("Platform Sync Status")
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.top, 30)
@@ -75,7 +76,7 @@ struct PlatformSyncStatusScreen: View {
             }
         }
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
     }
 
@@ -87,29 +88,29 @@ struct PlatformSyncStatusScreen: View {
                 SwiftUI.ProgressView().scaleEffect(0.7)
                 Text("Syncing…")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else if let lastSync = coordinator.lastSyncTime {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.green)
                 Text("Last sync: \(lastSync, style: .relative) ago")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else {
                 Image(systemName: "circle.dashed")
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                 Text(coordinator.isRunning ? "Not synced yet" : "Idle")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             Spacer()
             if let network = coordinator.runningNetwork {
                 Text(network.networkName)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -123,7 +124,7 @@ struct PlatformSyncStatusScreen: View {
                 value: "\(coordinator.activeAddressCount)")
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -132,13 +133,13 @@ struct PlatformSyncStatusScreen: View {
             HStack {
                 Text("Platform Addresses (\(coordinator.derivedAddresses.count))")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             if coordinator.derivedAddresses.isEmpty {
                 Text("No addresses derived yet")
                     .font(.system(size: 12))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             } else {
                 ForEach(coordinator.derivedAddresses) { addr in
                     addressRow(addr)
@@ -149,7 +150,7 @@ struct PlatformSyncStatusScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -160,7 +161,7 @@ struct PlatformSyncStatusScreen: View {
                     .font(.system(.caption, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 HStack(spacing: 6) {
                     Text("#\(addr.accountIndex)/\(addr.addressIndex)")
                     if addr.isUsed { Text("• used") }
@@ -169,13 +170,13 @@ struct PlatformSyncStatusScreen: View {
                     }
                 }
                 .font(.caption2)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             }
             Spacer()
             Button(action: { UIPasteboard.general.string = addr.address }) {
                 Image(systemName: "doc.on.doc")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .padding(6)
             }
             .buttonStyle(.plain)
@@ -201,19 +202,19 @@ struct PlatformSyncStatusScreen: View {
                 HStack {
                     Text("Block Time")
                         .font(.system(size: 13))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                     Spacer()
                     Text(blockTime, style: .date)
                         .font(.system(size: 12))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Text(blockTime, style: .time)
                         .font(.system(size: 12))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -222,11 +223,11 @@ struct PlatformSyncStatusScreen: View {
             HStack {
                 Text("Queries Since Launch")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text("\(coordinator.syncCountSinceLaunch) syncs")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             HStack(spacing: 8) {
                 queryBadge(label: "Trunk", count: coordinator.totalTrunkQueries, detail: nil, color: .blue)
@@ -236,7 +237,7 @@ struct PlatformSyncStatusScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -268,7 +269,7 @@ struct PlatformSyncStatusScreen: View {
                 .font(.system(size: 14, weight: .semibold))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .background(coordinator.isSyncing || coordinator.isClearing ? Color.gray300.opacity(0.3) : Color.blue.opacity(0.15))
+                .background(coordinator.isSyncing || coordinator.isClearing ? Color.dash.gray300.opacity(0.3) : Color.dash.blue.opacity(0.15))
                 .foregroundColor(coordinator.isSyncing || coordinator.isClearing ? .secondary : .blue)
                 .cornerRadius(8)
             }
@@ -284,8 +285,8 @@ struct PlatformSyncStatusScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(coordinator.isClearing ? .secondary : .primaryText)
+                    .background(Color.dash.gray300.opacity(0.3))
+                    .foregroundColor(coordinator.isClearing ? .secondary : .dash.primaryText)
                     .cornerRadius(8)
             }
             .disabled(coordinator.isClearing || coordinator.isSyncing)
@@ -297,7 +298,7 @@ struct PlatformSyncStatusScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(coordinator.isRunning ? Color.red.opacity(0.15) : Color.gray300.opacity(0.3))
+                    .background(coordinator.isRunning ? Color.red.opacity(0.15) : Color.dash.gray300.opacity(0.3))
                     .foregroundColor(coordinator.isRunning ? .red : .secondary)
                     .cornerRadius(8)
             }
@@ -311,11 +312,11 @@ struct PlatformSyncStatusScreen: View {
         HStack {
             Text(title)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .monospacedDigit()
         }
     }
@@ -328,7 +329,7 @@ struct PlatformSyncStatusScreen: View {
                 .monospacedDigit()
             Text(label)
                 .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             if let detail {
                 Text("\(detail)")
                     .font(.system(size: 10))

--- a/DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift
@@ -17,6 +17,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct ShieldedSyncInfoScreen: View {
@@ -38,10 +39,10 @@ struct ShieldedSyncInfoScreen: View {
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
                         .overlay(
-                            Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1)
+                            Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1)
                         )
                 }
                 Spacer()
@@ -54,7 +55,7 @@ struct ShieldedSyncInfoScreen: View {
                 Text("Shielded Sync Info")
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.top, 30)
@@ -81,7 +82,7 @@ struct ShieldedSyncInfoScreen: View {
             }
         }
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
     }
 
@@ -94,40 +95,40 @@ struct ShieldedSyncInfoScreen: View {
                     .foregroundColor(.orange)
                 Text("Platform sync is not running")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             } else if monitor.isSyncing {
                 SwiftUI.ProgressView().scaleEffect(0.7)
                 Text("Syncing…")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else if monitor.isBound == false {
                 Image(systemName: "shield.slash")
                     .foregroundColor(.orange)
                 Text("Not bound")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             } else if let lastSync = monitor.lastSyncTime {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.green)
                 Text("Last sync: \(lastSync, style: .relative) ago")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             } else {
                 Image(systemName: "circle.dashed")
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                 Text("Not synced yet")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             Spacer()
             if let network = coordinator.runningNetwork {
                 Text(network.networkName)
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -141,7 +142,7 @@ struct ShieldedSyncInfoScreen: View {
                 value: formattedCount(monitor.notesSynced))
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -150,12 +151,12 @@ struct ShieldedSyncInfoScreen: View {
             HStack {
                 Text("Current Pass")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 if let elapsed = monitor.currentSyncElapsed {
                     Text(String(format: "%.1f s", elapsed))
                         .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                         .monospacedDigit()
                 }
             }
@@ -174,7 +175,7 @@ struct ShieldedSyncInfoScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -189,7 +190,7 @@ struct ShieldedSyncInfoScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -198,11 +199,11 @@ struct ShieldedSyncInfoScreen: View {
             HStack {
                 Text("Queries Since Launch")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text("\(monitor.syncCountSinceLaunch) syncs")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             HStack(spacing: 8) {
                 counterBadge(label: "Scanned", count: monitor.totalScanned, color: .blue)
@@ -211,7 +212,7 @@ struct ShieldedSyncInfoScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -243,7 +244,7 @@ struct ShieldedSyncInfoScreen: View {
                 .font(.system(size: 14, weight: .semibold))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
-                .background(syncNowDisabled ? Color.gray300.opacity(0.3) : Color.purple.opacity(0.15))
+                .background(syncNowDisabled ? Color.dash.gray300.opacity(0.3) : Color.purple.opacity(0.15))
                 .foregroundColor(syncNowDisabled ? .secondary : .purple)
                 .cornerRadius(8)
             }
@@ -256,8 +257,8 @@ struct ShieldedSyncInfoScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(.primaryText)
+                    .background(Color.dash.gray300.opacity(0.3))
+                    .foregroundColor(.dash.primaryText)
                     .cornerRadius(8)
             }
         }
@@ -273,11 +274,11 @@ struct ShieldedSyncInfoScreen: View {
         HStack {
             Text(title)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .monospacedDigit()
         }
     }
@@ -289,20 +290,20 @@ struct ShieldedSyncInfoScreen: View {
         HStack(spacing: 8) {
             Text(label)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .frame(width: 90, alignment: .leading)
             if let value, let total, total > 0 {
                 SwiftUI.ProgressView(value: Double(min(value, total)), total: Double(total))
                     .tint(.purple)
                 Text("\(formattedCount(min(value, total))) / \(formattedCount(total))")
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .monospacedDigit()
             } else if let value {
                 SwiftUI.ProgressView().scaleEffect(0.6)
                 Text("\(formattedCount(value)) notes")
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .monospacedDigit()
                 Spacer()
             } else {
@@ -320,7 +321,7 @@ struct ShieldedSyncInfoScreen: View {
                 .monospacedDigit()
             Text(label)
                 .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
@@ -20,6 +20,7 @@
 import OSLog
 import SwiftData
 import SwiftUI
+import DashUIKit
 import UIKit
 import SwiftDashSDK
 
@@ -78,10 +79,10 @@ struct SwiftDashSDKSPVStatusScreen: View {
                 }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(.primary)
+                        .foregroundColor(Color.dash.primaryText)
                         .frame(width: 36, height: 36)
                         .overlay(
-                            Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1)
+                            Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1)
                         )
                 }
                 Spacer()
@@ -94,7 +95,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
                 Text("Core Sync Status")
                     .font(.title)
                     .fontWeight(.bold)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.top, 30)
@@ -117,7 +118,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
             }
         }
         .padding(.horizontal, 20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .confirmationDialog(
             NSLocalizedString("Rescan Filters", comment: "SPV diagnostics"),
@@ -215,11 +216,11 @@ struct SwiftDashSDKSPVStatusScreen: View {
                 .frame(width: 12, height: 12)
             Text(stateLabel)
                 .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -228,27 +229,27 @@ struct SwiftDashSDKSPVStatusScreen: View {
             HStack {
                 Text("Aggregate Progress")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text(percentageText)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
             // Custom bar — local UIKit `ProgressView` shadows SwiftUI's,
             // so we draw our own to avoid the name collision.
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.gray300.opacity(0.3))
+                        .fill(Color.dash.gray300.opacity(0.3))
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.blue)
+                        .fill(Color.dash.blue)
                         .frame(width: max(0, geo.size.width * clampedProgress))
                 }
             }
             .frame(height: 8)
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -264,11 +265,11 @@ struct SwiftDashSDKSPVStatusScreen: View {
             HStack {
                 Text(NSLocalizedString("Wallet birth height", comment: "SPV diagnostics"))
                     .font(.system(size: 13))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text(walletBirthHeight.map { "\($0)" } ?? "—")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .monospacedDigit()
                 Button(action: {
                     birthHeightEntryText = walletBirthHeight.map { "\($0)" } ?? ""
@@ -276,13 +277,13 @@ struct SwiftDashSDKSPVStatusScreen: View {
                 }) {
                     Image(systemName: "pencil")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
                 .disabled(walletBirthHeight == nil)
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -291,11 +292,11 @@ struct SwiftDashSDKSPVStatusScreen: View {
             HStack {
                 Text("Connected Peers")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
                 Text("\(coordinator.connectedPeers.count)")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .monospacedDigit()
             }
             .padding(.bottom, 4)
@@ -303,13 +304,13 @@ struct SwiftDashSDKSPVStatusScreen: View {
             if coordinator.connectedPeers.isEmpty {
                 Text("No peers connected")
                     .font(.system(size: 13))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             } else {
                 ForEach(coordinator.connectedPeers) { peer in
                     HStack {
                         Text(peer.address)
                             .font(.system(size: 13))
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                             .monospacedDigit()
                             .lineLimit(1)
                         Spacer()
@@ -319,7 +320,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
             }
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -355,7 +356,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Per-Phase Progress")
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.bottom, 4)
 
             phaseRow(
@@ -388,7 +389,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
             )
         }
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -396,13 +397,13 @@ struct SwiftDashSDKSPVStatusScreen: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("Filters", comment: "SPV diagnostics"))
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             Text(NSLocalizedString(
                 "Rewind this wallet's filter scan to re-download and re-match compact block filters, rediscovering any missed transactions.",
                 comment: "SPV diagnostics"))
                 .font(.system(size: 12))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
 
             Button(action: {
@@ -413,8 +414,8 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(rescanEnabled ? .primaryText : .secondary)
+                    .background(Color.dash.gray300.opacity(0.3))
+                    .foregroundColor(rescanEnabled ? .dash.primaryText : .secondary)
                     .cornerRadius(8)
             }
             .disabled(!rescanEnabled)
@@ -424,7 +425,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     "Available only while SPV is running with a wallet bound.",
                     comment: "SPV diagnostics"))
                     .font(.system(size: 12))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
 
             if let message = rescanResultMessage {
@@ -436,7 +437,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -465,8 +466,8 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(.primaryText)
+                    .background(Color.dash.gray300.opacity(0.3))
+                    .foregroundColor(.dash.primaryText)
                     .cornerRadius(8)
             }
             Button(action: {
@@ -477,8 +478,8 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     .font(.system(size: 14, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .background(Color.gray300.opacity(0.3))
-                    .foregroundColor(.primaryText)
+                    .background(Color.dash.gray300.opacity(0.3))
+                    .foregroundColor(.dash.primaryText)
                     .cornerRadius(8)
             }
         }
@@ -490,11 +491,11 @@ struct SwiftDashSDKSPVStatusScreen: View {
         HStack {
             Text(title)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .monospacedDigit()
         }
     }
@@ -503,11 +504,11 @@ struct SwiftDashSDKSPVStatusScreen: View {
         HStack {
             Text(title)
                 .font(.system(size: 13))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Text(phaseDetail(state: state, percentage: percentage, current: current, target: target))
                 .font(.system(size: 12, weight: .medium))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
                 .monospacedDigit()
         }
     }

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SyncInfoMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SyncInfoMenuScreen.swift
@@ -22,6 +22,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct SyncInfoMenuScreen: View {
@@ -61,14 +62,14 @@ struct SyncInfoMenuScreen: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-            .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
             .padding(.horizontal, 20)
 
             Spacer()
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .onReceive(viewModel.$navigationDestination) { destination in
             handleNavigation(destination)

--- a/DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct CSVExportSheet: View {
     @Environment(\.presentationMode) private var presentationMode
@@ -28,7 +29,7 @@ struct CSVExportSheet: View {
         VStack(spacing: 0) {
             // Grabber
             Capsule()
-                .fill(colorScheme == .dark ? Color.whiteAlpha20 : Color.gray300Alpha50)
+                .fill(colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.gray300Alpha50)
                 .frame(width: 36, height: 5)
                 .padding(.top, 6)
                 .padding(.bottom, 6)
@@ -52,13 +53,13 @@ struct CSVExportSheet: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(NSLocalizedString("The full transaction history will be exported as a CSV file", comment: ""))
                         .font(.system(size: 28, weight: .bold))
-                        .foregroundColor(Color.primaryText)
+                        .foregroundColor(Color.dash.primaryText)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
 
                     Text(NSLocalizedString("All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.", comment: ""))
                         .font(.system(size: 15))
-                        .foregroundColor(Color.secondaryText)
+                        .foregroundColor(Color.dash.secondaryText)
                         .multilineTextAlignment(.leading)
                         .lineSpacing(5)
                         .fixedSize(horizontal: false, vertical: true)
@@ -88,7 +89,7 @@ struct CSVExportSheet: View {
             .padding(.top, 20)
             .padding(.bottom, 20)
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 // MARK: - ExtendedPublicKeySheetViewModel
@@ -83,7 +84,7 @@ struct ExtendedPublicKeySheet: View {
             // Grabber
             VStack {
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(Color.gray300.opacity(0.5))
+                    .fill(Color.dash.gray300.opacity(0.5))
                     .frame(width: 36, height: 5)
             }
             .frame(maxWidth: .infinity, minHeight: 18)
@@ -102,7 +103,7 @@ struct ExtendedPublicKeySheet: View {
                         .frame(width: 180, height: 180)
                 } else {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(Color.gray300.opacity(0.2))
+                        .fill(Color.dash.gray300.opacity(0.2))
                         .frame(width: 180, height: 180)
                 }
             }
@@ -112,7 +113,7 @@ struct ExtendedPublicKeySheet: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(NSLocalizedString("Extended public key (BIP44)", comment: ""))
                     .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button(action: {
@@ -127,7 +128,7 @@ struct ExtendedPublicKeySheet: View {
                          ? NSLocalizedString("Not available", comment: "")
                          : viewModel.keyValue)
                         .font(.system(size: 15))
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -140,7 +141,7 @@ struct ExtendedPublicKeySheet: View {
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
                                 .background(copiedBackground)
-                                .foregroundColor(.whiteText)
+                                .foregroundColor(.dash.whiteText)
                                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                         }
                     }
@@ -161,7 +162,7 @@ struct ExtendedPublicKeySheet: View {
             .padding(.horizontal, 60)
             .padding(.bottom, 20)
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .sheet(isPresented: $showShareSheet) {
             if !viewModel.keyValue.isEmpty {
                 ShareSheet(items: [viewModel.keyValue])
@@ -174,10 +175,10 @@ struct ExtendedPublicKeySheet: View {
         if colorScheme == .dark {
             ZStack {
                 BackgroundBlurView()
-                Color.whiteAlpha15
+                Color.dash.whiteAlpha15
             }
         } else {
-            Color.black.opacity(0.8)
+            Color.dash.backgroundOverlay
         }
     }
 }

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/DerivationPathKeysView.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/DerivationPathKeysView.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 // MARK: - DerivationPathKeysViewModel
@@ -190,7 +191,7 @@ struct KeyInfoRow: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
                         .background(copiedBackground)
-                        .foregroundColor(.whiteText)
+                        .foregroundColor(.dash.whiteText)
                         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 }
             }
@@ -202,10 +203,10 @@ struct KeyInfoRow: View {
         if colorScheme == .dark {
             ZStack {
                 BackgroundBlurView()
-                Color.whiteAlpha15
+                Color.dash.whiteAlpha15
             }
         } else {
-            Color.black.opacity(0.8)
+            Color.dash.backgroundOverlay
         }
     }
 }

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -17,9 +17,9 @@
 //  limitations under the License.
 //
 
-import SwiftUI
 import DashUIKit
 import SwiftDashSDK
+import SwiftUI
 import UIKit
 
 // MARK: - MasternodesViewModel
@@ -173,7 +173,7 @@ struct MasternodesScreen: View {
                     VStack(spacing: 12) {
                         Image(systemName: "server.rack")
                             .font(.system(size: 40))
-                            .foregroundColor(Color.dash.gray500)
+                            .foregroundColor(Color.dash.tertiaryText)
 
                         Text(NSLocalizedString("No masternodes yet", comment: "Masternodes"))
                             .font(.headline)

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import SwiftDashSDK
 import UIKit
 
@@ -172,14 +173,14 @@ struct MasternodesScreen: View {
                     VStack(spacing: 12) {
                         Image(systemName: "server.rack")
                             .font(.system(size: 40))
-                            .foregroundColor(.gray)
+                            .foregroundColor(Color.dash.gray500)
 
                         Text(NSLocalizedString("No masternodes yet", comment: "Masternodes"))
                             .font(.headline)
 
                         Text(NSLocalizedString("Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs.", comment: "Masternodes"))
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.dash.secondaryText)
                             .multilineTextAlignment(.center)
                     }
                     .frame(maxWidth: .infinity)
@@ -221,7 +222,7 @@ private struct MasternodeListRow: View {
                 if let service = masternode.serviceAddress {
                     Text(service)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
 
@@ -359,7 +360,7 @@ struct MasternodeDetailScreen: View {
                             // `ProgressView` UIKit class that shadows it here.
                             SwiftUI.ProgressView().scaleEffect(0.8)
                             Text(NSLocalizedString("Fetching…", comment: "Masternodes"))
-                                .foregroundColor(.secondary)
+                                .foregroundColor(Color.dash.secondaryText)
                         }
                     } else if let credits = claimableCredits {
                         MasternodeDetailRow(
@@ -369,7 +370,7 @@ struct MasternodeDetailScreen: View {
                     } else if let error = balanceError {
                         Text(error)
                             .font(.caption)
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.dash.secondaryText)
                     }
 
                     Button {
@@ -440,7 +441,7 @@ private struct MasternodeDetailRow: View {
         HStack {
             Text(label)
                 .font(.subheadline)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             Spacer()
             Text(value)
                 .font(.subheadline)
@@ -468,15 +469,15 @@ private struct MasternodeCopyRow: View {
                 HStack {
                     Text(label)
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Spacer()
                     Image(systemName: copied ? "checkmark" : "doc.on.doc")
                         .font(.caption)
-                        .foregroundColor(copied ? .green : .dashBlue)
+                        .foregroundColor(copied ? .green : .dash.blue)
                 }
                 Text(value)
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundColor(.primary)
+                    .foregroundColor(Color.dash.primaryText)
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerUnavailableView.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerUnavailableView.swift
@@ -4,16 +4,17 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct StorageExplorerUnavailableView: View {
     var body: some View {
         VStack(spacing: 16) {
             Image(systemName: "cylinder.split.1x2")
                 .font(.largeTitle)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             Text("Storage Explorer requires the Platform sync runtime.")
                 .multilineTextAlignment(.center)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             Button("Start Platform Sync") {
                 PlatformAddressSyncCoordinator.startForCurrentNetwork()
             }

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 import SwiftData
 import SwiftDashSDK
 
@@ -117,7 +118,7 @@ struct StorageExplorerView: View {
                 Label(name, systemImage: icon)
                 Spacer()
                 Text("\(counts[String(describing: type)] ?? 0)")
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .font(.callout)
             }
         }
@@ -138,7 +139,7 @@ struct StorageExplorerView: View {
                 Label(name, systemImage: icon)
                 Spacer()
                 Text("\(counts[countKey] ?? 0)")
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .font(.callout)
             }
         }

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 import SwiftData
 import SwiftDashSDK
 
@@ -15,7 +16,7 @@ struct IdentityStorageListView: View {
                     Text(record.dpnsName ?? record.alias ?? record.identityIdBase58)
                         .font(.body).lineLimit(1)
                     Text(record.formattedBalance)
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -35,7 +36,7 @@ struct DocumentStorageListView: View {
             NavigationLink(destination: DocumentStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.displayTitle).font(.body).lineLimit(1)
-                    Text(record.documentType).font(.caption).foregroundColor(.secondary)
+                    Text(record.documentType).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -55,7 +56,7 @@ struct DataContractStorageListView: View {
             NavigationLink(destination: DataContractStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
-                    Text(record.idBase58).font(.caption).foregroundColor(.secondary).lineLimit(1).truncationMode(.middle)
+                    Text(record.idBase58).font(.caption).foregroundColor(Color.dash.secondaryText).lineLimit(1).truncationMode(.middle)
                 }
             }
         }
@@ -76,7 +77,7 @@ struct PublicKeyStorageListView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Key \(record.keyId)").font(.body)
                     Text("\(record.purpose) / \(record.securityLevel)")
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -96,7 +97,7 @@ struct TokenStorageListView: View {
             NavigationLink(destination: TokenStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
-                    Text(record.formattedBaseSupply).font(.caption).foregroundColor(.secondary)
+                    Text(record.formattedBaseSupply).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -116,7 +117,7 @@ struct TokenBalanceStorageListView: View {
             NavigationLink(destination: TokenBalanceStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.tokenName ?? record.tokenId).font(.body).lineLimit(1)
-                    Text(record.displayBalance).font(.caption).foregroundColor(.secondary)
+                    Text(record.displayBalance).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -136,7 +137,7 @@ struct TokenHistoryStorageListView: View {
             NavigationLink(destination: TokenHistoryStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.displayTitle).font(.body).lineLimit(1)
-                    Text(record.eventTimestamp, style: .date).font(.caption).foregroundColor(.secondary)
+                    Text(record.eventTimestamp, style: .date).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -156,7 +157,7 @@ struct DocumentTypeStorageListView: View {
             NavigationLink(destination: DocumentTypeStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
-                    Text(record.contractIdBase58).font(.caption).foregroundColor(.secondary).lineLimit(1).truncationMode(.middle)
+                    Text(record.contractIdBase58).font(.caption).foregroundColor(Color.dash.secondaryText).lineLimit(1).truncationMode(.middle)
                 }
             }
         }
@@ -176,7 +177,7 @@ struct IndexStorageListView: View {
             NavigationLink(destination: IndexStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
-                    Text(record.documentTypeName).font(.caption).foregroundColor(.secondary)
+                    Text(record.documentTypeName).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -196,7 +197,7 @@ struct PropertyStorageListView: View {
             NavigationLink(destination: PropertyStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
-                    Text(record.type).font(.caption).foregroundColor(.secondary)
+                    Text(record.type).font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -236,10 +237,10 @@ struct SyncStateStorageListView: View {
                         .font(.body)
                     Text("Height \(record.syncHeight)")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Text("Updated \(record.lastUpdated, style: .relative)")
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -261,7 +262,7 @@ struct WalletStorageListView: View {
                     Text(record.name ?? record.walletId.map { String(format: "%02x", $0) }.prefix(16).joined())
                         .font(.body).lineLimit(1)
                     Text("\(record.network) · height \(record.syncedHeight)")
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -299,7 +300,7 @@ struct AccountStorageListView: View {
                 Section(header: Text(walletHeader(for: wallet))) {
                     let sorted = sortedAccounts(wallet.accounts)
                     if sorted.isEmpty {
-                        Text("No accounts").font(.caption).foregroundColor(.secondary)
+                        Text("No accounts").font(.caption).foregroundColor(Color.dash.secondaryText)
                     } else {
                         ForEach(sorted) { account in
                             NavigationLink(destination: AccountStorageDetailView(record: account)) {
@@ -349,7 +350,7 @@ struct AccountStorageListView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text(record.accountTypeName).font(.body).lineLimit(1)
             Text("Index \(record.accountIndex)")
-                .font(.caption).foregroundColor(.secondary)
+                .font(.caption).foregroundColor(Color.dash.secondaryText)
         }
     }
 }
@@ -510,7 +511,7 @@ struct CoreAddressStorageListView: View {
                 if record.balance > 0 { Text("• \(record.balance)") }
             }
             .font(.caption2)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color.dash.secondaryText)
         }
     }
 }
@@ -614,7 +615,7 @@ struct PlatformAddressStorageListView: View {
                 if record.balance > 0 { Text("• \(record.balance)") }
             }
             .font(.caption2)
-            .foregroundColor(.secondary)
+            .foregroundColor(Color.dash.secondaryText)
         }
     }
 }
@@ -661,7 +662,7 @@ struct WalletManagerMetadataStorageListView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.network.networkName).font(.body)
                     Text("Height \(record.combinedSyncHeight) · \(record.walletCount) wallets")
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -697,7 +698,7 @@ struct DPNSNameStorageListView: View {
                     Text("\(record.label).\(record.parentDomainName)")
                         .font(.body).lineLimit(1)
                     Text(record.identity.identityIdBase58)
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                         .lineLimit(1).truncationMode(.middle)
                 }
             }
@@ -722,7 +723,7 @@ struct DashpayProfileStorageListView: View {
                     Text(record.displayName ?? "(no display name)")
                         .font(.body).lineLimit(1)
                     Text(record.identity.identityIdBase58)
-                        .font(.caption).foregroundColor(.secondary)
+                        .font(.caption).foregroundColor(Color.dash.secondaryText)
                         .lineLimit(1).truncationMode(.middle)
                 }
             }
@@ -747,7 +748,7 @@ struct DashpayContactProfileStorageListView: View {
                         .font(.body).lineLimit(1)
                     Text(shortIdHex(record.contactIdentityId))
                         .font(.system(.caption, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
         }
@@ -807,7 +808,7 @@ struct DashpayContactRequestStorageListView: View {
                     .font(.system(.body, design: .monospaced))
                     .lineLimit(1).truncationMode(.middle)
                 Text("from \(shortIdHex(record.ownerIdentityId))")
-                    .font(.caption).foregroundColor(.secondary)
+                    .font(.caption).foregroundColor(Color.dash.secondaryText)
                     .lineLimit(1).truncationMode(.middle)
             }
         }
@@ -833,7 +834,7 @@ struct DashpayPaymentStorageListView: View {
                     }
                     Text(record.txid)
                         .font(.system(.caption2, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                         .lineLimit(1).truncationMode(.middle)
                 }
             }
@@ -858,11 +859,11 @@ struct InvitationStorageListView: View {
                         .lineLimit(1).truncationMode(.middle)
                     HStack(spacing: 8) {
                         Text(invitationStatusLabel(record.statusRaw))
-                            .font(.caption2).foregroundColor(.secondary)
+                            .font(.caption2).foregroundColor(Color.dash.secondaryText)
                         Spacer()
                         Text(String(format: "%.8f DASH", Double(record.amountDuffs) / 100_000_000))
                             .font(.system(.caption2, design: .monospaced))
-                            .foregroundColor(.secondary)
+                            .foregroundColor(Color.dash.secondaryText)
                     }
                 }
             }
@@ -887,11 +888,11 @@ struct DashpayIgnoredSenderStorageListView: View {
                             .font(.body)
                         Spacer()
                         Text(record.ignoredAt, style: .date)
-                            .font(.caption).foregroundColor(.secondary)
+                            .font(.caption).foregroundColor(Color.dash.secondaryText)
                     }
                     Text(shortIdHex(record.ignoredSenderId))
                         .font(.system(.caption2, design: .monospaced))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
         }

--- a/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 import SwiftData
 import SwiftDashSDK
 
@@ -11,7 +12,7 @@ private struct FieldRow: View {
 
     var body: some View {
         HStack {
-            Text(label).foregroundColor(.secondary)
+            Text(label).foregroundColor(Color.dash.secondaryText)
             Spacer()
             Text(value).lineLimit(1).truncationMode(.middle).textSelection(.enabled)
             if didCopy {
@@ -21,7 +22,7 @@ private struct FieldRow: View {
             } else {
                 Image(systemName: "doc.on.doc")
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
         }
         .contentShape(Rectangle())
@@ -595,7 +596,7 @@ struct AccountStorageDetailView: View {
                                     }
                                 }
                                 .font(.caption2)
-                                .foregroundColor(.secondary)
+                                .foregroundColor(Color.dash.secondaryText)
                             }
                         }
                     }
@@ -640,7 +641,7 @@ struct CoreAddressDetailView: View {
             Form {
                 Section("Address") {
                     HStack {
-                        Text("Address").foregroundColor(.secondary)
+                        Text("Address").foregroundColor(Color.dash.secondaryText)
                         Spacer()
                         Text(record.address).lineLimit(1).truncationMode(.middle)
                     }

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
@@ -17,6 +17,7 @@
 
 import UIKit
 import SwiftUI
+import DashUIKit
 import SafariServices
 
 struct ToolsMenuScreen: View {
@@ -62,9 +63,9 @@ struct ToolsMenuScreen: View {
                     }
                 }
                 .padding(6)
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                 .padding(.horizontal, 20)
 
                 // Menu list - ZenLedger
@@ -83,16 +84,16 @@ struct ToolsMenuScreen: View {
                         .frame(minHeight: 56)
                     }
                     .padding(6)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    .shadow(color: Color.shadow, radius: 20, x: 0, y: 5)
+                    .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
                     .padding(.horizontal, 20)
                 }
 
                 Spacer()
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .onReceive(viewModel.$navigationDestination) { destination in
             handleNavigation(destination)

--- a/DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ZenLedgerInfoSheet: View {
     @ObservedObject private var viewModel = ZenLedgerViewModel()
@@ -31,7 +32,7 @@ struct ZenLedgerInfoSheet: View {
         VStack(spacing: 0) {
             // Grabber
             Capsule()
-                .fill(colorScheme == .dark ? Color.whiteAlpha20 : Color.gray300Alpha50)
+                .fill(colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.gray300Alpha50)
                 .frame(width: 36, height: 5)
                 .padding(.top, 6)
                 .padding(.bottom, 6)
@@ -55,13 +56,13 @@ struct ZenLedgerInfoSheet: View {
                 VStack(alignment: .center, spacing: 6) {
                     Text(NSLocalizedString("Simplify your crypto taxes", comment: "ZenLedger"))
                         .font(.system(size: 28, weight: .bold))
-                        .foregroundColor(Color.primaryText)
+                        .foregroundColor(Color.dash.primaryText)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
 
                     Text(NSLocalizedString("Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.", comment: "ZenLedger"))
                         .font(.system(size: 15))
-                        .foregroundColor(Color.secondaryText)
+                        .foregroundColor(Color.dash.secondaryText)
                         .multilineTextAlignment(.center)
                         .lineSpacing(5)
                         .fixedSize(horizontal: false, vertical: true)
@@ -100,7 +101,7 @@ struct ZenLedgerInfoSheet: View {
             .padding(.top, 20)
             .padding(.bottom, 20)
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .alert(isPresented: $showAlert) {
             resolveAlert()
         }

--- a/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import UIKit
 import Combine
 

--- a/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/BaseAmountViewController.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import UIKit
 import Combine
 

--- a/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import Foundation
 
 // MARK: - SendAmountError

--- a/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import Foundation
 
 // MARK: - SendAmountError

--- a/DashWallet/Sources/UI/Payments/Amount/SendAmountScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SendAmountScreen.swift
@@ -59,7 +59,7 @@ struct SendAmountView<AvatarView: View>: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            Color.primaryBackground
+            Color.dash.primaryBackground
                 .ignoresSafeArea(edges: .top)
 
             VStack(spacing: 0) {
@@ -102,7 +102,7 @@ struct SendAmountView<AvatarView: View>: View {
                         onSend: onSend
                     )
                 }
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
             }
         }
     }
@@ -219,7 +219,7 @@ private struct SendAmountErrorRow: View {
 
     private var errorColor: Color {
         guard let colorizedError = error as? ColorizedText else {
-            return .systemRed
+            return .dash.red
         }
 
         return Color(uiColor: colorizedError.textColor)

--- a/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SpecifyAmountViewController.swift
@@ -145,7 +145,7 @@ private struct SpecifyAmountView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            Color.primaryBackground
+            Color.dash.primaryBackground
                 .ignoresSafeArea(edges: .top)
 
             VStack(spacing: 0) {
@@ -157,7 +157,7 @@ private struct SpecifyAmountView: View {
                 VStack(alignment: .leading, spacing: 26) {
                     Text(NSLocalizedString("Specify Amount", comment: "Specify Amount"))
                         .font(.largeTitle.weight(.bold))
-                        .foregroundColor(Color.primaryText)
+                        .foregroundColor(Color.dash.primaryText)
                         .padding(.top, 10)
 
                     DashUIKit.EnterAmountView(
@@ -198,7 +198,7 @@ private struct SpecifyAmountView: View {
                 }
                 .padding(.horizontal, 20)
                 .padding(.bottom, 20)
-                .background(Color.secondaryBackground)
+                .background(Color.dash.secondaryBackground)
             }
         }
     }

--- a/DashWallet/Sources/UI/Payments/Amount/Views/AmountView.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Views/AmountView.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import UIKit
 
 

--- a/DashWallet/Sources/UI/Payments/Amount/Views/AmountView.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Views/AmountView.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import UIKit
 
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import SwiftDashSDK
 
 /// Confirmation half-sheet shown when the user taps `Continue` on the
@@ -49,7 +50,7 @@ struct InternalTransferConfirmSheet: View {
             Text(NSLocalizedString("Confirm", comment: ""))
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 20)
 
             switch coordinator.phase {
@@ -61,7 +62,7 @@ struct InternalTransferConfirmSheet: View {
                 detailsBody
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .interactiveDismissDisabled(isInFlight)
     }
 
@@ -156,7 +157,7 @@ struct InternalTransferConfirmSheet: View {
             Text(NSLocalizedString("Transfer complete", comment: ""))
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             DashAmount(
                 amount: dashDuffs,
@@ -182,7 +183,7 @@ struct InternalTransferConfirmSheet: View {
 
     private var dragHandle: some View {
         Rectangle()
-            .fill(Color(red: 0.83, green: 0.83, blue: 0.85))
+            .fill(Color.dash.grabberFill)
             .frame(width: 36, height: 5)
             .cornerRadius(2.5)
     }
@@ -190,7 +191,7 @@ struct InternalTransferConfirmSheet: View {
     private var secondaryLine: some View {
         Text(fiatText)
             .font(.subheadline)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
     }
 
     // MARK: - Network fee estimate
@@ -266,7 +267,7 @@ struct InternalTransferConfirmSheet: View {
                 label: NSLocalizedString("Total", comment: ""),
                 value: dashDuffs.formattedDashAmount)
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -302,14 +303,14 @@ struct InternalTransferConfirmSheet: View {
             valueView: AnyView(
                 Text(value)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primaryText)))
+                    .foregroundColor(.dash.primaryText)))
     }
 
     private func summaryRow(label: String, valueView: AnyView) -> some View {
         HStack {
             Text(label)
                 .font(.system(size: 14))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Spacer()
             valueView
         }
@@ -319,7 +320,7 @@ struct InternalTransferConfirmSheet: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(Color.gray300.opacity(0.3))
+            .fill(Color.dash.gray300.opacity(0.3))
             .frame(height: 1)
             .padding(.horizontal, 14)
     }
@@ -330,27 +331,27 @@ struct InternalTransferConfirmSheet: View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 30, height: 30)
                 Image(systemName: privacyTipIcon)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(privacyTipTitle)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Text(privacyTipBody)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
         }
         .padding(14)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -520,7 +521,7 @@ struct ShieldedRecoverySheet: View {
             Text(NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery"))
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 20)
 
             switch coordinator.phase {
@@ -538,7 +539,7 @@ struct ShieldedRecoverySheet: View {
                 }
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .interactiveDismissDisabled(isInFlight)
     }
 
@@ -607,7 +608,7 @@ struct ShieldedRecoverySheet: View {
                 "Building the privacy proof can take up to a minute. Keep the app open.",
                 comment: "InternalTransfer recovery"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
 
             Spacer(minLength: 12)
@@ -630,7 +631,7 @@ struct ShieldedRecoverySheet: View {
             Text(NSLocalizedString("Transfer complete", comment: ""))
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             DashAmount(
                 amount: Int64(transaction.dashAmount),
@@ -654,7 +655,7 @@ struct ShieldedRecoverySheet: View {
 
     private var dragHandle: some View {
         Rectangle()
-            .fill(Color(red: 0.83, green: 0.83, blue: 0.85))
+            .fill(Color.dash.grabberFill)
             .frame(width: 36, height: 5)
             .cornerRadius(2.5)
     }
@@ -663,29 +664,29 @@ struct ShieldedRecoverySheet: View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 30, height: 30)
                 Image(systemName: "shield.fill")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(NSLocalizedString("Your Dash is safe", comment: "InternalTransfer recovery"))
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Text(NSLocalizedString(
                     "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.",
                     comment: "InternalTransfer recovery"))
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
         }
         .padding(14)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -786,7 +787,7 @@ struct ShieldedTransferStepList: View {
             stepIndicator(state: state)
             Text(label)
                 .font(.system(size: 15, weight: state == .active ? .semibold : .regular))
-                .foregroundColor(state == .pending ? .secondaryText : .primaryText)
+                .foregroundColor(state == .pending ? .dash.secondaryText : .dash.primaryText)
             Spacer()
             if state == .active {
                 SwiftUI.ProgressView()
@@ -801,25 +802,25 @@ struct ShieldedTransferStepList: View {
         switch state {
         case .pending:
             Circle()
-                .stroke(Color.gray300.opacity(0.6), lineWidth: 1.5)
+                .stroke(Color.dash.gray300.opacity(0.6), lineWidth: 1.5)
                 .frame(width: 20, height: 20)
         case .active:
             ZStack {
                 Circle()
-                    .stroke(Color.dashBlue, lineWidth: 1.5)
+                    .stroke(Color.dash.blue, lineWidth: 1.5)
                     .frame(width: 20, height: 20)
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 10, height: 10)
             }
         case .complete:
             ZStack {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 20, height: 20)
                 Image(systemName: "checkmark")
                     .font(.system(size: 11, weight: .bold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
         }
     }
@@ -840,19 +841,19 @@ struct ShieldedSubmittedUnconfirmedView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 56, height: 56)
-                .foregroundColor(.dashBlue)
+                .foregroundColor(.dash.blue)
                 .padding(.top, 24)
 
             Text(NSLocalizedString("Submitted — confirming", comment: "InternalTransfer"))
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             Text(NSLocalizedString(
                 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.",
                 comment: "InternalTransfer"))
                 .font(.callout)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 24)

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -79,7 +79,7 @@ struct InternalTransferScreen: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 12)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .sheet(isPresented: $showConfirm) {
             InternalTransferConfirmSheet(
                 route: viewModel.route,
@@ -104,7 +104,7 @@ struct InternalTransferScreen: View {
     private var header: some View {
         Text(NSLocalizedString("Internal transfer", comment: ""))
             .font(.system(size: 24, weight: .bold))
-            .foregroundColor(.primaryText)
+            .foregroundColor(.dash.primaryText)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -309,7 +309,7 @@ struct InternalTransferScreen: View {
             balanceTrailing: AnyView(
                 Text(viewModel.shieldedBalanceFormatted)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)))
+                    .foregroundColor(.dash.primaryText)))
     }
 
     // MARK: - Reverse-direction From card
@@ -326,7 +326,7 @@ struct InternalTransferScreen: View {
             balanceTrailing: AnyView(
                 Text(viewModel.shieldedBalanceFormatted)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)))
+                    .foregroundColor(.dash.primaryText)))
     }
 
     /// Caption for the reusable source rows: "From" in the forward direction,
@@ -368,16 +368,16 @@ struct InternalTransferScreen: View {
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundColor(iconColor)
                 .frame(width: 36, height: 36)
-                .background(Color.blue.opacity(0.08))
+                .background(Color.dash.blue.opacity(0.08))
                 .clipShape(Circle())
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(caption)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                 Text(title)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
 
             Spacer()
@@ -386,7 +386,7 @@ struct InternalTransferScreen: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -394,11 +394,11 @@ struct InternalTransferScreen: View {
         Button(action: toggleDirection) {
             Image(systemName: "arrow.up.arrow.down")
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .frame(width: 28, height: 28)
-                .background(Color.primaryBackground)
+                .background(Color.dash.primaryBackground)
                 .clipShape(Circle())
-                .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
         }
         .buttonStyle(.plain)
     }
@@ -413,11 +413,11 @@ struct InternalTransferScreen: View {
         VStack(spacing: 2) {
             Text(NSLocalizedString("You will transfer", comment: ""))
                 .font(.system(size: 12))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             HStack(spacing: 4) {
                 Text("~ \(viewModel.dashAmountFormatted)")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Image("icon_dash_currency")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -465,7 +465,7 @@ struct TransferSourceRow: View {
             HStack(spacing: 2) {
                 Text(formatted)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Image("icon_dash_currency")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -480,16 +480,16 @@ struct TransferSourceRow: View {
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundColor(.blue)
                     .frame(width: 36, height: 36)
-                    .background(Color.blue.opacity(0.08))
+                    .background(Color.dash.blue.opacity(0.08))
                     .clipShape(Circle())
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(caption)
                         .font(.system(size: 11))
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Text(title)
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                 }
 
                 Spacer()
@@ -502,10 +502,10 @@ struct TransferSourceRow: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .overlay(
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(showsRadio && selected ? Color.dashBlue : Color.clear,
+                    .stroke(showsRadio && selected ? Color.dash.blue : Color.clear,
                             lineWidth: showsRadio && selected ? 1.5 : 0))
             .cornerRadius(12)
         }
@@ -516,11 +516,11 @@ struct TransferSourceRow: View {
     private var radioIndicator: some View {
         ZStack {
             Circle()
-                .stroke(selected ? Color.dashBlue : Color.gray300.opacity(0.6), lineWidth: 1.5)
+                .stroke(selected ? Color.dash.blue : Color.dash.gray300.opacity(0.6), lineWidth: 1.5)
                 .frame(width: 18, height: 18)
             if selected {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 10, height: 10)
             }
         }
@@ -548,10 +548,10 @@ struct TransferAmountRow: View {
             Button(action: onMax) {
                 Text(NSLocalizedString("Max", comment: ""))
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .clipShape(Capsule())
             }
 
@@ -560,7 +560,7 @@ struct TransferAmountRow: View {
 
                 Text(secondaryText)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             .frame(maxWidth: .infinity)
 
@@ -582,7 +582,7 @@ struct TransferAmountRow: View {
             case .dash:
                 Text(amountText)
                     .font(.system(size: 36, weight: .bold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                 Image("icon_dash_currency")
@@ -592,10 +592,10 @@ struct TransferAmountRow: View {
             case .fiat:
                 Text(currencySymbol)
                     .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Text(amountText)
                     .font(.system(size: 36, weight: .bold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
             }
@@ -606,10 +606,10 @@ struct TransferAmountRow: View {
         Button(action: action) {
             Text(label)
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundColor(selected ? .primaryText : .secondary)
+                .foregroundColor(selected ? .dash.primaryText : .secondary)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
-                .background(selected ? Color.secondaryBackground : Color.clear)
+                .background(selected ? Color.dash.secondaryBackground : Color.clear)
                 .clipShape(Capsule())
         }
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct TransferTimingSheet: View {
     @Environment(\.dismiss) private var dismiss
@@ -17,15 +18,15 @@ struct TransferTimingSheet: View {
                 Button(action: { dismiss() }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
                 }
             }
 
             Text(NSLocalizedString("Transfers take different times", comment: ""))
                 .font(.system(size: 24, weight: .bold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.leading)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -56,7 +57,7 @@ struct TransferTimingSheet: View {
         .padding(.horizontal, 24)
         .padding(.top, 14)
         .padding(.bottom, 24)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 
     private func timingRow(
@@ -74,11 +75,11 @@ struct TransferTimingSheet: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .fixedSize(horizontal: false, vertical: true)
                 Text(subtitle)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
             Spacer(minLength: 0)

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -9,6 +9,7 @@ import UIKit
 
 struct PaymentsLandingScreen: View {
     @ObservedObject var viewModel: PaymentsLandingViewModel
+    @Environment(\.colorScheme) private var colorScheme
 
     var onClose: () -> Void
     var onCopyAddress: () -> Void
@@ -137,12 +138,18 @@ struct PaymentsLandingScreen: View {
                         Text(tab.title)
                             .font(.system(size: 13, weight: .medium))
                     }
-                    .foregroundColor(viewModel.activeTab == tab ? .dash.primaryText : .secondary)
+                    .foregroundColor(viewModel.activeTab == tab ? Color.dash.primaryText : Color.dash.secondaryText)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 10)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(viewModel.activeTab == tab ? Color.dash.white : Color.clear)
+                            // Selected pill: a solid white raised card in light mode; a
+                            // translucent light fill in dark so the primaryText label stays
+                            // legible (pure white would be invisible on the dark selector).
+                            // Mirrors DashUIKit SegmentedControl's selected-fill treatment.
+                            .fill(viewModel.activeTab == tab
+                                ? (colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.white)
+                                : Color.clear)
                             .shadow(
                                 color: viewModel.activeTab == tab
                                     ? Color.dash.shadow : .clear,

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -3,8 +3,8 @@
 //  DashWallet
 //
 
-import SwiftUI
 import DashUIKit
+import SwiftUI
 import UIKit
 
 struct PaymentsLandingScreen: View {
@@ -146,7 +146,7 @@ struct PaymentsLandingScreen: View {
                             // Selected pill: a solid white raised card in light mode; a
                             // translucent light fill in dark so the primaryText label stays
                             // legible (pure white would be invisible on the dark selector).
-                            // Mirrors DashUIKit SegmentedControl's selected-fill treatment.
+                            // Mirrors the app's SegmentedControl selected-fill treatment.
                             .fill(viewModel.activeTab == tab
                                 ? (colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.white)
                                 : Color.clear)

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct PaymentsLandingScreen: View {
@@ -90,7 +91,7 @@ struct PaymentsLandingScreen: View {
                     showsHeader: false)
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
     }
 
@@ -101,14 +102,14 @@ struct PaymentsLandingScreen: View {
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.primary)
+                    .foregroundColor(Color.dash.primaryText)
                     .frame(width: 36, height: 36)
-                    .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                    .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
             }
             Spacer()
             Text(headerTitle)
                 .font(.headline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Color.clear.frame(width: 36, height: 36)
         }
@@ -136,21 +137,21 @@ struct PaymentsLandingScreen: View {
                         Text(tab.title)
                             .font(.system(size: 13, weight: .medium))
                     }
-                    .foregroundColor(viewModel.activeTab == tab ? .primaryText : .secondary)
+                    .foregroundColor(viewModel.activeTab == tab ? .dash.primaryText : .secondary)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 10)
                     .background(
                         RoundedRectangle(cornerRadius: 8)
-                            .fill(viewModel.activeTab == tab ? Color.white : Color.clear)
+                            .fill(viewModel.activeTab == tab ? Color.dash.white : Color.clear)
                             .shadow(
                                 color: viewModel.activeTab == tab
-                                    ? Color.black.opacity(0.08) : .clear,
+                                    ? Color.dash.shadow : .clear,
                                 radius: 2, x: 0, y: 1))
                 }
             }
         }
         .padding(4)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(10)
     }
 
@@ -187,16 +188,16 @@ struct PaymentsLandingScreen: View {
                     .resizable()
                     .frame(width: 220, height: 220)
                     .padding(12)
-                    .background(Color.white)
+                    .background(Color.dash.white)
                     .cornerRadius(16)
 
                 VStack(spacing: 4) {
                     Text(NSLocalizedString("Your DASH address", comment: ""))
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Text(address)
                         .font(.system(.footnote, design: .monospaced))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .multilineTextAlignment(.center)
                 }
                 .padding(.horizontal, 20)
@@ -218,7 +219,7 @@ struct PaymentsLandingScreen: View {
             SwiftUI.ProgressView()
             Text(message)
                 .font(.footnote)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
         }
         .frame(width: 220, height: 220)
     }
@@ -226,10 +227,10 @@ struct PaymentsLandingScreen: View {
     private func actionPill(title: String) -> some View {
         Text(title)
             .font(.system(size: 14, weight: .medium))
-            .foregroundColor(.primaryText)
+            .foregroundColor(.dash.primaryText)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
     }
 
@@ -239,7 +240,7 @@ struct PaymentsLandingScreen: View {
         VStack(alignment: .leading, spacing: 12) {
             Text(NSLocalizedString("Internal transfer to/from", comment: ""))
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
                 .padding(.horizontal, 20)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -266,12 +267,12 @@ struct PaymentsLandingScreen: View {
                     .frame(width: 24, height: 24)
                 Text(title)
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Spacer()
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 14)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
         }
         .disabled(action == nil)

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -89,7 +89,7 @@ struct SendScreen: View {
                 .padding(.horizontal, 16)
                 .padding(.bottom, 12)
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
         .sheet(isPresented: $showConfirm) {
             if let route = viewModel.route, route != .coreToCore {
@@ -134,14 +134,14 @@ struct SendScreen: View {
             Button(action: onClose) {
                 Image(systemName: "xmark")
                     .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.primary)
+                    .foregroundColor(Color.dash.primaryText)
                     .frame(width: 36, height: 36)
-                    .overlay(Circle().stroke(Color.gray300.opacity(0.3), lineWidth: 1))
+                    .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
             }
             Spacer()
             Text(NSLocalizedString("Send", comment: ""))
                 .font(.headline)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             Spacer()
             Color.clear.frame(width: 36, height: 36)
         }
@@ -162,7 +162,7 @@ struct SendScreen: View {
             HStack {
                 Text(NSLocalizedString("Address", comment: ""))
                     .font(.caption)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                 Spacer()
                 if let destination = viewModel.destination {
                     destinationBadge(destination)
@@ -176,9 +176,9 @@ struct SendScreen: View {
                     text: $viewModel.addressText,
                     axis: .vertical)
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .padding(12)
-                    .background(Color.secondaryBackground)
+                    .background(Color.dash.secondaryBackground)
                     .cornerRadius(10)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
@@ -233,16 +233,16 @@ struct SendScreen: View {
             HStack(spacing: 8) {
                 Text(truncateMiddle(viewModel.trimmedAddress, visible: 10))
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
                 Spacer()
                 Image(systemName: "pencil")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
             }
             .padding(12)
             .frame(maxWidth: .infinity)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(10)
         }
         .buttonStyle(.plain)
@@ -255,10 +255,10 @@ struct SendScreen: View {
             Text(destinationTitle(destination))
                 .font(.caption2.weight(.semibold))
         }
-        .foregroundColor(.dashBlue)
+        .foregroundColor(.dash.blue)
         .padding(.horizontal, 8)
         .padding(.vertical, 3)
-        .background(Color.dashBlue.opacity(0.1))
+        .background(Color.dash.blue.opacity(0.1))
         .clipShape(Capsule())
     }
 
@@ -286,24 +286,24 @@ struct SendScreen: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("Send to copied address", comment: ""))
                         .font(.caption)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(Color.dash.secondaryText)
                     Text(truncateMiddle(suggestion.address))
                         .font(.system(.footnote, design: .monospaced))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 Spacer()
                 Text(destinationTitle(suggestion.kind))
                     .font(.caption2)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(Color.dash.secondaryText)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(Color.gray300.opacity(0.3))
+                    .background(Color.dash.gray300.opacity(0.3))
                     .cornerRadius(8)
             }
             .padding(12)
-            .background(Color.blue.opacity(0.08))
+            .background(Color.dash.blue.opacity(0.08))
             .cornerRadius(10)
         }
         .padding(.horizontal, 20)
@@ -319,7 +319,7 @@ struct SendScreen: View {
             .foregroundColor(.blue)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
-            .background(Color.blue.opacity(0.12))
+            .background(Color.dash.blue.opacity(0.12))
             .cornerRadius(10)
         }
         .padding(.horizontal, 20)
@@ -433,7 +433,7 @@ struct SendConfirmSheet: View {
             Text(NSLocalizedString("Confirm", comment: ""))
                 .font(.subheadline)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.top, 20)
 
             switch coordinator.phase {
@@ -445,7 +445,7 @@ struct SendConfirmSheet: View {
                 detailsBody
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .interactiveDismissDisabled(isInFlight)
     }
 
@@ -471,7 +471,7 @@ struct SendConfirmSheet: View {
 
             Text(fiatText)
                 .font(.subheadline)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .padding(.top, 6)
 
             summaryCard
@@ -541,7 +541,7 @@ struct SendConfirmSheet: View {
             Text(NSLocalizedString("Sent", comment: "Send confirm sheet"))
                 .font(.title3)
                 .fontWeight(.semibold)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             DashAmount(
                 amount: dashDuffs,
@@ -551,7 +551,7 @@ struct SendConfirmSheet: View {
 
             Text(fiatText)
                 .font(.subheadline)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
 
             Spacer(minLength: 12)
 
@@ -569,7 +569,7 @@ struct SendConfirmSheet: View {
 
     private var dragHandle: some View {
         Rectangle()
-            .fill(Color(red: 0.83, green: 0.83, blue: 0.85))
+            .fill(Color.dash.grabberFill)
             .frame(width: 36, height: 5)
             .cornerRadius(2.5)
     }
@@ -583,11 +583,11 @@ struct SendConfirmSheet: View {
             HStack {
                 Text(NSLocalizedString("To", comment: ""))
                     .font(.system(size: 14))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                 Spacer()
                 Text(truncateMiddle(destinationAddress))
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .lineLimit(1)
             }
             .padding(.horizontal, 14)
@@ -601,7 +601,7 @@ struct SendConfirmSheet: View {
                 label: NSLocalizedString("Total", comment: ""),
                 value: dashDuffs.formattedDashAmount)
         }
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -620,11 +620,11 @@ struct SendConfirmSheet: View {
         HStack {
             Text(label)
                 .font(.system(size: 14))
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Spacer()
             Text(value)
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 14)
@@ -632,7 +632,7 @@ struct SendConfirmSheet: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(Color.gray300.opacity(0.3))
+            .fill(Color.dash.gray300.opacity(0.3))
             .frame(height: 1)
             .padding(.horizontal, 14)
     }
@@ -682,27 +682,27 @@ struct SendConfirmSheet: View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
                 Circle()
-                    .fill(Color.dashBlue)
+                    .fill(Color.dash.blue)
                     .frame(width: 30, height: 30)
                 Image(systemName: infoIcon)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
             }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(infoTitle)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 Text(infoBody)
                     .font(.system(size: 13))
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
         }
         .padding(14)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
@@ -848,7 +848,7 @@ struct SyncGateNote: View {
                 "Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes.",
                 comment: "Core send blocked until chain sync completes"))
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/DashWallet/Sources/UI/Swap/EnterAddress/Components/AddressSourceView.swift
+++ b/DashWallet/Sources/UI/Swap/EnterAddress/Components/AddressSourceView.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - AddressSourceType
 
@@ -81,7 +82,7 @@ struct AddressSourceView: View {
                         Text(subtitleText)
                             .font(.footnote)
                             .lineSpacing(4)
-                            .foregroundColor(Color.tertiaryText)
+                            .foregroundColor(Color.dash.tertiaryText)
                             .lineLimit(sourceType == .clipboard ? 2 : nil)
                             .multilineTextAlignment(.leading)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -130,7 +131,7 @@ struct AddressSourceView: View {
             AnyView(
                 Text(NSLocalizedString("Log In", comment: "Dash DEX"))
                     .font(.subheadMedium)
-                    .foregroundColor(.dashBlue)
+                    .foregroundColor(.dash.blue)
             )
         case .loading:
             AnyView(SwiftUI.ProgressView())
@@ -168,7 +169,7 @@ struct AddressSourceView: View {
         AddressSourceView(sourceType: .coinbase, state: .loading, onTap: {})
     }
     .padding(6)
-    .background(Color.secondaryBackground)
+    .background(Color.dash.secondaryBackground)
     .cornerRadius(12)
     .padding()
 }
@@ -179,7 +180,7 @@ struct AddressSourceView: View {
         AddressSourceView(sourceType: .coinbase, state: .notAvailable, onTap: {})
     }
     .padding(6)
-    .background(Color.secondaryBackground)
+    .background(Color.dash.secondaryBackground)
     .cornerRadius(12)
     .padding()
 }

--- a/DashWallet/Sources/UI/Swap/EnterAddress/EnterAddressHostingController.swift
+++ b/DashWallet/Sources/UI/Swap/EnterAddress/EnterAddressHostingController.swift
@@ -19,6 +19,7 @@
 
 import AuthenticationServices
 import SwiftUI
+import DashUIKit
 import UIKit
 
 class EnterAddressHostingController: UIViewController, NavigationBarDisplayable {
@@ -79,7 +80,7 @@ class EnterAddressHostingController: UIViewController, NavigationBarDisplayable 
         )
 
         let hostingController = UIHostingController(rootView: enterAddressView)
-        // Match SwiftUI's Color.primaryBackground to prevent flash during system paste banner dismissal
+        // Match SwiftUI's Color.dash.primaryBackground to prevent flash during system paste banner dismissal
         hostingController.view.backgroundColor = UIColor(named: "SecondaryBackgroundColor")
 
         addChild(hostingController)

--- a/DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift
+++ b/DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift
@@ -18,6 +18,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 /// Full-screen SwiftUI QR scanner with camera preview, scan frame, and torch toggle.
 struct GenericQRScannerView: View {
@@ -52,14 +53,14 @@ struct GenericQRScannerView: View {
                     Button(action: { onCancel?() }) {
                         Text(NSLocalizedString("Cancel", comment: ""))
                             .font(.system(size: 17))
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
                     }
 
                     Spacer()
 
                     Button(action: { torchOn.toggle() }) {
                         Image(systemName: torchOn ? "bolt.slash.fill" : "bolt.fill")
-                            .foregroundColor(.white)
+                            .foregroundColor(Color.dash.whiteText)
                             .font(.system(size: 20))
                     }
                 }
@@ -70,20 +71,20 @@ struct GenericQRScannerView: View {
 
                 // Scan frame
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(Color.white.opacity(0.6), lineWidth: 2)
+                    .stroke(Color.dash.white.opacity(0.6), lineWidth: 2)
                     .frame(width: 250, height: 250)
 
                 // Instruction label
                 Text(NSLocalizedString("Scan QR Code", comment: "Dash DEX"))
                     .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .padding(.top, 24)
 
                 Spacer()
                 Spacer()
             }
         }
-        .background(Color.black.ignoresSafeArea())
+        .background(Color.dash.black.ignoresSafeArea())
         .alert(isPresented: $showCameraAlert) {
             Alert(
                 title: Text(NSLocalizedString("Camera Unavailable", comment: "")),

--- a/DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift
+++ b/DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift
@@ -198,7 +198,7 @@ struct SelectCoinView: View {
         }) {
             Text(NSLocalizedString("Retry", comment: ""))
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(Color.dash.whiteText)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 10)
                 .background(Color.dash.blue)

--- a/DashWallet/Sources/UI/Swap/SwapMenuStyles.swift
+++ b/DashWallet/Sources/UI/Swap/SwapMenuStyles.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct SwapMenuCardStyle: ViewModifier {
     var shadowRadius: CGFloat = 10
@@ -23,7 +24,7 @@ struct SwapMenuCardStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .clipShape(.rect(cornerRadius: 20))
             .shadow(color: .shadow, radius: shadowRadius, x: 0, y: 5)
     }

--- a/DashWallet/Sources/UI/SwiftUI Components/BottomSheet.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/BottomSheet.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct BottomSheet<Content: View>: View {
     @Environment(\.presentationMode) private var presentationMode
@@ -38,7 +39,7 @@ struct BottomSheet<Content: View>: View {
 
             contentSection
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 
         if fillsHeight {
             sheet.edgesIgnoringSafeArea(.bottom)
@@ -68,7 +69,7 @@ struct BottomSheet<Content: View>: View {
         Rectangle()
             .foregroundColor(.clear)
             .frame(width: 36, height: 5)
-            .background(Color.gray300Alpha50)
+            .background(Color.dash.gray300Alpha50)
             .cornerRadius(5)
     }
 
@@ -84,7 +85,7 @@ struct BottomSheet<Content: View>: View {
             central: {
                 Text(title)
                     .font(.calloutMedium)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             },
             trailing: {
                 NavigationBarElement.close.button { presentationMode.wrappedValue.dismiss() }
@@ -99,13 +100,13 @@ struct BottomSheet<Content: View>: View {
                 content()
                     .navigationBarHidden(true)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color.primaryBackground)
+                    .background(Color.dash.primaryBackground)
             }
         } else {
             // Natural height — no greedy NavigationView / maxHeight so the sheet can self-size.
             content()
                 .frame(maxWidth: .infinity)
-                .background(Color.primaryBackground)
+                .background(Color.dash.primaryBackground)
         }
     }
 }

--- a/DashWallet/Sources/UI/SwiftUI Components/Button.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Button.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashButton: View {
     var text: String? = nil
@@ -62,7 +63,7 @@ struct DashButton: View {
                 if isLoading {
                     SwiftUI.ProgressView()
                         .progressViewStyle(.circular)
-                        .tint(.white)
+                        .tint(Color.dash.whiteText)
                         .scaleEffect(0.8)
                         .padding(.vertical, 2)
                 } else if let text = text {
@@ -115,19 +116,19 @@ struct DashButton: View {
         if !isEnabled {
             switch style {
             case .filled, .filledBlue:
-                return Color.black1000Alpha5
+                return Color.dash.black1000Alpha5
             default:
-                return Color.black1000Alpha5
+                return Color.dash.black1000Alpha5
             }
         }
 
         switch style {
         case .filled:
-            return overridenBackgroundColor ?? Color.dashBlue
+            return overridenBackgroundColor ?? Color.dash.blue
         case .filledBlue:
-            return Color.blue
+            return Color.dash.blue
         case .tintedBlue:
-            return Color.blueAlpha5
+            return Color.dash.blueAlpha5
         default:
             return Color.clear
         }
@@ -137,21 +138,21 @@ struct DashButton: View {
         if !isEnabled {
             switch style {
             case .filledBlue:
-                return Color.blackAlpha40
+                return Color.dash.black1000Alpha40
             default:
-                return colorScheme == .light ? Color.black1000Alpha40 : Color.whiteAlpha20
+                return colorScheme == .light ? Color.dash.black1000Alpha40 : Color.dash.whiteAlpha20
             }
         }
 
         switch style {
         case .filled:
-            return Color.white
+            return Color.dash.white
         case .filledBlue:
-            return Color.white
+            return Color.dash.white
         case .tintedBlue:
-            return Color.blue
+            return Color.dash.blue
         default:
-            return Color.primaryText
+            return Color.dash.primaryText
         }
     }
 
@@ -162,7 +163,7 @@ struct DashButton: View {
         
         switch style {
         case .outlined:
-            return Color.tertiaryText.opacity(0.25)
+            return Color.dash.tertiaryText.opacity(0.25)
         default:
             return Color.clear
         }
@@ -297,7 +298,7 @@ struct DashButtonStyle: ButtonStyle {
         configuration.label
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(Color.black.opacity(configuration.isPressed ? 0.2 : 0))
+                    .fill(Color.dash.black.opacity(configuration.isPressed ? 0.2 : 0))
             )
     }
 }
@@ -339,6 +340,6 @@ private struct DashButtonPreview: View {
             )
         }
         .padding(20)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }

--- a/DashWallet/Sources/UI/SwiftUI Components/ButtonsGroup.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/ButtonsGroup.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ButtonsGroup: View {
     enum Style {
@@ -65,20 +66,20 @@ struct ButtonsGroup: View {
         if orientation == .vertical {
             VStack(spacing: 6) {
                 positiveButton
-                    .overrideBackgroundColor(style == .regular ? .dashBlue : .buttonRed)
-                    .overrideForegroundColor(negativeButtonText == nil ? .dashBlue : .white)
+                    .overrideBackgroundColor(style == .regular ? .dash.blue : .buttonRed)
+                    .overrideForegroundColor(negativeButtonText == nil ? .dash.blue : .white)
                 negativeButton
-                    .overrideForegroundColor(.dashBlue)
+                    .overrideForegroundColor(.dash.blue)
             }
         } else {
             HStack(spacing: 6) {
                 negativeButton
                     .frame(maxWidth: .infinity)
-                    .overrideForegroundColor(.dashBlue)
+                    .overrideForegroundColor(.dash.blue)
                 positiveButton
                     .frame(maxWidth: .infinity)
-                    .overrideBackgroundColor(style == .regular ? .dashBlue : .buttonRed)
-                    .overrideForegroundColor(negativeButtonText == nil ? .dashBlue : .white)
+                    .overrideBackgroundColor(style == .regular ? .dash.blue : .buttonRed)
+                    .overrideForegroundColor(negativeButtonText == nil ? .dash.blue : .white)
             }
             .frame(maxWidth: .infinity)
         }

--- a/DashWallet/Sources/UI/SwiftUI Components/DashStepper.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/DashStepper.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct DashStepper: View {
     @Binding var count: Int
@@ -38,7 +39,7 @@ struct DashStepper: View {
 
             Text("\(count)")
                 .font(.headline.weight(.semibold))
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .frame(width: 30)
                 .multilineTextAlignment(.center)
 
@@ -63,12 +64,12 @@ struct DashStepper: View {
             .renderingMode(.template)
             .scaledToFit()
             .frame(width: 11, height: 11)
-            .foregroundColor(enabled ? .primaryText : Color.gray300)
+            .foregroundColor(enabled ? .dash.primaryText : Color.dash.gray300)
             .frame(width: 34, height: 34)
             .overlay(
                 Circle()
                     .stroke(
-                        enabled ? Color.black1000Alpha8 : Color.black1000Alpha5,
+                        enabled ? Color.dash.black1000Alpha8 : Color.dash.black1000Alpha5,
                         lineWidth: 1.5
                     )
             )

--- a/DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 
 struct ConfirmSpendDialog: View {
     @State private var isAccepted: Bool = false
@@ -13,7 +14,7 @@ struct ConfirmSpendDialog: View {
             HStack(spacing: 0) {
                 Spacer()
                 Rectangle()
-                    .fill(Color(red: 0.83, green: 0.83, blue: 0.85))
+                    .fill(Color.dash.grabberFill)
                     .frame(width: 36, height: 5)
                     .cornerRadius(2.50)
                 Spacer()
@@ -76,7 +77,7 @@ struct ConfirmSpendDialog: View {
         let text = (try? CurrencyExchanger.shared.convertDash(amount: abs(dashAmount.dashAmount), to: App.fiatCurrency).formattedFiatAmount) ?? NSLocalizedString("Not available", comment: "")
         Text(text)
             .font(.subhead)
-            .foregroundStyle(Color.secondaryText)
+            .foregroundStyle(Color.dash.secondaryText)
     }
 }
 

--- a/DashWallet/Sources/UI/SwiftUI Components/Dialogs/ModalDialog.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Dialogs/ModalDialog.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ModalDialog: View {
     enum Style {
@@ -57,7 +58,7 @@ struct ModalDialog: View {
                         .imageScale(.medium)
                         .frame(width: 20, height: 20)
                         .frame(width: 48, height: 48)
-                        .foregroundColor(.white)
+                        .foregroundColor(Color.dash.whiteText)
                         .background(iconBackgroundColor(for: style))
                         .clipShape(Circle())
                         .padding(.top, 12)
@@ -82,7 +83,7 @@ struct ModalDialog: View {
                     .font(.subhead)
                     .lineSpacing(3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .padding(.top, 1)
             }
             
@@ -91,7 +92,7 @@ struct ModalDialog: View {
                     .font(.subhead)
                     .lineSpacing(3)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .padding(.top, 1)
             }
             
@@ -106,7 +107,7 @@ struct ModalDialog: View {
                 ) {
                     smallButtonAction?()
                 }
-                .overrideForegroundColor(.dashBlue)
+                .overrideForegroundColor(.dash.blue)
             }
             
             ButtonsGroup(
@@ -120,7 +121,7 @@ struct ModalDialog: View {
             .padding(.top, 24)
         }
         .padding(20)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(16)
         .shadow(radius: 10)
         .frame(maxWidth: 340)
@@ -129,11 +130,11 @@ struct ModalDialog: View {
     private func iconBackgroundColor(for style: Style) -> Color {
         switch style {
         case .regular:
-            return .dashBlue
+            return .dash.blue
         case .warning:
-            return .systemYellow
+            return .dash.yellow
         case .error:
-            return .systemRed
+            return .dash.red
         }
     }
 }
@@ -185,7 +186,7 @@ extension UIViewController {
         let hostingController = UIHostingController(rootView: dialog)
         hostingController.modalPresentationStyle = .overFullScreen
         hostingController.modalTransitionStyle = .crossDissolve
-        hostingController.view.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        hostingController.view.backgroundColor = UIColor(Color.dash.backgroundOverlay)
             
         present(hostingController, animated: true, completion: nil)
     }
@@ -235,7 +236,7 @@ extension UIViewController {
             let hostingController = UIHostingController(rootView: dialog)
             hostingController.modalPresentationStyle = .overFullScreen
             hostingController.modalTransitionStyle = .crossDissolve
-            hostingController.view.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+            hostingController.view.backgroundColor = UIColor(Color.dash.backgroundOverlay)
             
             present(hostingController, animated: true, completion: nil)
         }

--- a/DashWallet/Sources/UI/SwiftUI Components/FeatureSingleItem.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/FeatureSingleItem.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct FeatureSingleItem: View {
     let iconName: IconName
@@ -33,11 +34,11 @@ struct FeatureSingleItem: View {
             VStack(alignment: .leading, spacing: 5) {
                 Text(title)
                     .font(.headline)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                 
                 Text(description)
                     .font(.subheadline)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             .padding(.top, 10)
         }

--- a/DashWallet/Sources/UI/SwiftUI Components/FeatureTopText.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/FeatureTopText.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct FeatureTopText: View {
     var title: String
@@ -34,14 +35,14 @@ struct FeatureTopText: View {
                 .lineLimit(2)
                 .fixedSize(horizontal: false, vertical: true)
                 .lineSpacing(3)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
           
             if let text = text {
                 Text(text)
                     .font(.subhead)
                     .multilineTextAlignment(alignment)
                     .lineSpacing(3)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             
             if let label = label {
@@ -49,7 +50,7 @@ struct FeatureTopText: View {
                     linkAction?()
                 }
                 .padding(.top, 8)
-                .overrideForegroundColor(.dashBlue)
+                .overrideForegroundColor(.dash.blue)
                 .wiggle(shakeLabel)
             }
         }

--- a/DashWallet/Sources/UI/SwiftUI Components/Icons/ArrowDownIcon.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Icons/ArrowDownIcon.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - ArrowDownIcon
 
@@ -23,7 +24,7 @@ import SwiftUI
 /// a vertical shaft and a chevron arrowhead. Scales cleanly to any `size`.
 struct ArrowDownIcon: View {
     var size: CGSize = CGSize(width: 9, height: 13)
-    var color: Color = .dashBlue
+    var color: Color = .dash.blue
     var lineWidth: CGFloat = 1.5
 
     var body: some View {
@@ -63,7 +64,7 @@ private struct ArrowDownShape: Shape {
         ArrowDownIcon(size: CGSize(width: 16, height: 24))
         ArrowDownIcon(size: CGSize(width: 24, height: 34), color: .white, lineWidth: 2)
             .padding(20)
-            .background(Color.dashBlue, in: RoundedRectangle(cornerRadius: 12))
+            .background(Color.dash.blue, in: RoundedRectangle(cornerRadius: 12))
     }
     .padding()
 }

--- a/DashWallet/Sources/UI/SwiftUI Components/Icons/ExclamationIcon.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Icons/ExclamationIcon.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 // MARK: - ExclamationIcon
@@ -25,9 +26,9 @@ import UIKit
 /// to any `size` without needing raster assets.
 struct ExclamationIcon: View {
     var size: CGSize = CGSize(width: 18, height: 17)
-    var fillColor: Color = Color(uiColor: UIColor(red: 1.0, green: 192.0 / 255.0, blue: 67.0 / 255.0, alpha: 1.0))
-    var strokeColor: Color = Color(uiColor: UIColor(red: 1.0, green: 192.0 / 255.0, blue: 67.0 / 255.0, alpha: 1.0))
-    var symbolColor: Color = Color(uiColor: UIColor(red: 10.0 / 255.0, green: 11.0 / 255.0, blue: 13.0 / 255.0, alpha: 1.0))
+    var fillColor: Color = Color.dash.yellow
+    var strokeColor: Color = Color.dash.yellow
+    var symbolColor: Color = Color.dash.black
     var lineWidth: CGFloat = 1.5
 
     var body: some View {

--- a/DashWallet/Sources/UI/SwiftUI Components/Icons/XmarkIcon.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Icons/XmarkIcon.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // MARK: - XmarkIcon
 
@@ -23,7 +24,7 @@ import SwiftUI
 /// inset from 0.75 to 7.75, round caps/joins). Scales cleanly to any `size`.
 struct XmarkIcon: View {
     var size: CGFloat = 9
-    var color: Color = .primaryText
+    var color: Color = .dash.primaryText
     var lineWidth: CGFloat = 1.5
 
     var body: some View {
@@ -61,7 +62,7 @@ private struct XmarkShape: Shape {
         XmarkIcon()
         XmarkIcon(size: 24, color: .white, lineWidth: 2)
             .padding(20)
-            .background(Color.dashBlue, in: .circle)
+            .background(Color.dash.blue, in: .circle)
         XmarkIcon(size: 40, color: .red, lineWidth: 3)
     }
     .padding()

--- a/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 typealias TransactionPreview = MenuItem
 
@@ -37,7 +38,7 @@ struct MenuItem: View {
     var showDashAmountDirection: Bool = true
     var overrideFiatAmount: String?
     var trailingStatusText: String? = nil
-    var trailingStatusColor: Color = Color(UIColor.dw_orange())
+    var trailingStatusColor: Color = Color.dash.orange
     var trailingView: AnyView?
     var showToggle: Bool = false
     @State private var isToggled: Bool = false
@@ -60,7 +61,7 @@ struct MenuItem: View {
          showDashAmountDirection: Bool = true,
          overrideFiatAmount: String? = nil,
          trailingStatusText: String? = nil,
-         trailingStatusColor: Color = Color(UIColor.dw_orange()),
+         trailingStatusColor: Color = Color.dash.orange,
          trailingView: AnyView? = nil,
          showToggle: Bool = false,
          isToggled: Bool = false,
@@ -73,7 +74,7 @@ struct MenuItem: View {
                     Text(text)
                         .font(.footnote)
                         .lineSpacing(4)
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .lineLimit(subtitleLineLimit)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 )
@@ -115,7 +116,7 @@ struct MenuItem: View {
          showDashAmountDirection: Bool = true,
          overrideFiatAmount: String? = nil,
          trailingStatusText: String? = nil,
-         trailingStatusColor: Color = Color(UIColor.dw_orange()),
+         trailingStatusColor: Color = Color.dash.orange,
          trailingView: AnyView? = nil,
          showToggle: Bool = false,
          isToggled: Bool = false,
@@ -168,7 +169,7 @@ struct MenuItem: View {
                                     Icon(name: secondaryIcon)
                                         .padding(2)
                                         .frame(width: 20, height: 20)
-                                        .background(Color.secondaryBackground)
+                                        .background(Color.dash.secondaryBackground)
                                         .clipShape(.circle)
                                         .offset(x: 2, y: 2)
                                 }
@@ -183,7 +184,7 @@ struct MenuItem: View {
                         Text(topText)
                             .font(.caption)
                             .lineSpacing(3)
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                     }
                     
                     HStack(spacing: 6) {
@@ -191,11 +192,11 @@ struct MenuItem: View {
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .lineSpacing(3)
-                            .foregroundColor(.primaryText)
+                            .foregroundColor(.dash.primaryText)
                         
                         if showInfo {
                             Image(systemName: "info.circle.fill")
-                                .foregroundColor(.gray300)
+                                .foregroundColor(.dash.gray300)
                                 .imageScale(.small)
                         }
                         
@@ -204,10 +205,10 @@ struct MenuItem: View {
                         if let badgeText = badgeText {
                             Text(badgeText)
                                 .font(.caption)
-                                .foregroundColor(.systemYellow)
+                                .foregroundColor(.dash.yellow)
                                 .padding(.vertical, 4)
                                 .padding(.horizontal, 8)
-                                .background(Color.systemYellow.opacity(0.2))
+                                .background(Color.dash.yellow.opacity(0.2))
                                 .clipShape(RoundedRectangle(cornerRadius: 6))
                         }
                     }
@@ -221,7 +222,7 @@ struct MenuItem: View {
                         Text(details)
                             .font(.caption)
                             .lineSpacing(3)
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                     }
                 }
                 .padding(.leading, 6)
@@ -229,7 +230,7 @@ struct MenuItem: View {
 
                 if showToggle {
                     Toggle(isOn: $isToggled) { }
-                        .tint(Color.dashBlue)
+                        .tint(Color.dash.blue)
                         .scaleEffect(0.75)
                         .frame(maxWidth: 60)
                 }
@@ -237,7 +238,7 @@ struct MenuItem: View {
                 if showChevron {
                     Image(systemName: "chevron.right")
                         .imageScale(.small)
-                        .foregroundColor(Color.gray)
+                        .foregroundColor(Color.dash.tertiaryText)
                         .padding(.trailing, 10)
                 } else if let trailingView = trailingView {
                     trailingView
@@ -252,14 +253,14 @@ struct MenuItem: View {
                                         .foregroundColor(trailingStatusColor)
                                 }
                                 DashAmount(amount: dashAmount, showDirection: showDashAmountDirection)
-                                    .foregroundColor(.primaryText)
+                                    .foregroundColor(.dash.primaryText)
                             }
 
                             if dashAmount != 0 && dashAmount != Int64.max && dashAmount != Int64.min {
                                 if let overriden = overrideFiatAmount {
                                     Text(overriden)
                                         .font(.caption)
-                                        .foregroundColor(.secondaryText)
+                                        .foregroundColor(.dash.secondaryText)
                                 } else {
                                     FormattedFiatText(from: dashAmount)
                                 }
@@ -283,7 +284,7 @@ struct MenuItem: View {
             
         Text(text)
             .font(.caption)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
     }
 }
 

--- a/DashWallet/Sources/UI/SwiftUI Components/MerchantDenominations.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MerchantDenominations.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct MerchantDenominations: View {
     let denominations: [Int]
@@ -42,11 +43,11 @@ struct MerchantDenominations: View {
         VStack(alignment: .leading, spacing: 0) {
             Text(NSLocalizedString("Select amount", comment: "DashSpend"))
                 .font(.title1)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
             
             Text(NSLocalizedString("This merchant sells gift cards at fixed prices", comment: "DashSpend"))
                 .font(.subhead)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
                 .padding(.top, 4)
             
             LazyVGrid(columns: columns, spacing: 16) {
@@ -86,18 +87,18 @@ private struct DenominationChip: View {
         Button(action: onTap) {
             Text(formattedValue)
                 .font(.calloutMedium)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
                 .frame(width: 76, height: 54)
                 .background(
                     RoundedRectangle(cornerRadius: 14)
-                        .fill(isSelected ? Color.dashBlue.opacity(0.1) : Color.clear)
+                        .fill(isSelected ? Color.dash.blue.opacity(0.1) : Color.clear)
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 14)
                         .stroke(
-                            isSelected ? Color.dashBlue : Color.primaryText.opacity(0.08),
+                            isSelected ? Color.dash.blue : Color.dash.primaryText.opacity(0.08),
                             lineWidth: 1.5
                         )
                 )

--- a/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
@@ -21,6 +21,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct NavigationBar<Leading: View, Central: View, Trailing: View>: View {
     private let leading: Leading
@@ -165,7 +166,7 @@ struct NavBarBack: View {
                        .aspectRatio(contentMode: .fit)
                        .frame(height: 12)
                        .offset(x: -1)
-                       .foregroundColor(.primaryText)
+                       .foregroundColor(.dash.primaryText)
                }
            }
            .padding(.leading, 20)
@@ -176,7 +177,7 @@ struct NavBarBack: View {
    }
 
    private var borderColor: Color {
-       .gray300Alpha30
+       .dash.gray300Alpha30
    }
 
    private var iconName: String {
@@ -221,7 +222,7 @@ struct NavBarBackPlus: View {
                        .aspectRatio(contentMode: .fit)
                        .frame(height: 12)
                        .offset(x: -1)
-                       .foregroundColor(.primaryText)
+                       .foregroundColor(.dash.primaryText)
                }
            }
            .padding(.leading, 20)
@@ -242,7 +243,7 @@ struct NavBarBackPlus: View {
                        .resizable()
                        .aspectRatio(contentMode: .fit)
                        .frame(height: 11)
-                       .foregroundColor(.primaryText)
+                       .foregroundColor(.dash.primaryText)
                }
            }
            .padding(.trailing, 20)
@@ -251,7 +252,7 @@ struct NavBarBackPlus: View {
    }
 
    private var borderColor: Color {
-       .gray300Alpha30
+       .dash.gray300Alpha30
    }
 
    private var backIconName: String {
@@ -289,14 +290,14 @@ struct NavBarClose: View {
                        .frame(width: 44, height: 44)
 
                    Circle()
-                       .stroke(Color.gray300Alpha30, lineWidth: 1.5)
+                       .stroke(Color.dash.gray300Alpha30, lineWidth: 1.5)
                        .frame(width: 34, height: 34)
 
                    Image("toolbar-close")
                        .resizable()
                        .aspectRatio(contentMode: .fit)
                        .frame(height: 11)
-                       .foregroundColor(.primaryText)
+                       .foregroundColor(.dash.primaryText)
                }
            }
            .padding(.trailing, 20)

--- a/DashWallet/Sources/UI/SwiftUI Components/NetworkUnavailableStateView.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/NetworkUnavailableStateView.swift
@@ -17,6 +17,7 @@
 
 import Combine
 import SwiftUI
+import DashUIKit
 
 // MARK: - NetworkReachabilityMonitor
 
@@ -78,11 +79,11 @@ struct NetworkUnavailableStateView: View {
             VStack(spacing: Layout.textSpacing) {
                 Text(NSLocalizedString("Network Unavailable", comment: "Network Unavailable"))
                     .font(.system(size: 17, weight: .medium))
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
 
                 Text(NSLocalizedString("Please check your network connection", comment: "Network Unavailable"))
                     .font(.footnote)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
             }
             .multilineTextAlignment(.center)
         }
@@ -93,6 +94,6 @@ struct NetworkUnavailableStateView: View {
 #Preview {
     NetworkUnavailableStateView()
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
 }
 #endif

--- a/DashWallet/Sources/UI/SwiftUI Components/SegmentedControl.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/SegmentedControl.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 private enum SegmentedControlLayout {
     static let containerPadding: CGFloat = 4
@@ -52,7 +53,7 @@ struct SegmentedControl<T: Hashable>: View {
     var body: some View {
         ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: Layout.segmentCornerRadius)
-                .fill(colorScheme == .dark ? Color.whiteAlpha20 : Color.white)
+                .fill(colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.white)
                 .shadow(color: .shadow, radius: Layout.shadowRadius, x: 0, y: Layout.shadowY)
                 .frame(width: max(1, segmentWidth))
                 .offset(x: indicatorOffset)
@@ -66,7 +67,7 @@ struct SegmentedControl<T: Hashable>: View {
                     }) {
                         Text(label(option))
                             .font(.footnoteMedium)
-                            .foregroundColor(selection == option ? .primaryText : .primaryText.opacity(0.4))
+                            .foregroundColor(selection == option ? .dash.primaryText : .dash.primaryText.opacity(0.4))
                             .lineLimit(1)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, Layout.segmentVerticalPadding)
@@ -99,7 +100,7 @@ struct SegmentedControl<T: Hashable>: View {
         )
         .padding(Layout.containerPadding)
         .frame(height: Layout.height)
-        .background(Color.gray300Alpha20)
+        .background(Color.dash.gray300Alpha20)
         .clipShape(RoundedRectangle(cornerRadius: Layout.containerCornerRadius))
     }
 

--- a/DashWallet/Sources/UI/SwiftUI Components/SelfSizingSheet.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/SelfSizingSheet.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 // Self-sizing sheet: the sheet hugs its content height instead of using a fixed
 // detent. Measures the content via GeometryReader and feeds the height into a
@@ -75,11 +76,11 @@ extension View {
                     // iOS 16.4..<26: apply the custom corner radius.
                     modified
                         .presentationCornerRadius(r)
-                        .presentationBackground(Color.primaryBackground)
+                        .presentationBackground(Color.dash.primaryBackground)
                 } else {
                     // iOS 26+: keep the system corner styling, skip the custom radius.
                     modified
-                        .presentationBackground(Color.primaryBackground)
+                        .presentationBackground(Color.dash.primaryBackground)
                 }
             } else {
                 modified

--- a/DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct SendIntro<Content: View>: View {
     @State private var balanceHidden: Bool = true
@@ -74,13 +75,13 @@ struct SendIntro<Content: View>: View {
                             .imageScale(.medium)
                             .frame(width: 17, height: 17)
                             .frame(width: 28, height: 28)
-                            .foregroundColor(.gray500)
-                            .background(Color.primaryText.opacity(0.05))
+                            .foregroundColor(.dash.gray500)
+                            .background(Color.dash.primaryText.opacity(0.05))
                             .clipShape(Circle())
                     }
                     .frame(width: 36, height: 36)
                 }
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             }
         }.frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -103,6 +104,6 @@ struct SendIntro<Content: View>: View {
             
         Text(text)
             .font(.subheadline)
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
     }
 }

--- a/DashWallet/Sources/UI/SwiftUI Components/TextInput.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/TextInput.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct TextInput: View {
     @FocusState private var isFocused: Bool
@@ -35,7 +36,7 @@ struct TextInput: View {
             ZStack(alignment: .leading) {
                 Text(label)
                     .font(.subhead)
-                    .foregroundColor(.secondaryText)
+                    .foregroundColor(.dash.secondaryText)
                     .offset(y: labelOffset)
                     .scaleEffect(labelScale, anchor: .leading)
                     .animation(.spring(response: 0.2, dampingFraction: 0.8), value: isFocused || !text.isEmpty)
@@ -58,7 +59,7 @@ struct TextInput: View {
                         trailingAction?() ?? clearText()
                     }) {
                         (trailingIcon ?? Image(systemName: "xmark.circle.fill"))
-                            .foregroundColor(.tertiaryText)
+                            .foregroundColor(.dash.tertiaryText)
                     }
                     .opacity(text.isEmpty ? 0 : 1)
                 }
@@ -76,7 +77,7 @@ struct TextInput: View {
             Group {
                 if isFocused && !isError {
                     RoundedRectangle(cornerRadius: 14)
-                        .stroke(Color.dashBlue.opacity(0.1), lineWidth: 3)
+                        .stroke(Color.dash.blue.opacity(0.1), lineWidth: 3)
                         .padding(-2)
                 }
             }
@@ -97,23 +98,23 @@ struct TextInput: View {
     
     private var backgroundColor: Color {
         if isError {
-            return Color.systemRed.opacity(0.1)
+            return Color.dash.red.opacity(0.1)
         }
         
         if isFocused {
             return Color.clear
         }
         
-        return Color.gray400.opacity(0.13)
+        return Color.dash.gray400.opacity(0.13)
     }
     
     private var borderColor: Color {
         if isError {
-            return .systemRed
+            return .dash.red
         }
         
         if isFocused {
-            return .dashBlue
+            return .dash.blue
         }
         
         return Color.clear

--- a/DashWallet/Sources/UI/SwiftUI Components/TextIntro.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/TextIntro.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct TextIntro: View {
     var icon: IconName? = nil
@@ -58,7 +59,7 @@ struct TextIntro: View {
                     Text(info)
                         .multilineTextAlignment(.center)
                         .font(.footnote)
-                        .foregroundColor(.tertiaryText)
+                        .foregroundColor(.dash.tertiaryText)
                         .frame(maxWidth: .infinity)
                 }
           
@@ -75,7 +76,7 @@ struct TextIntro: View {
                         
                         if inProgress != nil && inProgress!.wrappedValue {
                             SwiftUI.ProgressView()
-                                .tint(.white)
+                                .tint(Color.dash.whiteText)
                         }
                     }
                     .padding(.top, 10)

--- a/DashWallet/Sources/UI/SwiftUI Components/Toast.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/Toast.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 struct ToastView: View {
@@ -50,17 +51,17 @@ struct ToastView: View {
             
             if let text = actionText, let action = action {
                 DashButton(text: text, style: .plain, size: .extraSmall, stretch: false, action: action)
-                    .overrideForegroundColor(Color.primaryBackground)
+                    .overrideForegroundColor(Color.dash.primaryBackground)
             }
             
             if let icon = closeButtonIcon, let action = closeAction {
                 DashButton(leadingIcon: icon, style: .plain, size: .small, stretch: false, action: action)
-                    .overrideForegroundColor(Color.primaryBackground)
+                    .overrideForegroundColor(Color.dash.primaryBackground)
             }
         }
         .padding(.horizontal, 8)
-        .foregroundColor(Color.primaryBackground)
-        .background(Color.primaryText.opacity(0.9))
+        .foregroundColor(Color.dash.primaryBackground)
+        .background(Color.dash.primaryText.opacity(0.9))
         .cornerRadius(10)
     }
 }

--- a/DashWallet/Sources/UI/SwiftUI Components/TopIntro.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/TopIntro.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct TopIntro: View {
     let title: String
@@ -25,12 +26,12 @@ struct TopIntro: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title)
                 .font(.title1)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
 
             if let subtitle = subtitle {
                 Text(subtitle)
                     .font(.subhead)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
             }
         }
 

--- a/DashWallet/Sources/UI/SwiftUI Components/ValidationCheck.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/ValidationCheck.swift
@@ -16,6 +16,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 
 struct ValidationCheck: View {
     let validationResult: UsernameValidationRuleResult
@@ -30,10 +31,10 @@ struct ValidationCheck: View {
             } else {
                 Icon(name: getIconName())
                     .frame(width: 18, height: 18)
-                    .foregroundColor(.systemYellow)
+                    .foregroundColor(.dash.yellow)
             }
             Text(text)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .font(.subhead)
         }
     }

--- a/DashWallet/Sources/UI/Tx/Details/BlockExplorerSelectionView.swift
+++ b/DashWallet/Sources/UI/Tx/Details/BlockExplorerSelectionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 
 struct BlockExplorerSelectionView: View {
     @Environment(\.dismiss) private var dismiss
@@ -21,7 +22,7 @@ struct BlockExplorerSelectionView: View {
                             Text(explorer.title)
                                 .font(.subhead)
                                 .fontWeight(.medium)
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                             
                             Spacer()
                         }
@@ -31,7 +32,7 @@ struct BlockExplorerSelectionView: View {
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
             .shadow(color: .shadow, radius: 5, y: 2)
             .padding(.horizontal, 20)

--- a/DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift
+++ b/DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import DashUIKit
 import UIKit
 
 // MARK: - RawTransactionViewModel
@@ -67,16 +68,16 @@ struct RawTransactionView: View {
                 loadedBody(details)
             }
         }
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
         .onAppear { viewModel.load() }
         .overlay(alignment: .bottom) {
             if copiedFeedback {
                 Text(NSLocalizedString("Copied", comment: ""))
                     .font(.footnote.weight(.semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Color.dash.whiteText)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
-                    .background(Capsule().fill(Color.black.opacity(0.75)))
+                    .background(Capsule().fill(Color.dash.black.opacity(0.75)))
                     .padding(.bottom, 24)
                     .transition(.opacity)
             }
@@ -87,13 +88,13 @@ struct RawTransactionView: View {
         VStack(spacing: 8) {
             Image(systemName: "doc.questionmark")
                 .font(.system(size: 34))
-                .foregroundColor(.secondary)
+                .foregroundColor(Color.dash.secondaryText)
             Text(NSLocalizedString("Raw transaction unavailable", comment: "Raw transaction inspector"))
                 .font(.subheadline)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Text(NSLocalizedString("This transaction's raw bytes are not stored on this device.", comment: "Raw transaction inspector"))
                 .font(.caption)
-                .foregroundColor(.tertiaryText)
+                .foregroundColor(.dash.tertiaryText)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
         }
@@ -242,15 +243,15 @@ struct RawTransactionView: View {
                     HStack {
                         Text(NSLocalizedString("Tap to copy", comment: ""))
                             .font(.caption)
-                            .foregroundColor(.secondaryText)
+                            .foregroundColor(.dash.secondaryText)
                         Spacer()
                         Image(systemName: "doc.on.doc")
                             .font(.caption)
-                            .foregroundColor(.dashBlue)
+                            .foregroundColor(.dash.blue)
                     }
                     Text(hex)
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(.primaryText)
+                        .foregroundColor(.dash.primaryText)
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -267,13 +268,13 @@ struct RawTransactionView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(14)
-        .background(Color.secondaryBackground)
+        .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
     }
 
     private var divider: some View {
         Rectangle()
-            .fill(Color.gray300.opacity(0.3))
+            .fill(Color.dash.gray300.opacity(0.3))
             .frame(height: 1)
     }
 
@@ -281,10 +282,10 @@ struct RawTransactionView: View {
         VStack(alignment: .leading, spacing: 3) {
             Text(label)
                 .font(.caption)
-                .foregroundColor(.secondaryText)
+                .foregroundColor(.dash.secondaryText)
             Text(value)
                 .font(.footnote)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .fixedSize(horizontal: false, vertical: true)
         }
     }
@@ -295,15 +296,15 @@ struct RawTransactionView: View {
                 HStack {
                     Text(label)
                         .font(.caption)
-                        .foregroundColor(.secondaryText)
+                        .foregroundColor(.dash.secondaryText)
                     Spacer()
                     Image(systemName: "doc.on.doc")
                         .font(.system(size: 10))
-                        .foregroundColor(.dashBlue)
+                        .foregroundColor(.dash.blue)
                 }
                 Text(value)
                     .font(monospaced ? .system(size: 12, design: .monospaced) : .footnote)
-                    .foregroundColor(.primaryText)
+                    .foregroundColor(.dash.primaryText)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -314,7 +315,7 @@ struct RawTransactionView: View {
     private func sectionHeader(_ title: String) -> some View {
         Text(title)
             .font(.footnote.weight(.semibold))
-            .foregroundColor(.secondaryText)
+            .foregroundColor(.dash.secondaryText)
             .padding(.top, 4)
     }
 

--- a/DashWallet/Sources/UI/Tx/Details/Views/BlockExplorerSelectionView.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Views/BlockExplorerSelectionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DashUIKit
 
 struct BlockExplorerSelectionView: View {
     @Environment(\.dismiss) private var dismiss
@@ -8,7 +9,7 @@ struct BlockExplorerSelectionView: View {
         VStack(spacing: 0) {
             Text(NSLocalizedString("Select block explorer", comment: "Block explorer selection title"))
                 .font(.calloutMedium)
-                .foregroundColor(.primaryText)
+                .foregroundColor(.dash.primaryText)
                 .padding(.vertical, 16)
             
             VStack(spacing: 2) {
@@ -25,19 +26,19 @@ struct BlockExplorerSelectionView: View {
                             
                             Text(explorer.title)
                                 .font(.subhead)
-                                .foregroundColor(.primaryText)
+                                .foregroundColor(.dash.primaryText)
                             
                             Spacer()
                         }
                         .padding(.horizontal, 10)
                         .padding(.vertical, 12)
-                        .background(Color.secondaryBackground)
+                        .background(Color.dash.secondaryBackground)
                         .cornerRadius(8)
                     }
                 }
             }
             .padding(6)
-            .background(Color.secondaryBackground)
+            .background(Color.dash.secondaryBackground)
             .cornerRadius(12)
             .shadow(color: .shadow, radius: 5, y: 2)
             .padding(.horizontal, 20)
@@ -46,7 +47,7 @@ struct BlockExplorerSelectionView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.primaryBackground)
+        .background(Color.dash.primaryBackground)
     }
 }
 

--- a/DashWallet/Sources/UI/Views/DashInputField.swift
+++ b/DashWallet/Sources/UI/Views/DashInputField.swift
@@ -15,7 +15,6 @@
 //  limitations under the License.
 //
 
-import DashUIKit
 import QuartzCore
 import UIKit
 

--- a/DashWallet/Sources/UI/Views/DashInputField.swift
+++ b/DashWallet/Sources/UI/Views/DashInputField.swift
@@ -15,6 +15,7 @@
 //  limitations under the License.
 //
 
+import DashUIKit
 import QuartzCore
 import UIKit
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
The app follows the system appearance (it is not pinned to light mode), but many SwiftUI views used non-adaptive colors: hardcoded literals (`Color.white`, `Color.black`, `Color(red:…)`) and app-local `Color+DWStyle` tokens where only 26 of 125 colorsets carry a dark variant. In dark mode this produced broken visuals — invisible drag handles, a white-on-white selected tab pill, black shadows/scrims, and fixed-white cards under light text.

## What was done?
Migrated color usage across the SwiftUI view tree to DashUIKit's `Color.dash.*` tokens (asset-backed with proper light/dark variants):

- App tokens → `Color.dash.*` by name (`primaryText`, `secondaryBackground`, `gray300`, `blueAlpha10`, …).
- SwiftUI system semantics `.foregroundColor(.secondary/.primary)` → `Color.dash.secondaryText/primaryText`.
- Purpose-built tokens for the known bugs: drag handles → `grabberFill`, modal/screen scrims → `backgroundOverlay`, black-opacity shadows → `shadow`, white-on-colored content → `whiteText`.
- Dark-mode-specific cases resolved with `@Environment(\.colorScheme)` + the best-fitting token (e.g. the payments hero selected-tab pill: white in light, `whiteAlpha20` in dark, mirroring DashUIKit `SegmentedControl`); the "Customize shortcut bar" banner moved to `secondaryBackground`.
- `import DashUIKit` added where newly needed.

Out of scope, deliberately unchanged: legacy ObjC/UIKit views, `UIColor.system*` (already appearance-adaptive), and `ContactAvatarView`'s algorithmic hue-generated colors.

Three commits: shared components, remaining feature views, and the dark-mode tab/banner fix.

## How Has This Been Tested?
Full `dashpay` build green (`xcodebuild ... -scheme dashpay -sdk iphonesimulator ARCHS=arm64 build`). Ran on device in dark mode and fixed the reported white-on-white active tab pill; a further dark-mode spot-check across all screens is recommended before merge.

## Breaking Changes
None. Visual-only; no behavior changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone