### PR TITLE
fix(dashpay): fund contested identity with the contested denomination

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -267,6 +267,12 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         currentFundingSource = fundingSource
         failedAtPhase = nil
         lastErrorMessage = nil
+        let isContestedSubmission = DWContestedNameStatusService.isContestedLabel(username)
+        let requiredIdentityFundingDuffs = isContestedSubmission
+            ? DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME
+            : DWDP_MIN_BALANCE_TO_CREATE_USERNAME
+        Self.logger.info(
+            "🪪 IDENT-COORD :: contested=\(isContestedSubmission, privacy: .public) identityFundingDuffs=\(requiredIdentityFundingDuffs, privacy: .public)")
 
         let newController = DWIdentityRegistrationController()
         controller = newController
@@ -345,7 +351,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             switch fundingSource {
             case .core:
                 let result = try await wallet.registerIdentityWithFunding(
-                    amountDuffs: DWDP_MIN_BALANCE_TO_CREATE_USERNAME,
+                    amountDuffs: requiredIdentityFundingDuffs,
                     accountIndex: Self.defaultAccountIndex,
                     identityIndex: Self.pinnedIdentityIndex,
                     identityPubkeys: pubkeys,
@@ -353,7 +359,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 identityId = result.0
 
             case .platformPayment:
-                let targetCredits = UInt64(DWDP_MIN_BALANCE_TO_CREATE_USERNAME) * Self.creditsPerDuff
+                let targetCredits = UInt64(requiredIdentityFundingDuffs) * Self.creditsPerDuff
                 let inputs = try buildPlatformPaymentInputs(
                     walletId: wallet.walletId,
                     modelContainer: modelContainer,
@@ -466,7 +472,6 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         //      `handlePhaseChange` — they run when
         //      `checkPendingContestResolution()` detects the win and
         //      calls `DWContestedNameStatusService.finalizeWon(username:)`.
-        let isContestedSubmission = DWContestedNameStatusService.isContestedLabel(username)
         Self.logger.info("🪪 IDENT-COORD :: contested=\(isContestedSubmission, privacy: .public) label=\(username, privacy: .public)")
         if isContestedSubmission {
             DWContestedNameStatusService.shared.recordSubmission(label: username)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Registering a **contested** username via the **Core / Platform-Payment** funding path under-funded the new identity. `DWIdentityRegistrationCoordinator.startCreateUsername` hardcoded `DWDP_MIN_BALANCE_TO_CREATE_USERNAME` (0.03 DASH) for both `.core` and `.platformPayment`, ignoring whether the name is contested (which needs `DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME` = 0.25 DASH). The identity was created with ~0.03, then DPNS registration failed with `Insufficient identity balance` (~0.028 vs the ~0.2 DASH a contested name requires), spending funds and leaving a **funded orphan identity with no name and no retry path**. The `.shielded` path was unaffected — it already used the contested denomination.

## What was done?
Compute the funding amount once, branching on `isContested`, and use it for both funding paths:

```swift
let requiredIdentityFundingDuffs = isContestedSubmission
    ? DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME   // 0.25 DASH
    : DWDP_MIN_BALANCE_TO_CREATE_USERNAME        // 0.03 DASH
```

- `.core` → `registerIdentityWithFunding(amountDuffs: requiredIdentityFundingDuffs, …)`
- `.platformPayment` → `targetCredits = UInt64(requiredIdentityFundingDuffs) * creditsPerDuff`
- Moved the existing `isContestedSubmission` computation up (removing the later duplicate) and added a diagnostic log line (`identityFundingDuffs=…`).

## How Has This Been Tested?
Manual smoke on testnet, on device (iPhone 17 Pro):

- **Before:** contested via Core funded 0.03 → `Insufficient identity balance` → orphan identity, no name.
- **After:** fresh wallet, contested `Addda` via Core → identity funded **0.25** (funding tx `+0.25`, identity `bb732e81…` balance `0.24878120`), username registered, no error, no orphan.
- Recommended follow-up: confirm non-contested via Core still funds 0.03 — preserved by the ternary; the non-contested Core path passed before this change.

(No automated test added — the unit-test target is currently broken; verified via testnet smoke per the repo's current verification standard.)

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
