### PR TITLE
fix(dashpay): present readiness flow modally

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
@@ -32,6 +32,8 @@ struct JoinDashPayReadinessScreen: View {
     /// transparent escape (the picker pins to the viable transparent
     /// source).
     let onProceed: () -> Void
+    /// Return to the screen that opened this interstitial.
+    let onClose: () -> Void
 
     /// Suggested deposit headroom (0.001 DASH in credits) added to the
     /// shortfall prefill: the Core→Shielded route carves the Platform
@@ -46,10 +48,28 @@ struct JoinDashPayReadinessScreen: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Spacer()
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                        .frame(width: 36, height: 36)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.dash.gray300Alpha30, lineWidth: 1.5)
+                        )
+                }
+                .frame(width: 44, height: 44)
+                .accessibilityLabel(NSLocalizedString("Close", comment: "Accessibility"))
+            }
+            .padding(.top, 4)
+
             Text(NSLocalizedString("Get ready to join DashPay", comment: "Usernames"))
                 .font(.title1)
                 .foregroundColor(.dash.primaryText)
-                .padding(.top, 12)
+                .padding(.top, 4)
 
             Text(NSLocalizedString("Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash.", comment: "Usernames"))
                 .font(.system(size: 14))

--- a/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+Shortcuts.swift
@@ -205,19 +205,28 @@ extension HomeViewController: DWLocalCurrencyViewControllerDelegate {
 
     #if DASHPAY
     private func showJoinDashPayReadiness() {
+        weak var readinessNavigationController: UINavigationController?
+
         let screen = JoinDashPayReadinessScreen(
-            onAddFunds: { [weak self] suggestedDash in
+            onAddFunds: { suggestedDash in
                 let controller = InternalTransferHostingController(prefillDashAmount: suggestedDash)
-                controller.hidesBottomBarWhenPushed = true
-                self?.navigationController?.pushViewController(controller, animated: true)
+                readinessNavigationController?.pushViewController(controller, animated: true)
             },
             onProceed: { [weak self] in
-                self?.pushCreateUsernameForm()
+                readinessNavigationController?.dismiss(animated: true) {
+                    self?.pushCreateUsernameForm()
+                }
+            },
+            onClose: {
+                readinessNavigationController?.dismiss(animated: true)
             })
         let hosting = UIHostingController(rootView: screen)
         hosting.view.backgroundColor = UIColor.dw_background()
-        hosting.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(hosting, animated: true)
+        let modalNavigationController = BaseNavigationController(rootViewController: hosting)
+        modalNavigationController.isNavigationBarHidden = true
+        modalNavigationController.modalPresentationStyle = .fullScreen
+        readinessNavigationController = modalNavigationController
+        present(modalNavigationController, animated: true)
     }
 
     private func pushCreateUsernameForm(invitationURL: URL? = nil, definedUsername: String? = nil) {


### PR DESCRIPTION
## Summary
- present the DashPay readiness screen modally from Home
- add a close button that dismisses the flow
- keep add-funds navigation inside the modal and dismiss before username creation

## Testing
- xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -configuration Debug -destination 'platform=iOS Simulator,id=45923D58-3919-450E-B785-7463EE46652D' CODE_SIGNING_ALLOWED=NO -skipPackageUpdates build