### PR TITLE
feat(wallet): restore Dash DEX on SwiftDashSDK (memo-less NEAR swaps)

### DIFF
--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -122,6 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
     [CurrencyExchangerObjcWrapper startExchangeRateFetching];
     [CoinbaseObjcWrapper start];
     [CrowdNodeObjcWrapper start];
+    [SwapTrackingServiceObjcWrapper start];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(dsApplicationTerminationRequestNotification:)

--- a/DashWallet/Sources/Models/Swap/SwapBuyTransactionMatcher.swift
+++ b/DashWallet/Sources/Models/Swap/SwapBuyTransactionMatcher.swift
@@ -37,8 +37,8 @@ enum SwapBuyTransactionMatcher {
 
     static func matchedTransaction(
         for order: SwapOrder,
-        in transactions: [DSTransaction]
-    ) -> DSTransaction? {
+        in transactions: [Transaction]
+    ) -> Transaction? {
         guard order.direction == "buy" else { return nil }
 
         let receiveAddress = order.toAddress.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -59,8 +59,10 @@ enum SwapBuyTransactionMatcher {
         }
 
         return candidates.min(by: { lhs, rhs in
-            if lhs.timestamp != rhs.timestamp {
-                return lhs.timestamp < rhs.timestamp
+            let lhsTimestamp = lhs.date.timeIntervalSince1970
+            let rhsTimestamp = rhs.date.timeIntervalSince1970
+            if lhsTimestamp != rhsTimestamp {
+                return lhsTimestamp < rhsTimestamp
             }
 
             let lhsDifference = amountDifference(
@@ -84,26 +86,26 @@ enum SwapBuyTransactionMatcher {
 
     static func walletTxHashData(
         for order: SwapOrder,
-        in transactions: [DSTransaction]
+        in transactions: [Transaction]
     ) -> Data? {
         matchedTransaction(for: order, in: transactions)?.txHashData
     }
 
     static func walletTxHashHexString(
         for order: SwapOrder,
-        in transactions: [DSTransaction]
+        in transactions: [Transaction]
     ) -> String? {
         matchedTransaction(for: order, in: transactions)?.txHashHexString
     }
 
     private static func matches(
-        _ tx: DSTransaction,
+        _ tx: Transaction,
         receiveAddress: String,
         minimumTimestamp: TimeInterval,
         expectedDashAmount: Decimal
     ) -> Bool {
         guard tx.direction == .received else { return false }
-        guard tx.timestamp >= minimumTimestamp - timestampSlack else { return false }
+        guard tx.date.timeIntervalSince1970 >= minimumTimestamp - timestampSlack else { return false }
         guard tx.outputReceiveAddresses.contains(receiveAddress) else { return false }
 
         guard let receivedDashAmount = receivedDashAmount(for: tx) else { return false }
@@ -122,13 +124,13 @@ enum SwapBuyTransactionMatcher {
         return Decimal(string: raw, locale: Locale(identifier: "en_US_POSIX"))
     }
 
-    private static func receivedDashAmount(for tx: DSTransaction) -> Decimal? {
+    private static func receivedDashAmount(for tx: Transaction) -> Decimal? {
         guard tx.dashAmount != UInt64.max else { return nil }
         return Decimal(tx.dashAmount) / baseUnits
     }
 
     private static func amountDifference(
-        tx: DSTransaction,
+        tx: Transaction,
         expectedDashAmount: Decimal
     ) -> Decimal {
         (receivedDashAmount(for: tx) ?? 0) - expectedDashAmount

--- a/DashWallet/Sources/Models/Swap/SwapExecutionData.swift
+++ b/DashWallet/Sources/Models/Swap/SwapExecutionData.swift
@@ -20,7 +20,8 @@
 import Foundation
 
 struct SwapExecutionData {
+    /// The route's unique deposit address. DashDEX exposes only memo-less NEAR-intents routes,
+    /// so a plain send to this address is the whole swap — no OP_RETURN memo is involved.
     let vaultAddress: String
-    let memo: String?
     let executionNetwork: String
 }

--- a/DashWallet/Sources/Models/Swap/SwapPendingGate.swift
+++ b/DashWallet/Sources/Models/Swap/SwapPendingGate.swift
@@ -17,6 +17,7 @@
 //  limitations under the License.
 //
 
+import CoreData
 import Foundation
 
 /// Serialises consecutive swaps: after a swap's Dash transaction is broadcast, the next swap is
@@ -33,7 +34,8 @@ final class SwapPendingGate {
     private let timeout: TimeInterval = 60
 
     private let lock = NSLock()
-    private var pendingTxid: String?
+    /// Wire-order txid (`Transaction.txHashData` convention) of the swap tx being gated on.
+    private var pendingTxidWire: Data?
     private var registeredAt: Date?
     private var observer: NSObjectProtocol?
 
@@ -42,7 +44,7 @@ final class SwapPendingGate {
     /// True while a previously-broadcast swap tx is still awaiting its InstantSend lock.
     var isAwaitingISLock: Bool {
         lock.lock(); defer { lock.unlock() }
-        guard pendingTxid != nil, let registeredAt else { return false }
+        guard pendingTxidWire != nil, let registeredAt else { return false }
         if Date().timeIntervalSince(registeredAt) > timeout {
             clearLocked()
             return false
@@ -50,41 +52,43 @@ final class SwapPendingGate {
         return true
     }
 
-    /// Call right after a swap's Dash tx is published. Begins gating until the tx is IS-locked.
-    func register(txid: String) {
+    /// Call right after a swap's Dash tx is broadcast. Begins gating until the tx is IS-locked.
+    /// - Parameter txidWire: wire-order txid returned by `WalletSendService.send`.
+    func register(txidWire: Data) {
         lock.lock()
         defer { lock.unlock() }
 
-        pendingTxid = txid
+        pendingTxidWire = txidWire
         registeredAt = Date()
         if let observer { NotificationCenter.default.removeObserver(observer) }
 
+        // SDK re-plumb: the Rust persister updates a transaction's context byte
+        // (0=mempool → 1=instantSend) and saves, which fires NSManagedObjectContextDidSave —
+        // the same signal HomeViewModel uses to refresh its tx list. On each save we re-read
+        // the gated tx's `state`; `.ok` means context >= 1 (InstantSend-locked or better).
         // Assign inside the lock so it can't race with `clearLocked()` (also lock-held).
         // `addObserver(forName:…)` only registers — the block is never invoked synchronously,
         // so `handle()` (which re-acquires the lock) cannot deadlock here.
         observer = NotificationCenter.default.addObserver(
-            forName: .DSTransactionManagerTransactionStatusDidChange,
+            forName: .NSManagedObjectContextDidSave,
             object: nil,
             queue: nil
-        ) { [weak self] notification in
-            self?.handle(notification)
+        ) { [weak self] _ in
+            self?.handleSave()
         }
     }
 
-    private func handle(_ notification: Notification) {
+    private func handleSave() {
         lock.lock()
-        let expected = pendingTxid
+        let expected = pendingTxidWire
         lock.unlock()
 
         guard let expected,
-              let userInfo = notification.userInfo,
-              let tx = userInfo[DSTransactionManagerNotificationTransactionKey] as? DSTransaction,
-              tx.txHashHexString == expected,
-              let changes = userInfo[DSTransactionManagerNotificationTransactionChangesKey] as? [String: Any],
-              changes[DSTransactionManagerNotificationInstantSendTransactionLockKey] != nil
+              let tx = SwiftDashSDKWalletSource.fetch(txid: expected),
+              tx.state == .ok  // context >= 1: InstantSend-locked (or inBlock/chainLocked)
         else { return }
 
-        DSLogger.log("SwapPendingGate: IS-lock received for \(expected) — gate released")
+        DSLogger.log("SwapPendingGate: IS-lock observed for \(Transaction.displayHex(expected)) — gate released")
         lock.lock()
         clearLocked()
         lock.unlock()
@@ -92,7 +96,7 @@ final class SwapPendingGate {
 
     /// Must be called with `lock` held.
     private func clearLocked() {
-        pendingTxid = nil
+        pendingTxidWire = nil
         registeredAt = nil
         if let observer {
             NotificationCenter.default.removeObserver(observer)

--- a/DashWallet/Sources/Models/Swap/SwapTrackingService.swift
+++ b/DashWallet/Sources/Models/Swap/SwapTrackingService.swift
@@ -211,7 +211,9 @@ final class SwapTrackingService {
 
     @MainActor
     private func completedWalletTxHash(for order: SwapOrder) -> String? {
-        let transactions = DWEnvironment.sharedInstance().currentWallet.allTransactions
+        // Read the wallet's transactions from SwiftDashSDK; DashSync's allTransactions is frozen
+        // (empty) post-migration, so a buy's incoming DASH would never match.
+        let transactions = SwiftDashSDKWalletSource.fetchAll()
         return SwapBuyTransactionMatcher.walletTxHashHexString(for: order, in: transactions)
     }
 }

--- a/DashWallet/Sources/Models/SwapKit/SwapKitSwapProvider.swift
+++ b/DashWallet/Sources/Models/SwapKit/SwapKitSwapProvider.swift
@@ -139,7 +139,18 @@ final class SwapKitSwapProvider: SwapProvider {
     /// so `SelectCoinViewModel` shows its error/retry state rather than an unfiltered list.
     /// Sell is always unaffected — all pools are returned regardless of classification state.
     private func filteredPools(_ pools: [SwapPool], for direction: SwapDirection) async throws -> [SwapPool] {
-        guard direction == .buy else { return pools }
+        guard direction == .buy else {
+            // Sell: hide coins that can ONLY route via MAYACHAIN. Those routes require an
+            // OP_RETURN memo on the DASH deposit, which SwiftDashSDK cannot build. Coins also
+            // routable via NEAR (nearOnly or both) stay — the Sell quote forces NEAR intents,
+            // so they deposit memo-less. If classification is unusable (network error)
+            // mayaOnlyAssets is empty and nothing is hidden; a mayaOnly coin tapped in that
+            // state simply returns "no route" from the NEAR-forced quote, so no OP_RETURN swap
+            // can be built.
+            if !classificationBuilt { await buildClassification() }
+            guard classificationUsable, !mayaOnlyAssets.isEmpty else { return pools }
+            return pools.filter { !mayaOnlyAssets.contains($0.asset.uppercased()) }
+        }
 
         if !classificationUsable {
             await buildClassification()
@@ -401,6 +412,15 @@ final class SwapKitSwapProvider: SwapProvider {
             return errorResult(NSLocalizedString("No vault address returned by SwapKit", comment: "SwapKit"))
         }
 
+        // Defense-in-depth: NEAR-forced routing must never carry a memo. If a memo does come
+        // back, the deposit would need an OP_RETURN output that SwiftDashSDK cannot build, so
+        // fail loudly here instead of silently building an invalid (memo-less) deposit that the
+        // network would treat as a plain send and never credit the swap.
+        if let memo = swapResponse.memo, !memo.isEmpty {
+            DSLogger.log("SwapKit: rejecting memo-bearing route for \(toAsset) — OP_RETURN unsupported")
+            return errorResult(NSLocalizedString("This coin isn’t available for swapping right now.", comment: "SwapKit"))
+        }
+
         // Step 4: map to neutral result.
         let expectedOut = humanToBaseUnits(swapResponse.expectedBuyAmount ?? best.expectedBuyAmount)
         let fees = swapResponse.fees ?? best.fees ?? []
@@ -417,7 +437,8 @@ final class SwapKitSwapProvider: SwapProvider {
             expectedAmountOut: expectedOut,
             fees: SwapFeeResult(total: feeBaseUnits, outbound: feeBaseUnits),
             inboundAddress: vaultAddress,
-            memo: swapResponse.memo,
+            // Always nil after the NEAR-forced routing + guard above; the deposit is a plain send.
+            memo: nil,
             executionNetwork: executionNetwork
         )
     }
@@ -533,7 +554,12 @@ final class SwapKitSwapProvider: SwapProvider {
             slippage: SwapKitConstants.defaultSlippagePercent,
             sourceAddress: nil,
             destinationAddress: destination,
-            providers: nil,
+            // Force NEAR-intents routing: those routes deposit to a unique address with NO
+            // memo, so the DASH tx is a plain send that SwiftDashSDK can build. MAYACHAIN
+            // routes would return an OP_RETURN memo the SDK cannot express, so we never ask
+            // for them here (mayaOnly coins are hidden from the picker; both-routable coins
+            // stay memoless via NEAR). Mirrors requestBuyRoute, which already forces NEAR.
+            providers: [SwapKitConstants.providerNear],
             affiliateFee: nil
         )
 
@@ -907,8 +933,9 @@ final class SwapKitSwapProvider: SwapProvider {
 
     private func walletSourceAddress() -> String {
         // Current receive address is always valid for SwapKit's format check.
-        // Any SwapKit refund will be returned here.
-        DWEnvironment.sharedInstance().currentAccount.receiveAddress ?? ""
+        // Any SwapKit refund will be returned here. Read from SwiftDashSDK — the frozen
+        // DashSync account's receiveAddress is stale post-migration.
+        SwiftDashSDKReceiveAddressReader.receiveAddress() ?? ""
     }
 
     // MARK: - Private: Helpers

--- a/DashWallet/Sources/Models/SwapKit/SwapKitSwapProvider.swift
+++ b/DashWallet/Sources/Models/SwapKit/SwapKitSwapProvider.swift
@@ -327,10 +327,13 @@ final class SwapKitSwapProvider: SwapProvider {
         sellAmount: String,
         refundAddress: String
     ) async throws {
+        guard let destination = walletSourceAddress() else {
+            throw Self.walletUnavailableError()
+        }
         _ = try await requestBuyRoute(
             sellAsset: sellAsset,
             sellAmount: sellAmount,
-            destination: walletSourceAddress(),
+            destination: destination,
             refundAddress: refundAddress
         )
     }
@@ -384,7 +387,9 @@ final class SwapKitSwapProvider: SwapProvider {
         // Step 3: build swap — get vault address + memo.
         // sourceAddress must be a real wallet address for SwapKit's format check and
         // so any SwapKit refund is returned to this wallet.
-        let sourceAddress = walletSourceAddress()
+        guard let sourceAddress = walletSourceAddress() else {
+            return errorResult(Self.walletUnavailableMessage)
+        }
         let swapRequest = SwapKitSwapRequest(
             routeId: best.routeId,
             sourceAddress: sourceAddress,
@@ -931,11 +936,24 @@ final class SwapKitSwapProvider: SwapProvider {
 
     // MARK: - Private: Wallet
 
-    private func walletSourceAddress() -> String {
-        // Current receive address is always valid for SwapKit's format check.
-        // Any SwapKit refund will be returned here. Read from SwiftDashSDK — the frozen
-        // DashSync account's receiveAddress is stale post-migration.
-        SwiftDashSDKReceiveAddressReader.receiveAddress() ?? ""
+    /// Current receive address, used for SwapKit's source-address format check and refund
+    /// routing. Read from SwiftDashSDK (the frozen DashSync account's receiveAddress is stale
+    /// post-migration). Returns `nil` when the wallet isn't bound yet (or FFI failure) — callers
+    /// must fail fast rather than send an empty address into the swap request, which would
+    /// surface as an opaque provider error.
+    private func walletSourceAddress() -> String? {
+        guard let address = SwiftDashSDKReceiveAddressReader.receiveAddress(), !address.isEmpty else {
+            return nil
+        }
+        return address
+    }
+
+    private static var walletUnavailableMessage: String {
+        NSLocalizedString("Your wallet isn’t ready yet. Please try again in a moment.", comment: "SwapKit")
+    }
+
+    private static func walletUnavailableError() -> Error {
+        NSError(domain: "SwapKit", code: 1, userInfo: [NSLocalizedDescriptionKey: walletUnavailableMessage])
     }
 
     // MARK: - Private: Helpers

--- a/DashWallet/Sources/Models/Transactions/SendCoinsService.swift
+++ b/DashWallet/Sources/Models/Transactions/SendCoinsService.swift
@@ -15,14 +15,10 @@
 //  limitations under the License.
 //
 
+import Foundation
+
 public final class SendCoinsService: NSObject {
     private let walletSendService = WalletSendService.shared
-
-    /// DashSync publish path, used only by `sendMayaSwap` — the Maya swap builds a
-    /// raw `DSTransaction` (OP_RETURN memo + fixed output order), which
-    /// SwiftDashSDK's sender cannot express yet. Every other spend goes through
-    /// `walletSendService`. TODO(maya-sdk-port): drop with the SDK OP_RETURN support.
-    private let transactionManager: DSTransactionManager = DWEnvironment.sharedInstance().currentChainManager.transactionManager
 
     /// - Returns: the wire-order txid of the broadcast transaction
     ///   (`Transaction.txHashData` convention).
@@ -39,201 +35,33 @@ public final class SendCoinsService: NSObject {
         )
     }
 
-    /// Sends a MAYA swap transaction where:
-    /// - VOUT0 pays DASH to the MAYA vault address
-    /// - VOUT1 stores MAYA memo in OP_RETURN
-    /// - VOUT2 is change back to the wallet (if any)
+    /// Submits a memo-less DashDEX (SwapKit) deposit: a plain send of `dashAmount` to the
+    /// route's deposit address. DashDEX only exposes NEAR-intents routes, which deposit to a
+    /// unique per-swap address with NO memo — so the DASH transaction is an ordinary send that
+    /// SwiftDashSDK builds, signs, and broadcasts via `WalletSendService`. There is no
+    /// OP_RETURN output (the SDK cannot express one); MAYACHAIN-style memo routes never reach
+    /// here because the provider forces NEAR routing, hides Maya-only coins, and rejects any
+    /// residual memo-bearing quote before submission.
     ///
-    /// DSTransactionSortType.none is used so the wallet builder preserves the
-    /// vault→memo→change insertion order without BIP69 sorting or shuffling,
-    /// matching the Android sendRequest.sortByBIP69 = false / shuffleOutputs = false
-    /// requirement from MayaBlockchainApi.kt.
-    func sendMayaSwap(vaultAddress: String, dashAmount: UInt64, memo: String) async throws -> DSTransaction {
+    /// - Returns: the wire-order txid of the broadcast transaction
+    ///   (`Transaction.txHashData` convention).
+    func sendSwapKitSwap(depositAddress: String, dashAmount: UInt64) async throws -> Data {
         // Serialise swaps: don't start a new one until the previous swap tx is InstantSend-locked.
         if SwapPendingGate.shared.isAwaitingISLock {
             throw DashSpendError.swapAwaitingInstantLock
         }
 
-        let memoByteCount = memo.utf8.count
-        DSLogger.log("sendMayaSwap memo=\(memo) bytes=\(memoByteCount)")
-        guard memoByteCount <= 80 else {
-            throw DashSpendError.paymentProcessingError("Swap memo (\(memoByteCount) bytes) exceeds the 80-byte OP_RETURN limit. Try a simpler destination asset.")
-        }
-
-        let chain = DWEnvironment.sharedInstance().currentChain
-        let account = DWEnvironment.sharedInstance().currentAccount
-
-        let transaction = DSTransaction(on: chain)
-
-        let vaultScript = NSData.scriptPubKey(forAddress: vaultAddress, for: chain)
-        let memoScript = opReturnScript(for: memo)
-
-        _ = account.update(
-            transaction,
-            forAmounts: [NSNumber(value: dashAmount), NSNumber(value: 0)],
-            toOutputScripts: [vaultScript, memoScript],
-            withFee: true,
-            sortType: DSTransactionSortType.none  // preserve vault→memo→change order
-        )
-
-        guard transaction.outputs.count >= 2 else {
-            logOutputs(transaction, label: "build-failed")
-            throw DashSpendError.paymentProcessingError("Failed to build MAYA swap outputs")
-        }
-
-        // Validate VOUT0: must be the vault payment output
-        guard transaction.outputs[0].address == vaultAddress else {
-            logOutputs(transaction, label: "order-invalid")
-            throw DashSpendError.paymentProcessingError("MAYA swap output ordering is invalid")
-        }
-
-        // Validate VOUT1: must be the OP_RETURN memo output (amount 0, script starts with 0x6a)
-        let memoOutput = transaction.outputs[1]
-        guard memoOutput.amount == 0,
-              let firstByte = memoOutput.outScript.first, firstByte == 0x6a else {
-            logOutputs(transaction, label: "memo-invalid")
-            throw DashSpendError.paymentProcessingError("MAYA memo output is invalid")
-        }
-
-        // Pre-sign diagnostics: log full tx structure, fee, and VIN0 relationship
-        // (mirrors Android's log.info("maya swap transaction: {}", sendRequest.tx))
-        let txSize = transaction.size
-        let estimatedFee = chain.fee(forTxSize: UInt(txSize))
-        let feePerByte = txSize > 0 ? estimatedFee / UInt64(txSize) : 0
-
-        // Real wire size of the OP_RETURN output: transaction.size uses TX_OUTPUT_SIZE=34
-        // for every output, but OP_RETURN is 8 (value) + varint(scriptLen) + scriptLen.
-        let memoScriptLen = memoOutput.outScript.count
-        let varintLen = memoScriptLen < 253 ? 1 : 3
-        let realOpReturnSize = 8 + varintLen + memoScriptLen
-        let realEstimatedSize = Int(txSize) - 34 + realOpReturnSize
-
-        // FEE FIX: account.update uses TX_OUTPUT_SIZE=34 for every output, but the
-        // OP_RETURN output is realOpReturnSize bytes. The builder therefore under-pays
-        // the fee by extraBytes duffs. Close the gap by reducing the change output (VOUT2)
-        // so the effective fee rate clears TX_FEE_PER_B against the real wire size.
-        // DSTransactionOutput.amount is readonly in the public header but readwrite in its
-        // class extension, so KVC setValue(_:forKey:) reaches the private setter safely.
-        var correctedFee = estimatedFee
-        let extraBytes = realEstimatedSize > Int(txSize) ? realEstimatedSize - Int(txSize) : 0
-        if extraBytes > 0 {
-            let requiredFee = chain.fee(forTxSize: UInt(realEstimatedSize) + 1) // +1 byte safety margin
-            if requiredFee > estimatedFee, transaction.outputs.count >= 3 {
-                let feeDelta = requiredFee - estimatedFee
-                let changeOutput = transaction.outputs[2]
-                guard changeOutput.amount >= feeDelta + chain.minOutputAmount else {
-                    throw DashSpendError.paymentProcessingError(
-                        "Change output (\(changeOutput.amount) duffs) too small to absorb fee correction (\(feeDelta) duffs)"
-                    )
-                }
-                let correctedChangeAmount = changeOutput.amount - feeDelta
-                changeOutput.setValue(NSNumber(value: correctedChangeAmount), forKey: "amount")
-                correctedFee = requiredFee
-                DSLogger.log("sendMayaSwap FEE FIX: extraBytes=\(extraBytes) feeDelta=\(feeDelta) requiredFee=\(requiredFee) correctedChange=\(correctedChangeAmount)")
-            }
-        }
-
-        DSLogger.log("sendMayaSwap pre-sign: inputs=\(transaction.inputs.count) outputs=\(transaction.outputs.count) size=\(txSize) estimatedFee=\(estimatedFee) feePerByte=\(feePerByte)")
-        logOutputs(transaction, label: "pre-sign")
-        logVin0(transaction, chain: chain)
-
-        // Guard: check fee rate against the REAL wire size, not the builder's undercount.
-        // Before this fix, feePerByte was measured against txSize (= under-counted estimate),
-        // giving a false pass even when the relay fee was below the 1 duff/byte minimum.
-        let correctedFeePerByte = realEstimatedSize > 0 ? correctedFee / UInt64(realEstimatedSize) : 0
-        guard correctedFeePerByte >= TX_FEE_PER_B else {
-            throw DashSpendError.paymentProcessingError(
-                "Transaction fee too low: \(correctedFeePerByte) duff/byte against real size \(realEstimatedSize) (min \(TX_FEE_PER_B))"
-            )
-        }
-
-        // Guard against stale UTXOs caused by DSAccount.updateBalance treating the
-        // Maya swap tx as "pending" (OP_RETURN output amount=0 < TX_MIN_OUTPUT_AMOUNT,
-        // i.e. 546 duffs). The pending path calls `continue` before the reconciliation
-        // step that removes spent entries from `utxos`, so the just-spent input stays
-        // visible to the next coin-selection call and gets re-selected — producing a
-        // double-spend. `spentOutputs` IS always updated correctly (before the continue);
-        // `-isInputSpent:atIndex:` reads that set and catches stale re-use early.
-        for input in transaction.inputs {
-            if account.isInputSpent(input.inputHash, at: input.index) {
-                throw DashSpendError.previousSwapPending
-            }
-        }
-
-        let authenticated = await authenticate()
-        if !authenticated {
+        let txidWire: Data
+        do {
+            txidWire = try await walletSendService.send(address: depositAddress, amount: dashAmount)
+        } catch let error as NSError where WalletSendService.isAuthenticationCancelledError(error) {
+            // Preserve the swap flow's existing auth-cancel handling, which keys on
+            // `DashSpendError.authenticationCancelled` rather than the send service's NSError.
             throw DashSpendError.authenticationCancelled
         }
 
-        account.sign(transaction)
-        DSLogger.log("sendMayaSwap post-sign txid=\(transaction.txHashHexString)")
-        // saveImmediately:true: crash-safe — tx is in Core Data before broadcast.
-        // Does NOT affect UTXO state; updateBalance runs the same either way.
-        account.register(transaction, saveImmediately: true)
-        try await transactionManager.publishTransaction(transaction)
-        DSLogger.log("sendMayaSwap published txid=\(transaction.txHashHexString)")
-        SwapPendingGate.shared.register(txid: transaction.txHashHexString)
-        return transaction
-    }
-
-    /// Submits a SwapKit deposit. Two shapes:
-    /// - memo present: deposit output + OP_RETURN memo (same on-chain shape as Maya swaps)
-    /// - memo nil/empty: plain send to the route-specific deposit address (no OP_RETURN)
-    /// Kept separate from `sendMayaSwap` so the Maya path stays untouched while SwapKit can
-    /// diverge for memo-less routes such as NEAR intents.
-    func sendSwapKitSwap(depositAddress: String, dashAmount: UInt64, memo: String?) async throws -> DSTransaction {
-        // Serialise swaps: don't start a new one until the previous swap tx is InstantSend-locked.
-        if SwapPendingGate.shared.isAwaitingISLock {
-            throw DashSpendError.swapAwaitingInstantLock
-        }
-        let chain = DWEnvironment.sharedInstance().currentChain
-        let account = DWEnvironment.sharedInstance().currentAccount
-
-        let transaction: DSTransaction
-        if let memo, !memo.isEmpty {
-            transaction = try buildSwapKitVaultPlusMemoTx(
-                account: account,
-                chain: chain,
-                vaultAddress: depositAddress,
-                dashAmount: dashAmount,
-                memo: memo
-            )
-        } else {
-            guard let plainSendTransaction = account.transaction(for: dashAmount, to: depositAddress, withFee: true) else {
-                throw DashSpendError.paymentProcessingError("Failed to build SwapKit deposit transaction")
-            }
-            transaction = plainSendTransaction
-        }
-
-        return try await publishSwapTransaction(transaction, account: account)
-    }
-
-    private func logOutputs(_ tx: DSTransaction, label: String) {
-        DSLogger.log("sendMayaSwap [\(label)] \(tx.outputs.count) output(s):")
-        for (i, out) in tx.outputs.enumerated() {
-            let scriptHex = out.outScript.map { String(format: "%02x", $0) }.joined()
-            let isOpReturn = out.outScript.first == 0x6a
-            if isOpReturn {
-                let payload = out.outScript.dropFirst(2)
-                let memoStr = String(bytes: payload, encoding: .utf8) ?? scriptHex
-                DSLogger.log("  [\(i)] amount=\(out.amount) OP_RETURN memo=\(memoStr)")
-            } else {
-                DSLogger.log("  [\(i)] amount=\(out.amount) addr=\(out.address ?? "(none)") script=\(scriptHex.prefix(40))")
-            }
-        }
-    }
-
-    private func logVin0(_ tx: DSTransaction, chain: DSChain) {
-        guard let vin0 = tx.inputs.first else { return }
-        var hash = vin0.inputHash
-        let hashData = withUnsafeBytes(of: &hash) { Data($0) }
-        let hashHex = hashData.reversed().map { String(format: "%02x", $0) }.joined()
-        DSLogger.log("sendMayaSwap VIN0: prevout=\(hashHex):\(vin0.index)")
-        if let parentTx = chain.transaction(forHash: vin0.inputHash),
-           Int(vin0.index) < parentTx.outputs.count {
-            let vin0Out = parentTx.outputs[Int(vin0.index)]
-            DSLogger.log("sendMayaSwap VIN0 script: addr=\(vin0Out.address ?? "(none)")")
-        }
+        SwapPendingGate.shared.register(txidWire: txidWire)
+        return txidWire
     }
 
     // MARK: - BIP70
@@ -266,125 +94,5 @@ public final class SendCoinsService: NSObject {
             fee: result.fee)
 
         return txidWire
-    }
-    
-    private func authenticate() async -> Bool {
-        @MainActor func performAuthentication() async -> Bool {
-            await withCheckedContinuation { continuation in
-                DSAuthenticationManager.sharedInstance().authenticate(
-                    withPrompt: nil,
-                    usingBiometricAuthentication: DWGlobalOptions.sharedInstance().biometricAuthEnabled,
-                    alertIfLockout: true
-                ) { authenticatedOrSuccess, _, cancelled in
-                    continuation.resume(returning: authenticatedOrSuccess && !cancelled)
-                }
-            }
-        }
-        return await performAuthentication()
-    }
-
-    private func buildSwapKitVaultPlusMemoTx(
-        account: DSAccount,
-        chain: DSChain,
-        vaultAddress: String,
-        dashAmount: UInt64,
-        memo: String
-    ) throws -> DSTransaction {
-        let memoByteCount = memo.utf8.count
-        DSLogger.log("sendSwapKitSwap memo=\(memo) bytes=\(memoByteCount)")
-        guard memoByteCount <= 80 else {
-            throw DashSpendError.paymentProcessingError("Swap memo (\(memoByteCount) bytes) exceeds the 80-byte OP_RETURN limit. Try a simpler destination asset.")
-        }
-
-        let transaction = DSTransaction(on: chain)
-        let vaultScript = NSData.scriptPubKey(forAddress: vaultAddress, for: chain)
-        let memoScript = opReturnScript(for: memo)
-
-        _ = account.update(
-            transaction,
-            forAmounts: [NSNumber(value: dashAmount), NSNumber(value: 0)],
-            toOutputScripts: [vaultScript, memoScript],
-            withFee: true,
-            sortType: DSTransactionSortType.none
-        )
-
-        guard transaction.outputs.count >= 2 else {
-            logOutputs(transaction, label: "swapkit-build-failed")
-            throw DashSpendError.paymentProcessingError("Failed to build SwapKit deposit outputs")
-        }
-
-        guard transaction.outputs[0].address == vaultAddress else {
-            logOutputs(transaction, label: "swapkit-order-invalid")
-            throw DashSpendError.paymentProcessingError("SwapKit deposit output ordering is invalid")
-        }
-
-        let memoOutput = transaction.outputs[1]
-        guard memoOutput.amount == 0,
-              let firstByte = memoOutput.outScript.first, firstByte == 0x6a else {
-            logOutputs(transaction, label: "swapkit-memo-invalid")
-            throw DashSpendError.paymentProcessingError("SwapKit memo output is invalid")
-        }
-
-        let txSize = transaction.size
-        let estimatedFee = chain.fee(forTxSize: UInt(txSize))
-        let memoScriptLength = memoOutput.outScript.count
-        let varintLength = memoScriptLength < 253 ? 1 : 3
-        let realOpReturnSize = 8 + varintLength + memoScriptLength
-        let realEstimatedSize = Int(txSize) - 34 + realOpReturnSize
-
-        let extraBytes = realEstimatedSize > Int(txSize) ? realEstimatedSize - Int(txSize) : 0
-        if extraBytes > 0 {
-            let requiredFee = chain.fee(forTxSize: UInt(realEstimatedSize) + 1)
-            if requiredFee > estimatedFee, transaction.outputs.count >= 3 {
-                let feeDelta = requiredFee - estimatedFee
-                let changeOutput = transaction.outputs[2]
-                guard changeOutput.amount >= feeDelta + chain.minOutputAmount else {
-                    throw DashSpendError.paymentProcessingError(
-                        "Change output (\(changeOutput.amount) duffs) too small to absorb fee correction (\(feeDelta) duffs)"
-                    )
-                }
-                let correctedChangeAmount = changeOutput.amount - feeDelta
-                changeOutput.setValue(NSNumber(value: correctedChangeAmount), forKey: "amount")
-                DSLogger.log("sendSwapKitSwap fee correction: extraBytes=\(extraBytes) feeDelta=\(feeDelta) correctedChange=\(correctedChangeAmount)")
-            }
-        }
-
-        return transaction
-    }
-
-    private func publishSwapTransaction(_ transaction: DSTransaction, account: DSAccount) async throws -> DSTransaction {
-        for input in transaction.inputs where account.isInputSpent(input.inputHash, at: input.index) {
-            throw DashSpendError.previousSwapPending
-        }
-
-        guard await authenticate() else {
-            throw DashSpendError.authenticationCancelled
-        }
-
-        account.sign(transaction)
-        account.register(transaction, saveImmediately: true)
-        try await transactionManager    .publishTransaction(transaction)
-        SwapPendingGate.shared.register(txid: transaction.txHashHexString)
-        return transaction
-    }
-    
-    private func opReturnScript(for memo: String) -> Data {
-        let payload = Data(memo.utf8)
-        var script = Data([0x6a]) // OP_RETURN
-
-        let count = payload.count
-        if count <= 0x4b {
-            script.append(UInt8(count))
-        } else if count <= 0xff {
-            script.append(0x4c) // OP_PUSHDATA1
-            script.append(UInt8(count))
-        } else {
-            script.append(0x4d) // OP_PUSHDATA2
-            script.append(UInt8(count & 0xff))
-            script.append(UInt8((count >> 8) & 0xff))
-        }
-
-        script.append(payload)
-        return script
     }
 }

--- a/DashWallet/Sources/UI/Buy Sell/BuySellPortalView.swift
+++ b/DashWallet/Sources/UI/Buy Sell/BuySellPortalView.swift
@@ -47,6 +47,9 @@ private struct MenuCardStyle: ViewModifier {
 
 struct BuySellPortalView: View {
     let showCoinbase: Bool
+    /// Dash DEX (SwapKit) entry visibility, decided by the controller (mainnet + API key
+    /// configured). Dash DEX now runs on SwiftDashSDK via memo-less NEAR-intents routes.
+    let showSwapKit: Bool
 
     @ObservedObject var model: BuySellPortalModel
     var onBack: () -> Void
@@ -56,15 +59,9 @@ struct BuySellPortalView: View {
     var onMaya: () -> Void
     var onSwapKit: () -> Void
 
-    // Maya and SwapKit (Dash DEX) are both withheld for the SwiftDashSDK migration
-    // release: their swap paths build a DSTransaction and broadcast through DashSync,
-    // whose SPV is frozen post-M6 (balances/UTXOs read stale/zero), so a swap would be
-    // built against dead state and fail. The screens stay compiled; only the entry
-    // points are withheld.
-    // TODO(swap-sdk-port): restore once the SwiftDashSDK sender can build these swaps
-    // (Maya needs an OP_RETURN output with preserved output order).
+    // Maya remains withheld: its swap path is inherently OP_RETURN (memo-based), which
+    // SwiftDashSDK cannot build. Dash DEX (SwapKit) replaces it via memo-less NEAR routing.
     private var showsMaya: Bool { false }
-    private var showsSwapKit: Bool { false }
 
     var body: some View {
         ScrollView {
@@ -82,7 +79,7 @@ struct BuySellPortalView: View {
                     if showsMaya {
                         mayaCard
                     }
-                    if showsSwapKit {
+                    if showSwapKit {
                         swapKitCard
                     }
                 }
@@ -200,6 +197,7 @@ private extension BuySellPortalModel {
 #Preview("BuySell Portal - Coinbase") {
     BuySellPortalView(
         showCoinbase: true,
+        showSwapKit: true,
         model: .preview,
         onBack: {},
         onUphold: {},
@@ -213,6 +211,7 @@ private extension BuySellPortalModel {
 #Preview("BuySell Portal - No Coinbase") {
     BuySellPortalView(
         showCoinbase: false,
+        showSwapKit: false,
         model: .preview,
         onBack: {},
         onUphold: {},

--- a/DashWallet/Sources/UI/Buy Sell/BuySellPortalViewController.swift
+++ b/DashWallet/Sources/UI/Buy Sell/BuySellPortalViewController.swift
@@ -140,6 +140,9 @@ final class BuySellPortalViewController: UIViewController, NavigationBarDisplaya
     private func setupSwiftUIView() {
         let portalView = BuySellPortalView(
             showCoinbase: CoinbaseDataSource.shouldShow(),
+            // Dash DEX swaps real assets — mainnet only, and only when the SwapKit API key
+            // is configured. Mirrors ServiceDataProvider.shouldShow(.swapKit).
+            showSwapKit: DWEnvironment.sharedInstance().currentChain.isMainnet() && SwapKitConstants.isConfigured,
             model: model,
             onBack: { [weak self] in
                 guard let self else { return }

--- a/DashWallet/Sources/UI/Home/Tx Metadata/SwapOrderMetadataProvider.swift
+++ b/DashWallet/Sources/UI/Home/Tx Metadata/SwapOrderMetadataProvider.swift
@@ -27,10 +27,10 @@ import DashUIKit
 ///   Convert: `Data(hex: order.id).map { Data($0.reversed()) }`.
 /// - **Buy**: prefer `order.outboundTxHash` once tracking has resolved it, but re-validate
 ///   that hash against the precise buy matcher before trusting it. Otherwise walk
-///   `DWEnvironment.sharedInstance().currentWallet.allTransactions` and match the incoming
-///   Dash tx by address + time + approximate amount. Return that tx's `txHashData`.
-///   Re-resolves on `NSNotification.Name.DSWalletBalanceDidChange` so a buy that lands
-///   after the order is stored still gets labelled.
+///   `SwiftDashSDKWalletSource.fetchAll()` and match the incoming Dash tx by address + time
+///   + approximate amount. Return that tx's `txHashData`. Re-resolves on
+///   `SwiftDashSDKWalletState.balanceDidChangeNotification` so a buy that lands after the
+///   order is stored still gets labelled.
 class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
     static let shared = SwapOrderMetadataProvider()
 
@@ -52,7 +52,11 @@ class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
             }
             .store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: NSNotification.Name.DSWalletBalanceDidChange)
+        // Re-resolve buy orders when the wallet state changes (the incoming DASH landing is
+        // what lets the matcher key a buy order to its tx). Uses the SwiftDashSDK balance
+        // notification — the legacy DSWalletBalanceDidChange is frozen post-migration and
+        // never fires, so buy metadata never attached.
+        NotificationCenter.default.publisher(for: SwiftDashSDKWalletState.balanceDidChangeNotification)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.refreshMetadata() }
             .store(in: &cancellables)
@@ -88,7 +92,7 @@ class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
             if let outboundTxHash = order.outboundTxHash?.trimmingCharacters(in: .whitespacesAndNewlines),
                !outboundTxHash.isEmpty,
                let txHashData = Data(hex: outboundTxHash),
-               let matchingTx = DWEnvironment.sharedInstance().currentWallet.allTransactions.first(
+               let matchingTx = SwiftDashSDKWalletSource.fetchAll().first(
                     where: { $0.txHashHexString.caseInsensitiveCompare(outboundTxHash) == .orderedSame }
                ),
                SwapBuyTransactionMatcher.matchedTransaction(for: order, in: [matchingTx]) != nil {
@@ -100,7 +104,8 @@ class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
     }
 
     private func walletTxHashData(for order: SwapOrder) -> Data? {
-        let transactions = DWEnvironment.sharedInstance().currentWallet.allTransactions
+        // SwiftDashSDK tx set; DashSync's allTransactions is frozen (empty) post-migration.
+        let transactions = SwiftDashSDKWalletSource.fetchAll()
         return SwapBuyTransactionMatcher.walletTxHashData(for: order, in: transactions)
     }
 

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -970,10 +970,12 @@ extension HomeViewModel {
                     if type == .switchWallet && !canSwitchWallet {
                         type = .receive
                     }
-                    // Dash DEX swaps real assets, so it's mainnet-only; a saved DEX
-                    // shortcut degrades to Spend on testnet. The saved config is
-                    // untouched, so it returns when the wallet is back on mainnet.
-                    if type == .dashDEX && isTestnet {
+                    // Dash DEX is offered only on mainnet with SwapKit configured (mirrors
+                    // ShortcutActionType.customizableActions and ServiceDataProvider.shouldShow);
+                    // a saved DEX shortcut degrades to Spend whenever that gate isn't met. The
+                    // saved config is untouched, so it returns once the gate passes again.
+                    let dashDEXAvailable = !isTestnet && SwapKitConstants.isConfigured
+                    if type == .dashDEX && !dashDEXAvailable {
                         type = .spend
                     }
                     return ShortcutAction(type: type)

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -970,10 +970,10 @@ extension HomeViewModel {
                     if type == .switchWallet && !canSwitchWallet {
                         type = .receive
                     }
-                    // Dash DEX is withheld for the migration release (frozen-DashSync
-                    // swap path); a saved DEX shortcut degrades to Spend. The saved
-                    // config is untouched, so it returns if DEX is restored.
-                    if type == .dashDEX {
+                    // Dash DEX swaps real assets, so it's mainnet-only; a saved DEX
+                    // shortcut degrades to Spend on testnet. The saved config is
+                    // untouched, so it returns when the wallet is back on mainnet.
+                    if type == .dashDEX && isTestnet {
                         type = .spend
                     }
                     return ShortcutAction(type: type)

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
@@ -62,9 +62,11 @@ extension ShortcutActionType {
             .send, .scanToPay, .payToAddress,
             .coinbase, .uphold, .topper
         ]
-        // Dash DEX is withheld for the SwiftDashSDK migration release (its swap
-        // path builds through frozen DashSync), so it is not offered as a
-        // customizable shortcut. Mirrors the gated Buy & Sell portal card.
+        // Dash DEX swaps real assets, so it's offered only on mainnet and only when
+        // the SwapKit API key is configured. Mirrors the gated Buy & Sell portal card.
+        if !WalletEnvironment.isTestnet && SwapKitConstants.isConfigured {
+            actions.append(.dashDEX)
+        }
         let state = CrowdNode.shared.signUpState
         if state == .finished || state == .linkedOnline {
             actions.append(.crowdNode)

--- a/DashWallet/Sources/UI/Swap/Buy/RefundAddress/RefundAddressViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/Buy/RefundAddress/RefundAddressViewModel.swift
@@ -153,7 +153,9 @@ final class RefundAddressViewModel: ObservableObject {
         shouldShowAddressValidationError = true
         guard SwapAddressValidator.isValid(address: candidate, for: coin) else { return nil }
 
-        guard let destination = DWEnvironment.sharedInstance().currentAccount.receiveAddress,
+        // SwiftDashSDK receive address — the frozen DashSync account's receiveAddress reads
+        // stale post-migration.
+        guard let destination = SwiftDashSDKReceiveAddressReader.receiveAddress(),
               !destination.isEmpty else {
             orderError = NSLocalizedString("Unable to determine your Dash receive address.", comment: "Dash DEX")
             return nil

--- a/DashWallet/Sources/UI/Swap/Convert/SwapConvertViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/Convert/SwapConvertViewModel.swift
@@ -69,18 +69,25 @@ final class SwapConvertViewModel: ObservableObject {
 
     // MARK: - Computed Properties
 
+    /// Max Dash (duffs) available to convert: SDK spendable balance minus the send fee reserve.
+    /// The frozen DashSync account balance reads stale/zero post-migration, so all balance reads
+    /// in this flow go through SwiftDashSDK.
+    private var availableDashDuffs: UInt64 {
+        SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+    }
+
     var dashBalance: Int64 {
-        Int64(DWEnvironment.sharedInstance().currentAccount.balance)
+        Int64(availableDashDuffs)
     }
 
     /// Symbol-free formatted Dash balance (e.g. "1.5") for the convert source row.
     var dashBalanceFormatted: String {
-        DWEnvironment.sharedInstance().currentAccount.balance.formattedDashAmountWithoutCurrencySymbol
+        availableDashDuffs.formattedDashAmountWithoutCurrencySymbol
     }
 
     var dashBalanceFiat: String {
         do {
-            let balance = DWEnvironment.sharedInstance().currentAccount.balance.dashAmount
+            let balance = availableDashDuffs.dashAmount
             let amount = try CurrencyExchanger.shared.convertDash(amount: balance, to: currentFiatCurrency)
             return NumberFormatter.fiatDisplayFormatter(currencyCode: currentFiatCurrency)
                 .string(from: amount as NSNumber) ?? "\(amount)"
@@ -145,7 +152,7 @@ final class SwapConvertViewModel: ObservableObject {
 
     /// Sets the input to the wallet's full balance, preserving the active currency display.
     func setMax() {
-        let balance = DWEnvironment.sharedInstance().currentAccount.balance
+        let balance = availableDashDuffs
         amount.setDash(Self.dashRoundedDown(balance.dashAmount))
         isMaxFromBalance = true
         clearQuoteState()
@@ -252,7 +259,7 @@ final class SwapConvertViewModel: ObservableObject {
         let satoshis = activeSellSatoshis
         guard satoshis > 0 else { return .empty }
 
-        let accountBalance = Int64(DWEnvironment.sharedInstance().currentAccount.balance)
+        let accountBalance = Int64(availableDashDuffs)
         if satoshis > accountBalance { return .insufficientBalance }
 
         return .valid(dashSatoshis: satoshis)
@@ -260,7 +267,7 @@ final class SwapConvertViewModel: ObservableObject {
 
     private func checkBalance() {
         let satoshis = activeSellSatoshis
-        let accountBalance = Int64(DWEnvironment.sharedInstance().currentAccount.balance)
+        let accountBalance = Int64(availableDashDuffs)
         errorMessage = satoshis > accountBalance
             ? maximumTransactionAmountMessage()
             : nil

--- a/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewViewModel.swift
@@ -16,6 +16,7 @@
 //
 
 import Combine
+import CoreData
 import Foundation
 
 private extension Error {
@@ -223,11 +224,9 @@ final class OrderPreviewViewModel: ObservableObject {
     private let swapProvider: SwapProvider
     private var daoCancellable: AnyCancellable?
     private var isLockCancellable: AnyCancellable?
-    // Strong reference to the broadcast Dash tx. DashSync mutates its `blockHeight` in place
-    // when the tx is included in a block, which the confirmation observer re-reads on each
-    // transaction-status notification.
-    private var submittedTransaction: DSTransaction?
-    private var confirmationCancellable: AnyCancellable?
+    /// Wire-order txid (`Transaction.txHashData` convention) of the broadcast swap deposit,
+    /// returned by `WalletSendService.send`. Used to re-fetch the tx's SDK-tracked state.
+    private var submittedTxidWire: Data?
     private var didInitialLoad = false
     private var lastDepositAddress: String?
     private let networkStatus: NetworkStatusProviding
@@ -266,7 +265,6 @@ final class OrderPreviewViewModel: ObservableObject {
         countdownCancellable?.cancel()
         daoCancellable?.cancel()
         isLockCancellable?.cancel()
-        confirmationCancellable?.cancel()
         networkCancellable?.cancel()
     }
 
@@ -290,9 +288,7 @@ final class OrderPreviewViewModel: ObservableObject {
         daoCancellable = nil
         isLockCancellable?.cancel()
         isLockCancellable = nil
-        confirmationCancellable?.cancel()
-        confirmationCancellable = nil
-        submittedTransaction = nil
+        submittedTxidWire = nil
         swapStatus = .idle
         submittedTxId = nil
         lastDepositAddress = nil
@@ -429,8 +425,8 @@ final class OrderPreviewViewModel: ObservableObject {
             applyQuote(freshQuote)
 
             let execution = try resolveExecutionData(from: freshQuote)
-            let tx = try await submitDashTransaction(using: execution)
-            setSubmittedTransaction(tx, depositAddress: execution.vaultAddress)
+            let txidWire = try await submitDashTransaction(using: execution)
+            setSubmittedSwap(txidWire: txidWire, depositAddress: execution.vaultAddress)
         } catch {
             if case .some(.previousSwapPending) = error as? DashSpendError {
                 pendingSwapAlertMessage = error.localizedDescription
@@ -449,31 +445,27 @@ final class OrderPreviewViewModel: ObservableObject {
         }
     }
 
-    private func mayaFieldError(_ message: String) -> Error {
-        NSError(domain: "Maya", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
+    private func swapFieldError(_ message: String) -> Error {
+        NSError(domain: "DashDEX", code: 0, userInfo: [NSLocalizedDescriptionKey: message])
     }
 
     private func resolveExecutionData(from quote: SwapQuoteResult) throws -> SwapExecutionData {
         guard let vaultAddress = quote.inboundAddress, !vaultAddress.isEmpty else {
-            throw mayaFieldError(NSLocalizedString("Vault address is missing. Please refresh and try again.", comment: "Dash DEX"))
+            throw swapFieldError(NSLocalizedString("Deposit address is missing. Please refresh and try again.", comment: "Dash DEX"))
         }
 
-        let memo: String?
-        if let quoteMemo = quote.memo, !quoteMemo.isEmpty {
-            memo = quoteMemo
-        } else if swapProvider.buildsSwapKitDeposit {
-            let shortAsset = coin.swapAsset.uppercased().components(separatedBy: "-").first
-                ?? coin.swapAsset.uppercased()
-            memo = "=:\(shortAsset):\(address)"
-        } else {
-            throw mayaFieldError(NSLocalizedString("Swap memo is missing. Please refresh and try again.", comment: "Dash DEX"))
+        // Safety net: the deposit is a plain send with NO OP_RETURN (SwiftDashSDK can't build
+        // one). A memo-bearing quote (e.g. a MAYACHAIN route) would need that memo encoded
+        // on-chain — sending memo-less would silently orphan the funds at the vault. Refuse it
+        // here, provider-agnostically, so no swap can ever be submitted without its required memo.
+        if let memo = quote.memo, !memo.isEmpty {
+            throw swapFieldError(NSLocalizedString("This coin isn’t available for swapping right now.", comment: "Dash DEX"))
         }
 
         let resolvedExecutionNetwork = quote.executionNetwork?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return SwapExecutionData(
             vaultAddress: vaultAddress,
-            memo: memo,
             executionNetwork: {
                 if let resolvedExecutionNetwork, !resolvedExecutionNetwork.isEmpty {
                     return resolvedExecutionNetwork
@@ -483,23 +475,13 @@ final class OrderPreviewViewModel: ObservableObject {
         )
     }
 
-    private func submitDashTransaction(using execution: SwapExecutionData) async throws -> DSTransaction {
-        if swapProvider.buildsSwapKitDeposit {
-            return try await sendCoinsService.sendSwapKitSwap(
-                depositAddress: execution.vaultAddress,
-                dashAmount: UInt64(dashSatoshis),
-                memo: execution.memo
-            )
-        } else {
-            guard let memo = execution.memo, !memo.isEmpty else {
-                throw mayaFieldError(NSLocalizedString("Swap memo is missing. Please refresh and try again.", comment: "Dash DEX"))
-            }
-            return try await sendCoinsService.sendMayaSwap(
-                vaultAddress: execution.vaultAddress,
-                dashAmount: UInt64(dashSatoshis),
-                memo: memo
-            )
-        }
+    /// Broadcasts the DASH deposit and returns its wire-order txid. DashDEX routes are memo-less
+    /// (NEAR intents), so this is a plain send built by SwiftDashSDK — no OP_RETURN output.
+    private func submitDashTransaction(using execution: SwapExecutionData) async throws -> Data {
+        try await sendCoinsService.sendSwapKitSwap(
+            depositAddress: execution.vaultAddress,
+            dashAmount: UInt64(dashSatoshis)
+        )
     }
 
     // MARK: - Private: State Mutation
@@ -514,25 +496,23 @@ final class OrderPreviewViewModel: ObservableObject {
         SwapKitErrorCopy.message(for: message, coin: coin)
     }
 
-    private func setSubmittedTransaction(_ tx: DSTransaction, depositAddress: String) {
-        submittedTransaction = tx
-        submittedTxId = tx.txHashHexString
+    private func setSubmittedSwap(txidWire: Data, depositAddress: String) {
+        let txidHex = Transaction.displayHex(txidWire)
+        submittedTxidWire = txidWire
+        submittedTxId = txidHex
         lastDepositAddress = depositAddress
         swapStatus = .pendingConfirmation
-        saveSwapOrder(tx: tx, depositAddress: depositAddress)
-        startObservingISLock(txid: tx.txHashHexString)
-        if Self.successTrigger == .onDashConfirmation {
-            startObservingDashConfirmation(tx: tx)
-        }
-        startObservingDAO(orderId: tx.txHashHexString)
+        saveSwapOrder(txidHex: txidHex, depositAddress: depositAddress)
+        startObservingISLock(txidWire: txidWire)
+        startObservingDAO(orderId: txidHex)
     }
 
     // MARK: - Private: Swap order persistence
 
-    private func saveSwapOrder(tx: DSTransaction, depositAddress: String) {
+    private func saveSwapOrder(txidHex: String, depositAddress: String) {
         let service = swapProvider is MayaSwapProvider ? "maya" : "swapkit"
         let order = SwapOrder(
-            id: tx.txHashHexString,
+            id: txidHex,
             direction: "sell",
             service: service,
             provider: resolvedExecutionNetwork,
@@ -550,101 +530,56 @@ final class OrderPreviewViewModel: ObservableObject {
 
     // MARK: - Private: IS-Lock Observation
 
-    private func startObservingISLock(txid: String) {
+    /// Observes the broadcast deposit's InstantSend lock via SwiftDashSDK. The Rust persister
+    /// updates the tx's context byte (0=mempool → 1=instantSend) and saves, which fires
+    /// `NSManagedObjectContextDidSave` — the same signal `HomeViewModel` refreshes on. On each
+    /// save we re-read the tx's `state`; `.ok` means context >= 1 (InstantSend-locked or
+    /// better). No `DS*` notifications and no `DSTransaction` are involved.
+    private func startObservingISLock(txidWire: Data) {
+        // Fast path: already locked (e.g. re-entry after a quick lock).
+        if handleISLockIfLocked(txidWire: txidWire) { return }
+
         isLockCancellable = NotificationCenter.default
-            .publisher(for: .DSTransactionManagerTransactionStatusDidChange)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] notification in
-                guard let self else { return }
-
-                guard
-                    let userInfo = notification.userInfo,
-                    let tx = userInfo[DSTransactionManagerNotificationTransactionKey] as? DSTransaction,
-                    tx.txHashHexString == txid
-                else { return }
-
-                guard
-                    let changes = userInfo[DSTransactionManagerNotificationTransactionChangesKey] as? [String: Any],
-                    changes[DSTransactionManagerNotificationInstantSendTransactionLockKey] != nil
-                else { return }
-
-                DSLogger.log("sendMayaSwap IS-lock received for \(txid)")
-
-                switch Self.successTrigger {
-                case .onISLock:
-                    switch self.swapStatus {
-                    case .pendingConfirmation, .processingSwap:
-                        // IS-lock is the user-facing success point for this trigger.
-                        // DAO/tracking stays background-only and must not block Done.
-                        self.swapStatus = .completed(outHashes: [])
-                    default:
-                        break
-                    }
-                case .onObserved, .onDone, .onDashConfirmation:
-                    if case .pendingConfirmation = self.swapStatus {
-                        // IS-lock alone is NOT success here — it only advances the UI to
-                        // "processing". Success requires a block confirmation (or, for the
-                        // other triggers, their own backend condition).
-                        self.swapStatus = .processingSwap
-                    }
-                }
-
-                self.isLockCancellable = nil  // one-shot
-            }
-    }
-
-    // MARK: - Private: Dash Confirmation Observation
-
-    /// Observes the broadcast Dash transaction locally and shows success once it reaches
-    /// its first block confirmation. Uses DashSync state/notifications only — no external
-    /// explorer. The transaction-status notification fires on every block/mempool sync
-    /// update (sometimes without a transaction payload), so each firing simply re-reads the
-    /// tracked tx's confirmation count.
-    private func startObservingDashConfirmation(tx: DSTransaction) {
-        // Fast path: already confirmed (e.g. re-entry after a quick block).
-        if completeIfConfirmed(tx: tx) { return }
-
-        confirmationCancellable = NotificationCenter.default
-            .publisher(for: .DSTransactionManagerTransactionStatusDidChange)
+            .publisher(for: .NSManagedObjectContextDidSave)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.completeIfConfirmed(tx: tx)
+                _ = self?.handleISLockIfLocked(txidWire: txidWire)
             }
     }
 
-    /// Flips `swapStatus` to `.completed` when `tx` has >= 1 confirmation.
-    /// Never regresses a terminal user-facing state. Returns true once terminal so the
-    /// caller can stop observing.
+    /// Advances `swapStatus` once the deposit tx is InstantSend-locked (SDK `state == .ok`).
+    /// Returns true once locked so the caller can stop observing. Never regresses a terminal state.
     @discardableResult
-    private func completeIfConfirmed(tx: DSTransaction) -> Bool {
-        switch swapStatus {
-        case .completed, .failed:
-            confirmationCancellable?.cancel()
-            confirmationCancellable = nil
-            return true
-        default:
-            break
+    private func handleISLockIfLocked(txidWire: Data) -> Bool {
+        guard let tx = SwiftDashSDKWalletSource.fetch(txid: txidWire), tx.state == .ok else {
+            return false
         }
 
-        let confirmations = Self.confirmations(for: tx)
-        guard confirmations >= 1 else { return false }
+        DSLogger.log("DashDEX: IS-lock observed for \(Transaction.displayHex(txidWire))")
 
-        DSLogger.log("Maya: Dash tx \(tx.txHashHexString) confirmed in block "
-            + "(blockHeight=\(tx.blockHeight), confirmations=\(confirmations)) — showing success")
-        swapStatus = .completed(outHashes: [])
-        confirmationCancellable?.cancel()
-        confirmationCancellable = nil
+        switch Self.successTrigger {
+        case .onISLock, .onDashConfirmation:
+            // context >= 1 (InstantSend-locked) is the on-chain finality signal under
+            // SwiftDashSDK. DAO/tracking stays background-only and must not block Done.
+            // TODO(swap-sdk-confirmation): a strict ".onDashConfirmation" (>= 1 block) would need
+            // an SDK accessor for context >= 2 (inBlock); today `Transaction.state` only exposes
+            // context == 0 vs >= 1, and IS-lock is a stronger finality signal than a single block.
+            switch swapStatus {
+            case .pendingConfirmation, .processingSwap:
+                swapStatus = .completed(outHashes: [])
+            default:
+                break
+            }
+        case .onObserved, .onDone:
+            if case .pendingConfirmation = swapStatus {
+                // IS-lock alone is NOT success here — it only advances the UI to "processing".
+                // Success requires the backend condition, surfaced via the DAO observer.
+                swapStatus = .processingSwap
+            }
+        }
+
+        isLockCancellable = nil  // one-shot
         return true
-    }
-
-    /// Number of block confirmations for `tx` against the current chain tip.
-    /// Returns 0 while the tx is still in the mempool (`blockHeight == TX_UNCONFIRMED`).
-    /// Mirrors the calculation in `Transaction.swift`.
-    private static func confirmations(for tx: DSTransaction) -> Int {
-        let lastHeight = DWEnvironment.sharedInstance().currentChain.lastTerminalBlockHeight
-        let txHeight = tx.blockHeight
-        guard txHeight != UInt32(TX_UNCONFIRMED), txHeight <= lastHeight else { return 0 }
-        return Int(lastHeight - txHeight) + 1
     }
 
     // MARK: - Private: DAO observation (replaces the in-memory 30-min polling loop)
@@ -746,10 +681,10 @@ final class OrderPreviewViewModel: ObservableObject {
 
         let firstQuote = try await fetchFreshQuote(dashSatoshis: dashSatoshis)
         if let apiError = firstQuote.error {
-            throw mayaFieldError(apiError)
+            throw swapFieldError(apiError)
         }
         guard let firstPoint = makeQuotePoint(dashSatoshis: dashSatoshis, quote: firstQuote) else {
-            throw mayaFieldError(NSLocalizedString("Unable to refresh quote. Please try again.", comment: "Swap"))
+            throw swapFieldError(NSLocalizedString("Unable to refresh quote. Please try again.", comment: "Swap"))
         }
         points.append(firstPoint)
 
@@ -856,7 +791,9 @@ final class OrderPreviewViewModel: ObservableObject {
     }
 
     private var dashBalance: Int64 {
-        Int64(DWEnvironment.sharedInstance().currentAccount.balance)
+        // Cap swaps at the SDK's max-sendable balance (spendable minus the send fee reserve);
+        // the frozen DashSync account balance reads stale/zero post-migration.
+        Int64(SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0)
     }
 
     // MARK: - Private: Formatting

--- a/DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinViewModel.swift
@@ -200,7 +200,9 @@ class SelectCoinViewModel: ObservableObject {
     }
 
     private func normalizedNetworkLabels(_ labels: [String: String]) -> [String: String] {
-        guard direction == .buy else { return labels }
+        // Both Buy and Sell now route exclusively through NEAR intents (mayaOnly coins are
+        // hidden and the quote layer forces NEAR), so a "Multiple networks" label is never
+        // accurate — a both-routable coin effectively resolves to a single provider (NEAR).
         return labels.mapValues { $0 == RouteProvider.multiple.shortLabel ? RouteProvider.near.shortLabel : $0 }
     }
 

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -118,6 +118,71 @@ class TxDetailModel: NSObject {
         UIPasteboard.general.string = transactionId
         return true
     }
+
+    // MARK: - Dash DEX (swap) explorer
+
+    /// A "View NEAR/Maya Explorer" action for a transaction that belongs to a Dash DEX swap.
+    struct SwapExplorerLink {
+        let title: String
+        let url: URL
+    }
+
+    /// Resolved on demand (see `resolveSwapExplorerLink`); nil until resolved or when this
+    /// transaction is not part of a swap order.
+    private(set) var swapExplorerLink: SwapExplorerLink?
+
+    /// Looks up whether this transaction is the on-chain leg of a stored swap order and, if so,
+    /// builds the provider explorer link. Runs off the main actor (DAO reads), then calls
+    /// `completion` on the main actor so the caller can rebuild its rows.
+    func resolveSwapExplorerLink(completion: @escaping () -> Void) {
+        let transaction = self.transaction
+        let transactionId = self.transactionId
+        Task {
+            let link = await Self.swapExplorerLink(transaction: transaction, transactionId: transactionId)
+            await MainActor.run {
+                self.swapExplorerLink = link
+                completion()
+            }
+        }
+    }
+
+    private static func swapExplorerLink(transaction: Transaction, transactionId: String) async -> SwapExplorerLink? {
+        let dao = SwapOrdersDAOImpl.shared
+
+        // Sell: the swap order id IS the Dash deposit tx id (display-order hex == transactionId).
+        if let order = await dao.get(byId: transactionId), order.direction == "sell" {
+            return link(for: order, dashTxId: transactionId)
+        }
+
+        // Buy: the incoming Dash tx is matched to a buy order by address + amount + time.
+        let orders = await dao.all()
+        if let order = orders.first(where: { candidate in
+            candidate.direction == "buy"
+                && SwapBuyTransactionMatcher.matchedTransaction(for: candidate, in: [transaction]) != nil
+        }) {
+            return link(for: order, dashTxId: transactionId)
+        }
+
+        return nil
+    }
+
+    private static func link(for order: SwapOrder, dashTxId: String) -> SwapExplorerLink? {
+        let provider = order.provider?.lowercased() ?? ""
+
+        // Maya-routed legacy orders (retired for new swaps) link to the Maya explorer by Dash txid.
+        if provider.contains("maya") || order.service == "maya" {
+            return SwapExplorerLink(
+                title: NSLocalizedString("View Maya Explorer", comment: "Dash DEX / tx details action"),
+                url: MayaConstants.mayaScanTransactionURL(txHash: dashTxId.uppercased()))
+        }
+
+        // NEAR intents: tracked by the deposit address, not the Dash txid.
+        let title = NSLocalizedString("View NEAR Explorer", comment: "Dash DEX / tx details action")
+        if let deposit = order.depositAddress?.trimmingCharacters(in: .whitespacesAndNewlines), !deposit.isEmpty {
+            return SwapExplorerLink(title: title, url: NearConstants.explorerTransactionURL(depositAddress: deposit))
+        }
+        return SwapExplorerLink(title: title, url: NearConstants.explorerHomeURL)
+    }
 }
 
 extension TxDetailModel {

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -114,6 +114,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case taxCategory
         case rawTransaction
         case explorer
+        case swapExplorer
     }
 
     enum Item: Hashable {
@@ -130,6 +131,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case viewTransaction
         case copyRawTransaction
         case explorer
+        case swapExplorer(String)
 
         /// Per-case identity strings — the diffable-identifier content. The
         /// leading case tag keeps two different cases with identical (notably
@@ -151,6 +153,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
             case .viewTransaction: return ["ViewTransaction"]
             case .copyRawTransaction: return ["CopyRawTransaction"]
             case .explorer: return ["Explorer"]
+            case .swapExplorer(let title): return ["SwapExplorer", title]
             }
         }
 
@@ -192,6 +195,12 @@ class TXDetailViewController: BaseTxDetailsViewController {
 
         configureDataSource()
         reloadDataSource()
+
+        // Dash DEX swap legs get an extra "View NEAR/Maya Explorer" action; the order lookup
+        // is async (DAO reads), so resolve then rebuild the rows when it lands.
+        model.resolveSwapExplorerLink { [weak self] in
+            self?.reloadDataSource()
+        }
     }
 }
 
@@ -220,6 +229,15 @@ extension TXDetailViewController {
         let hostingController = UIHostingController(rootView: swiftUIView)
         hostingController.setDetent(240)
         present(hostingController, animated: true, completion: nil)
+    }
+
+    /// Opens the Dash DEX (NEAR/Maya) explorer for a swap transaction in an in-app browser.
+    private func openSwapExplorer() {
+        guard let link = model.swapExplorerLink else { return }
+        let vc = SFSafariViewController.dw_controller(with: link.url)
+        vc.modalPresentationStyle = .overFullScreen
+        vc.modalPresentationCapturesStatusBarAppearance = true
+        present(vc, animated: true)
     }
 
     /// Full consensus-field inspector for this transaction's stored raw bytes.
@@ -293,6 +311,14 @@ extension TXDetailViewController {
                                                              for: indexPath) as! TxDetailActionCell
                     cell.titleLabel.text = NSLocalizedString("View in Block Explorer", comment: "")
                     return cell
+
+                case .swapExplorer:
+                    let cell = tableView.dequeueReusableCell(withIdentifier: TxDetailActionCell.reuseIdentifier,
+                                                             for: indexPath) as! TxDetailActionCell
+                    if case .swapExplorer(let title) = item {
+                        cell.titleLabel.text = title
+                    }
+                    return cell
                 }
         }
     }
@@ -352,6 +378,10 @@ extension TXDetailViewController {
         currentSnapshot.appendItems([.taxCategory(taxCategory)], toSection: .taxCategory)
         currentSnapshot.appendItems([.viewTransaction, .copyRawTransaction], toSection: .rawTransaction)
         currentSnapshot.appendItems([.explorer], toSection: .explorer)
+        if let swapLink = model.swapExplorerLink {
+            currentSnapshot.appendSections([.swapExplorer])
+            currentSnapshot.appendItems([.swapExplorer(swapLink.title)], toSection: .swapExplorer)
+        }
         dataSource.apply(currentSnapshot, animatingDifferences: false)
         dataSource.defaultRowAnimation = .none
     }
@@ -380,6 +410,8 @@ extension TXDetailViewController {
             }
         case .explorer:
             viewInBlockExplorer()
+        case .swapExplorer:
+            openSwapExplorer()
         default:
             break
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Dash DEX (SwapKit swaps) was withheld for the SwiftDashSDK migration: its swap path built an **OP_RETURN memo transaction through frozen DashSync**, which SwiftDashSDK cannot express, and its balance/address/tx reads all went through the now-frozen DashSync wallet. This restores Dash DEX **without OP_RETURN** and moves the whole flow onto SwiftDashSDK.

## What was done?
Restored the flow memo-less by dropping the routes that need OP_RETURN and running everything on the SDK:

- **Memo-less SDK send.** Force NEAR-intents routing on Sell quotes so the DASH deposit is a plain, memo-less send; hide MAYACHAIN-only coins in the picker and reject any residual memo-bearing quote as a fund-loss safety net. `SendCoinsService` reduced to one memo-less deposit send via `WalletSendService` (returns the wire-order txid; all OP_RETURN / `DSTransaction` builders removed).
- **Off DashSync.** IS-lock gate + OrderPreview observation re-plumbed from `DS*` notifications onto `NSManagedObjectContextDidSave` + `SwiftDashSDKWalletSource`. Balance / receive-address reads moved to SwiftDashSDK. Buy `SwapBuyTransactionMatcher` migrated to the app `Transaction` model; tracking + metadata read `SwiftDashSDKWalletSource.fetchAll()`. Swap-row metadata refreshes on `SwiftDashSDKWalletState.balanceDidChange` (the legacy `DSWalletBalanceDidChange` is frozen). **Zero DashSync reads remain in the swap flow.**
- **Entry points.** Lifted the three withhold gates (Buy & Sell card, customizable shortcut, saved-shortcut degrade), keeping Dash DEX **mainnet-only** (real assets) and consistently gated on `!isTestnet && SwapKitConstants.isConfigured`.
- **Fixes.** Start `SwapTrackingService` at launch (the AppDelegate call was missing → statuses never advanced → completed swaps stuck at "Pending"); normalize the "Multiple networks" coin label to NEAR; add a "View NEAR/Maya Explorer" action to transaction details for swap legs; fail fast on an unavailable wallet source address instead of substituting `""`.

## How Has This Been Tested?
- Clean `dashpay` build on iOS Simulator (`ARCHS=arm64`), the working scheme for this branch.
- On-device manual testing on **mainnet**: Buy (crypto→DASH) and Sell (DASH→crypto) swaps end-to-end; verified the "Converted · A/B" history rows, status advancing off "Pending", and the NEAR explorer link in transaction details.
- The unit-test target is currently broken on this branch (pre-existing), so no new automated tests were added.

## Breaking Changes
None. Dash DEX stays mainnet-only and off by default on testnet; no public API or on-chain format changes for existing transactions.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone