### PR TITLE
fix(wallet): correct network-switched explore.db, merchant logo placeholder, and test-merchant re-seed

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -731,6 +731,8 @@
 		7566F4842BB6949E005238D2 /* ToolsMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */; };
 		7566F48A2BB6CAF2005238D2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4892BB6CAF2005238D2 /* MenuItem.swift */; };
 		7566F48B2BB6CAF2005238D2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4892BB6CAF2005238D2 /* MenuItem.swift */; };
+		5E1C0A0100000000000000F2 /* MerchantLogoPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */; };
+		5E1C0A0100000000000000F3 /* MerchantLogoPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */; };
 		7569D6832DE6DA6800768BFF /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7569D6822DE6DA6800768BFF /* ExploreViewController.swift */; };
 		7569D6842DE6DA6800768BFF /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7569D6822DE6DA6800768BFF /* ExploreViewController.swift */; };
 		7569D6862DE6DB2200768BFF /* ExploreHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7569D6852DE6DB1B00768BFF /* ExploreHeaderView.swift */; };
@@ -2882,6 +2884,7 @@
 		756557B42CE84FF70060348D /* FeeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeInfo.swift; sourceTree = "<group>"; };
 		7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsMenuScreen.swift; sourceTree = "<group>"; };
 		7566F4892BB6CAF2005238D2 /* MenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
+		5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantLogoPlaceholder.swift; sourceTree = "<group>"; };
 		7569D6822DE6DA6800768BFF /* ExploreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewController.swift; sourceTree = "<group>"; };
 		7569D6852DE6DB1B00768BFF /* ExploreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreHeaderView.swift; sourceTree = "<group>"; };
 		7569D6882DE6DB6700768BFF /* ExploreContentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreContentsView.swift; sourceTree = "<group>"; };
@@ -6768,6 +6771,7 @@
 				75EBAA082BB9791B004488E3 /* Icon.swift */,
 				AA0031012FD0000000000011 /* IconName+DashIconSource.swift */,
 				7566F4892BB6CAF2005238D2 /* MenuItem.swift */,
+				5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */,
 				75EBAA0B2BB9792F004488E3 /* FeatureTopText.swift */,
 				754C27CB2CC3C14F00BA7B9F /* FeatureSingleItem.swift */,
 				75EBAA0E2BB99036004488E3 /* TextIntro.swift */,
@@ -9942,6 +9946,7 @@
 				7503643A2C89CFB70029EC0D /* CoinJoinProgressView.swift in Sources */,
 				47A2A2E9293E612900938DB7 /* CBAuth.swift in Sources */,
 				7566F48A2BB6CAF2005238D2 /* MenuItem.swift in Sources */,
+				5E1C0A0100000000000000F2 /* MerchantLogoPlaceholder.swift in Sources */,
 				0F6EDFD128C896BD000427E7 /* CoinbaseCreateAddressesRequest.swift in Sources */,
 				2A10EB352358996700C38B61 /* DWImportWalletInfoViewController.m in Sources */,
 				C9F451EE2A0BF1F500825057 /* SyncingAlertContentView.swift in Sources */,
@@ -10463,6 +10468,7 @@
 				C943B32F2A408CED00AF23C5 /* DWSaveAlertViewController.m in Sources */,
 				C930784C2A6AD59700906E4B /* TitleValueCell.swift in Sources */,
 				7566F48B2BB6CAF2005238D2 /* MenuItem.swift in Sources */,
+				5E1C0A0100000000000000F3 /* MerchantLogoPlaceholder.swift in Sources */,
 				C9D2C74F2A320AA000D15901 /* DWSeedPhraseRow.m in Sources */,
 				C943B5132A40A54600AF23C5 /* DWHistoryFilterContentView.m in Sources */,
 				C943B4BC2A40A54600AF23C5 /* DWRootContactsViewController.m in Sources */,

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -11529,7 +11529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -11669,7 +11669,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -11843,7 +11843,7 @@
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -11865,7 +11865,7 @@
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -11890,7 +11890,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -11917,7 +11917,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -11949,7 +11949,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -11978,7 +11978,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -12026,7 +12026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12159,7 +12159,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12302,7 +12302,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12443,7 +12443,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12646,7 +12646,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12759,7 +12759,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -12815,7 +12815,7 @@
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -12840,7 +12840,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -12957,7 +12957,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -13069,7 +13069,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -13124,7 +13124,7 @@
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -13149,7 +13149,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 8.6.1;
+				MARKETING_VERSION = 8.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
@@ -49,6 +49,13 @@ class ExploreDatabaseConnection {
 
             // Add test merchant after database sync for TestFlight builds
             #if DEBUG || Testflight
+            // The database was just replaced on disk (a version update, or a re-download
+            // forced by a mainnet/testnet switch), so the file may no longer contain the
+            // test merchants even though they were seeded earlier this session. Clear the
+            // once-per-session guard so seeding re-evaluates against the new file; the
+            // count check inside `addPiggyCardsTestMerchants` still avoids redundant
+            // trigger churn when they are already present.
+            self?.didInsertTestMerchants = false
             self?.addTestMerchantAfterSync()
             #endif
         }

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -61,12 +61,6 @@ public class ExploreDatabaseSyncManager {
     var syncState: State
     var lastServerUpdateDate: Date { Date(timeIntervalSince1970: exploreDatabaseLastVersion) }
 
-    // Network-specific name for the downloaded archive only — the database itself always unzips to
-    // the single `explore.db`, so see `installedDatabaseNetwork` for the mainnet/testnet conflict.
-    private var networkSpecificFileName: String {
-        return currentNetworkName == "mainnet" ? "explore-mainnet" : "explore-testnet"
-    }
-
     private var currentNetworkName: String {
         return DWEnvironment.sharedInstance().currentChain.isMainnet() ? "mainnet" : "testnet"
     }
@@ -106,8 +100,18 @@ public class ExploreDatabaseSyncManager {
     private func syncIfNeeded() {
         syncState = .fetchingInfo
 
-        storageRef.getMetadata { [weak self] metadata, _ in
+        // Snapshot the network and its storage reference for the whole operation. `storageRef`
+        // and `currentNetworkName` are computed from the live chain, so a switch between the
+        // metadata fetch, the data fetch and the marker save would otherwise mix one archive's
+        // timestamp/checksum with another's bytes, or record the marker for a network whose
+        // archive was never extracted. Everything below uses this snapshot, and each async hop
+        // bails if the chain has moved on — the switch already scheduled its own syncIfNeeded.
+        let syncNetwork = currentNetworkName
+        let syncStorageRef = storageRef
+
+        syncStorageRef.getMetadata { [weak self] metadata, _ in
             guard let wSelf = self else { return }
+            guard syncNetwork == wSelf.currentNetworkName else { return }
 
             guard let metadata else {
                 wSelf.syncState = .error(Date(), nil)
@@ -128,16 +132,16 @@ public class ExploreDatabaseSyncManager {
             // regardless of saved version timestamp to avoid falling back to in-memory DB.
             if !localDatabaseExists {
                 DSLogger.log("ExploreDash: local explore.db missing, forcing cloud database download")
-                wSelf.downloadDatabase(metadata: metadata)
+                wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
                 return
             }
 
             // The file on disk may belong to the other network (the chain was switched since it was
             // downloaded). Its version is tracked under that network's key, so the check below would
             // read as up to date and leave us serving the wrong network's merchants.
-            if wSelf.installedDatabaseNetwork != wSelf.currentNetworkName {
-                DSLogger.log("ExploreDash: explore.db belongs to \(wSelf.installedDatabaseNetwork ?? "an unknown network"), current network is \(wSelf.currentNetworkName) — forcing download")
-                wSelf.downloadDatabase(metadata: metadata)
+            if wSelf.installedDatabaseNetwork != syncNetwork {
+                DSLogger.log("ExploreDash: explore.db belongs to \(wSelf.installedDatabaseNetwork ?? "an unknown network"), current network is \(syncNetwork) — forcing download")
+                wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
                 return
             }
 
@@ -146,7 +150,7 @@ public class ExploreDatabaseSyncManager {
                 return
             }
 
-            wSelf.downloadDatabase(metadata: metadata)
+            wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
         }
     }
 
@@ -162,7 +166,7 @@ public class ExploreDatabaseSyncManager {
 }
 
 extension ExploreDatabaseSyncManager {
-    private func downloadDatabase(metadata: StorageMetadata) {
+    private func downloadDatabase(metadata: StorageMetadata, network: String, storageRef: StorageReference) {
         guard let timestamp = metadata.customMetadata?[timestampKey],
               let checksum = metadata.customMetadata?[checksumKey],
               let timeIntervalMillesecond = TimeInterval(timestamp) else {
@@ -171,8 +175,11 @@ extension ExploreDatabaseSyncManager {
         }
 
         syncState = .syncing
-        let urlToSave = getDocumentsDirectory().appendingPathComponent("\(networkSpecificFileName)-\(timestamp).zip")
+        let fileName = network == "mainnet" ? "explore-mainnet" : "explore-testnet"
+        let urlToSave = getDocumentsDirectory().appendingPathComponent("\(fileName)-\(timestamp).zip")
 
+        // The same snapshot's reference the metadata came from, so timestamp/checksum and bytes
+        // always describe one archive.
         storageRef.getData(maxSize: metadata.size) { [weak self] data, error in
             let date = Date()
             let now = date.timeIntervalSince1970
@@ -181,13 +188,22 @@ extension ExploreDatabaseSyncManager {
                 self?.syncState = .error(date, e)
             } else {
                 try? data?.write(to: urlToSave)
-                
+
                 Task {
                     do {
+                        // The chain may have switched while the archive downloaded. Unzipping now
+                        // would overwrite explore.db with the wrong network's data and save a
+                        // marker that hides the mismatch; the switch already scheduled a fresh
+                        // sync, so drop this one instead.
+                        guard network == self?.currentNetworkName else {
+                            try? FileManager.default.removeItem(at: URL(fileURLWithPath: urlToSave.path))
+                            return
+                        }
+
                         try await self?.unzipFile(at: urlToSave.path, password: checksum)
                         self?.exploreDatabaseLastSyncTimestamp = now
                         self?.exploreDatabaseLastVersion = timeIntervalMillesecond / 1000
-                        self?.installedDatabaseNetwork = self?.currentNetworkName
+                        self?.installedDatabaseNetwork = network
                         self?.syncState = .synced(date)
 
                         NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -42,7 +42,16 @@ public class ExploreDatabaseSyncManager {
     static let databaseHasBeenUpdatedNotification = NSNotification.Name(rawValue: "databaseHasBeenUpdatedNotification")
 
     private let storage = Storage.storage()
-    private let storageRef: StorageReference
+
+    // Computed per access so a mainnet/testnet switch always targets the current network's archive.
+    // Caching this in `init()` meant the singleton kept downloading the launch-network's database
+    // after a chain switch, so the wrong network's merchants stayed on disk.
+    private var storageRef: StorageReference {
+        let databasePath = currentNetworkName == "mainnet"
+            ? "gs://dash-wallet-firebase.appspot.com/explore/explore-v4.db"
+            : "gs://dash-wallet-firebase.appspot.com/explore/explore-v4-testnet.db"
+        return storage.reference(forURL: databasePath)
+    }
 
     private var timer: Timer!
 
@@ -72,17 +81,6 @@ public class ExploreDatabaseSyncManager {
 
     init() {
         syncState = .inititialing
-
-        // Initialize storageRef with computed database path
-        let databasePath: String
-        let isMainnet = DWEnvironment.sharedInstance().currentChain.isMainnet()
-        if isMainnet {
-            databasePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v4.db"
-        } else {
-            databasePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v4-testnet.db"
-        }
-
-        storageRef = storage.reference(forURL: databasePath)
     }
 
     public func start() {

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -52,10 +52,22 @@ public class ExploreDatabaseSyncManager {
     var syncState: State
     var lastServerUpdateDate: Date { Date(timeIntervalSince1970: exploreDatabaseLastVersion) }
 
-    // Network-specific filename to prevent mainnet/testnet database conflicts
+    // Network-specific name for the downloaded archive only — the database itself always unzips to
+    // the single `explore.db`, so see `installedDatabaseNetwork` for the mainnet/testnet conflict.
     private var networkSpecificFileName: String {
-        let isMainnet = DWEnvironment.sharedInstance().currentChain.isMainnet()
-        return isMainnet ? "explore-mainnet" : "explore-testnet"
+        return currentNetworkName == "mainnet" ? "explore-mainnet" : "explore-testnet"
+    }
+
+    private var currentNetworkName: String {
+        return DWEnvironment.sharedInstance().currentChain.isMainnet() ? "mainnet" : "testnet"
+    }
+
+    /// The network whose data currently sits in `explore.db`. Both networks share that one file
+    /// while the sync bookkeeping (`versionKey`) is per-network, so after a chain switch the saved
+    /// version reads as up to date while the file on disk still holds the other network's merchants.
+    private var installedDatabaseNetwork: String? {
+        get { UserDefaults.standard.string(forKey: kExploreDatabaseInstalledNetworkKey) }
+        set { UserDefaults.standard.setValue(newValue, forKey: kExploreDatabaseInstalledNetworkKey) }
     }
 
     init() {
@@ -111,6 +123,15 @@ public class ExploreDatabaseSyncManager {
                 return
             }
 
+            // The file on disk may belong to the other network (the chain was switched since it was
+            // downloaded). Its version is tracked under that network's key, so the check below would
+            // read as up to date and leave us serving the wrong network's merchants.
+            if wSelf.installedDatabaseNetwork != wSelf.currentNetworkName {
+                DSLogger.log("ExploreDash: explore.db belongs to \(wSelf.installedDatabaseNetwork ?? "an unknown network"), current network is \(wSelf.currentNetworkName) — forcing download")
+                wSelf.downloadDatabase(metadata: metadata)
+                return
+            }
+
             guard timeInterval > installedVersion else {
                 wSelf.syncState = .synced(Date())
                 return
@@ -154,6 +175,7 @@ extension ExploreDatabaseSyncManager {
                         try await self?.unzipFile(at: urlToSave.path, password: checksum)
                         self?.exploreDatabaseLastSyncTimestamp = now
                         self?.exploreDatabaseLastVersion = timeIntervalMillesecond / 1000
+                        self?.installedDatabaseNetwork = self?.currentNetworkName
                         self?.syncState = .synced(date)
 
                         NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)
@@ -197,6 +219,7 @@ extension ExploreDatabaseSyncManager {
 
 private let kExploreDatabaseLastSyncTimestampKey = "kExploreDatabaseLastSyncTimestampKey"
 private let kExploreDatabaseLastVersion = "kExploreDatabaseLastVersion"
+private let kExploreDatabaseInstalledNetworkKey = "kExploreDatabaseInstalledNetwork"
 
 extension ExploreDatabaseSyncManager {
     // Network-specific UserDefaults keys

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -79,12 +79,23 @@ public class ExploreDatabaseSyncManager {
         set { UserDefaults.standard.setValue(newValue, forKey: kExploreDatabaseInstalledNetworkKey) }
     }
 
+    private var networkDidChangeObserver: NSObjectProtocol?
+
     init() {
         syncState = .inititialing
     }
 
     public func start() {
         syncIfNeeded()
+
+        // A chain switch at runtime otherwise goes unnoticed until the next launch: the
+        // version check only runs from here and the 24h timer. Re-run it on a network
+        // change so the installedDatabaseNetwork mismatch forces a same-session re-download.
+        networkDidChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.DWCurrentNetworkDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.syncIfNeeded()
+        }
 
         // Try to sync every 24h
         timer = Timer.scheduledTimer(withTimeInterval: 60*60*24, repeats: true) { [weak self] _ in
@@ -142,6 +153,9 @@ public class ExploreDatabaseSyncManager {
     deinit {
         timer.invalidate()
         timer = nil
+        if let networkDidChangeObserver {
+            NotificationCenter.default.removeObserver(networkDidChangeObserver)
+        }
     }
 
     static let share = ExploreDatabaseSyncManager()

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
@@ -119,9 +119,7 @@ struct POIDetailsView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                 } else {
-                    Image(merchant.emptyLogoImageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                    MerchantLogoPlaceholder(merchantName: merchant.title ?? "", usableFraction: 0.84)
                 }
             }
             .frame(width: 50, height: 50)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
@@ -137,10 +137,10 @@ private struct MerchantHeaderView: View {
         }
     }
 
+    // Rounded square, so the text may use almost the whole box — same fraction as the
+    // POI details header.
     private var emptyLogo: some View {
-        Image(pointOfUse.emptyLogoImageName)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
+        MerchantLogoPlaceholder(merchantName: pointOfUse.name, usableFraction: 0.84)
     }
 }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Cells/PointOfUseItemCell.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Cells/PointOfUseItemCell.swift
@@ -46,10 +46,13 @@ class PointOfUseItemCell: UITableViewCell {
     func update(with pointOfUse: ExplorePointOfUse) {
         nameLabel.text = pointOfUse.name
 
+        let logoPlaceholder = MerchantLogoPlaceholder.image(merchantName: pointOfUse.name,
+                                                            size: CGSize(width: 36, height: 36),
+                                                            cornerRadius: 8)
         if let urlString = pointOfUse.logoLocation, let url = URL(string: urlString) {
-            logoImageView.sd_setImage(with: url)
+            logoImageView.sd_setImage(with: url, placeholderImage: logoPlaceholder)
         } else {
-            logoImageView.image = UIImage(named: pointOfUse.emptyLogoImageName)
+            logoImageView.image = logoPlaceholder
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapAnnotationView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapAnnotationView.swift
@@ -64,10 +64,13 @@ final class ExploreMapAnnotationView: MKAnnotationView {
     }
 
     public func update(with pointOfUse: ExplorePointOfUse) {
+        let logoPlaceholder = MerchantLogoPlaceholder.image(merchantName: pointOfUse.name,
+                                                            size: CGSize(width: 36, height: 36),
+                                                            cornerRadius: 18)
         if let str = pointOfUse.logoLocation, let url = URL(string: str) {
-            imageView.sd_setImage(with: url, completed: nil)
+            imageView.sd_setImage(with: url, placeholderImage: logoPlaceholder, completed: nil)
         } else {
-            imageView.image = UIImage(named: pointOfUse.emptyLogoImageName)
+            imageView.image = logoPlaceholder
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
@@ -47,9 +47,9 @@ struct DashSpendPayIntro: View {
                 .scaledToFit()
                 .clipShape(Circle())
         } placeholder: {
-            // No icon yet (missing URL or still loading): show a grey circle of the same size.
-            Circle()
-                .fill(Color.gray300Alpha50)
+            // No icon yet (missing URL or still loading): show the generated name placeholder.
+            MerchantLogoPlaceholder(merchantName: merchantTitle)
+                .clipShape(Circle())
         }
         .frame(width: Layout.merchantIconSize, height: Layout.merchantIconSize)
     }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -86,13 +86,18 @@ struct DashSpendConfirmationDialog: View {
 
                     detailsRow(title: NSLocalizedString("To", comment: "DashSpend")) {
                         HStack(spacing: 8) {
-                            WebImage(url: URL(string: merchantIconUrl))
-                                .resizable()
-                                .placeholder { MerchantLogoPlaceholder(merchantName: merchantName) }
-                                .transition(.fade(duration: 0.3))
-                                .scaledToFit()
-                                .frame(width: 20, height: 20)
-                                .clipShape(RoundedRectangle(cornerRadius: 7))
+                            // The placeholder stands in while loading and on failure, so a
+                            // missing or broken icon URL still shows the merchant's initials.
+                            WebImage(url: URL(string: merchantIconUrl)) { image in
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                            } placeholder: {
+                                MerchantLogoPlaceholder(merchantName: merchantName)
+                            }
+                            .transition(.fade(duration: 0.3))
+                            .frame(width: 20, height: 20)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
                             Text(merchantName)
                                 .font(.subhead)
                                 .foregroundColor(.primaryText)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -93,7 +93,9 @@ struct DashSpendConfirmationDialog: View {
                                     .resizable()
                                     .scaledToFit()
                             } placeholder: {
-                                MerchantLogoPlaceholder(merchantName: merchantName)
+                                // Rounded-rect clip (below), so the text may fill almost the
+                                // whole box — same fraction as the other rounded-rect sites.
+                                MerchantLogoPlaceholder(merchantName: merchantName, usableFraction: 0.84)
                             }
                             .transition(.fade(duration: 0.3))
                             .frame(width: 20, height: 20)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -88,7 +88,7 @@ struct DashSpendConfirmationDialog: View {
                         HStack(spacing: 8) {
                             WebImage(url: URL(string: merchantIconUrl))
                                 .resizable()
-                                .indicator(.activity)
+                                .placeholder { MerchantLogoPlaceholder(merchantName: merchantName) }
                                 .transition(.fade(duration: 0.3))
                                 .scaledToFit()
                                 .frame(width: 20, height: 20)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
@@ -33,10 +33,9 @@ struct GiftCardDetailsMerchantHeader: View {
                         .frame(width: 50, height: 50)
                         .clipShape(Circle())
                 } else {
-                    Image("image.explore.dash.wts.payment.gift-card")
-                        .resizable()
-                        .scaledToFit()
+                    MerchantLogoPlaceholder(merchantName: merchantName)
                         .frame(width: 50, height: 50)
+                        .clipShape(Circle())
                 }
 
                 if merchantIcon != nil {

--- a/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
@@ -129,7 +129,7 @@ extension MerchantLogoPlaceholder {
         let fontSize = fittedFontSize(words: words, side: side, usableFraction: usableFraction)
 
         let renderer = UIGraphicsImageRenderer(size: size)
-        return renderer.image { ctx in
+        return renderer.image { _ in
             let rect = CGRect(origin: .zero, size: size)
             let path = UIBezierPath(roundedRect: rect, cornerRadius: min(cornerRadius, side / 2))
             uiColor(for: merchantName).setFill()

--- a/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
@@ -1,0 +1,191 @@
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+
+/// A generated fallback icon for a merchant that has no logo: the merchant's name (or
+/// initials) in white on a circle/rounded square whose colour is derived deterministically
+/// from the name, so the same merchant always looks the same.
+///
+/// Mirrors the Android implementation (`MerchantInitialIcon.kt`, dash-wallet #1506):
+/// HSV with fixed 30% saturation / 60% brightness, hue spread over a hash of the name.
+/// The hash replicates Java's `String.hashCode()` so a merchant gets the same colour on
+/// both platforms.
+struct MerchantLogoPlaceholder: View {
+    enum Style {
+        /// Full name, one word per line ("Home Depot" -> "Home" / "Depot").
+        case name
+        /// Initials of up to the first two words ("Home Depot" -> "HD").
+        case initials
+    }
+
+    let merchantName: String
+    var style: Style = .name
+    /// Fraction of the box the text may use. A circle only exposes its inscribed square
+    /// (~0.66 of the diameter); a rounded square exposes almost the whole box (~0.84).
+    var usableFraction: CGFloat = 0.66
+
+    var body: some View {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height)
+            ZStack {
+                MerchantLogoPlaceholder.color(for: merchantName)
+                text(side: side)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(style == .name ? max(words.count, 1) : 1)
+                    .padding(side * (1 - usableFraction) / 2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func text(side: CGFloat) -> some View {
+        switch style {
+        case .initials:
+            Text(MerchantLogoPlaceholder.initials(merchantName))
+                .font(.system(size: side * 0.4, weight: .semibold))
+        case .name:
+            Text(words.joined(separator: "\n"))
+                .font(.system(size: fittedFontSize(side: side), weight: .semibold))
+        }
+    }
+
+    private var words: [String] {
+        merchantName.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+    }
+
+    /// Estimate-based fit (no measurement pass): constrained by line count (height) and the
+    /// longest word (width) against the usable area, then capped so short names aren't oversized.
+    private func fittedFontSize(side: CGFloat) -> CGFloat {
+        MerchantLogoPlaceholder.fittedFontSize(words: words, side: side, usableFraction: usableFraction)
+    }
+
+    // MARK: - Deterministic name → colour / initials (shared logic, matches Android)
+
+    /// Deterministic background colour for a merchant name. HSV(hue, 0.3, 0.6) where the hue
+    /// is spread over a Java-compatible hash of the lowercased name.
+    static func color(for name: String) -> Color {
+        let key = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let hue = key.isEmpty ? 0 : ((javaHashCode(key) % 360) + 360) % 360
+        return Color(hue: Double(hue) / 360.0, saturation: 0.3, brightness: 0.6)
+    }
+
+    /// Initials: first letter of up to the first two words. "Home Depot" -> "HD", "Brinker" -> "B".
+    static func initials(_ name: String) -> String {
+        let words = name.split(whereSeparator: { $0.isWhitespace })
+        switch words.count {
+        case 0: return ""
+        case 1: return words[0].prefix(1).uppercased()
+        default: return (words[0].prefix(1) + words[1].prefix(1)).uppercased()
+        }
+    }
+
+    /// Replicates `java.lang.String.hashCode()`: `h = 31*h + c` over UTF-16 code units, with
+    /// 32-bit wrapping overflow. Kept in sync with Android so colours match across platforms.
+    private static func javaHashCode(_ s: String) -> Int {
+        var hash: Int32 = 0
+        for unit in s.utf16 {
+            hash = 31 &* hash &+ Int32(unit)
+        }
+        return Int(hash)
+    }
+}
+
+// MARK: - UIKit rendering
+
+extension MerchantLogoPlaceholder {
+    /// `UIColor` counterpart of `color(for:)` for UIKit call sites.
+    static func uiColor(for name: String) -> UIColor {
+        let key = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let hue = key.isEmpty ? 0 : ((javaHashCode(key) % 360) + 360) % 360
+        return UIColor(hue: CGFloat(hue) / 360.0, saturation: 0.3, brightness: 0.6, alpha: 1)
+    }
+
+    /// Renders the full-name placeholder as a `UIImage`, for UIKit spots (list cell, map marker).
+    /// Mirrors the SwiftUI `.name` style: white words (one per line, auto-fitted) on the
+    /// deterministic colour, clipped to a circle or rounded square.
+    static func image(merchantName: String, size: CGSize, cornerRadius: CGFloat) -> UIImage {
+        let side = min(size.width, size.height)
+        // A circle only exposes its inscribed square (~0.66); a rounded square exposes ~0.84.
+        let isCircle = cornerRadius >= side / 2
+        let usableFraction: CGFloat = isCircle ? 0.66 : 0.84
+
+        let words = merchantName.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        let fontSize = fittedFontSize(words: words, side: side, usableFraction: usableFraction)
+
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            let rect = CGRect(origin: .zero, size: size)
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: min(cornerRadius, side / 2))
+            uiColor(for: merchantName).setFill()
+            path.fill()
+
+            guard !words.isEmpty else { return }
+
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.alignment = .center
+            paragraph.lineBreakMode = .byClipping
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: fontSize, weight: .semibold),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: paragraph
+            ]
+            let text = words.joined(separator: "\n") as NSString
+            let usable = side * usableFraction
+            let bounding = CGSize(width: usable, height: side)
+            let textRect = text.boundingRect(with: bounding,
+                                             options: [.usesLineFragmentOrigin, .usesFontLeading],
+                                             attributes: attrs, context: nil)
+            let drawRect = CGRect(x: (size.width - textRect.width) / 2,
+                                  y: (size.height - textRect.height) / 2,
+                                  width: textRect.width, height: textRect.height)
+            text.draw(with: drawRect, options: [.usesLineFragmentOrigin, .usesFontLeading],
+                      attributes: attrs, context: nil)
+        }
+    }
+
+    /// Shared with the SwiftUI view: estimate-based font fit (no measurement pass).
+    fileprivate static func fittedFontSize(words: [String], side: CGFloat, usableFraction: CGFloat) -> CGFloat {
+        guard !words.isEmpty else { return 1 }
+        let usable = side * usableFraction
+        let longestWord = CGFloat(words.map(\.count).max() ?? 1)
+        let byHeight = usable / (CGFloat(words.count) * 1.15)
+        let byWidth = usable / (longestWord * 0.58)
+        let maxFont = side * 0.4
+        return max(min(byHeight, byWidth, maxFont), 6)
+    }
+}
+
+#if DEBUG
+struct MerchantLogoPlaceholder_Previews: PreviewProvider {
+    static var previews: some View {
+        HStack(spacing: 12) {
+            MerchantLogoPlaceholder(merchantName: "Home Depot")
+                .frame(width: 50, height: 50).clipShape(Circle())
+            MerchantLogoPlaceholder(merchantName: "Brinker")
+                .frame(width: 50, height: 50).clipShape(Circle())
+            MerchantLogoPlaceholder(merchantName: "Mortons The Steak House", usableFraction: 0.84)
+                .frame(width: 50, height: 50).clipShape(RoundedRectangle(cornerRadius: 8))
+            MerchantLogoPlaceholder(merchantName: "Amazon", style: .initials)
+                .frame(width: 50, height: 50).clipShape(Circle())
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif


### PR DESCRIPTION
## Issue being fixed or feature implemented

Three related Explore Dash problems, all stemming from how `explore.db` is downloaded and replaced. On testnet the merchant list was showing the mainnet database (no Brinker, fewer merchants than Android), merchants without a logo drew a flat empty asset, and the PiggyCards test merchants disappeared after a network switch.

**Wrong database served after a network switch.** Sync bookkeeping is per-network (`kExploreDatabaseLastVersion_Mainnet`/`_Testnet`) but both networks share one `explore.db` on disk. After switching chains the saved version for the new network already read as up to date and the file check passed, so the app kept serving the other network's merchants. The record of which network the file belongs to is now stored, and a download is forced when it differs. `storageRef` is also computed per access rather than cached at init, so the forced download targets the current network's archive instead of the launch network's.

**No fallback when a merchant has no logo.** Merchant surfaces drew the flat `emptyLogoImageName` asset. They now use a generated `MerchantLogoPlaceholder` — the merchant's name or initials on a colour derived deterministically from the name, matching the Android `MerchantInitialIcon` (HSV, Java `hashCode` over the name so colours line up across platforms).

**Test merchants vanished after the database was replaced.** The PiggyCards test merchants are seeded once per session, guarded by `didInsertTestMerchants`. That was safe while the file never changed mid-session, but the network-switch re-download replaces `explore.db` in place: after switching to testnet the fresh archive has no test merchants, yet the guard was already set from the mainnet database seeded at launch, so seeding returned early. The guard is now cleared when the database-updated notification fires.

## What was done?

- Store the installed database's network and force a re-download when it no longer matches the current chain; compute `storageRef` per access.
- Add `MerchantLogoPlaceholder` and route the merchant logo slots through it (POI details, list cell, map annotation, DashSpend pay intro / confirmation dialog, gift-card header, and the redesigned all-locations header).
- Clear `didInsertTestMerchants` on `databaseHasBeenUpdatedNotification` so the test merchants re-seed against the new file. The existing count check still short-circuits before touching the FTS triggers when they are already present.

## How Has This Been Tested?

`xcodebuild -scheme dashwallet` succeeds. Verified against the two booted simulators:

- After the network-switch fix, the testnet database on the active simulator refreshed to the testnet archive — Brinker and both `Piggy Cards Test Merchant` entries present, where before it held the stale mainnet file.
- Confirmed the test-merchant path directly against the live testnet DB: the five `2e393…` merchants were absent (count 0) while the FTS triggers were intact, so clearing the session guard lets the count check fall through to insertion. The same five IDs are already present on the other simulator, exercising the insert path.

Two cherry-picked commits did not build against this tree and were repaired: `DashSpendConfirmationDialog` used a `.placeholder { }` modifier absent from SDWebImageSwiftUI 3.1.3, and `ExploreDatabaseSyncManager` referenced a `currentNetworkName` that existed nowhere — the original `DWEnvironment…isMainnet()` call was restored.

## Breaking Changes

None. Existing installs have no network marker, so the database refreshes once on the next launch.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent merchant logo placeholders using merchant names or initials when logos are unavailable or loading.
  * Updated merchant lists, maps, details, DashSpend, and gift card views with dynamic placeholders.
  * Placeholders now adapt to different sizes and shapes with deterministic colors and readable text.

* **Bug Fixes**
  * Improved Explore database synchronization when switching networks or replacing the local database.
  * Ensured test merchant data can be reseeded after database replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->