### PR TITLE
fix(dashpay): hide registration banners after signup

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1369,8 +1369,20 @@ private struct HomeViewModelPreviewTransactionSource: TransactionSource {
 #if DASHPAY
 extension HomeViewModel {
     func checkJoinDashPay() {
+        let options = DWGlobalOptions.sharedInstance()
+        var hasRegisteredUsername =
+            options.dashpayRegistrationCompleted &&
+            options.dashpayUsername?.isEmpty == false
+        if !hasRegisteredUsername {
+            hasRegisteredUsername = MainActor.assumeIsolated {
+                options.dashpayRegistrationCompleted &&
+                DWCurrentUserIdentityInfo.shared.username?.isEmpty == false
+            }
+        }
+
         self.showJoinDashpay = syncModel.state == .syncDone &&
             !UsernamePrefs.shared.joinDashPayDismissed &&
+            !hasRegisteredUsername &&
             joinDashPayState != .voting && joinDashPayState != .registered
     }
     

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -220,26 +220,21 @@ struct MainMenuScreen: View {
                     .padding(.bottom, 20)
 
                 #if DASHPAY
-                // FIXME: TEMPORARY — bypasses `viewModel.showJoinDashpay`
-                // (which becomes false once sync isn't done, the user
-                // dismissed the banner, or registration completed) so
-                // the Join DashPay entry point stays reachable for
-                // SwiftDashSDK identity registration testing. Restore
-                // the `if viewModel.showJoinDashpay { ... }` guard
-                // before merging anything that depends on this file.
-                JoinDashPayView(
-                    viewModel: joinDPViewModel,
-                    onTap: { state in
-                        handleJoinDashPayTap(state: state)
-                    },
-                    onActionButton: { state in
-                        handleJoinDashPayAction(state: state)
-                    },
-                    onDismissButton: { state in
-                        joinDPViewModel.markAsDismissed()
-                    }
-                )
-                .padding(.horizontal, 18)
+                if viewModel.showJoinDashpay {
+                    JoinDashPayView(
+                        viewModel: joinDPViewModel,
+                        onTap: { state in
+                            handleJoinDashPayTap(state: state)
+                        },
+                        onActionButton: { state in
+                            handleJoinDashPayAction(state: state)
+                        },
+                        onDismissButton: { state in
+                            joinDPViewModel.markAsDismissed()
+                        }
+                    )
+                    .padding(.horizontal, 18)
+                }
                 #endif
                 
                 // Menu items grouped in sections
@@ -397,15 +392,16 @@ struct MainMenuScreen: View {
     
     #if DASHPAY
     private func handleJoinDashPayTap(state: JoinDashPayState) {
-        // FIXME: TEMPORARY — every banner tap routes straight to
-        // `joinDashPay()` (Create Username) so the SwiftDashSDK
-        // identity registration flow stays reachable for debugging
-        // even after a successful registration (when the banner state
-        // becomes `.registered` and would normally open Edit Profile).
-        // Restore the state switch (registered → editProfile, voting →
-        // showRequestDetails, none → handleJoinButtonAction) before
-        // shipping anything that depends on this file.
-        handleJoinButtonAction()
+        switch state {
+        case .registered:
+            editProfile()
+        case .voting:
+            showRequestDetails()
+        case .none:
+            handleJoinButtonAction()
+        default:
+            break
+        }
     }
     
     private func handleJoinDashPayAction(state: JoinDashPayState) {


### PR DESCRIPTION
## Summary
- restore the registration-aware visibility guard for the More-screen Join DashPay banner
- restore the normal registered and voting tap routes removed by the temporary SDK debug override
- hide the Home-screen Upgrade to DashPay banner once registration is complete and the username is available from either app preferences or SwiftDashSDK identity state

## Context
Git history shows commit 35424759d intentionally made the More banner unconditional for repeated SDK registration testing. This removes that temporary behavior and fixes the separate Home banner gate.

## Testing
- dashpay Debug build for generic iOS Simulator: BUILD SUCCEEDED
- git diff --check