### PR TITLE
feat(ui): parse DashSpend amount locale-agnostically so comma decimals aren't dropped

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFlexibleContent.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendFlexibleContent.swift
@@ -179,7 +179,10 @@ struct DashSpendFlexibleContent: View {
                             if newValue == .single {
                                 // Restore single-mode amount-driven validation after returning
                                 // from multiple mode where total is derived from quantities.
-                                viewModel.updateTotalAmount(viewModel.input.decimal() ?? 0)
+                                // Region-agnostic parse: `input.decimal()` (nil-locale
+                                // `Decimal(string:)`) truncates "5,5" to 5 on comma-decimal
+                                // locales, dropping the fraction.
+                                viewModel.updateTotalAmount(PastedAmountParser.parse(viewModel.input, locale: .current)?.decimalValue ?? viewModel.amount)
                             }
                         }
                     ),

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
@@ -191,7 +191,11 @@ struct DashSpendPayScreen: View {
         if !viewModel.isUserSignedIn { showSignInError(); return }
         let snapshotQuantities = quantities.filter { $0.value > 0 }
         let snapshotTotal = snapshotQuantities.reduce(Decimal(0)) { $0 + $1.key * Decimal($1.value) }
-        let snapshotSingleAmount = viewModel.input.decimal() ?? viewModel.amount
+        // `input.decimal()` is `Decimal(string:locale:)` with a nil locale, which only
+        // understands "." as the decimal mark — on a comma-decimal locale it truncates
+        // "5,5" to 5, silently dropping the fraction. Use the same region-agnostic parser
+        // the view model already feeds `amount` from so both agree.
+        let snapshotSingleAmount = PastedAmountParser.parse(viewModel.input, locale: .current)?.decimalValue ?? viewModel.amount
 
         confirmationQuantities = snapshotQuantities
         confirmationOriginalPrice = snapshotQuantities.isEmpty ? snapshotSingleAmount : snapshotTotal


### PR DESCRIPTION
## Issue being fixed or feature implemented
On a comma-decimal locale (e.g. UK/most of Europe, device shows `11,83 US$`), entering a fractional DashSpend gift-card amount such as `5.5` or `5.9` silently drops the fraction and buys `5`.

Root cause: the flexible-amount confirmation (`DashSpendPayScreen.handlePayAction`) and the single/multiple segment toggle (`DashSpendFlexibleContent`) read the typed amount via `String.decimal()`, which is `Decimal(string:locale:)` with a `nil` locale. That only recognizes `.` as the decimal mark, so on a comma locale the input string `"5,5"` parses only up to the comma and returns `5`. The `?? viewModel.amount` fallback never fires because the naive parse returns a (wrong) non-nil value, so the correct `viewModel.amount` (5.5, already computed via the region-agnostic parser) is discarded.

## What was done?
Routed both call sites through `PastedAmountParser.parse(_:locale:)` — the same region-agnostic parser the view model already feeds `amount` from (a single `.` or `,` is always the decimal separator). Now every code path agrees on the entered amount regardless of device locale.

## How Has This Been Tested?
Root-caused from code: `Decimal(string: "5,5", locale: nil) == 5`, and the input string carries the locale separator (the view model validates the fractional part against `Locale.current.decimalSeparator`). Fix verified by inspection against the shared parser's behavior. Not yet run through a device build — recommend a testnet smoke on a comma-decimal locale: enter `5.5`/`5.9` for a flexible gift-card amount and confirm the fraction is preserved at the confirmation screen; regression-check a `.`-decimal locale still works.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone