### PR TITLE
fix(dashpay): raise shielded funding headroom to cover the shield fee

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
@@ -35,12 +35,13 @@ struct JoinDashPayReadinessScreen: View {
     /// Return to the screen that opened this interstitial.
     let onClose: () -> Void
 
-    /// Suggested deposit headroom (0.001 DASH in credits) added to the
+    /// Suggested deposit headroom (0.003 DASH in credits) added to the
     /// shortfall prefill: the Core→Shielded route carves the Platform
-    /// pool fee from the locked value, so depositing the bare shortfall
-    /// would net slightly under the denomination. Only a suggestion —
-    /// the gates re-evaluate on the notes that actually land.
-    private static let fundingFeeHeadroomCredits: UInt64 = 100_000_000
+    /// pool fee from the locked value. The current Type-18 fee is about
+    /// 0.003 DASH, so depositing less headroom can leave the resulting
+    /// note below the required denomination. Only a suggestion — the
+    /// gates re-evaluate on the notes that actually land.
+    private static let fundingFeeHeadroomCredits: UInt64 = 300_000_000
 
     private var snapshot: ShieldedIdentityFundingReadiness.Snapshot? {
         readiness.standardSnapshot


### PR DESCRIPTION
## Issue being fixed or feature implemented
The **"Add"** prefill on the "Get ready to join DashPay" interstitial added only **0.001 DASH** of headroom over the shortfall (`fundingFeeHeadroomCredits`), but the Core→Shielded shield operation carves ~0.003 DASH (Type-18 pool fee + asset-lock base cost) from the locked value. Depositing the app-suggested **0.101** netted a **0.098** note — **below the 0.1 DASH exit denomination** — so readiness stayed in `needsFunding` even though the user followed the app's own suggestion.

## What was done?
Raise `fundingFeeHeadroomCredits` from `100_000_000` (0.001 DASH) to `300_000_000` (0.003 DASH) so the suggested deposit comfortably clears the denomination.

## How Has This Been Tested?
Manual, testnet, on device: adding the suggested amount (0.103) via the "Add" prefill now lands a shielded note of **0.10087** (≥ 0.1), and the funding gate flips to met instead of remaining `needsFunding`.

## Breaking Changes
None. (Only a suggested prefill amount; the readiness gates still re-evaluate on the notes that actually land.)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
