### PR TITLE
fix(dashpay): reset identity cache after wallet wipe

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -1,6 +1,6 @@
 # DashSync -> SwiftDashSDK migration status
 
-Current-state ledger for the DashSync removal. Updated 2026-07-22 from the
+Current-state ledger for the DashSync removal. Updated 2026-07-23 from the
 working tree on `swift-sdk-integration`; historical stage-by-stage detail is
 available in Git history.
 
@@ -104,7 +104,7 @@ Status meanings:
 | 11 | SPV sync | Done; teardown tail | Core restart/peer rotation is serialized `stopSpv → startSpv` on the existing manager, preserving Platform sync, wallet state and the process-cached per-network `ModelContainer`; clear-and-resync deletes the chain store off MainActor on the next process launch. Remove `setupDashSyncOnce` / `DSOptionsManager` and remaining legacy notification names at unlink. |
 | 12 | Network switch | Done; teardown tail | Remove the temporary DashSync wallet-registry mirror with C6-E. |
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
-| 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state for retry. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |
+| 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state and the in-memory identity snapshot for retry. After a successful wipe the stopped runtime installs an empty identity snapshot and publishes the wallet-context change; a newly started wallet publishes the same event, rebuilding the DashPay tab bar as 3 or 5 items from that wallet's identity state. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |
 | 15 | Provider-key derivation | Done | All four families are SDK-native: Owner/Voting via the key-wallet path surface, Operator (BLS) and Evonode Operator (Ed25519) via `ManagedPlatformWallet.providerKeyAtIndex` (`platform_wallet_provider_key_at_index` grew per-index BLS/EdDSA public-key export, removing the earlier blocker). Overview counts and per-keypair “used at” restored from the Rust masternode aggregation (`PlatformWalletManager.masternodes(for:)`). |
 | 16 | DashPay identity creation | Done; invitation tail | Standard SDK-funded identity/name registration is migrated, with three funding paths (Core asset-lock, Platform Payment, shielded Type-20 — the privacy-preserving default, gated by `ShieldedIdentityFundingReadiness`). Invitation-funded create/accept remains part of the invitation decision. |
 | 17 | DashPay identity/profile read-write | Done; compatibility tail | Retire remaining `DSBlockchainIdentity`-typed profile properties/categories and route every old view directly through `DWCurrentUserIdentityInfo` / `DWProfileUpdateBridge`. |

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -254,6 +254,19 @@ public final class DWCurrentUserIdentityInfo: NSObject {
         invalidate()
     }
 
+    /// Install an authoritative empty snapshot at the wallet-removal boundary.
+    /// Unlike a regular invalidation this does not depend on the SDK host being
+    /// available, because the host has already stopped by the time the wipe
+    /// lifecycle invokes it.
+    @nonobjc
+    func resetForWalletRemoval() {
+        currentRevision &+= 1
+        cachedSnapshot = .empty
+        cachedRevision = currentRevision
+        Self.logger.info(
+            "🪪 IDENT-INFO :: wallet-context reset; revision → \(self.currentRevision, privacy: .public)")
+    }
+
     /// Fire-and-forget blockchain refresh of the local DPNS-names
     /// cache via `wallet.syncDpnsNames(identityId:)`. The local
     /// cache (`ManagedIdentity.dpns_names`) only contains names

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -172,10 +172,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
             throw SwitchError.bindFailed
         }
 
-        NotificationCenter.default.post(
-            name: SwiftDashSDKWalletState.activeWalletDidChangeNotification,
-            object: nil)
-        Self.logger.info("🧭 RUNTIME :: switchWallet — bound new active wallet and posted change")
+        publishActiveWalletDidChange(reason: "wallet-switch")
     }
 
     /// Validate that `walletId` is a switchable target on the current network:
@@ -310,6 +307,9 @@ final class SwiftDashSDKWalletRuntime: NSObject {
                 try await SwiftDashSDKSPVCoordinator.shared.startAsync(for: network)
                 try await PlatformAddressSyncCoordinator.shared.startAsync(for: network)
                 currentNetwork = network
+                if trigger == .walletMaterialChanged {
+                    publishActiveWalletDidChange(reason: "wallet-started")
+                }
             } catch {
                 Self.logger.error("🧭 RUNTIME :: start failed: \(String(describing: error), privacy: .public)")
                 await fullReset(lastError: error.localizedDescription, forWipe: false)
@@ -332,9 +332,22 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         SwiftDashSDKWalletState.shared.clearAllState()
         SwiftDashSDKHost.shared.stop()
         currentNetwork = nil
+        if forWipe {
+            DWCurrentUserIdentityInfo.shared.resetForWalletRemoval()
+            publishActiveWalletDidChange(reason: "wallet-removed")
+        }
     }
 
     // MARK: - Helpers
+
+    private func publishActiveWalletDidChange(reason: String) {
+        let walletId = SwiftDashSDKHost.shared.wallet?.walletId.hexEncodedString() ?? "none"
+        NotificationCenter.default.post(
+            name: SwiftDashSDKWalletState.activeWalletDidChangeNotification,
+            object: nil)
+        Self.logger.info(
+            "🧭 RUNTIME :: active-wallet change reason=\(reason, privacy: .public) wallet=\(walletId, privacy: .public)")
+    }
 
     private func shouldSkipRefresh(for network: Network, trigger: RefreshTrigger) -> Bool {
         switch trigger {

--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -18,7 +18,6 @@
 import SwiftUI
 import UIKit
 import Combine
-import SwiftUI
 
 // MARK: - MainTabbarTabs
 
@@ -246,6 +245,11 @@ extension MainTabbarController {
         nvc.tabBarItem = item
         viewControllers.append(nvc)
 
+        #if !DASHPAY
+        let identityAvailable = false
+        #endif
+        DWLogger.log(
+            "TABBAR wallet-context: \(identityAvailable ? "dashpay" : "core") layout, \(viewControllers.count) items")
         self.viewControllers = viewControllers
     }
 


### PR DESCRIPTION
## Summary
- clear the in-memory current-user identity snapshot after a successful full wallet wipe
- publish the active-wallet change after wipe and after a newly created wallet starts
- rebuild and log the 3-tab or 5-tab layout without deleting SDK, SPV, or SQLite storage

## Verification
- dashpay Debug build for generic iOS Simulator succeeds
- diff check passes
- platform repository is unchanged