### PR TITLE
fix(dashpay): validate Core→Shielded amount up-front instead of failing at build time

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -196,15 +196,6 @@ struct InternalTransferConfirmSheet: View {
 
     // MARK: - Network fee estimate
 
-    /// Asset-lock processing base cost folded into a ShieldFromAssetLock
-    /// (Type 18) pool fee on top of `compute_minimum_shielded_fee`. Mirrors
-    /// the Rust `shield_from_asset_lock_pool_fee`:
-    /// `required_asset_lock_duff_balance_for_processing_start_for_address_funding`
-    /// (50_000 duffs) × 1000 credits/duff. Versioned constant; estimate-only.
-    /// Internal — the Send confirm sheet estimates its Core → Shielded
-    /// route with the same number.
-    static let assetLockBaseCostCredits: UInt64 = 50_000_000
-
     /// Platform credits per DASH (1e11).
     private static let creditsPerDash: Decimal = 100_000_000_000
 
@@ -214,10 +205,7 @@ struct InternalTransferConfirmSheet: View {
     private var networkFeeCredits: UInt64? {
         switch route {
         case .coreToShielded:
-            // ShieldFromAssetLock: base shielded fee + asset-lock base cost.
-            guard let base = try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
-            else { return nil }
-            return base + Self.assetLockBaseCostCredits
+            return CoreToShieldedAmountPolicy.poolFeeCredits
         case .platformToShielded:
             // Shield (Type 15): base shielded fee. Real metered storage is
             // extra and only knowable on-chain, so this is a lower bound.
@@ -231,7 +219,7 @@ struct InternalTransferConfirmSheet: View {
             // (the same 50k-duff base the Rust side reserves for address
             // funding). The funding ST's metered fee is extra and only
             // knowable on-chain, so this is a lower bound.
-            return Self.assetLockBaseCostCredits
+            return CoreToShieldedAmountPolicy.assetLockBaseCostCredits
         case .platformToCore:
             // The exact transition fee the preflight already netted out of
             // the payout amount.

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -60,6 +60,11 @@ struct InternalTransferScreen: View {
                             .padding(.horizontal, 20)
                     }
 
+                    if let message = viewModel.amountValidationMessage {
+                        TransferAmountValidationNote(message: message)
+                            .padding(.horizontal, 20)
+                    }
+
                     if viewModel.canContinue {
                         transferPreview
                             .padding(.horizontal, 20)
@@ -439,6 +444,29 @@ struct InternalTransferScreen: View {
                     viewModel.amountText = newValue
                 }
             })
+    }
+}
+
+// MARK: - TransferAmountValidationNote
+
+/// Inline explanation for a route-specific amount that cannot be submitted.
+/// Keeping this next to the amount/source controls prevents a protective SDK
+/// build-time refusal from becoming the user's first feedback.
+private struct TransferAmountValidationNote: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 13))
+                .foregroundColor(.orange)
+            Text(message)
+                .font(.system(size: 13))
+                .foregroundColor(.dash.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -51,6 +51,38 @@ enum InternalTransferRoute: Equatable {
     case platformToCore
 }
 
+/// Shared Type-18 amount boundary for Core → Shielded transfers.
+///
+/// `ShieldFromAssetLock` carves its pool fee from the single-use asset-lock
+/// value, so the lock must contain strictly more credits than that fee. Keep
+/// the estimator here as the one source of truth for amount validation and
+/// both transfer confirmation screens.
+@MainActor
+enum CoreToShieldedAmountPolicy {
+    /// Asset-lock processing base cost folded into a ShieldFromAssetLock
+    /// pool fee on top of `compute_minimum_shielded_fee`. Mirrors Rust
+    /// `required_asset_lock_duff_balance_for_processing_start_for_address_funding`
+    /// (50_000 duffs) × 1000 credits/duff.
+    static let assetLockBaseCostCredits: UInt64 = 50_000_000
+
+    static var poolFeeCredits: UInt64? {
+        guard let shieldedFee = try? PlatformWalletManager.estimateShieldedFee(
+            kind: .transfer,
+            numActions: 2)
+        else { return nil }
+
+        let (total, overflow) = shieldedFee.addingReportingOverflow(assetLockBaseCostCredits)
+        return overflow ? nil : total
+    }
+
+    /// User-entered Core amounts have duff precision (1000 Platform credits).
+    /// The SDK rejects `amountCredits <= poolFeeCredits`, so the smallest valid
+    /// value is the first whole duff strictly above the fee.
+    static func minimumAmountDuffs(poolFeeCredits: UInt64) -> UInt64 {
+        poolFeeCredits / 1000 + 1
+    }
+}
+
 @MainActor
 final class InternalTransferViewModel: ObservableObject {
 
@@ -329,6 +361,34 @@ final class InternalTransferViewModel: ObservableObject {
         }
     }
 
+    var coreToShieldedMinimumAmountDuffs: UInt64? {
+        guard route == .coreToShielded,
+              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits
+        else { return nil }
+        return CoreToShieldedAmountPolicy.minimumAmountDuffs(
+            poolFeeCredits: poolFeeCredits)
+    }
+
+    /// Inline, user-facing explanation for a Core → Shielded amount rejected
+    /// before Confirm. Zero stays quiet while the user has not entered an
+    /// amount; a fee-estimation failure fails closed with a generic retry.
+    var amountValidationMessage: String? {
+        guard route == .coreToShielded, dashDuffsUnsigned > 0 else { return nil }
+        guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
+            return NSLocalizedString(
+                "There was an error, please try again later",
+                comment: "Internal transfer fee estimate unavailable")
+        }
+        guard dashDuffsUnsigned < minimumDuffs else { return nil }
+
+        let formattedMinimum = "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "The minimum amount you can send is %@",
+                comment: "Internal transfer minimum amount"),
+            formattedMinimum)
+    }
+
     var canContinue: Bool {
         // Gate on duffs, not raw DASH: a sub-duff amount (e.g. 1e-9 DASH)
         // renders as 0 in the confirm sheet, so it must not enable Continue —
@@ -336,7 +396,15 @@ final class InternalTransferViewModel: ObservableObject {
         // UI shows 0.
         guard dashDuffsUnsigned > 0, !isBlockedBySync else { return false }
         switch route {
-        case .coreToShielded, .coreToPlatform:
+        case .coreToShielded:
+            // The Type-18 pool fee is carved from the asset-lock value. The
+            // SDK refuses to broadcast a single-use lock at or below that fee;
+            // enforce the same strict boundary before opening Confirm.
+            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs,
+                  dashDuffsUnsigned >= minimumDuffs
+            else { return false }
+            return dashDuffsUnsigned <= coreBalanceDuffs
+        case .coreToPlatform:
             // Asset-lock routes: the pool/processing fee is carved from the
             // locked value (not charged on top of the Core balance) and the
             // Rust side rejects an undersized lock, so no source-balance fee

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -865,11 +865,7 @@ struct SendConfirmSheet: View {
     private var networkFeeCredits: UInt64? {
         switch route {
         case .coreToShielded:
-            // ShieldFromAssetLock: base shielded fee + asset-lock base cost
-            // (same estimate as the internal Core → Shielded transfer).
-            guard let base = try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
-            else { return nil }
-            return base + InternalTransferConfirmSheet.assetLockBaseCostCredits
+            return CoreToShieldedAmountPolicy.poolFeeCredits
         case .platformToPlatform:
             // Credit transfer: the metered transition fee. The executor
             // states ~0.001 DASH as the conservative max.


### PR DESCRIPTION
## Issue being fixed or feature implemented
A **Core → Shielded** transfer whose amount was at or below the Type-18 pool fee (~0.00213 DASH) was accepted through the amount screen and the Confirm sheet, and only rejected **at build time** with a raw SDK string:

```
shielded fund-from-asset-lock failed: … asset lock (…) is at or below the
ShieldFromAssetLock pool fee (… = shielded fee + asset_lock_base_cost) —
refusing to broadcast a single-use L1 outpoint …
```

So a protective SDK refusal became the user's first feedback — there was no up-front minimum-amount validation.

## What was done?
- Added `CoreToShieldedAmountPolicy` — a single source of truth for the Type-18 amount boundary (`estimateShieldedFee` + asset-lock base cost, with overflow protection) and the derived `minimumAmountDuffs` (first whole duff strictly above the fee).
- `InternalTransferViewModel.canContinue` for the `.coreToShielded` route now gates on `dashDuffsUnsigned >= minimum` **before** Confirm can open.
- Added `amountValidationMessage` → an inline "The minimum amount you can send is X DASH" note (`TransferAmountValidationNote`) on the amount screen; stays quiet at 0, fails closed with a generic retry if the fee estimate is unavailable.
- Refactored `InternalTransferConfirmSheet` and `SendConfirmSheet` to reuse `CoreToShieldedAmountPolicy` (removing the duplicated constant/estimate), so the internal-transfer and Send-screen Core → Shielded routes share one estimator.

## How Has This Been Tested?
Manual, testnet, on device: entering a sub-fee Core → Shielded amount now shows the inline minimum-amount note and keeps Continue disabled, instead of reaching Confirm and failing at build time. Valid amounts above the minimum proceed as before.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
