### PR TITLE
fix(ui): QR scanner accepts Platform and Shielded addresses

### DIFF
--- a/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.m
+++ b/DashWallet/Sources/UI/Payments/Pay/DWBasePayViewController.m
@@ -110,10 +110,33 @@ NS_ASSUME_NONNULL_BEGIN
     self.view.userInteractionEnabled = NO;
     [self dismissViewControllerAnimated:YES
                              completion:^{
-                                 [self processPaymentInput:paymentInput];
+                                 // A bech32m Platform/Shielded destination can't ride the classic
+                                 // L1 payment processor — open the Send screen prefilled instead
+                                 // (its route model handles all destination forms). Base58 Core
+                                 // scans keep the legacy processor path unchanged.
+                                 DWParsedPaymentURI *parsed = paymentInput.parsedURI;
+                                 if (parsed.requiresSendScreenRouting && parsed.address != nil) {
+                                     [self routeScannedBech32Address:parsed];
+                                 }
+                                 else {
+                                     [self processPaymentInput:paymentInput];
+                                 }
 
                                  self.view.userInteractionEnabled = YES;
                              }];
+}
+
+/// Present the Send screen prefilled with a scanned bech32m destination —
+/// same presentation chrome as the payments landing (hidden-bar navigation
+/// controller, full screen; the screen draws its own X/title header).
+- (void)routeScannedBech32Address:(DWParsedPaymentURI *)parsed {
+    DWSendScreenViewController *controller = [[DWSendScreenViewController alloc] init];
+    [controller prefillWithAddress:parsed.address amountDuffs:parsed.amount];
+    DWNavigationController *navigationController =
+        [[DWNavigationController alloc] initWithRootViewController:controller];
+    navigationController.navigationBarHidden = YES;
+    navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
+    [self presentViewController:navigationController animated:YES completion:nil];
 }
 
 - (void)qrScanModelDidCancel:(DWQRScanModel *)viewModel {

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
@@ -15,6 +15,17 @@ final class SendScreenViewController: DWBasePayViewController {
     /// action as tapping the clipboard suggestion chip.
     var prefillsFromClipboard = false
 
+    /// Scan-routing prefill (`DWBasePayViewController`'s ObjC scan handler):
+    /// a scanned bech32m Platform/Shielded destination opens this screen
+    /// with the address (and BIP21 amount, when present) applied on load.
+    @objc func prefill(address: String, amountDuffs: UInt64) {
+        prefillAddress = address
+        prefillAmountDuffs = amountDuffs
+    }
+
+    private var prefillAddress: String?
+    private var prefillAmountDuffs: UInt64 = 0
+
     private let sendViewModel = SendViewModel()
     private lazy var hostingController: UIHostingController<SendScreen> = {
         let screen = SendScreen(
@@ -49,6 +60,13 @@ final class SendScreenViewController: DWBasePayViewController {
 
         if prefillsFromClipboard {
             sendViewModel.useClipboardSuggestion()
+        }
+        if let prefillAddress {
+            sendViewModel.addressText = prefillAddress
+            if prefillAmountDuffs > 0 {
+                sendViewModel.unit = .dash
+                sendViewModel.amountText = prefillAmountDuffs.formattedDashAmountWithoutCurrencySymbol
+            }
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -152,35 +152,15 @@ final class SendViewModel: ObservableObject {
 
     // MARK: - Destination classification
 
-    /// Decode `text` into what it actually is on the wire:
-    /// - Base58Check L1 address (network-checked) → `.core`
-    /// - bech32m HRP `dash`/`tdash` (current network), 21-byte payload with a
-    ///   DIP-0018 wire type byte (0xb0 P2PKH / 0x80 P2SH) → `.platform`
-    /// - bech32m, 44-byte payload `0x10` + 43 raw Orchard bytes → `.shielded`
-    /// Anything else (wrong-network HRP included) → nil.
+    /// Forwards to `DashAddressClassifier` — the single wire-form decoder,
+    /// shared with the QR scan gate (which classifies off-main).
     static func classify(_ text: String) -> DestinationKind? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        if trimmed.isValidDashAddressForCurrentNetwork {
-            return .core
+        switch DashAddressClassifier.classify(text) {
+        case .core: return .core
+        case .platform: return .platform
+        case .shielded(let raw43): return .shielded(raw43: raw43)
+        case nil: return nil
         }
-
-        guard let decoded = Bech32m.decode(trimmed.lowercased()) else { return nil }
-        let expectedHrp = Bech32m.platformHrp(mainnet: !WalletEnvironment.isTestnet)
-        guard decoded.hrp == expectedHrp else { return nil }
-
-        if decoded.data.count == 21,
-           decoded.data[0] == 0xb0 || decoded.data[0] == 0x80 {
-            return .platform
-        }
-        // DIP-0018 shielded display form: 0x10 type byte + 43 raw Orchard
-        // bytes (the encoding `PaymentsLandingViewModel.reloadShieldedAddress`
-        // produces for our own address).
-        if decoded.data.count == 44, decoded.data[0] == 0x10 {
-            return .shielded(raw43: decoded.data.subdata(in: 1..<44))
-        }
-        return nil
     }
 
     /// The trimmed entered address (what execution should use).

--- a/DashWallet/Sources/UI/Payments/PaymentModels/DWParsedPaymentURI.swift
+++ b/DashWallet/Sources/UI/Payments/PaymentModels/DWParsedPaymentURI.swift
@@ -13,6 +13,53 @@
 //
 
 import Foundation
+import SwiftDashSDK
+
+// MARK: - DashAddressClassifier
+
+/// Decode a destination string into what it actually is on the wire. Lives
+/// here (nonisolated) rather than on `SendViewModel` because the QR scan
+/// pipeline classifies on its capture queue; `SendViewModel.classify`
+/// forwards to this.
+enum DashAddressClassifier {
+    enum Kind: Equatable {
+        case core
+        case platform
+        /// Carries the recipient's raw 43-byte Orchard payload so confirm
+        /// flows don't re-decode the bech32m.
+        case shielded(raw43: Data)
+    }
+
+    /// - Base58Check L1 address (network-checked) → `.core`
+    /// - bech32m HRP `dash`/`tdash` (current network), 21-byte payload with a
+    ///   DIP-0018 wire type byte (0xb0 P2PKH / 0x80 P2SH) → `.platform`
+    /// - bech32m, 44-byte payload `0x10` + 43 raw Orchard bytes → `.shielded`
+    /// Anything else (wrong-network HRP included) → nil.
+    static func classify(_ text: String) -> Kind? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.isValidDashAddressForCurrentNetwork {
+            return .core
+        }
+
+        guard let decoded = Bech32m.decode(trimmed.lowercased()) else { return nil }
+        let expectedHrp = Bech32m.platformHrp(mainnet: !WalletEnvironment.isTestnet)
+        guard decoded.hrp == expectedHrp else { return nil }
+
+        if decoded.data.count == 21,
+           decoded.data[0] == 0xb0 || decoded.data[0] == 0x80 {
+            return .platform
+        }
+        // DIP-0018 shielded display form: 0x10 type byte + 43 raw Orchard
+        // bytes (the encoding `PaymentsLandingViewModel.reloadShieldedAddress`
+        // produces for our own address).
+        if decoded.data.count == 44, decoded.data[0] == 0x10 {
+            return .shielded(raw43: decoded.data.subdata(in: 1..<44))
+        }
+        return nil
+    }
+}
 
 @objc(DWParsedPaymentURI)
 final class ParsedPaymentURI: NSObject {
@@ -41,12 +88,22 @@ final class ParsedPaymentURI: NSObject {
     /// false for bare schemeless inputs (implicit dash) — drives the invalid-QR error copy.
     @objc let hasExplicitScheme: Bool
     /// `String.isValidDashAddressForCurrentNetwork`, computed at parse time.
+    /// Core (base58) only — the BIP70-fallback path still keys on this.
     @objc let isAddressValidForCurrentNetwork: Bool
+    /// True when `address` is payable in ANY form this wallet supports on
+    /// the current network: base58 Core, DIP-0018 bech32m Platform, or
+    /// shielded. The QR scanner's accept gate.
+    @objc let isAddressPayableForCurrentNetwork: Bool
+    /// True when the address is a bech32m Platform/Shielded destination —
+    /// those can't ride the classic L1 payment processor, so scan entry
+    /// points route them into the Send screen instead.
+    @objc let requiresSendScreenRouting: Bool
 
     /// Mirrors `DSPaymentRequest.isValidAsNonDashpayPaymentRequest` (dash-only arm; the `bitcoin:`
-    /// arms are compiled out under `SHAPESHIFT_ENABLED`, undefined in this app).
+    /// arms are compiled out under `SHAPESHIFT_ENABLED`, undefined in this app), widened to accept
+    /// every payable address form (bech32m Platform/Shielded included).
     @objc var isValidDashPaymentIntent: Bool {
-        scheme == "dash" && (isAddressValidForCurrentNetwork || rURL != nil)
+        scheme == "dash" && (isAddressPayableForCurrentNetwork || rURL != nil)
     }
 
     private init(rawString: String,
@@ -61,7 +118,9 @@ final class ParsedPaymentURI: NSObject {
                  fiatCurrencyCode: String?,
                  fiatAmount: Float,
                  hasExplicitScheme: Bool,
-                 isAddressValidForCurrentNetwork: Bool) {
+                 isAddressValidForCurrentNetwork: Bool,
+                 isAddressPayableForCurrentNetwork: Bool,
+                 requiresSendScreenRouting: Bool) {
         self.rawString = rawString
         self.scheme = scheme
         self.address = address
@@ -75,6 +134,8 @@ final class ParsedPaymentURI: NSObject {
         self.fiatAmount = fiatAmount
         self.hasExplicitScheme = hasExplicitScheme
         self.isAddressValidForCurrentNetwork = isAddressValidForCurrentNetwork
+        self.isAddressPayableForCurrentNetwork = isAddressPayableForCurrentNetwork
+        self.requiresSendScreenRouting = requiresSendScreenRouting
         super.init()
     }
 
@@ -87,10 +148,14 @@ final class ParsedPaymentURI: NSObject {
             return ParsedPaymentURI(rawString: raw, scheme: nil, address: nil, amount: 0,
                                     label: nil, message: nil, rURL: nil, callbackScheme: nil,
                                     dashpayUsername: nil, fiatCurrencyCode: nil, fiatAmount: 0,
-                                    hasExplicitScheme: false, isAddressValidForCurrentNetwork: false)
+                                    hasExplicitScheme: false, isAddressValidForCurrentNetwork: false,
+                                    isAddressPayableForCurrentNetwork: false,
+                                    requiresSendScreenRouting: false)
         }
 
         let addressValid = uri.address?.isValidDashAddressForCurrentNetwork ?? false
+        let classified = uri.address.flatMap(DashAddressClassifier.classify)
+        let isBech32Destination = !addressValid && classified != nil
 
         return ParsedPaymentURI(rawString: raw,
                                 scheme: uri.scheme,
@@ -104,7 +169,9 @@ final class ParsedPaymentURI: NSObject {
                                 fiatCurrencyCode: uri.fiatCurrencyCode,
                                 fiatAmount: uri.fiatAmount ?? 0,
                                 hasExplicitScheme: uri.kind != .bareAddress,
-                                isAddressValidForCurrentNetwork: addressValid)
+                                isAddressValidForCurrentNetwork: addressValid,
+                                isAddressPayableForCurrentNetwork: addressValid || classified != nil,
+                                requiresSendScreenRouting: isBech32Destination)
     }
 
     /// The fetch-failed fallback: a copy without the BIP70 request URL (was the
@@ -123,6 +190,8 @@ final class ParsedPaymentURI: NSObject {
                          fiatCurrencyCode: fiatCurrencyCode,
                          fiatAmount: fiatAmount,
                          hasExplicitScheme: hasExplicitScheme,
-                         isAddressValidForCurrentNetwork: isAddressValidForCurrentNetwork)
+                         isAddressValidForCurrentNetwork: isAddressValidForCurrentNetwork,
+                         isAddressPayableForCurrentNetwork: isAddressPayableForCurrentNetwork,
+                         requiresSendScreenRouting: requiresSendScreenRouting)
     }
 }


### PR DESCRIPTION
## What

The QR scanner only recognized base58 Core addresses — scanning a bech32m Platform (`tdash1…`/`dash1…`) or Shielded (`0x10` + 43-byte Orchard payload) QR (e.g. the app's own Quick Receive codes) read as an invalid code. Now:

- **Scan gate widened**: `ParsedPaymentURI` gains `isAddressPayableForCurrentNetwork` — base58 Core OR bech32m Platform/Shielded, all network-checked — and `isValidDashPaymentIntent` accepts it. The Core-only verdict (`isAddressValidForCurrentNetwork`) lives on for the BIP70-fallback path.
- **Correct routing**: base58 scans keep the classic payment-processor path unchanged. Bech32m destinations can't ride that processor, so the base scan handler (`DWBasePayViewController`) presents the **Send screen prefilled** with the scanned address (+ BIP21 amount when present), where the existing route model picks the funding source and executes. Same presentation chrome as the payments landing (hidden-bar nav, full screen, self-drawn header).
- The Send screen's own in-form scanner needed no change — it already ingests scanned input and benefits automatically once the gate passes these payloads.

## Implementation

The wire-form decoder moved from `SendViewModel.classify` into a shared **nonisolated** `DashAddressClassifier` (the scan pipeline classifies on its capture queue, where the `@MainActor` VM method isn't callable); the VM forwards to it — one decoder, no copies. `SendScreenViewController` gains an ObjC-visible `prefill(address:amountDuffs:)` for the scan-routing entry.

## Testing

Testnet smoke on QA-iPhone16 / iPhone 16 Pro sims: scanning the app's own Quick Receive QR codes for Platform and Shielded lands in the Send form with the address prefilled and the correct destination badge; base58 Core scans (bare + BIP21 with amount) still route through the classic processor; a wrong-network bech32m QR still reads invalid. Unit-test target pre-existing-broken per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)