### PR TITLE
feat(wallet): block core sends while the device is offline

### DIFF
--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -60,6 +60,10 @@ final class PreparedStandardSend: NSObject {
 
     @objc(broadcastAndReturnError:)
     func broadcast() throws {
+        // Catches airplane mode toggled on the confirm sheet after the tx was
+        // prepared: without this the offline broadcast is silently accepted.
+        try WalletSendService.ensureOnline()
+
         claimLock.lock()
         guard !broadcastClaimed else {
             claimLock.unlock()
@@ -164,6 +168,23 @@ final class WalletSendService: NSObject {
         }
     }
 
+    /// Blocks a send when the device is offline. The SDK's broadcast accepts a
+    /// tx offline (queuing it to send on reconnect) without throwing, so a send
+    /// confirmed after airplane mode was enabled would silently "succeed" with
+    /// no feedback — and a user who assumes it failed could retry into a
+    /// double-spend. Fail loudly instead. Only blocks when the reachability
+    /// monitor is live and reports offline; if monitoring hasn't started, falls
+    /// through (fail-open) rather than block a send on an unknown signal.
+    static func ensureOnline() throws {
+        if NetworkReachability.shared.isMonitoring, !NetworkReachability.shared.isReachable {
+            throw Self.makeError(
+                code: .offline,
+                description: NSLocalizedString(
+                    "No internet connection. Reconnect to the network and try again.",
+                    comment: "Send blocked while the device is offline"))
+        }
+    }
+
     func prepareStandardSendForConfirmation(address: String, amount: UInt64, sessionAuthSufficient: Bool = false) async throws -> PreparedStandardSend {
         Self.logger.info("💸 TXSEND :: preparing standard send")
         try Self.ensureChainSynced()
@@ -183,6 +204,9 @@ final class WalletSendService: NSObject {
         sessionAuthSufficient: Bool = false
     ) async throws -> Data {
         try Self.ensureChainSynced()
+        // Also covers the selected-input path below, whose `buildAndSignFromAddress`
+        // broadcasts internally and never reaches `PreparedStandardSend.broadcast()`.
+        try Self.ensureOnline()
         if let inputSelector {
             Self.logger.info("💸 TXSEND :: routing to selected-input (SwiftDashSDK) path")
             try await sendAuthorizer.authorizeSend(spendAmount: amount, sessionAuthSufficient: sessionAuthSufficient)
@@ -490,6 +514,7 @@ private extension WalletSendService {
         case alreadyBroadcast = 5
         case dashPayPaymentUnavailable = 6
         case chainNotSynced = 7
+        case offline = 8
     }
 
     static let errorDomain = "org.dashfoundation.dash.wallet-send-service"


### PR DESCRIPTION
## Issue being fixed or feature implemented
A core send confirmed while the device is offline is silently accepted with no feedback. Repro: start a send, authenticate, and on the confirm sheet enable airplane mode, then tap Confirm — nothing visible happens; the transaction only broadcasts once connectivity returns.

Root cause: the SDK's broadcast accepts a transaction offline (queuing it to send on reconnect) without throwing, and the send path had no reachability check — only `ensureChainSynced()`, which gates on sync state, not connectivity (a wallet that reached `.syncDone` before airplane mode stays `.syncDone`). With no error thrown, the UI has nothing to report. Beyond the missing feedback, a user who assumes the send failed can retry into a double-spend.

## What was done?
Added a shared `WalletSendService.ensureOnline()` gate (mirroring the existing `ensureChainSynced()`) and called it from both send paths:
- `PreparedStandardSend.broadcast()` — the interactive confirm-sheet path (the reported repro).
- `send()` right after the sync gate — covers the selected-input/sweep path, whose `buildAndSignFromAddress` broadcasts internally and never reaches `broadcast()`.

It only blocks when the reachability monitor is live and reports offline (`isMonitoring && !isReachable`); if monitoring hasn't started it falls through (fail-open) rather than block a send on an unknown signal. Reuses the existing `NetworkReachability` (NWPathMonitor) already started at app launch.

## How Has This Been Tested?
Not yet run through a device build (Xcode was open on the project; CLI build skipped to avoid a build.db collision). Recommended testnet smoke: start a core send, authenticate, enable airplane mode on the confirm sheet, tap Confirm — expect a clear "No internet connection" error and no queued/silent broadcast; then disable airplane mode and confirm no phantom/duplicate transaction. Regression-check a normal online send still works.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone