### PR TITLE
fix(dashpay): route the menu Join DashPay entry through the shielded-readiness gate

### DIFF
--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -158,6 +158,7 @@ struct MainMenuScreen: View {
     @State private var showSecurity: Bool = false
     @State private var showDashPayInfo: Bool = false
     @State private var showCreditsPurchasedToast: Bool = false
+    @State private var navigateToDashPayFlow: Bool = false
     
     #if DASHPAY
     private let joinDPViewModel = JoinDashPayViewModel(initialState: .none)
@@ -372,10 +373,15 @@ struct MainMenuScreen: View {
             handleNavigation(destination)
         }
         #if DASHPAY
-        .sheet(isPresented: $showDashPayInfo) {
+        .sheet(isPresented: $showDashPayInfo, onDismiss: {
+            if navigateToDashPayFlow {
+                navigateToDashPayFlow = false
+                joinDashPay()
+            }
+        }) {
             let dialog = JoinDashPayInfoDialog(
                 action: {
-                    self.joinDashPay()
+                    navigateToDashPayFlow = true
                 },
                 onClaimInvitation: {
                     self.claimInvitation()
@@ -527,24 +533,70 @@ struct MainMenuScreen: View {
 
     private func joinDashPay() {
         guard let dashPayModel = viewModel.dashPayModel else { return }
-        
+
+        let readiness = ShieldedIdentityFundingReadiness.shared.evaluate(
+            requiredCredits: ShieldedIdentityFundingReadiness.standardDenominationCredits)
+        if let readiness, readiness.state != .ready {
+            showJoinDashPayReadiness(dashPayModel: dashPayModel)
+        } else {
+            pushCreateUsernameForm(dashPayModel: dashPayModel)
+        }
+    }
+
+    private func showJoinDashPayReadiness(dashPayModel: DWDashPayProtocol) {
+        weak var readinessNavigationController: UINavigationController?
+        weak var menuNavigationController = vc
+
+        let screen = JoinDashPayReadinessScreen(
+            onAddFunds: { suggestedDash in
+                let controller = InternalTransferHostingController(prefillDashAmount: suggestedDash)
+                readinessNavigationController?.pushViewController(controller, animated: true)
+            },
+            onProceed: {
+                readinessNavigationController?.dismiss(animated: true) {
+                    guard let menuNavigationController else { return }
+                    Self.pushCreateUsernameForm(
+                        on: menuNavigationController,
+                        dashPayModel: dashPayModel)
+                }
+            },
+            onClose: {
+                readinessNavigationController?.dismiss(animated: true)
+            })
+        let hosting = UIHostingController(rootView: screen)
+        hosting.view.backgroundColor = UIColor.dw_background()
+        let modalNavigationController = BaseNavigationController(rootViewController: hosting)
+        modalNavigationController.isNavigationBarHidden = true
+        modalNavigationController.modalPresentationStyle = .fullScreen
+        readinessNavigationController = modalNavigationController
+        vc.present(modalNavigationController, animated: true)
+    }
+
+    private func pushCreateUsernameForm(dashPayModel: DWDashPayProtocol) {
+        Self.pushCreateUsernameForm(on: vc, dashPayModel: dashPayModel)
+    }
+
+    private static func pushCreateUsernameForm(
+        on navigationController: UINavigationController,
+        dashPayModel: DWDashPayProtocol
+    ) {
         let controller = CreateUsernameViewController(
             dashPayModel: dashPayModel,
             invitationURL: nil,
             definedUsername: nil
         )
         controller.hidesBottomBarWhenPushed = true
-        controller.completionHandler = { result in
+        controller.completionHandler = { [weak navigationController] result in
             let message = result 
                 ? NSLocalizedString("Username was successfully requested", comment: "Usernames")
                 : NSLocalizedString("Your request was cancelled", comment: "Usernames")
             
             // Find the root view controller to show HUD
-            if let rootVC = self.vc.viewControllers.first {
+            if let rootVC = navigationController?.viewControllers.first {
                 rootVC.view.dw_showInfoHUD(withText: message, offsetForNavBar: true)
             }
         }
-        vc.pushViewController(controller, animated: true)
+        navigationController.pushViewController(controller, animated: true)
     }
     #endif
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
**Menu → Join DashPay** pushed the Create Username form directly (`MainMenuViewController.joinDashPay`), skipping the shielded **"Get ready to join DashPay"** interstitial that the Home banner routes through (`HomeViewController+Shortcuts` evaluates `ShieldedIdentityFundingReadiness` and shows the interstitial when `state != .ready`). As a result, half the entry points bypassed the privacy-preserving readiness gate — a user joining via the menu never saw the shielded-funding readiness step and landed straight on the form.

## What was done?
`joinDashPay()` now mirrors the Home path:

```swift
let readiness = ShieldedIdentityFundingReadiness.shared.evaluate(
    requiredCredits: ShieldedIdentityFundingReadiness.standardDenominationCredits)
if let readiness, readiness.state != .ready {
    showJoinDashPayReadiness(dashPayModel: dashPayModel)   // interstitial
} else {
    pushCreateUsernameForm(dashPayModel: dashPayModel)      // form
}
```

- `showJoinDashPayReadiness` presents `JoinDashPayReadinessScreen` **modally** with the `onClose` affordance (consistent with the Home path after the modal-readiness change), so the menu entry also gets a back-out.
- The `JoinDashPayInfoDialog` action now defers to the sheet's `onDismiss` (via a `navigateToDashPayFlow` flag) so the readiness modal isn't presented while the info sheet is still dismissing.
- Extracted a shared `pushCreateUsernameForm(on:dashPayModel:)` so both entry paths reuse the same form push + completion HUD.

## How Has This Been Tested?
Manual, testnet, on device: entering the create-username flow from **Menu → Join DashPay** now shows the "Get ready to join DashPay" interstitial when the shielded pool isn't ready (matching the Home banner), and pushes the form directly when it is ready. The readiness screen can be dismissed via its close control.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
