### PR TITLE
fix(dashpay): hold the shielded balance through post-spend sync instead of flashing zero

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -923,7 +923,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
 
         Self.logger.info("🪪 IDENT-COORD :: shielded create denomination=\(denomination, privacy: .public) contested=\(contested, privacy: .public)")
         do {
-            return try await manager.shieldedIdentityCreateFromPool(
+            let identityId = try await manager.shieldedIdentityCreateFromPool(
                 walletId: walletId,
                 // Per-operation Orchard spend authority (seedless
                 // shielded bind) — same pattern as the app's other
@@ -935,8 +935,13 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 denomination: denomination,
                 sendToAddressOnCreationFailure: fallbackAddressBytes,
                 identitySigner: signer)
+            PlatformAddressSyncCoordinator.shared
+                .refreshShieldedBalanceAfterSpend(using: manager)
+            return identityId
         } catch let unconfirmed as ShieldedIdentityCreateUnconfirmedError {
             Self.logger.warning("🪪 IDENT-COORD :: shielded create unconfirmed id=\(unconfirmed.identityId.map { String(format: "%02x", $0) }.joined().prefix(8), privacy: .public)…")
+            PlatformAddressSyncCoordinator.shared
+                .refreshShieldedBalanceAfterSpend(using: manager)
             throw CoordinatorError.shieldedCreateUnconfirmed
         }
     }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -60,6 +60,10 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     @Published public private(set) var platformBalance: UInt64 = 0
     @Published public private(set) var shieldedBalance: UInt64 = 0
+    /// True while a shielded spend has been observed but its change note has
+    /// not reached the local scan yet. During this window `shieldedBalance`
+    /// keeps the last reliable value instead of publishing a transient zero.
+    @Published public private(set) var isShieldedBalanceReconciling: Bool = false
     @Published public private(set) var activeAddressCount: Int = 0
     @Published public private(set) var derivedAddresses: [DerivedPlatformAddress] = []
 
@@ -97,6 +101,8 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     private var syncEventCancellable: AnyCancellable?
     private var syncStateCancellable: AnyCancellable?
     private var shieldedEventCancellable: AnyCancellable?
+    private var shieldedReconciliationTask: Task<Void, Never>?
+    private var latestObservedShieldedBalance: UInt64 = 0
 
     /// Long-lived resolver for the shielded sub-wallet bind in `performStart`.
     /// Stored (not local) because `MnemonicResolver` hands Rust an unretained
@@ -549,8 +555,12 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     /// Clear the UI counters/display without tearing down the sync loop.
     public func clearDisplay() {
+        shieldedReconciliationTask?.cancel()
+        shieldedReconciliationTask = nil
         platformBalance = 0
         shieldedBalance = 0
+        latestObservedShieldedBalance = 0
+        isShieldedBalanceReconciling = false
         activeAddressCount = 0
         derivedAddresses = []
         checkpointHeight = 0
@@ -835,9 +845,14 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
         // Seed once from whatever the manager already saw (the publisher only
         // fires on new events), then mirror the shielded balance from each
-        // completed shielded sync pass — same source/filter as
-        // `InternalTransferViewModel`. Balance is in credits (1e11/DASH).
-        shieldedBalance = manager.lastShieldedSyncEvent?.result(for: walletId)?.balance ?? 0
+        // completed shielded sync pass. Balance is in credits (1e11/DASH).
+        // Cooldown skips carry a zero payload, so they are never a valid seed.
+        if let result = manager.lastShieldedSyncEvent?.result(for: walletId),
+           result.success,
+           !result.cooldownSkip {
+            shieldedBalance = result.balance
+            latestObservedShieldedBalance = result.balance
+        }
         // Seed the shielded funding-tx → locked-amount map (for the home tx
         // list's "Shielded transfer" rows) from whatever is already
         // persisted, then refresh it after each completed shielded sync pass
@@ -851,9 +866,89 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
                       let result = event?.result(for: walletId),
                       result.success,
                       !result.cooldownSkip else { return }
-                self.shieldedBalance = result.balance
+                self.handleShieldedBalanceResult(result, manager: manager)
                 ShieldedTxLookup.shared.refresh()
             }
+    }
+
+    /// Run an immediate post-spend readback. If the first pass observes spent
+    /// inputs before their change output, `handleShieldedBalanceResult` starts
+    /// a bounded retry sequence and keeps the last reliable balance visible.
+    func refreshShieldedBalanceAfterSpend(using manager: PlatformWalletManager) {
+        Task {
+            do {
+                try await manager.syncShieldedNow()
+            } catch {
+                Self.logger.warning(
+                    "🛡️ SHIELD :: post-spend sync failed: \(String(describing: error), privacy: .public)")
+            }
+        }
+    }
+
+    private func handleShieldedBalanceResult(
+        _ result: ShieldedWalletSyncResult,
+        manager: PlatformWalletManager
+    ) {
+        latestObservedShieldedBalance = result.balance
+
+        if isShieldedBalanceReconciling {
+            guard result.balance > 0 else { return }
+            finishShieldedBalanceReconciliation(with: result.balance)
+            return
+        }
+
+        // A spend's nullifier and its change note can become visible in
+        // separate Platform reads. Publishing the intermediate zero makes the
+        // user's remaining funds appear to vanish. Hold the previous snapshot
+        // only when this pass actually discovered newly-spent notes; ordinary
+        // zero balances still publish immediately.
+        if result.balance == 0, result.newlySpent > 0, shieldedBalance > 0 {
+            isShieldedBalanceReconciling = true
+            Self.logger.info(
+                "🛡️ SHIELD :: holding transient zero after \(result.newlySpent, privacy: .public) newly-spent note(s)")
+            scheduleShieldedBalanceReconciliation(using: manager)
+            return
+        }
+
+        shieldedBalance = result.balance
+    }
+
+    private func scheduleShieldedBalanceReconciliation(using manager: PlatformWalletManager) {
+        shieldedReconciliationTask?.cancel()
+        shieldedReconciliationTask = Task { [weak self] in
+            // The background loop sleeps for 60 seconds. These bounded kicks
+            // cover the common Platform-indexing window without leaving a
+            // legitimate fully-spent balance stale indefinitely.
+            for delayNanos in [UInt64(4_000_000_000), 12_000_000_000, 24_000_000_000] {
+                do {
+                    try await Task.sleep(nanoseconds: delayNanos)
+                } catch {
+                    return
+                }
+                guard let self, self.isShieldedBalanceReconciling else { return }
+                do {
+                    try await manager.syncShieldedNow()
+                } catch {
+                    Self.logger.warning(
+                        "🛡️ SHIELD :: reconciliation sync failed: \(String(describing: error), privacy: .public)")
+                }
+            }
+
+            // Combine delivers the completion on the main run loop. Give that
+            // delivery one turn before deciding the bounded retries are done.
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard let self, self.isShieldedBalanceReconciling else { return }
+            Self.logger.info("🛡️ SHIELD :: reconciliation window ended with zero balance")
+            self.finishShieldedBalanceReconciliation(
+                with: self.latestObservedShieldedBalance)
+        }
+    }
+
+    private func finishShieldedBalanceReconciliation(with balance: UInt64) {
+        shieldedBalance = balance
+        isShieldedBalanceReconciling = false
+        shieldedReconciliationTask?.cancel()
+        shieldedReconciliationTask = nil
     }
 
     private func handleSyncEvent(_ event: PlatformAddressSyncEvent, walletId: Data) {

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift
@@ -36,6 +36,7 @@ enum HomeBalanceViewState: Int {
 struct HomeBalanceView: View {
     @ObservedObject var viewModel: BalanceModel
     @ObservedObject private var platformSync = PlatformAddressSyncCoordinator.shared
+    @ObservedObject private var shieldedSync = ShieldedSyncMonitor.shared
     @State private var opacity: Double = 0.3
     var onLongPress: () -> Void
     var onReceive: (ChainNetwork) -> Void = { _ in }
@@ -148,6 +149,7 @@ struct HomeBalanceView: View {
                 icon: "shield",
                 title: NSLocalizedString("Shielded", comment: ""),
                 duffs: shieldedDuffs,
+                isSyncing: shieldedSync.isSyncing || platformSync.isShieldedBalanceReconciling,
                 infoAction: { onInfo(.shielded) },
                 inAction: { onReceive(.shielded) },
                 outAction: { onSend(.shielded) })
@@ -179,6 +181,7 @@ struct HomeBalanceView: View {
         icon: String,
         title: String,
         duffs: UInt64,
+        isSyncing: Bool = false,
         infoAction: @escaping () -> Void,
         inAction: @escaping () -> Void,
         outAction: @escaping () -> Void
@@ -192,11 +195,23 @@ struct HomeBalanceView: View {
                     .foregroundColor(Color.dash.whiteText)
                     .frame(width: 20)
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
-                        .font(.footnote)
-                        .fontWeight(.medium)
-                        .foregroundColor(Color.dash.whiteText)
-                    Text(viewModel.fiatString(forDuffs: duffs))
+                    HStack(spacing: 5) {
+                        Text(title)
+                            .font(.footnote)
+                            .fontWeight(.medium)
+                            .foregroundColor(Color.dash.whiteText)
+                        if isSyncing {
+                            SwiftUI.ProgressView()
+                                .scaleEffect(0.7)
+                                .tint(Color.dash.whiteText)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                    Text(
+                        isSyncing
+                            ? NSLocalizedString("Syncing", comment: "Shielded balance")
+                            : viewModel.fiatString(forDuffs: duffs)
+                    )
                         .font(.caption2)
                         .foregroundColor(.white.opacity(0.7))
                 }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -386,7 +386,8 @@ class HomeViewModel: ObservableObject {
             // Platform↔Shielded moves, shielded identity fundings) — the
             // Core rows above only cover operations with an L1 leg. The
             // day-grouping sort below merges the two timelines.
-            let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity()
+            let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity(
+                coreTransactions: transactions)
             for shielded in shieldedItems {
                 guard self.passesShieldedFilter(
                     item: shielded,
@@ -1103,17 +1104,18 @@ class SwiftDashSDKWalletSource: TransactionSource {
     /// - ShieldFromAssetLock entries are dropped: their Core asset-lock
     ///   spend always renders as a history row already
     ///   (`Transaction.isShieldedTransfer`).
-    /// - Withdrawal entries are dropped ONLY when the destination script
-    ///   is one of the active wallet's own Core addresses — that's the
-    ///   internal Shielded→Transparent transfer, whose Core receipt
-    ///   renders via `Transaction.isShieldedWithdrawalReceipt`. A
-    ///   withdrawal to an EXTERNAL Core address produces no wallet-side
-    ///   Core transaction at all, so it stays and renders as a Sent row.
+    /// - An internal Withdrawal is projected as Pending until its matching
+    ///   Core receipt appears, then dropped so the receipt becomes the single
+    ///   authoritative history row. A withdrawal to an EXTERNAL Core address
+    ///   produces no wallet-side Core transaction, so it always stays and
+    ///   renders as a Sent row.
     /// - Rows are deduped by `entryId`: an intra-wallet transfer writes
     ///   a Sent row on the sending account and a Received row on the
     ///   receiving account for the same operation; the outgoing
     ///   (initiating) side wins.
-    static func fetchShieldedActivity() -> [ShieldedActivityItem] {
+    static func fetchShieldedActivity(
+        coreTransactions: [Transaction] = []
+    ) -> [ShieldedActivityItem] {
         guard let (container, walletId) = hostHandles() else { return [] }
         let context = ModelContext(container)
         let descriptor = FetchDescriptor<PersistentShieldedActivity>(
@@ -1139,8 +1141,21 @@ class SwiftDashSDKWalletSource: TransactionSource {
             case ShieldedActivityItem.Kind.withdrawal.rawValue:
                 let address = withdrawalDestinationAddress(counterparty: row.counterparty)
                 if let address, isActiveWalletCoreAddress(address, walletId: walletId, in: context) {
-                    // Internal Shielded→Transparent transfer — the Core
-                    // receipt row represents it.
+                    let pendingItem = ShieldedActivityItem(
+                        row: row,
+                        destinationAddress: address,
+                        isAwaitingTransparentReceipt: true)
+                    // Keep a local Pending row during the gap between the
+                    // shielded spend and the asynchronously persisted L1
+                    // receipt. Once a matching receipt exists, suppress the
+                    // placeholder so the operation never renders twice.
+                    if hasMatchingCoreReceipt(
+                        for: pendingItem,
+                        address: address,
+                        in: coreTransactions) {
+                        continue
+                    }
+                    items.append(pendingItem)
                     continue
                 }
                 // External (or undecodable-script) withdrawal: nothing
@@ -1171,6 +1186,26 @@ class SwiftDashSDKWalletSource: TransactionSource {
             }
         }
         return items
+    }
+
+    /// Match the eventual Core receipt without relying on a txid the opaque
+    /// shielded-withdraw call does not return. Address + principal + a bounded
+    /// time window avoids consuming an unrelated historical receipt of the
+    /// same amount while tolerating block timestamp skew and indexing delay.
+    private static func hasMatchingCoreReceipt(
+        for pending: ShieldedActivityItem,
+        address: String,
+        in transactions: [Transaction]
+    ) -> Bool {
+        transactions.contains { transaction in
+            guard transaction.isShieldedWithdrawalReceipt,
+                  transaction.dashAmount == pending.amountDuffs,
+                  transaction.outputReceiveAddresses.contains(address) else {
+                return false
+            }
+            let delta = transaction.date.timeIntervalSince(pending.date)
+            return delta >= -3600 && delta <= 86_400
+        }
     }
 
     /// Decode an unshield entry's counterparty (21-byte serialized

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -23,14 +23,11 @@
 //  home history interleaves with the Core transaction rows, plus the
 //  detail sheet a tapped row opens.
 //
-//  Kinds whose Core leg is already a history row are NOT projected —
-//  ShieldFromAssetLock (the Core asset-lock spend renders via
-//  `Transaction.isShieldedTransfer`) and Withdrawal (the Core receipt
-//  renders via `Transaction.isShieldedWithdrawalReceipt`). Projecting
-//  them too would show one user action as two rows. There is no txid
-//  on the activity entry to dedupe by, so the exclusion is by kind —
-//  guaranteed-correct for live-recorded entries because those two
-//  kinds have a Core transaction by construction.
+//  Kinds whose Core leg is already a history row are not projected twice:
+//  ShieldFromAssetLock is always omitted because its Core asset-lock spend
+//  renders via `Transaction.isShieldedTransfer`. An internal Withdrawal is
+//  temporarily projected as Pending until its Core receipt appears, then
+//  matched by destination, amount, and time and replaced by that receipt.
 //
 
 import Foundation
@@ -92,9 +89,13 @@ struct ShieldedActivityItem: Identifiable {
     /// True when the destination is NOT one of the active wallet's own
     /// addresses — the operation is money leaving the wallet, not an
     /// internal move. Set at fetch time (the ownership lookup needs the
-    /// store). All projected withdrawals are external by construction;
-    /// unshields can be either.
+    /// store). Withdrawals and unshields can both be internal or external.
     let isExternalDestination: Bool
+    /// True for the temporary Shielded → Transparent row shown after the
+    /// shielded spend is recorded but before its matching Core receipt is
+    /// persisted. The row is replaced by the real Core transaction once it
+    /// arrives, so the history never has a silent post-spend gap.
+    let isAwaitingTransparentReceipt: Bool
 
     var id: String {
         "shielded-" + entryId.map { String(format: "%02x", $0) }.joined() + "-\(accountIndex)"
@@ -103,15 +104,19 @@ struct ShieldedActivityItem: Identifiable {
     init(
         row: PersistentShieldedActivity,
         destinationAddress: String? = nil,
-        isExternalDestination: Bool = false
+        isExternalDestination: Bool = false,
+        isAwaitingTransparentReceipt: Bool = false
     ) {
         self.destinationAddress = destinationAddress
         self.isExternalDestination = isExternalDestination
+        self.isAwaitingTransparentReceipt = isAwaitingTransparentReceipt
         entryId = row.entryId
         accountIndex = row.accountIndex
         kind = Kind(rawValue: row.kindTag) ?? .shieldedSpend
         direction = Direction(rawValue: row.direction) ?? .selfTransfer
-        status = Status(rawValue: row.status) ?? .confirmed
+        status = isAwaitingTransparentReceipt
+            ? .pending
+            : Status(rawValue: row.status) ?? .confirmed
         amountDuffs = row.amount / 1000
         feeDuffs = row.hasFee ? row.fee / 1000 : nil
         blockHeight = row.hasBlockHeight ? row.blockHeight : nil
@@ -125,6 +130,9 @@ struct ShieldedActivityItem: Identifiable {
     // MARK: Display
 
     var title: String {
+        if isAwaitingTransparentReceipt {
+            return NSLocalizedString("Internal Transfer", comment: "Transaction within the wallet, transfer of own funds")
+        }
         switch kind {
         case .shield, .shieldFromAssetLock:
             return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
@@ -161,7 +169,9 @@ struct ShieldedActivityItem: Identifiable {
                 }
                 return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
             }
-            return NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
+            return kind == .unshield
+                ? NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
+                : NSLocalizedString("Shielded → Transparent", comment: "Transfer of own funds from the private shielded balance back to the transparent wallet")
         case .received, .sent, .identityCreate, .shieldedSpend:
             return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
         }
@@ -173,7 +183,10 @@ struct ShieldedActivityItem: Identifiable {
         switch kind {
         case .received: return "arrow.down"
         case .sent: return "arrow.up"
-        case .unshield, .withdrawal: return isExternalDestination ? "arrow.up" : nil
+        case .unshield:
+            return isExternalDestination ? "arrow.up" : "creditcard.fill"
+        case .withdrawal:
+            return isExternalDestination ? "arrow.up" : "d.circle.fill"
         case .identityCreate: return "person.crop.circle.fill"
         case .shieldedSpend: return "questionmark"
         case .shield, .shieldFromAssetLock: return nil

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -232,10 +232,8 @@ final class InternalTransferViewModel: ObservableObject {
     /// drawing transparent credits directly).
     @Published private(set) var platformCredits: UInt64 = 0
 
-    /// Real shielded balance in credits, fed by the SDK's shielded sync
-    /// pass (`PlatformWalletManager.$lastShieldedSyncEvent → result(for:)`).
-    /// Updates whenever the shielded sync loop completes a pass — including
-    /// the manual `syncShieldedNow()` kick after a successful transfer.
+    /// Real shielded balance in credits, fed by the coordinator's reconciled
+    /// balance mirror. Updates whenever a shielded sync pass completes.
     @Published private(set) var shieldedBalance: UInt64 = 0
 
     /// True once the L1 chain sync completed (`SyncingActivityMonitor`
@@ -271,27 +269,13 @@ final class InternalTransferViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        if let manager = SwiftDashSDKHost.shared.manager,
-           let wallet = SwiftDashSDKHost.shared.wallet {
-            let walletId = wallet.walletId
-            // Seed once from whatever the manager already saw — the
-            // publisher only fires on new sync events.
-            shieldedBalance = manager.lastShieldedSyncEvent?
-                .result(for: walletId)?
-                .balance ?? 0
-
-            manager.$lastShieldedSyncEvent
-                .receive(on: RunLoop.main)
-                .sink { [weak self] event in
-                    guard let self else { return }
-                    if let walletResult = event?.result(for: walletId),
-                       walletResult.success,
-                       !walletResult.cooldownSkip {
-                        self.shieldedBalance = walletResult.balance
-                    }
-                }
-                .store(in: &cancellables)
-        }
+        shieldedBalance = PlatformAddressSyncCoordinator.shared.shieldedBalance
+        PlatformAddressSyncCoordinator.shared.$shieldedBalance
+            .receive(on: RunLoop.main)
+            .sink { [weak self] credits in
+                self?.shieldedBalance = credits
+            }
+            .store(in: &cancellables)
     }
 
     /// The raw numeric value the user has typed, with locale comma normalised

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -874,13 +874,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// Captures only `manager` (a long-lived singleton) — no retain on the
     /// coordinator past the sheet's lifetime.
     private func scheduleShieldedResync(manager: PlatformWalletManager) {
-        Task {
-            do {
-                try await manager.syncShieldedNow()
-            } catch {
-                Self.logger.warning("🛡️ SHIELD-TX :: syncShieldedNow failed (ignored): \(String(describing: error), privacy: .public)")
-            }
-        }
+        PlatformAddressSyncCoordinator.shared
+            .refreshShieldedBalanceAfterSpend(using: manager)
     }
 
     /// Kick the Platform-address (BLAST) sync after a transfer that changes the

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -129,25 +129,13 @@ final class SendViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        if let manager = SwiftDashSDKHost.shared.manager,
-           let wallet = SwiftDashSDKHost.shared.wallet {
-            let walletId = wallet.walletId
-            shieldedBalance = manager.lastShieldedSyncEvent?
-                .result(for: walletId)?
-                .balance ?? 0
-
-            manager.$lastShieldedSyncEvent
-                .receive(on: RunLoop.main)
-                .sink { [weak self] event in
-                    guard let self else { return }
-                    if let walletResult = event?.result(for: walletId),
-                       walletResult.success,
-                       !walletResult.cooldownSkip {
-                        self.shieldedBalance = walletResult.balance
-                    }
-                }
-                .store(in: &cancellables)
-        }
+        shieldedBalance = PlatformAddressSyncCoordinator.shared.shieldedBalance
+        PlatformAddressSyncCoordinator.shared.$shieldedBalance
+            .receive(on: RunLoop.main)
+            .sink { [weak self] credits in
+                self?.shieldedBalance = credits
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Destination classification


### PR DESCRIPTION
## Issue being fixed or feature implemented
After a shielded spend (e.g. identity registration), the Shielded balance briefly showed **0** until a background sync repopulated the remaining change — the user's remaining shielded funds appeared to **vanish and then reappear**, with no "syncing" hint. A shielded sync pass can observe the spent notes' nullifiers before their change note lands, so the intermediate read is zero. The internal Shielded→Transparent history row also disappeared during the gap before its Core receipt was persisted.

## What was done?
**Balance:** `PlatformAddressSyncCoordinator` becomes the single reconciled source of the shielded balance.
- When a pass returns `balance == 0` with `newlySpent > 0` while a prior balance was non-zero, it **holds the last reliable value**, sets `isShieldedBalanceReconciling`, and runs bounded readbacks (`syncShieldedNow` at ~4s/12s/24s) to pick up the change note — accepting a genuine zero if the window closes. A `refreshShieldedBalanceAfterSpend` kick runs right after a shielded spend (identity create + internal transfer).
- `HomeBalanceView` shows a spinner + **"Syncing"** on the Shielded row during that window.
- `InternalTransferViewModel` / `SendViewModel` now read the reconciled `$shieldedBalance` mirror instead of the raw sync event (single source of truth).

**History:** the internal Shielded→Transparent withdrawal is projected as a **Pending "Internal Transfer"** row during the gap before its Core receipt is persisted, then matched by destination + amount + a bounded time window and replaced by the receipt — so the operation never renders twice and the history has no silent post-spend gap.

## How Has This Been Tested?
Manual, testnet, on device: after a shielded spend the Shielded row now shows **"Syncing"** and keeps the last balance instead of flashing 0, then settles on the reconciled value; the internal transfer shows a Pending row that is replaced by the Core receipt.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
