### PR TITLE
fix(syncing): keep Core restart responsive

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -1,6 +1,6 @@
 # DashSync -> SwiftDashSDK migration status
 
-Current-state ledger for the DashSync removal. Updated 2026-07-11 from the
+Current-state ledger for the DashSync removal. Updated 2026-07-22 from the
 working tree on `swift-sdk-integration`; historical stage-by-stage detail is
 available in Git history.
 
@@ -101,7 +101,7 @@ Status meanings:
 | 8 | Send Dash | Done | None. Money movement goes through `WalletSendService` / `SwiftDashSDKTransactionSender`. |
 | 9 | Fee estimation | Done | None. Confirmation uses the transaction builder's fee. |
 | 10 | PIN / biometrics | Done; teardown tail | Remove incidental DashSync imports/constants and retain the byte-compatible app-owned keychain contract. |
-| 11 | SPV sync | Done; teardown tail | Remove `setupDashSyncOnce` / `DSOptionsManager` and remaining legacy notification names at unlink. |
+| 11 | SPV sync | Done; teardown tail | Core restart/peer rotation is serialized `stopSpv → startSpv` on the existing manager, preserving Platform sync, wallet state and the process-cached per-network `ModelContainer`; clear-and-resync deletes the chain store off MainActor on the next process launch. Remove `setupDashSyncOnce` / `DSOptionsManager` and remaining legacy notification names at unlink. |
 | 12 | Network switch | Done; teardown tail | Remove the temporary DashSync wallet-registry mirror with C6-E. |
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
 | 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state for retry. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -448,6 +448,7 @@
 		478C983C2945801D00FAA0F0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478C983B2945801D00FAA0F0 /* Constants.swift */; };
 		47976E4A2987772700612988 /* AmountObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47976E492987772700612988 /* AmountObjectTests.swift */; };
 		A17EED0126C7000000000001 /* WalletWipeSerialExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */; };
+		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
 		47976E4B2987781A00612988 /* DWAmountInputValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A2120E92214566A009906DC /* DWAmountInputValidator.m */; };
 		479DBDDD2995168C00F30AF1 /* Transactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479DBDDC2995168C00F30AF1 /* Transactions.swift */; };
 		479E7924287C00EC00D0F7D7 /* DatabaseConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 479E7923287C00EC00D0F7D7 /* DatabaseConnection.swift */; };
@@ -2709,6 +2710,7 @@
 		478C983B2945801D00FAA0F0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		47976E492987772700612988 /* AmountObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountObjectTests.swift; sourceTree = "<group>"; };
 		A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletWipeSerialExecutorTests.swift; sourceTree = "<group>"; };
+		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
 		479DBDDC2995168C00F30AF1 /* Transactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transactions.swift; sourceTree = "<group>"; };
 		479E7923287C00EC00D0F7D7 /* DatabaseConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseConnection.swift; sourceTree = "<group>"; };
 		47A184E4299CC19A0017E32C /* rates.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rates.json; sourceTree = "<group>"; };
@@ -7170,6 +7172,7 @@
 				471DD1BB290AE30B00E030C8 /* String+DashWalletTests.swift */,
 				47976E492987772700612988 /* AmountObjectTests.swift */,
 				A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */,
+				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
 				AA0003032CA0F58E00A1B402 /* SwapAddressValidatorTests.swift */,
 				AA00F1002FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift */,
 				AA00100D2CA0B10001A0B10D /* SwapKitQuoteDecodingTests.swift */,
@@ -10463,6 +10466,7 @@
 				471DD1C0290AECE900E030C8 /* String+DashWalletTests.swift in Sources */,
 				47976E4A2987772700612988 /* AmountObjectTests.swift in Sources */,
 				A17EED0126C7000000000001 /* WalletWipeSerialExecutorTests.swift in Sources */,
+				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
 				AA0003042CA0F58E00A1B402 /* SwapAddressValidatorTests.swift in Sources */,
 				AA00F1012FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift in Sources */,
 				AA00100E2CA0B10001A0B10E /* SwapKitQuoteDecodingTests.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -37,6 +37,26 @@ enum MnemonicFirstWalletCreationError: Error {
     case walletCreation(Error)
 }
 
+/// Process-lifetime cache used for network-scoped objects that must not be
+/// opened twice over the same backing store. Generic so identity and network
+/// separation can be tested without constructing SwiftData.
+@MainActor
+final class ProcessNetworkValueCache<Value> {
+    private var values: [String: Value] = [:]
+
+    func value(
+        for networkKey: String,
+        create: () throws -> Value
+    ) rethrows -> (value: Value, reused: Bool) {
+        if let existing = values[networkKey] {
+            return (existing, true)
+        }
+        let created = try create()
+        values[networkKey] = created
+        return (created, false)
+    }
+}
+
 /// Enforces the seed-safety ordering for wallet creation: persist and verify
 /// the mnemonic before making the wallet live in a manager. If creation then
 /// fails, only the provisional mnemonic is rolled back.
@@ -90,6 +110,7 @@ final class SwiftDashSDKHost {
     private(set) var wallet: ManagedPlatformWallet?
     private(set) var modelContainer: ModelContainer?
     private(set) var runningNetwork: Network?
+    private let modelContainerCache = ProcessNetworkValueCache<ModelContainer>()
 
     // MARK: - Process-wide SDK init guard
 
@@ -262,6 +283,7 @@ final class SwiftDashSDKHost {
 
         let handles = try buildRuntime(for: network)
         let resolvedWallet: ManagedPlatformWallet
+        Self.logger.info("🪺 HOST :: stage 4/4 restoring wallet for \(network.rawValue, privacy: .public)")
         do {
             resolvedWallet = try loadPersistedWallet(manager: handles.manager, network: network)
         } catch HostError.walletNotFound {
@@ -282,6 +304,7 @@ final class SwiftDashSDKHost {
         }
 
         publish(handles: handles, wallet: resolvedWallet)
+        Self.logger.info("🪺 HOST :: stage 4/4 wallet restored for \(network.rawValue, privacy: .public)")
         Self.logger.info("🪺 HOST :: started for \(network.rawValue, privacy: .public)")
         return (handles.manager, resolvedWallet)
     }
@@ -484,8 +507,9 @@ final class SwiftDashSDKHost {
         }
     }
 
-    /// Tear down the host's references. The actual SDK / FFI handles drop
-    /// when their last strong reference goes away.
+    /// Tear down the host's active references. The per-network
+    /// `ModelContainer` remains process-cached so a later runtime rebuild does
+    /// not open a second container over the same SQLite store.
     ///
     /// Persisted-row cleanup on wipe is owned by `PlatformAddressSyncCoordinator`
     /// — it must happen BEFORE BLAST's tokio task winds down so in-flight
@@ -514,6 +538,7 @@ final class SwiftDashSDKHost {
         }
 
         Self.ensureSDKInitialized()
+        Self.logger.info("🪺 HOST :: stage 1/4 creating SDK for \(network.rawValue, privacy: .public)")
 
         let newSDK: SDK
         do {
@@ -529,6 +554,7 @@ final class SwiftDashSDKHost {
             // the `DashSDKConfig.platform_version` field (dashpay/platform
             // #3751); bump this when the agreed protocol moves past v12.
             newSDK = try SDK(network: network, platformVersion: 12)
+            Self.logger.info("🪺 HOST :: stage 1/4 SDK created for \(network.rawValue, privacy: .public)")
         } catch {
             Self.logger.error("🪺 HOST :: SDK init failed: \(String(describing: error), privacy: .public)")
             throw HostError.sdkInitFailed(error)
@@ -536,7 +562,12 @@ final class SwiftDashSDKHost {
 
         let container: ModelContainer
         do {
-            container = try buildModelContainer(for: network)
+            Self.logger.info("🪺 HOST :: stage 2/4 obtaining ModelContainer for \(network.rawValue, privacy: .public)")
+            let cached = try modelContainerCache.value(for: network.networkName) {
+                try buildModelContainer(for: network)
+            }
+            container = cached.value
+            Self.logger.info("🪺 HOST :: stage 2/4 ModelContainer \(cached.reused ? "reused" : "created", privacy: .public) for \(network.rawValue, privacy: .public)")
         } catch {
             Self.logger.error("🪺 HOST :: ModelContainer build failed: \(String(describing: error), privacy: .public)")
             throw HostError.modelContainerFailed(error)
@@ -544,7 +575,9 @@ final class SwiftDashSDKHost {
 
         let newManager = PlatformWalletManager()
         do {
+            Self.logger.info("🪺 HOST :: stage 3/4 configuring manager for \(network.rawValue, privacy: .public)")
             try newManager.configure(sdk: newSDK, modelContainer: container)
+            Self.logger.info("🪺 HOST :: stage 3/4 manager configured for \(network.rawValue, privacy: .public)")
         } catch {
             Self.logger.error("🪺 HOST :: configure failed: \(String(describing: error), privacy: .public)")
             throw HostError.configureFailed(error)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -28,6 +28,23 @@ import Foundation
 import OSLog
 import SwiftDashSDK
 
+/// The exact transaction used for an in-process Core SPV restart. It is kept
+/// free of SDK types so the stop → start ordering, error propagation and busy
+/// state cleanup can be tested with closures.
+@MainActor
+enum CoreSPVRestartOperation {
+    static func run(
+        setRestarting: (Bool) -> Void,
+        stop: () async throws -> Void,
+        start: () async throws -> Void
+    ) async throws {
+        setRestarting(true)
+        defer { setRestarting(false) }
+        try await stop()
+        try await start()
+    }
+}
+
 // MARK: - Local stand-ins for SDK surface that consumers still expect
 
 /// Local replacement for the SDK's removed `SPVSyncState`. Shape matches
@@ -101,6 +118,8 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     @Published public private(set) var bestPeerHeight: UInt32 = 0
     @Published public private(set) var lastError: String? = nil
     @Published public private(set) var syncProgress: SPVSyncProgress = .default()
+    @Published public private(set) var isRestarting = false
+    @Published public private(set) var isApplyingChainResync = false
     /// Peers the SPV client is currently connected to, classified against
     /// the masternode list (Evonode / Masternode / Normal, or Unknown while
     /// the masternode phase hasn't synced).
@@ -118,6 +137,9 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     /// complete when nothing remains to recover. `nil` when no widen is active.
     private var coinJoinRecoveryWidenedNetwork: Network?
 
+    @MainActor
+    var isRunning: Bool { runningNetwork != nil }
+
     // MARK: - Init
 
     private override init() {
@@ -132,7 +154,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
 
     @MainActor
     func startAsync(for network: Network) async throws {
-        switch performStart(for: network) {
+        switch await performStart(for: network) {
         case .success: return
         case .failure(let error): throw error
         }
@@ -140,13 +162,62 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
 
     @MainActor
     func stopAsync(lastError: String?) async {
-        performStop(lastError: lastError)
+        do {
+            try performStop(lastError: lastError, clearBalance: true)
+        } catch {
+            Self.logger.error("🛰️ SPVCOORD :: stop failed during full reset: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Stop only Core SPV, preserving the host, wallet and published balance.
+    @MainActor
+    func stopCoreAsync() async {
+        do {
+            try performStop(lastError: nil, clearBalance: false)
+        } catch {
+            Self.logger.error("🛰️ SPVCOORD :: Core-only stop failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Atomically stop and start Core SPV on the manager already owned by the
+    /// host. Runtime serialization prevents a second lifecycle request from
+    /// entering until this whole transaction completes.
+    @MainActor
+    func restartAsync() async throws {
+        let host = SwiftDashSDKHost.shared
+        guard let manager = host.manager,
+              host.wallet != nil,
+              let network = host.runningNetwork else {
+            let error = StartError.runtimeNotRunning
+            lastError = error.localizedDescription
+            throw error
+        }
+
+        do {
+            try await CoreSPVRestartOperation.run(
+                setRestarting: { self.isRestarting = $0 },
+                stop: {
+                    try self.performStop(lastError: nil, clearBalance: false)
+                },
+                start: {
+                    switch await self.performStart(manager: manager, for: network) {
+                    case .success:
+                        return
+                    case .failure(let error):
+                        throw error
+                    }
+                })
+        } catch {
+            lastError = error.localizedDescription
+            Self.logger.error("🛰️ SPVCOORD :: restart failed: \(String(describing: error), privacy: .public)")
+            throw error
+        }
     }
 
     // MARK: - Implementation
 
     @MainActor
-    private func performStart(for network: Network) -> Result<Void, Error> {
+    private func performStart(for network: Network) async -> Result<Void, Error> {
         let host = SwiftDashSDKHost.shared
         let manager: PlatformWalletManager
         do {
@@ -156,6 +227,14 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
             return .failure(StartError.walletImport(error))
         }
 
+        return await performStart(manager: manager, for: network)
+    }
+
+    @MainActor
+    private func performStart(
+        manager: PlatformWalletManager,
+        for network: Network
+    ) async -> Result<Void, Error> {
         // If SPV is already running on this network, treat it as a
         // success. Mirrors `SwiftDashSDKWalletRuntime.shouldSkipRefresh`'s
         // start-elision intent.
@@ -198,7 +277,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
         // run before startSpv so the delete never races the sync loop's
         // segment writes. See `SPVChainResyncMarker` for why this only
         // happens on the launch after the marker was armed.
-        let appliedChainResync = applyPendingChainResyncIfNeeded(
+        let appliedChainResync = await applyPendingChainResyncIfNeeded(
             for: network, dataDir: dataDir, manager: manager)
 
         do {
@@ -226,7 +305,7 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     }
 
     @MainActor
-    private func performStop(lastError: String?) {
+    private func performStop(lastError: String?, clearBalance: Bool) throws {
         progressCancellable?.cancel()
         progressCancellable = nil
         peersCancellable?.cancel()
@@ -242,20 +321,24 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
                 Self.logger.info("🛰️ SPVCOORD :: stopped")
             } catch {
                 Self.logger.error("🛰️ SPVCOORD :: stopSpv threw: \(String(describing: error), privacy: .public)")
+                subscribeToManagerProgress(manager: manager)
+                self.lastError = error.localizedDescription
+                state = .error
+                throw StartError.stopSpv(error)
             }
         }
 
-        // Drop the bridge'd balance so a network switch / wipe doesn't leak
-        // the previous wallet's value into the next session. The next
-        // `performStart` re-seeds via `refreshBalanceBridge()`.
-        SwiftDashSDKWalletState.shared.clearBalance()
+        if clearBalance {
+            // Drop the bridge'd balance so a network switch / wipe doesn't
+            // leak the previous wallet's value into the next session. A
+            // Core-only stop/restart deliberately preserves it.
+            SwiftDashSDKWalletState.shared.clearBalance()
+        }
 
         runningNetwork = nil
         coinJoinRecoveryWidenedNetwork = nil
         resetPublishedState()
-        if let lastError {
-            self.lastError = lastError
-        }
+        self.lastError = lastError
     }
 
     // MARK: - CoinJoin recovery (one-time wide gap)
@@ -313,19 +396,17 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
         for network: Network,
         dataDir: String,
         manager: PlatformWalletManager
-    ) -> Bool {
+    ) async -> Bool {
         guard let pending = SPVChainResyncMarker.pending(for: network) else { return false }
         guard !pending.armedByThisSession else {
             Self.logger.info("🛰️ SPVCOORD :: chain resync armed this session — deferred to next launch")
             return false
         }
 
-        let dir = URL(fileURLWithPath: dataDir, isDirectory: true)
+        isApplyingChainResync = true
+        defer { isApplyingChainResync = false }
         do {
-            if FileManager.default.fileExists(atPath: dir.path) {
-                try FileManager.default.removeItem(at: dir)
-            }
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try await Self.resetSPVStore(atPath: dataDir)
         } catch {
             Self.logger.error("🛰️ SPVCOORD :: chain resync store delete failed: \(String(describing: error), privacy: .public)")
             return false
@@ -341,6 +422,20 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
 
         Self.logger.info("🛰️ SPVCOORD :: chain store cleared for resync from height \(pending.fromHeight, privacy: .public)")
         return true
+    }
+
+    /// Potentially large directory deletion is never performed on MainActor.
+    /// The caller resumes on MainActor before rewinding the filter checkpoint
+    /// and starting SPV.
+    private nonisolated static func resetSPVStore(atPath dataDir: String) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            let fileManager = FileManager()
+            let dir = URL(fileURLWithPath: dataDir, isDirectory: true)
+            if fileManager.fileExists(atPath: dir.path) {
+                try fileManager.removeItem(at: dir)
+            }
+            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }.value
     }
 
     /// After a widened recovery scan reaches `.synced`, mark recovery complete
@@ -521,8 +616,10 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
     enum StartError: LocalizedError {
         case dataDirectory(Error)
         case spvClient(Error)
+        case stopSpv(Error)
         case walletImport(Error)
         case walletIdMismatch
+        case runtimeNotRunning
 
         var errorDescription: String? {
             switch self {
@@ -530,10 +627,14 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
                 return "Failed to create SPV data directory: \(error.localizedDescription)"
             case .spvClient(let error):
                 return "Failed to start SPV client: \(error.localizedDescription)"
+            case .stopSpv(let error):
+                return "Failed to stop SPV client: \(error.localizedDescription)"
             case .walletImport(let error):
                 return "Failed to import wallet: \(error.localizedDescription)"
             case .walletIdMismatch:
                 return "Imported wallet ID mismatch"
+            case .runtimeNotRunning:
+                return "Core SPV cannot restart because the wallet runtime is not running"
             }
         }
     }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -8,8 +8,9 @@
 //
 //  Lifecycle shape: every Obj-C / Swift entrypoint enqueues a single async
 //  operation onto an internal task chain that serializes lifecycle work
-//  end-to-end. The two real operations are `refresh(trigger:)` and
-//  `fullReset(lastError:forWipe:)`, both `@MainActor`, both awaitable —
+//  end-to-end. Full runtime rebuilds use `refresh(trigger:)` /
+//  `fullReset(lastError:forWipe:)`; Core-only controls use the same queue but
+//  call only the SPV coordinator, preserving the host, wallet and BLAST —
 //  no `DispatchGroup`, no `Thread.sleep`, no fire-and-forget Tasks
 //  inside lifecycle work. Stop order is BLAST → SPV → wallet state →
 //  host; start order is host (via SPV) → SPV → BLAST.
@@ -18,6 +19,25 @@
 import Foundation
 import OSLog
 import SwiftDashSDK
+
+/// Small, testable serial task chain used by the wallet runtime. Keeping the
+/// queue independent from the singleton lets lifecycle ordering be regression
+/// tested without constructing the SDK/FFI stack.
+@MainActor
+final class SerialAsyncLifecycleQueue {
+    private var currentTask: Task<Void, Never>?
+
+    @discardableResult
+    func enqueue(_ operation: @escaping @MainActor () async -> Void) -> Task<Void, Never> {
+        let previous = currentTask
+        let task = Task { @MainActor in
+            await previous?.value
+            await operation()
+        }
+        currentTask = task
+        return task
+    }
+}
 
 @objc(DWSwiftDashSDKWalletRuntime)
 @MainActor
@@ -47,7 +67,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         qos: .userInitiated)
 
     private var observerToken: NSObjectProtocol?
-    private var currentLifecycleTask: Task<Void, Never>?
+    private let lifecycleQueue = SerialAsyncLifecycleQueue()
     private var currentNetwork: Network?
 
     private override init() {
@@ -70,6 +90,22 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         dispatchOnPipeline { shared.enqueueFullReset(lastError: nil, forWipe: false) }
     }
 
+    /// Stop only Core SPV. The host, wallet, published balance and Platform
+    /// sync services stay alive so a later Core restart does not rebuild the
+    /// shared SDK runtime.
+    @objc(stopCoreSPV)
+    nonisolated static func stopCoreSPV() {
+        dispatchOnPipeline { shared.enqueueStopCoreSPV() }
+    }
+
+    /// Redial Core SPV peers on the existing PlatformWalletManager. This is
+    /// deliberately separate from `startIfReady`, whose job is a complete
+    /// runtime refresh after network/wallet material changes.
+    @objc(restartCoreSPV)
+    nonisolated static func restartCoreSPV() {
+        dispatchOnPipeline { shared.enqueueRestartCoreSPV() }
+    }
+
     @objc(startObservingNetworkChanges)
     nonisolated static func startObservingNetworkChanges() {
         dispatchOnPipeline { shared.installNetworkObserver() }
@@ -85,15 +121,14 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         dispatchOnPipeline { shared.enqueueFullReset(lastError: nil, forWipe: true) }
     }
 
-    /// Restart the sync stack to dial a fresh peer set ("sync too slow?
-    /// change peers"). A full stop → start through the serial lifecycle
-    /// pipeline: dash-spv re-discovers peers from the DNS seeds on start,
-    /// and chain data persists on disk so sync resumes where it left off.
+    /// Restart Core SPV to dial a fresh peer set ("sync too slow? change
+    /// peers"). Shares the exact Core-only restart operation with the
+    /// diagnostics screen.
     /// Peer selection is seed-random — a redial of a previous peer is
     /// possible (no exclude-list in the SDK yet).
     @objc(rotatePeers)
     nonisolated static func rotatePeers() {
-        dispatchOnPipeline { shared.enqueueRefresh(trigger: .peerRotation) }
+        restartCoreSPV()
     }
 
     // MARK: - Runtime wallet switching
@@ -182,7 +217,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// Push one ordered step from any thread into the MainActor lifecycle.
     /// `entryQueue` serializes Task creation; the MainActor then processes
     /// the enqueue calls in the order their Tasks were created. The block
-    /// itself only touches `currentLifecycleTask` (synchronous), so no
+    /// itself only touches the lifecycle queue (synchronous), so no
     /// `await` boundaries open up inside it for reordering.
     nonisolated private static func dispatchOnPipeline(
         _ block: @escaping @Sendable @MainActor () -> Void
@@ -196,10 +231,10 @@ final class SwiftDashSDKWalletRuntime: NSObject {
 
     /// Append a lifecycle operation to the serial task chain. Every new op
     /// awaits the previous task before running, so two callers in quick
-    /// succession (e.g. `stop()` then `startIfReady()` from the diagnostic
-    /// Restart button) are processed strictly in order.
+    /// succession (for example two peer-rotation requests) are processed
+    /// strictly in order.
     private func enqueue(_ op: @escaping @MainActor () async -> Void) {
-        currentLifecycleTask = enqueueAwaitable(op)
+        lifecycleQueue.enqueue(op)
     }
 
     /// Same serial-chain append as `enqueue`, but returns the appended task so
@@ -209,13 +244,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// lifecycle task before running.
     @discardableResult
     private func enqueueAwaitable(_ op: @escaping @MainActor () async -> Void) -> Task<Void, Never> {
-        let previous = currentLifecycleTask
-        let task = Task { @MainActor in
-            await previous?.value
-            await op()
-        }
-        currentLifecycleTask = task
-        return task
+        lifecycleQueue.enqueue(op)
     }
 
     private func enqueueRefresh(trigger: RefreshTrigger) {
@@ -227,6 +256,22 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     private func enqueueFullReset(lastError: String?, forWipe: Bool) {
         enqueue { [weak self] in
             await self?.fullReset(lastError: lastError, forWipe: forWipe)
+        }
+    }
+
+    private func enqueueStopCoreSPV() {
+        enqueue {
+            await SwiftDashSDKSPVCoordinator.shared.stopCoreAsync()
+        }
+    }
+
+    private func enqueueRestartCoreSPV() {
+        enqueue {
+            do {
+                try await SwiftDashSDKSPVCoordinator.shared.restartAsync()
+            } catch {
+                Self.logger.error("🧭 RUNTIME :: Core SPV restart failed: \(String(describing: error), privacy: .public)")
+            }
         }
     }
 
@@ -293,12 +338,11 @@ final class SwiftDashSDKWalletRuntime: NSObject {
 
     private func shouldSkipRefresh(for network: Network, trigger: RefreshTrigger) -> Bool {
         switch trigger {
-        case .walletMaterialChanged, .walletDidChange, .peerRotation:
+        case .walletMaterialChanged, .walletDidChange:
             // A runtime wallet switch always rebuilds — the active-wallet
             // registry was repointed to a different wallet on the SAME
             // network, so `currentNetwork == network` would otherwise wrongly
-            // elide the rebind. Peer rotation exists precisely to force the
-            // stop → start (fresh peer dial), so it never skips either.
+            // elide the rebind.
             return false
         case .startIfReady, .networkDidChange:
             // External callers (PlatformSyncStatusScreen, StorageExplorerUnavailableView,
@@ -310,6 +354,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
             return currentNetwork == network
                 && blast.isRunning
                 && blast.runningNetwork == network
+                && SwiftDashSDKSPVCoordinator.shared.isRunning
         }
     }
 
@@ -367,7 +412,6 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         case networkDidChange
         case walletMaterialChanged
         case walletDidChange
-        case peerRotation
     }
 
     enum RuntimeError: LocalizedError {

--- a/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertView.swift
+++ b/DashWallet/Sources/UI/Home/Syncing Views/Alert/SyncingAlertView.swift
@@ -33,7 +33,8 @@ final class SyncingAlertViewModel: ObservableObject {
     /// True after `stallThreshold` seconds without a progress change
     /// while syncing — shows the "Sync too slow?" row.
     @Published private(set) var isStalled = false
-    /// True from the Change-peers tap until progress moves again.
+    /// Mirrors the coordinator's complete stop → start transaction, including
+    /// restarts initiated from the diagnostics screen.
     @Published private(set) var isRotatingPeers = false
 
     private let monitor = SyncingActivityMonitor.shared
@@ -51,6 +52,13 @@ final class SyncingAlertViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] peers in
                 self?.peers = peers
+            }
+            .store(in: &cancellables)
+
+        SwiftDashSDKSPVCoordinator.shared.$isRestarting
+            .receive(on: RunLoop.main)
+            .sink { [weak self] isRestarting in
+                self?.isRotatingPeers = isRestarting
             }
             .store(in: &cancellables)
 
@@ -83,7 +91,6 @@ final class SyncingAlertViewModel: ObservableObject {
     @MainActor
     func rotatePeers() {
         guard canRotatePeers else { return }
-        isRotatingPeers = true
         isStalled = false
         lastProgressChange = Date()
         SwiftDashSDKWalletRuntime.rotatePeers()
@@ -105,7 +112,6 @@ extension SyncingAlertViewModel: SyncingActivityMonitorObserver {
         if progress != self.progress {
             lastProgressChange = Date()
             isStalled = false
-            isRotatingPeers = false
         }
         self.progress = progress
         snapshot = monitor.snapshot

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
@@ -201,7 +201,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
         } message: { height in
             Text(String(
                 format: NSLocalizedString(
-                    "Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start.",
+                    "Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. Fully close and relaunch the app to start; the in-app Restart button does not apply this reset.",
                     comment: "SPV diagnostics"),
                 height))
         }
@@ -460,7 +460,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
     private var controlsCard: some View {
         HStack(spacing: 12) {
             Button(action: {
-                SwiftDashSDKWalletRuntime.stop()
+                SwiftDashSDKWalletRuntime.stopCoreSPV()
             }) {
                 Text("Stop")
                     .font(.system(size: 14, weight: .semibold))
@@ -470,19 +470,30 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     .foregroundColor(.dash.primaryText)
                     .cornerRadius(8)
             }
+            .disabled(coreLifecycleBusy)
             Button(action: {
-                SwiftDashSDKWalletRuntime.stop()
-                SwiftDashSDKWalletRuntime.startIfReady()
+                SwiftDashSDKWalletRuntime.restartCoreSPV()
             }) {
-                Text("Restart")
-                    .font(.system(size: 14, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 12)
-                    .background(Color.dash.gray300.opacity(0.3))
-                    .foregroundColor(.dash.primaryText)
-                    .cornerRadius(8)
+                HStack(spacing: 8) {
+                    if coordinator.isRestarting {
+                        SwiftUI.ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(coordinator.isRestarting ? "Restarting…" : "Restart")
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.dash.gray300.opacity(0.3))
+                .foregroundColor(.dash.primaryText)
+                .cornerRadius(8)
             }
+            .disabled(coreLifecycleBusy)
         }
+    }
+
+    private var coreLifecycleBusy: Bool {
+        coordinator.isRestarting || coordinator.isApplyingChainResync
     }
 
     // MARK: - Row builders
@@ -602,6 +613,9 @@ extension SwiftDashSDKSPVStatusScreen {
     /// True when SPV is running AND a wallet is bound — the two
     /// conditions `spvRescanFilters` needs for an immediate rescan.
     var rescanEnabled: Bool {
+        guard !coordinator.isRestarting, !coordinator.isApplyingChainResync else {
+            return false
+        }
         guard SwiftDashSDKHost.shared.wallet != nil,
               let manager = SwiftDashSDKHost.shared.manager else {
             return false
@@ -795,7 +809,7 @@ extension SwiftDashSDKSPVStatusScreen {
         rescanResultIsError = false
         rescanResultMessage = String(
             format: NSLocalizedString(
-                "Resync armed from height %u — quit and reopen the app to start.",
+                "Resync armed from height %u. Fully close the app, then launch it again to start. The in-app Restart button does not apply this reset.",
                 comment: "SPV diagnostics"),
             height)
     }

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -1,0 +1,94 @@
+//
+//  SwiftDashSDKCoreLifecycleTests.swift
+//  DashWalletTests
+//
+//  Regression coverage for Core-only SPV restart and process-lifetime
+//  network-scoped runtime caching.
+//
+
+import XCTest
+@testable import dashwallet
+
+private enum CoreLifecycleTestError: Error {
+    case start
+}
+
+@MainActor
+final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
+    func testRestartRunsExactlyStopThenStartAndResetsBusyState() async throws {
+        var events: [String] = []
+        var restartingStates: [Bool] = []
+
+        try await CoreSPVRestartOperation.run(
+            setRestarting: { restartingStates.append($0) },
+            stop: { events.append("stop") },
+            start: { events.append("start") })
+
+        XCTAssertEqual(events, ["stop", "start"])
+        XCTAssertEqual(restartingStates, [true, false])
+    }
+
+    func testRestartPropagatesStartFailureAndAlwaysResetsBusyState() async {
+        var events: [String] = []
+        var restartingStates: [Bool] = []
+
+        do {
+            try await CoreSPVRestartOperation.run(
+                setRestarting: { restartingStates.append($0) },
+                stop: { events.append("stop") },
+                start: {
+                    events.append("start")
+                    throw CoreLifecycleTestError.start
+                })
+            XCTFail("Expected restart failure")
+        } catch CoreLifecycleTestError.start {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(events, ["stop", "start"])
+        XCTAssertEqual(restartingStates, [true, false])
+    }
+
+    func testQueuedRestartsNeverOverlap() async {
+        let queue = SerialAsyncLifecycleQueue()
+        var events: [String] = []
+        var operationsInFlight = 0
+        var maximumOperationsInFlight = 0
+
+        func operation(_ name: String) async {
+            operationsInFlight += 1
+            maximumOperationsInFlight = max(maximumOperationsInFlight, operationsInFlight)
+            events.append("\(name)-stop")
+            await Task.yield()
+            events.append("\(name)-start")
+            operationsInFlight -= 1
+        }
+
+        queue.enqueue { await operation("first") }
+        let second = queue.enqueue { await operation("second") }
+        await second.value
+
+        XCTAssertEqual(maximumOperationsInFlight, 1)
+        XCTAssertEqual(events, [
+            "first-stop", "first-start",
+            "second-stop", "second-start",
+        ])
+    }
+
+    func testProcessCacheReusesValuesPerNetworkAndSeparatesNetworks() {
+        final class Token {}
+
+        let cache = ProcessNetworkValueCache<Token>()
+        let mainnetFirst = cache.value(for: "mainnet") { Token() }
+        let mainnetSecond = cache.value(for: "mainnet") { Token() }
+        let testnet = cache.value(for: "testnet") { Token() }
+
+        XCTAssertFalse(mainnetFirst.reused)
+        XCTAssertTrue(mainnetSecond.reused)
+        XCTAssertFalse(testnet.reused)
+        XCTAssertTrue(mainnetFirst.value === mainnetSecond.value)
+        XCTAssertFalse(mainnetFirst.value === testnet.value)
+    }
+}


### PR DESCRIPTION
## Summary
- restart and peer rotation now run serialized stopSpv -> startSpv on the existing PlatformWalletManager
- preserve Platform sync, wallet state, balance, BLAST, and the process-cached per-network ModelContainer
- move clear-and-resync store deletion off MainActor and consume its marker only after a successful SPV start
- expose restart progress in Core Sync and Change peers UI
- add lifecycle serialization, error propagation, and ModelContainer cache regression coverage

## Validation
- dashpay Debug iOS Simulator build: passed
- git diff --check: passed
- project.pbxproj plutil validation: passed
- dashwallet build is currently blocked by pre-existing target errors for missing DWCurrentUserIdentityInfo; the test action is likewise blocked by missing DashPayPaymentTxLookup
- normal dashwallet build also encounters a local Watch Simulator runtime mismatch before the one-time asset exclusion workaround

No changes were made in the platform repository.