### PR TITLE
fix(wallet): handle L1 broadcast outcomes

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -188,7 +188,8 @@ final class SwiftDashSDKTransactionSender: NSObject {
                     let tx = try builder.buildSigned(
                         wallet: wallet, accountType: .coinJoin,
                         accountIndex: Self.coinJoinAccountIndex)
-                    _ = try core.broadcastTransaction(tx)
+                    let outcome = try core.broadcastTransactionWithOutcome(tx)
+                    _ = try Self.requireAccepted(outcome)
                     // Wire (internal) byte order to match `Transaction.txHashData` /
                     // `CoinJoinWithdrawalStore`: `computeTxHash` yields display order,
                     // so reverse it back to wire order.
@@ -310,7 +311,8 @@ final class SwiftDashSDKTransactionSender: NSObject {
             try builder.setFeeRate(satPerKb: Self.feeRateSatPerKb)
             let tx = try builder.buildSigned(
                 wallet: wallet, accountType: .bip44, accountIndex: Self.bip44AccountIndex)
-            _ = try core.broadcastTransaction(tx)
+            let outcome = try core.broadcastTransactionWithOutcome(tx)
+            _ = try Self.requireAccepted(outcome)
             return (tx.data, tx.fee)
         }
 
@@ -417,33 +419,54 @@ final class SwiftDashSDKTransactionSender: NSObject {
     /// submits the held `CoreTransaction`'s bytes to the network.
     ///
     /// - Parameter tx: The built transaction returned by `buildAndSign`.
-    /// - Returns: The txid string reported by the SDK.
+    /// - Returns: The SDK's authoritative network-acceptance outcome.
     @discardableResult
-    static func broadcast(_ tx: CoreTransaction) throws -> String {
-        let submit = { @MainActor () throws -> String in
+    static func broadcast(_ tx: CoreTransaction) throws -> CoreTransactionBroadcastOutcome {
+        let submit = { @MainActor () throws -> CoreTransactionBroadcastOutcome in
             guard let wallet = SwiftDashSDKHost.shared.wallet else {
                 throw SendError.walletNotReady("PlatformWalletManager wallet is not available")
             }
             let core = try wallet.coreWallet()
-            return try core.broadcastTransaction(tx)
+            return try core.broadcastTransactionWithOutcome(tx)
         }
 
-        let txid: String
+        let outcome: CoreTransactionBroadcastOutcome
         if Thread.isMainThread {
-            txid = try MainActor.assumeIsolated { try submit() }
+            outcome = try MainActor.assumeIsolated { try submit() }
         } else {
-            var captured: Result<String, Error> = .failure(SendError.walletNotReady("uninitialized result"))
+            var captured: Result<CoreTransactionBroadcastOutcome, Error> =
+                .failure(SendError.walletNotReady("uninitialized result"))
             DispatchQueue.main.sync {
                 captured = Result { try MainActor.assumeIsolated { try submit() } }
             }
-            txid = try captured.get()
+            outcome = try captured.get()
         }
 
-        // Log both: the SDK-reported txid string and the app-computed
-        // display-order hash (the SDK string's byte order is unverified).
         let displayHash = computeTxHash(from: tx.data).map { String(format: "%02x", $0) }.joined()
-        logger.info("💸 TXSEND :: broadcast — sdkTxid=\(txid, privacy: .public) txHash=\(displayHash, privacy: .public)")
-        return txid
+        switch outcome {
+        case .accepted(let txid):
+            logger.info("💸 TXSEND :: broadcast accepted — sdkTxid=\(txid, privacy: .public) txHash=\(displayHash, privacy: .public)")
+        case .rejected(let txid, let reason):
+            logger.error("💸 TXSEND :: broadcast rejected — sdkTxid=\(txid, privacy: .public) txHash=\(displayHash, privacy: .public) reason=\(reason, privacy: .public)")
+        case .unknown(let txid, let reason):
+            logger.error("💸 TXSEND :: broadcast unknown — sdkTxid=\(txid, privacy: .public) txHash=\(displayHash, privacy: .public) reason=\(reason, privacy: .public)")
+        }
+        return outcome
+    }
+
+    /// Require a positive Core acceptance verdict for programmatic send paths
+    /// that do not expose the outcome enum directly. Rejected and unknown are
+    /// deliberately different errors: rejected may be retried, while unknown
+    /// must not be automatically broadcast again.
+    static func requireAccepted(_ outcome: CoreTransactionBroadcastOutcome) throws -> String {
+        switch outcome {
+        case .accepted(let txid):
+            return txid
+        case .rejected(let txid, let reason):
+            throw SendError.transactionRejected(txid: txid, reason: reason)
+        case .unknown(let txid, let reason):
+            throw SendError.transactionStatusUnknown(txid: txid, reason: reason)
+        }
     }
 
     // MARK: - Helpers
@@ -495,6 +518,8 @@ final class SwiftDashSDKTransactionSender: NSObject {
         case invalidInput(String)
         case walletNotReady(String)
         case insufficientSelectedFunds(selected: UInt64, amount: UInt64, fee: UInt64)
+        case transactionRejected(txid: String, reason: String)
+        case transactionStatusUnknown(txid: String, reason: String)
 
         var errorDescription: String? {
             switch self {
@@ -504,6 +529,10 @@ final class SwiftDashSDKTransactionSender: NSObject {
                 return "Wallet not ready: \(reason)"
             case .insufficientSelectedFunds(let selected, let amount, let fee):
                 return "Not enough funds. Selected: \(selected), Amount: \(amount), Fee: \(fee)"
+            case .transactionRejected(_, let reason):
+                return "The transaction wasn't sent. You can try again. \(reason)"
+            case .transactionStatusUnknown(_, let reason):
+                return "We couldn't confirm whether the transaction was accepted. Don't send it again; wait for wallet synchronization. \(reason)"
             }
         }
     }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletSending.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletSending.swift
@@ -26,7 +26,8 @@ final class SwiftDashSDKWalletSending: WalletSending {
             throw SwiftDashSDKTransactionSender.SendError.invalidInput(
                 "PreparedSend carries no SDK transaction handle")
         }
-        _ = try SwiftDashSDKTransactionSender.broadcast(tx)
+        let outcome = try SwiftDashSDKTransactionSender.broadcast(tx)
+        _ = try SwiftDashSDKTransactionSender.requireAccepted(outcome)
         // Return contract is the display-order txid hex; keep the deterministic
         // app-computed value (the sender logs the SDK-reported txid alongside).
         return prepared.txHashDisplay.map { String(format: "%02x", $0) }.joined()

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -30,17 +30,23 @@ final class PreparedStandardSend: NSObject {
     /// points.
     @objc var txidWire: Data { Data(txHash.reversed()) }
 
-    /// The built+signed SDK transaction, held (not broadcast) until the user
-    /// confirms. Swift-only: `CoreTransaction` is not ObjC-representable.
-    private let coreTransaction: CoreTransaction
+    private enum BroadcastState {
+        case ready
+        case broadcasting
+        case accepted
+        case unknown(NSError)
+    }
 
-    /// One-shot guard: set once `broadcast()` succeeds. Defense-in-depth behind
-    /// the confirm sheet's self-disabling button — a duplicate call errors
-    /// instead of re-firing the success flow. A *failed* broadcast releases the
-    /// claim so the same prepared object can be retried (re-broadcasting
-    /// identical bytes is network-idempotent: same txid).
+    /// Production captures the built SDK transaction in this closure; tests
+    /// inject deterministic outcomes without manufacturing an FFI transaction.
+    private let broadcastAction: () throws -> CoreTransactionBroadcastOutcome
+    private let ensureOnlineAction: () throws -> Void
+
+    /// A rejected or local failure returns to `ready`. An ambiguous network
+    /// outcome is terminal for this prepared transaction: broadcasting it again
+    /// could double-send if the first request actually reached Core.
     private let claimLock = NSLock()
-    private var broadcastClaimed = false
+    private var broadcastState = BroadcastState.ready
 
     init(
         txData: Data,
@@ -55,39 +61,99 @@ final class PreparedStandardSend: NSObject {
         self.fee = fee
         self.address = address
         self.amount = amount
-        self.coreTransaction = coreTransaction
+        self.broadcastAction = {
+            try SwiftDashSDKTransactionSender.broadcast(coreTransaction)
+        }
+        self.ensureOnlineAction = {
+            try WalletSendService.ensureOnline()
+        }
+        super.init()
+    }
+
+    /// Test seam for the broadcast state machine. The production initializer
+    /// above remains the only path that holds a real `CoreTransaction`.
+    init(
+        txData: Data,
+        txHash: Data,
+        fee: UInt64,
+        address: String,
+        amount: UInt64,
+        ensureOnlineAction: @escaping () throws -> Void = {},
+        broadcastAction: @escaping () throws -> CoreTransactionBroadcastOutcome
+    ) {
+        self.txData = txData
+        self.txHash = txHash
+        self.fee = fee
+        self.address = address
+        self.amount = amount
+        self.ensureOnlineAction = ensureOnlineAction
+        self.broadcastAction = broadcastAction
+        super.init()
     }
 
     @objc(broadcastAndReturnError:)
     func broadcast() throws {
-        // Catches airplane mode toggled on the confirm sheet after the tx was
-        // prepared: without this the offline broadcast is silently accepted.
-        try WalletSendService.ensureOnline()
-
         claimLock.lock()
-        guard !broadcastClaimed else {
+        switch broadcastState {
+        case .ready:
+            broadcastState = .broadcasting
+            claimLock.unlock()
+        case .unknown(let error):
+            claimLock.unlock()
+            throw error
+        case .broadcasting, .accepted:
             claimLock.unlock()
             throw WalletSendService.makeError(
                 code: .alreadyBroadcast,
-                description: "Transaction was already broadcast"
+                description: "Transaction was already broadcast or is being broadcast"
             )
         }
-        broadcastClaimed = true
-        claimLock.unlock()
 
+        let outcome: CoreTransactionBroadcastOutcome
         do {
-            _ = try SwiftDashSDKTransactionSender.broadcast(coreTransaction)
+            // Catches airplane mode toggled on the confirm sheet after the tx
+            // was prepared. Claiming the state first ensures a stored unknown
+            // result is returned without consulting changing network state.
+            try ensureOnlineAction()
+            outcome = try broadcastAction()
         } catch {
             claimLock.lock()
-            broadcastClaimed = false
+            broadcastState = .ready
             claimLock.unlock()
             throw error
         }
 
-        // `txHash` is display order (see `buildAndSign`); the registry keys
-        // by wire order to match `Transaction.txHashData`.
-        WalletSendService.shared.recentSends.record(
-            txidWire: Data(txHash.reversed()), address: address, amount: amount, fee: fee)
+        switch outcome {
+        case .accepted:
+            claimLock.lock()
+            broadcastState = .accepted
+            claimLock.unlock()
+
+            // `txHash` is display order (see `buildAndSign`); the registry keys
+            // by wire order to match `Transaction.txHashData`.
+            WalletSendService.shared.recentSends.record(
+                txidWire: Data(txHash.reversed()), address: address, amount: amount, fee: fee)
+
+        case .rejected(_, let reason):
+            let error = WalletSendService.makeError(
+                code: .broadcastRejected,
+                description: "The transaction wasn't sent. You can try again. \(reason)"
+            )
+            claimLock.lock()
+            broadcastState = .ready
+            claimLock.unlock()
+            throw error
+
+        case .unknown(_, let reason):
+            let error = WalletSendService.makeError(
+                code: .broadcastUnknown,
+                description: "We couldn't confirm whether the transaction was accepted. Don't send it again; wait for wallet synchronization. \(reason)"
+            )
+            claimLock.lock()
+            broadcastState = .unknown(error)
+            claimLock.unlock()
+            throw error
+        }
     }
 }
 
@@ -227,6 +293,16 @@ final class WalletSendService: NSObject {
                 throw Self.makeError(
                     code: .insufficientSelectedFunds,
                     description: "Not enough funds. Selected: \(selected), Amount: \(amount), Fee: \(fee)"
+                )
+            } catch SwiftDashSDKTransactionSender.SendError.transactionRejected(_, let reason) {
+                throw Self.makeError(
+                    code: .broadcastRejected,
+                    description: "The transaction wasn't sent. You can try again. \(reason)"
+                )
+            } catch SwiftDashSDKTransactionSender.SendError.transactionStatusUnknown(_, let reason) {
+                throw Self.makeError(
+                    code: .broadcastUnknown,
+                    description: "We couldn't confirm whether the transaction was accepted. Don't send it again; wait for wallet synchronization. \(reason)"
                 )
             }
         }
@@ -383,6 +459,16 @@ final class WalletSendService: NSObject {
         error.domain == errorDomain && error.code == ErrorCode.authenticationCancelled.rawValue
     }
 
+    @objc(isBroadcastRejectedError:)
+    static func isBroadcastRejectedError(_ error: NSError) -> Bool {
+        error.domain == errorDomain && error.code == ErrorCode.broadcastRejected.rawValue
+    }
+
+    @objc(isBroadcastUnknownError:)
+    static func isBroadcastUnknownError(_ error: NSError) -> Bool {
+        error.domain == errorDomain && error.code == ErrorCode.broadcastUnknown.rawValue
+    }
+
     /// ObjC facade over `AuthenticationGate` for completion-based callers
     /// (DWPaymentProcessor's broadcast paths). Reads the user's biometric
     /// preference like every other spend gate, and guarantees the completion
@@ -515,6 +601,8 @@ private extension WalletSendService {
         case dashPayPaymentUnavailable = 6
         case chainNotSynced = 7
         case offline = 8
+        case broadcastRejected = 9
+        case broadcastUnknown = 10
     }
 
     static let errorDomain = "org.dashfoundation.dash.wallet-send-service"

--- a/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/PaymentController.swift
@@ -59,6 +59,10 @@ final class PaymentController: NSObject {
     private weak var confirmViewController: ConfirmPaymentViewController?
     private weak var provideAmountViewController: AmountProviding?
 
+    static func shouldReenableSending(after error: NSError) -> Bool {
+        !WalletSendService.isBroadcastUnknownError(error)
+    }
+
     override init() {
         paymentProcessor = DWPaymentProcessor()
 
@@ -154,14 +158,15 @@ extension PaymentController: DWPaymentProcessorDelegate {
         // Pre-existing behavior kept: nil-error failures (invalid-address rejections)
         // stay silent here. The DashSync DSErrorDomain special-case is gone — live
         // errors carry WalletSendService / SDK / BIP70 domains.
-        guard error != nil else {
+        guard let error else {
             return
         }
 
         presentationAnchor?.topController().view.dw_hideProgressHUD()
         provideAmountViewController?.hideActivityIndicator()
 
-        confirmViewController?.isSendingEnabled = true
+        confirmViewController?.isSendingEnabled =
+            Self.shouldReenableSending(after: error as NSError)
 
         showAlert(with: title, message: message)
     }

--- a/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.m
+++ b/DashWallet/Sources/UI/Payments/PaymentModels/DWPaymentProcessor.m
@@ -154,8 +154,15 @@ static NSString *DWReversedHexString(NSData *data) {
 
         dispatch_async(dispatch_get_main_queue(), ^{
             if (error) {
+                NSString *title = NSLocalizedString(@"Couldn't make payment", nil);
+                if ([DWWalletSendService isBroadcastUnknownError:error]) {
+                    title = NSLocalizedString(@"Transaction status unknown", nil);
+                }
+                else if ([DWWalletSendService isBroadcastRejectedError:error]) {
+                    title = NSLocalizedString(@"Transaction not sent", nil);
+                }
                 [self failedWithError:error
-                                title:NSLocalizedString(@"Couldn't make payment", nil)
+                                title:title
                               message:error.localizedDescription];
             }
             else {

--- a/DashWalletTests/PaymentProtocolTests.swift
+++ b/DashWalletTests/PaymentProtocolTests.swift
@@ -338,6 +338,173 @@ final class PaymentProtocolTests: XCTestCase {
     }
 }
 
+final class PreparedStandardSendBroadcastTests: XCTestCase {
+    private func prepared(
+        hashByte: UInt8,
+        ensureOnline: @escaping () throws -> Void = {},
+        action: @escaping () throws -> CoreTransactionBroadcastOutcome
+    ) -> PreparedStandardSend {
+        PreparedStandardSend(
+            txData: Data([0x01]),
+            txHash: Data(repeating: hashByte, count: 32),
+            fee: 226,
+            address: "ybt3gVM6cM9WprG7bRTMst1YR2GnAbWGLr",
+            amount: 100_000,
+            ensureOnlineAction: ensureOnline,
+            broadcastAction: action
+        )
+    }
+
+    func testAcceptedRecordsRecentSendAndBecomesOneShot() throws {
+        var calls = 0
+        let send = prepared(hashByte: 0xa1) {
+            calls += 1
+            return .accepted(txid: String(repeating: "a1", count: 32))
+        }
+
+        try send.broadcast()
+
+        XCTAssertEqual(calls, 1)
+        XCTAssertNotNil(WalletSendService.shared.recentSends.entry(forTxidWire: send.txidWire))
+        XCTAssertThrowsError(try send.broadcast())
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testRejectedCanBeRetriedAndIsNotRecorded() {
+        var calls = 0
+        let send = prepared(hashByte: 0xb2) {
+            calls += 1
+            return .rejected(
+                txid: String(repeating: "b2", count: 32),
+                reason: "broadcast was not started")
+        }
+
+        for _ in 0..<2 {
+            XCTAssertThrowsError(try send.broadcast()) { error in
+                XCTAssertTrue(WalletSendService.isBroadcastRejectedError(error as NSError))
+            }
+        }
+
+        XCTAssertEqual(calls, 2)
+        XCTAssertNil(WalletSendService.shared.recentSends.entry(forTxidWire: send.txidWire))
+    }
+
+    func testUnknownBlocksSecondBroadcastAndIsNotRecorded() {
+        var calls = 0
+        let send = prepared(hashByte: 0xc3) {
+            calls += 1
+            return .unknown(txid: String(repeating: "c3", count: 32), reason: "timeout")
+        }
+
+        var firstError: NSError?
+        XCTAssertThrowsError(try send.broadcast()) { error in
+            firstError = error as NSError
+            XCTAssertTrue(WalletSendService.isBroadcastUnknownError(error as NSError))
+        }
+        var secondError: NSError?
+        XCTAssertThrowsError(try send.broadcast()) { error in
+            secondError = error as NSError
+            XCTAssertTrue(WalletSendService.isBroadcastUnknownError(error as NSError))
+        }
+
+        XCTAssertEqual(calls, 1)
+        XCTAssertTrue(firstError === secondError)
+        XCTAssertNil(WalletSendService.shared.recentSends.entry(forTxidWire: send.txidWire))
+    }
+
+    func testOfflineFailureReturnsToReady() throws {
+        let offline = NSError(
+            domain: "test.network", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "offline"])
+        var isOnline = false
+        var calls = 0
+        let send = prepared(
+            hashByte: 0xd4,
+            ensureOnline: {
+                if !isOnline { throw offline }
+            },
+            action: {
+                calls += 1
+                return .accepted(txid: String(repeating: "d4", count: 32))
+            })
+
+        XCTAssertThrowsError(try send.broadcast())
+        XCTAssertEqual(calls, 0)
+
+        isOnline = true
+        try send.broadcast()
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testLocalBroadcastFailureReturnsToReady() throws {
+        let localError = NSError(
+            domain: "test.local", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "local failure"])
+        var calls = 0
+        let send = prepared(hashByte: 0xe5) {
+            calls += 1
+            if calls == 1 { throw localError }
+            return .accepted(txid: String(repeating: "e5", count: 32))
+        }
+
+        XCTAssertThrowsError(try send.broadcast())
+        try send.broadcast()
+        XCTAssertEqual(calls, 2)
+    }
+
+    func testUnknownRemainsTerminalWhenNetworkStateChanges() {
+        let offline = NSError(
+            domain: "test.network", code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "offline"])
+        var onlineChecks = 0
+        var shouldFailOnlineCheck = false
+        var calls = 0
+        let send = prepared(
+            hashByte: 0xf6,
+            ensureOnline: {
+                onlineChecks += 1
+                if shouldFailOnlineCheck { throw offline }
+            },
+            action: {
+                calls += 1
+                return .unknown(
+                    txid: String(repeating: "f6", count: 32),
+                    reason: "peer echo timed out")
+            })
+
+        XCTAssertThrowsError(try send.broadcast()) { error in
+            XCTAssertTrue(WalletSendService.isBroadcastUnknownError(error as NSError))
+        }
+        shouldFailOnlineCheck = true
+        XCTAssertThrowsError(try send.broadcast()) { error in
+            XCTAssertTrue(WalletSendService.isBroadcastUnknownError(error as NSError))
+        }
+        XCTAssertEqual(onlineChecks, 1)
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testPaymentControllerReenablesSendExceptForUnknown() throws {
+        let rejected = prepared(hashByte: 0x17) {
+            .rejected(txid: String(repeating: "17", count: 32), reason: "not started")
+        }
+        let unknown = prepared(hashByte: 0x28) {
+            .unknown(txid: String(repeating: "28", count: 32), reason: "timeout")
+        }
+
+        var rejectedError: NSError?
+        XCTAssertThrowsError(try rejected.broadcast()) { rejectedError = $0 as NSError }
+        var unknownError: NSError?
+        XCTAssertThrowsError(try unknown.broadcast()) { unknownError = $0 as NSError }
+
+        XCTAssertTrue(PaymentController.shouldReenableSending(
+            after: try XCTUnwrap(rejectedError)))
+        XCTAssertFalse(PaymentController.shouldReenableSending(
+            after: try XCTUnwrap(unknownError)))
+        XCTAssertTrue(PaymentController.shouldReenableSending(
+            after: NSError(domain: "test.local", code: 3)))
+    }
+}
+
 // MARK: - L5 orchestrator (fakes, no network/SDK)
 
 private final class FakeTransport: PaymentProtocolTransporting {
@@ -361,13 +528,16 @@ private final class FakeWallet: WalletSending {
     var calls: [String] = []
     var lastRecipients: [(address: String, amountDuffs: UInt64)] = []
     var buildErrorsRemaining = 0 // throw from build this many times before succeeding (pre-spend failure)
+    var broadcastError: BIP70Error?
     func buildSignedTransaction(recipients: [(address: String, amountDuffs: UInt64)]) async throws -> PreparedSend {
         calls.append("build")
         if buildErrorsRemaining > 0 { buildErrorsRemaining -= 1; throw BIP70Error.walletNotReady }
         lastRecipients = recipients; return prepared
     }
     func broadcast(_ p: PreparedSend) async throws -> String {
-        calls.append("broadcast"); return p.txHashDisplay.map { String(format: "%02x", $0) }.joined()
+        calls.append("broadcast")
+        if let broadcastError { throw broadcastError }
+        return p.txHashDisplay.map { String(format: "%02x", $0) }.joined()
     }
 }
 
@@ -446,6 +616,20 @@ final class BIP70PaymentServiceTests: XCTestCase {
         await assertThrowsBIP70(try await svc.confirmAndSend(confirmation), .walletNotReady) // build throws → guard reset
         _ = try await svc.confirmAndSend(confirmation) // retry on the SAME confirmation now succeeds
         XCTAssertEqual(w.calls.filter { $0 == "build" }.count, 2)
+        XCTAssertEqual(w.calls.filter { $0 == "broadcast" }.count, 1)
+    }
+
+    func testBroadcastFailureKeepsBIP70ConfirmationOneShot() async throws {
+        let w = FakeWallet()
+        w.broadcastError = .walletNotReady
+        let svc = service(FakeTransport(unsigned(paymentURL: nil)), w)
+        let confirmation = try await svc.prepareForConfirmation(
+            from: url, scheme: "dash", network: .testnet)
+
+        await assertThrowsBIP70(
+            try await svc.confirmAndSend(confirmation), .walletNotReady)
+        await assertThrowsBIP70(
+            try await svc.confirmAndSend(confirmation), .alreadySent)
         XCTAssertEqual(w.calls.filter { $0 == "broadcast" }.count, 1)
     }
 


### PR DESCRIPTION
## Summary
- handle accepted, rejected, and unknown L1 broadcast outcomes explicitly
- show success only after accepted; allow retry after rejected/local failures
- keep unknown terminal for the prepared send and prevent a duplicate broadcast
- apply the shared outcome handling to standard sends, selected-input sends, CoinJoin sweep, and BIP70

## Validation
- rebuilt Swift SDK XCFramework from current Platform v4.1-dev
- Swift Example App build succeeded
- dashpay simulator build succeeded
- added state-machine, UI behavior, and BIP70 one-shot tests
- local test execution is currently blocked by the missing matching watchOS simulator runtime (23S303)