### PR TITLE
refactor(home): single string-based avatar path; profile delegate goes parameterless

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Views/DWDPAvatarView.h
+++ b/DashWallet/Sources/UI/DashPay/Views/DWDPAvatarView.h
@@ -31,13 +31,23 @@ typedef NS_ENUM(NSUInteger, DWDPAvatarBackgroundMode) {
 @interface DWDPAvatarView : UIView
 
 @property (nonatomic, assign) DWDPAvatarBackgroundMode backgroundMode;
-@property (nullable, nonatomic, copy) DSBlockchainIdentity *blockchainIdentity;
+
+/// TODO(invitations-sdk-rebuild): invitation-flow-only legacy setter, kept so the
+/// DashSync-backed invitation screens compile untouched until they are rebuilt on
+/// SwiftDashSDK. Everything else configures with
+/// `configureWithUsername:avatarURLString:` or `configureAsCurrentUser`.
+@property (nullable, nonatomic, strong) DSBlockchainIdentity *blockchainIdentity;
 @property (nonatomic, assign, getter=isSmall) BOOL small;
 
 - (void)setAsDashPlaceholder;
 - (void)configureWithUsername:(NSString *)username;
 /// Current-user render path backed by `DWCurrentUserIdentityInfo.shared`.
 - (void)configureAsCurrentUser;
+
+/// Letter + remote profile image from plain strings (no identity object needed).
+/// `avatarURLString` is the raw profile `avatarUrl` — percent-encoding is applied
+/// here. Falls back to the username letter when the URL is nil or fails to load.
+- (void)configureWithUsername:(nullable NSString *)username avatarURLString:(nullable NSString *)avatarURLString;
 
 @end
 

--- a/DashWallet/Sources/UI/DashPay/Views/DWDPAvatarView.m
+++ b/DashWallet/Sources/UI/DashPay/Views/DWDPAvatarView.m
@@ -75,31 +75,8 @@ NS_ASSUME_NONNULL_END
 - (void)setBlockchainIdentity:(DSBlockchainIdentity *)blockchainIdentity {
     _blockchainIdentity = blockchainIdentity;
 
-    [self.imageView sd_cancelCurrentImageLoad];
-
-    NSString *username = blockchainIdentity.currentDashpayUsername;
-    NSString *avatarUrlString = [blockchainIdentity.avatarPath stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
-
-    [self setUsername:username];
-
-    __block typeof(self) weakSelf = self;
-
-    [self.imageView dw_setAvatarWithURLString:avatarUrlString
-                                   completion:^(UIImage *_Nullable image) {
-                                       __strong typeof(weakSelf) strongSelf = weakSelf;
-                                       if (!strongSelf) {
-                                           return;
-                                       }
-
-                                       if (image) {
-                                           strongSelf.imageView.hidden = NO;
-                                           strongSelf.letterLabel.hidden = YES;
-                                           strongSelf.imageView.image = image;
-                                       }
-                                       else {
-                                           [strongSelf setUsername:username];
-                                       }
-                                   }];
+    [self configureWithUsername:blockchainIdentity.currentDashpayUsername
+                avatarURLString:blockchainIdentity.avatarPath];
 }
 
 - (void)configureWithUsername:(NSString *)username {
@@ -107,16 +84,20 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)configureAsCurrentUser {
+    [self configureWithUsername:DWCurrentUserIdentityInfo.shared.username
+                avatarURLString:DWCurrentUserIdentityInfo.shared.avatarURL];
+}
+
+- (void)configureWithUsername:(nullable NSString *)username avatarURLString:(nullable NSString *)avatarURLString {
     [self.imageView sd_cancelCurrentImageLoad];
 
-    NSString *username = DWCurrentUserIdentityInfo.shared.username;
-    NSString *avatarRaw = DWCurrentUserIdentityInfo.shared.avatarURL;
-    NSString *avatarUrlString = [avatarRaw stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSString *encodedUrlString = [avatarURLString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
 
     [self setUsername:username];
 
     __block typeof(self) weakSelf = self;
-    [self.imageView dw_setAvatarWithURLString:avatarUrlString
+
+    [self.imageView dw_setAvatarWithURLString:encodedUrlString
                                    completion:^(UIImage *_Nullable image) {
                                        __strong typeof(weakSelf) strongSelf = weakSelf;
                                        if (!strongSelf) {

--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -178,13 +178,12 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
     // MARK: - Private
 
     #if DASHPAY
-    /// Row #17 stage A — re-evaluate avatar visibility + notification
-    /// bell from the central model state. Called from the legacy
-    /// `homeView(_:didUpdateProfile:)` delegate (DashSync-side
-    /// updates), from the `DWDashPayRegistrationStatusUpdated`
-    /// observer in `configureObservers()` (SwiftDashSDK-side
-    /// updates), and once from `viewDidLoad` to seed visibility on
-    /// re-launch for an already-registered wallet.
+    /// Re-evaluate avatar content, visibility, and the notification
+    /// bell from the central model state. Called from the
+    /// `homeViewDidUpdateProfile()` delegate, from the
+    /// `DWDashPayRegistrationStatusUpdated` observer in
+    /// `configureObservers()`, and once from `viewDidLoad` to seed
+    /// visibility on re-launch for an already-registered wallet.
     func refreshIdentityAvatar() {
         let hasIdentity = model.dashPayModel.hasIdentity
         let hasNotifications = model.dashPayModel.unreadNotificationsCount > 0
@@ -348,17 +347,11 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
     
     private func configureObservers() {
         #if DASHPAY
-        // Row #17 stage A — the legacy `homeView(_:didUpdateProfile:)`
-        // delegate callback only fires when DashSync's
-        // `defaultBlockchainIdentity` flips. A SwiftDashSDK-side
-        // registration (Platform-Payment path, or Core path on a
-        // wallet without DashSync identity reconstruction) never
-        // toggles that delegate, so the avatar wouldn't appear until
-        // a screen change forced a redraw. Subscribing to the
+        // The `homeViewDidUpdateProfile()` delegate only fires on
+        // `JoinDashPayViewModel` state transitions. Subscribing to the
         // canonical `DWDashPayRegistrationStatusUpdatedNotification`
-        // re-evaluates the visibility gate against the central
-        // `hasIdentity` flag as soon as the bridge posts a terminal
-        // phase.
+        // additionally refreshes the avatar as soon as the registration
+        // bridge posts a terminal phase or a profile edit lands.
         NotificationCenter.default.publisher(for: .DWDashPayRegistrationStatusUpdated)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -696,23 +689,8 @@ extension HomeViewController: HomeViewDelegate {
     }
     
     #if DASHPAY
-    func homeView(_ homeView: HomeView, didUpdateProfile identity: DSBlockchainIdentity?, unreadNotifications: UInt) {
-        updateAvatarContent(identity: identity)
-        // Row #17 stage A — visibility gate uses
-        // `model.dashPayModel.hasIdentity` (OR of DashSync's
-        // `defaultBlockchainIdentity != nil` and SwiftDashSDK's
-        // `dashpayRegistrationCompleted`) so SDK-registered
-        // identities surface in the avatar even when DashSync has
-        // no `DSBlockchainIdentity` object to populate it with.
-        // The `DSBlockchainIdentity` passed in is still assigned to
-        // `avatarView.blockchainIdentity` so DashSync-side avatar
-        // rendering (letter, branded color, profile image) keeps
-        // working; SDK-only identities use the current-user avatar
-        // data from `DWCurrentUserIdentityInfo`.
-        let hasIdentity = model.dashPayModel.hasIdentity
-        let hasNotifications = unreadNotifications > 0
-        avatarView.isHidden = !hasIdentity
-        refreshNotificationBell(hasIdentity: hasIdentity, hasNotifications: hasNotifications)
+    func homeViewDidUpdateProfile() {
+        refreshIdentityAvatar()
     }
 
     func homeViewEditProfile() {

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -36,7 +36,9 @@ protocol HomeViewDelegate: AnyObject {
     func homeViewDidChangeTopBarVisibility(shouldShow: Bool)
 
 #if DASHPAY
-    func homeView(_ homeView: HomeView, didUpdateProfile identity: DSBlockchainIdentity?, unreadNotifications: UInt)
+    /// The current user's DashPay profile/registration state changed; the
+    /// controller re-reads avatar content + visibility from the central model.
+    func homeViewDidUpdateProfile()
     func homeViewRequestUsername()
     func homeViewClaimInvitation()
     func homeViewEditProfile()
@@ -142,20 +144,7 @@ final class HomeView: UIView {
     #if DASHPAY
     
     private func setIdentity() {
-        guard let model = model else { return }
-        
-        let status = model.dashPayModel.registrationStatus
-        let completed = model.dashPayModel.registrationCompleted
-        
-        if status?.state == .done || completed {
-            let identity = model.dashPayModel.blockchainIdentity
-            let notificationAmount = model.dashPayModel.unreadNotificationsCount
-            
-            delegate?.homeView(self, didUpdateProfile: identity, unreadNotifications: notificationAmount)
-        } else {
-            delegate?.homeView(self, didUpdateProfile: nil, unreadNotifications: 0)
-        }
-        
+        delegate?.homeViewDidUpdateProfile()
         setNeedsLayout()
     }
     


### PR DESCRIPTION
## What

Shrinks the Home surface's `DSBlockchainIdentity` footprint to just the deliberate DashSync-vs-SDK discriminators, ahead of the invitations SDK rebuild:

- **`DWDPAvatarView`**: `setBlockchainIdentity:` and `configureAsCurrentUser` were copy-paste twins. Both now delegate to a single `configureWithUsername:avatarURLString:` core (percent-encoding applied inside, identical letter-fallback and SDWebImage behavior). The typed `blockchainIdentity` property is kept **only** for the DashSync-backed invitation screens — marked `TODO(invitations-sdk-rebuild)` so it's deleted with that rebuild; no invitation files are touched.
- **`HomeViewDelegate`**: `homeView(_:didUpdateProfile: DSBlockchainIdentity?, unreadNotifications:)` became parameterless `homeViewDidUpdateProfile()`. The old callback duplicated the visibility + notification-bell logic `refreshIdentityAvatar()` already owns; it now just funnels there. `HomeView.setIdentity()` collapses from 17 lines to 2, and `HomeView.swift` no longer references `DSBlockchainIdentity` at all.
- Stale "Row #17 stage A" comment blocks in the touched regions updated to describe current behavior.

Net −42 lines. Deliberately **left alone**: `updateAvatarContent(identity:)` and the `profileAction()` editor branch (real DashSync-vs-SDK path discriminators), and everything under `Invites/`.

## Behavior notes

- One gating nuance: the old `setIdentity()` skipped pushing profile data unless registration was `.done`/completed; `refreshIdentityAvatar()` reads the central state unconditionally but visibility still gates on `hasIdentity`, so the only observable difference is on the deprecated DashSync invitation arm mid-registration (dev-only).

## Verification

⚠️ Not build-verified: `../platform` is mid-transition (checked out on `v4.1-dev`, which is missing 4 of the 5 APIs the app's pin branch carries), so **no** dashwallet build compiles right now — failure is entirely in the SwiftDashSDK package, upstream of the app target. Once the pin branch is reconciled and `DashSDKFFI.xcframework` rebuilt, this needs one `dashpay` arm64-sim build + a smoke of the home avatar (letter + profile image for an SDK-registered identity) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)