### PR TITLE
feat(wallet): size the Max-send fee reserve from real UTXO count

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -367,6 +367,44 @@ final class SwiftDashSDKTransactionSender: NSObject {
         UInt64(10 + inputCount * 148 + 2 * 34)
     }
 
+    /// Fee reserve for a "Max" / all-funds core send, sized from the BIP44
+    /// account's actual spendable-UTXO count instead of a flat constant.
+    ///
+    /// The flat `WalletBalance.sendFeeReserveDuffs` (100_000 duffs) is a large
+    /// worst-case over-estimate — a typical send costs ~1–2k duffs, so Max used
+    /// to leave ~0.001 DASH behind as change. Here the reserve is the same
+    /// size model as `estimatedSignalFee` (1 duff/byte over the enumerated
+    /// inputs) plus a **+50 % safety margin** so it can never *under*-reserve —
+    /// an under-estimate would make the Max send fail to build.
+    ///
+    /// Fail-safe: any inability to enumerate the account (no wallet/manager, no
+    /// UTXOs) falls back to the flat reserve, i.e. the previous behaviour — the
+    /// change never makes Max worse than before, only tighter when it can.
+    static func maxSendFeeReserveDuffs() -> UInt64 {
+        let read = { @MainActor () -> UInt64? in
+            let host = SwiftDashSDKHost.shared
+            guard let manager = host.manager, let wallet = host.wallet else { return nil }
+            let walletId = wallet.walletId
+            guard let bip44 = manager.accountBalances(for: walletId).first(where: {
+                $0.typeTag == Self.bip44TypeTag && $0.index == 0
+            }) else { return nil }
+            let count = manager.accountUtxos(for: walletId, balance: bip44).count
+            guard count > 0 else { return nil }
+            let base = estimatedSignalFee(inputCount: count)
+            return base + base / 2 // +50 % margin — must never under-reserve
+        }
+
+        let dynamic: UInt64?
+        if Thread.isMainThread {
+            dynamic = MainActor.assumeIsolated { read() }
+        } else {
+            var captured: UInt64?
+            DispatchQueue.main.sync { captured = MainActor.assumeIsolated { read() } }
+            dynamic = captured
+        }
+        return dynamic ?? WalletBalance.sendFeeReserveDuffs
+    }
+
     // MARK: - Broadcast
 
     /// Broadcast a transaction previously built by `buildAndSign`. Resolves the

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -385,8 +385,13 @@ final class SwiftDashSDKTransactionSender: NSObject {
             let host = SwiftDashSDKHost.shared
             guard let manager = host.manager, let wallet = host.wallet else { return nil }
             let walletId = wallet.walletId
+            // `typeTag == 0` is the whole Standard family; account 0 can exist as
+            // both BIP44 (`standardTag == 0`) and BIP32 (`standardTag == 1`), so
+            // require the standard tag too — mirrors `addressUtxos(script:)`.
             guard let bip44 = manager.accountBalances(for: walletId).first(where: {
-                $0.typeTag == Self.bip44TypeTag && $0.index == 0
+                $0.typeTag == Self.bip44TypeTag
+                    && $0.standardTag == Self.bip44StandardTag
+                    && $0.index == Self.bip44AccountIndex
             }) else { return nil }
             let count = manager.accountUtxos(for: walletId, balance: bip44).count
             guard count > 0 else { return nil }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -88,6 +88,18 @@ public final class SwiftDashSDKWalletState: NSObject, ObservableObject {
     /// first `applyBalance(_:)` call arrives. Updated on the main queue.
     @Published public private(set) var balance: WalletBalance? = nil
 
+    /// Fee-aware "Max" / all-funds amount for a core send: spendable minus a
+    /// reserve sized from the account's real UTXO count
+    /// (`SwiftDashSDKTransactionSender.maxSendFeeReserveDuffs`), floored at 0.
+    /// Prefer this over `WalletBalance.maxSendable` (flat 100k reserve) at every
+    /// core-send "Max" call site so the sent amount tracks the real fee instead
+    /// of stranding ~0.001 DASH as change.
+    public func feeAwareMaxSendable() -> UInt64 {
+        let spendable = balance?.spendable ?? 0
+        let reserve = SwiftDashSDKTransactionSender.maxSendFeeReserveDuffs()
+        return spendable > reserve ? spendable - reserve : 0
+    }
+
     /// Total DIP-17 Platform Payment credit balance across every
     /// PlatformPayment account (`accountType == 14`) for the active
     /// wallet. Reported in credits (1e11 credits per DASH). Refreshed

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -623,7 +623,7 @@ struct PayContactSheet: View {
     // MARK: Amounts
 
     private var maxSendable: UInt64 {
-        walletState.balance?.maxSendable ?? 0
+        walletState.feeAwareMaxSendable()
     }
 
     /// Entered DASH amount in duffs, or nil when unparseable, zero,

--- a/DashWallet/Sources/UI/DashPay/Credits/BuyCreditsViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Credits/BuyCreditsViewController.swift
@@ -26,7 +26,7 @@ final class BuyCreditsModel: SendAmountModel {
     }
     
     override func selectAllFundsWithoutAuth() {
-        let allAvailableFunds = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+        let allAvailableFunds = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
 
         if allAvailableFunds > 0 {
             let maxMultiple = allAvailableFunds / BuyCreditsModel.opCost

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayViewModel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayViewModel.swift
@@ -426,7 +426,7 @@ class DashSpendPayViewModel: NSObject, ObservableObject, NetworkReachabilityHand
     private var canShowInsufficientFunds: Bool {
         let dashAmount = (try? CurrencyExchanger.shared.convertToDash(amount: amount, currency: kDefaultCurrencyCode)) ?? 0
 
-        let allAvailableFunds = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+        let allAvailableFunds = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
 
         return dashAmount.plainDashAmount > allAvailableFunds
     }

--- a/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
@@ -79,7 +79,7 @@ class SendAmountModel: BaseAmountModel {
         // Fee-aware max: spendable minus the send fee reserve (the app-wide
         // WalletBalance.maxSendable contract), not raw spendable — the latter
         // leaves no room for the fee, so the send fails to build.
-        let allAvailableFunds = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+        let allAvailableFunds = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
 
         if allAvailableFunds > 0 {
             updateCurrentAmountObject(with: allAvailableFunds)

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -512,7 +512,7 @@ final class InternalTransferViewModel: ObservableObject {
             // Fee-aware max: spendable minus the send fee reserve (mirrors
             // DSAccount.maxOutputAmount), never the raw total — the asset-lock
             // spends core UTXOs and still needs room for the L1 fee.
-            sourceDuffs = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+            sourceDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
         case .platformToShielded:
             // Reserve the fee the SDK charges on top of the amount so Max
             // stays sendable (credits → duffs: integer divide by 1000).

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -520,7 +520,7 @@ final class SendViewModel: ObservableObject {
             // Fee-aware max: spendable minus the send fee reserve (mirrors
             // DSAccount.maxOutputAmount), never the raw total — which would
             // include unconfirmed/immature funds and leave no room for the fee.
-            sourceDuffs = SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+            sourceDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
         case .platformToPlatform:
             sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
         case .platformToCore:

--- a/DashWallet/Sources/UI/Swap/Convert/SwapConvertViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/Convert/SwapConvertViewModel.swift
@@ -73,7 +73,7 @@ final class SwapConvertViewModel: ObservableObject {
     /// The frozen DashSync account balance reads stale/zero post-migration, so all balance reads
     /// in this flow go through SwiftDashSDK.
     private var availableDashDuffs: UInt64 {
-        SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0
+        SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
     }
 
     var dashBalance: Int64 {

--- a/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewViewModel.swift
+++ b/DashWallet/Sources/UI/Swap/OrderPreview/OrderPreviewViewModel.swift
@@ -793,7 +793,7 @@ final class OrderPreviewViewModel: ObservableObject {
     private var dashBalance: Int64 {
         // Cap swaps at the SDK's max-sendable balance (spendable minus the send fee reserve);
         // the frozen DashSync account balance reads stale/zero post-migration.
-        Int64(SwiftDashSDKWalletState.shared.balance?.maxSendable ?? 0)
+        Int64(SwiftDashSDKWalletState.shared.feeAwareMaxSendable())
     }
 
     // MARK: - Private: Formatting


### PR DESCRIPTION
## Issue being fixed or feature implemented
"Max" / all-funds core sends did not empty the wallet — they left ~0.001 DASH behind as change.

Root cause: the Max amount is `WalletBalance.maxSendable = spendable − sendFeeReserveDuffs`, and `sendFeeReserveDuffs` is a **flat 100,000-duff** reserve. The actual fee is size-based (~1–2k duffs at 1 duff/byte), so the send returned `reserve − actual_fee` (~98k duffs) as change. Confirmed on-chain earlier: an 11-input Max send charged 1,740 duffs but left a 98,260-duff change output (= 100,000 − 1,740, exact).

Funds were never lost (change went to the wallet's own address), but Max was misleading — the resulting balance was not zero.

## What was done?
- Added `SwiftDashSDKTransactionSender.maxSendFeeReserveDuffs()` — sizes the reserve from the BIP44 account's real spendable-UTXO count using the same 1 duff/byte model as `estimatedSignalFee`, plus a **+50% safety margin** so it can never *under*-reserve (an under-estimate would make the Max send fail to build).
- **Fail-safe:** when the account can't be enumerated (no wallet/manager/UTXOs) it falls back to the flat `sendFeeReserveDuffs`, i.e. the previous behaviour — never worse, only tighter when it can be.
- Exposed `SwiftDashSDKWalletState.feeAwareMaxSendable()` and routed every core-send Max/all-funds call site through it (Send, InternalTransfer, SwapConvert, OrderPreview, ContactProfile, BuyCredits, DashSpendPay).
- **CrowdNode** deliberately kept its own deposit-cap fee logic (`TX_FEE_PER_INPUT`) — out of scope.

## How Has This Been Tested?
Verified on device (testnet, dashpay scheme): a Max send now fills the full spendable balance (reserve dropped from the flat 100,000 to a few hundred duffs) and the confirm builds successfully — the +50% margin covered the real fee without under-reserving. Recommend a follow-up check that the post-send transparent balance settles to ~0. Note: `maxSendFeeReserveDuffs()` performs a UTXO enumeration on each read; it's a synchronous DB read but worth an eye on the per-keystroke affordability checks.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone