### PR TITLE
fix(dashpay): authenticate and provision contact requests

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -1,6 +1,6 @@
 # DashSync -> SwiftDashSDK migration status
 
-Current-state ledger for the DashSync removal. Updated 2026-07-23 from the
+Current-state ledger for the DashSync removal. Updated 2026-07-24 from the
 working tree on `swift-sdk-integration`; historical stage-by-stage detail is
 available in Git history.
 
@@ -106,9 +106,9 @@ Status meanings:
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
 | 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state and the in-memory identity snapshot for retry. After a successful wipe the stopped runtime installs an empty identity snapshot and publishes the wallet-context change; a newly started wallet publishes the same event, rebuilding the DashPay tab bar as 3 or 5 items from that wallet's identity state. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |
 | 15 | Provider-key derivation | Done | All four families are SDK-native: Owner/Voting via the key-wallet path surface, Operator (BLS) and Evonode Operator (Ed25519) via `ManagedPlatformWallet.providerKeyAtIndex` (`platform_wallet_provider_key_at_index` grew per-index BLS/EdDSA public-key export, removing the earlier blocker). Overview counts and per-keypair “used at” restored from the Rust masternode aggregation (`PlatformWalletManager.masternodes(for:)`). |
-| 16 | DashPay identity creation | Done; invitation tail | Standard SDK-funded identity/name registration is migrated, with three funding paths (Core asset-lock, Platform Payment, shielded Type-20 — the privacy-preserving default, gated by `ShieldedIdentityFundingReadiness`). Invitation-funded create/accept remains part of the invitation decision. |
+| 16 | DashPay identity creation | Done; invitation tail | Standard SDK-funded identity/name registration is migrated, with three funding paths (Core asset-lock, Platform Payment, shielded Type-20 — the privacy-preserving default, gated by `ShieldedIdentityFundingReadiness`). Every new identity registers the DashPay ENCRYPTION/DECRYPTION pair in IdentityCreate; the lazy IdentityUpdate upgrader remains as a fallback for incomplete identities. Invitation-funded create/accept remains part of the invitation decision. |
 | 17 | DashPay identity/profile read-write | Done; compatibility tail | Retire remaining `DSBlockchainIdentity`-typed profile properties/categories and route every old view directly through `DWCurrentUserIdentityInfo` / `DWProfileUpdateBridge`. |
-| 18 | DashPay contacts and pay-to-contact | Done | PR #787 rebuilt contacts on SwiftDashSDK/SwiftData/SwiftUI and removed the old contacts subsystem. Invitations were explicitly out of scope. |
+| 18 | DashPay contacts and pay-to-contact | Done | PR #787 rebuilt contacts on SwiftDashSDK/SwiftData/SwiftUI and removed the old contacts subsystem. Recipient eligibility matches the SDK's DECRYPTION-preferred, ENCRYPTION-fallback policy so encryption-only mobile identities remain reachable. Invitations were explicitly out of scope. |
 | 18a | Contested DPNS-name detection | Done for retained scope | Warning/bookmark behavior is SDK-native; richer resolution/status UX remains optional product work, not a DashSync blocker. |
 | 19 | DPNS lookup | Done | Availability and contact search use SDK APIs. |
 | 20 | CoinJoin | Done for retained scope | Mixing was dropped; recovery/sweep is SDK-native. Only stale imports/comments should be removed during unlink. |

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -604,6 +604,9 @@
 		51530E742FD6EE1D00175308 /* MerchantCellRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51530E682FD6EE1D00175308 /* MerchantCellRow.swift */; };
 		51530E752FD6EE1D00175308 /* AllMerchantLocationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51530E6A2FD6EE1D00175308 /* AllMerchantLocationsView.swift */; };
 		51629A945A8CEF6EF50F9A4A /* DWIdentityKeyUpgrader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AAC8F08DF00D0070EE71C3 /* DWIdentityKeyUpgrader.swift */; };
+		DA5A00000000000000000001 /* DWDashPayIdentityKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A00000000000000000003 /* DWDashPayIdentityKeys.swift */; };
+		DA5A00000000000000000002 /* DWDashPayIdentityKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A00000000000000000003 /* DWDashPayIdentityKeys.swift */; };
+		DA5A00000000000000000004 /* DashPayIdentityKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A00000000000000000005 /* DashPayIdentityKeysTests.swift */; };
 		51646C723006263C00BE3070 /* Uphold-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 51646C713006263C00BE3070 /* Uphold-Info.plist */; };
 		51646C733006263C00BE3070 /* Uphold-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 51646C713006263C00BE3070 /* Uphold-Info.plist */; };
 		516983C22FCAEDEB00BA91A2 /* XmarkIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516983C12FCAEDEB00BA91A2 /* XmarkIcon.swift */; };
@@ -2866,6 +2869,8 @@
 		7249AC40404B20F2AEE590F1 /* InternalTransferViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalTransferViewModel.swift; sourceTree = "<group>"; };
 		726054552E79221F6B9D97AE /* Pods-dashwallet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-dashwallet.debug.xcconfig"; path = "Target Support Files/Pods-dashwallet/Pods-dashwallet.debug.xcconfig"; sourceTree = "<group>"; };
 		74AAC8F08DF00D0070EE71C3 /* DWIdentityKeyUpgrader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DWIdentityKeyUpgrader.swift; sourceTree = "<group>"; };
+		DA5A00000000000000000003 /* DWDashPayIdentityKeys.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DWDashPayIdentityKeys.swift; sourceTree = "<group>"; };
+		DA5A00000000000000000005 /* DashPayIdentityKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashPayIdentityKeysTests.swift; sourceTree = "<group>"; };
 		7502A4862AE401EF00ACDDD3 /* UsernameVotingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameVotingViewController.swift; sourceTree = "<group>"; };
 		750364392C89CFB70029EC0D /* CoinJoinProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinJoinProgressView.swift; sourceTree = "<group>"; };
 		7503643D2C89D49A0029EC0D /* CoinJoinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinJoinService.swift; sourceTree = "<group>"; };
@@ -7178,6 +7183,7 @@
 				AA00100D2CA0B10001A0B10D /* SwapKitQuoteDecodingTests.swift */,
 				5EAD222130A0000000A1B202 /* DashAmountFormatterTests.swift */,
 				DA57A1010000000000000001 /* PastedAmountNormalizationTests.swift */,
+				DA5A00000000000000000005 /* DashPayIdentityKeysTests.swift */,
 			);
 			path = DashWalletTests;
 			sourceTree = "<group>";
@@ -7266,6 +7272,7 @@
 				5C3839568283FDC3A6933824 /* DWRegistrationPhaseAdapter.swift */,
 				01D55D0FA9AE953CD23DE6B6 /* DWIdentityRegistrationController.swift */,
 				33FBA94DA84A9EE303FF48B4 /* DWIdentityAuthorizer.swift */,
+				DA5A00000000000000000003 /* DWDashPayIdentityKeys.swift */,
 				74AAC8F08DF00D0070EE71C3 /* DWIdentityKeyUpgrader.swift */,
 				D826C39F49D5CD6EC19C8C8E /* DWIdentityRegistrationCoordinator.swift */,
 				D54F8E662513F09BA840FB94 /* DWIdentityRegistrationBridge.swift */,
@@ -10373,6 +10380,7 @@
 				A3ED42ED80F32AA5CA530A40 /* DamerauLevenshtein.swift in Sources */,
 				EDA94EDDBAB5D5E1DEC635D9 /* SwiftDashSDKWalletRuntime.swift in Sources */,
 				16AA1B384A9758C1DA97676A /* SwiftDashSDKHost.swift in Sources */,
+				DA5A00000000000000000001 /* DWDashPayIdentityKeys.swift in Sources */,
 				19CF9D60B276558AA48380C2 /* SwiftDashSDKSPVCoordinator.swift in Sources */,
 				85448D7537BBD0AE40682EC8 /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				8EAA05FA797008525050A2A7 /* PlatformAddressSyncCoordinator.swift in Sources */,
@@ -10472,6 +10480,7 @@
 				AA00100E2CA0B10001A0B10E /* SwapKitQuoteDecodingTests.swift in Sources */,
 				5EAD222230A0000000A1B202 /* DashAmountFormatterTests.swift in Sources */,
 				DA57A1010000000000000002 /* PastedAmountNormalizationTests.swift in Sources */,
+				DA5A00000000000000000004 /* DashPayIdentityKeysTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11387,6 +11396,7 @@
 				B66D25CAD54ABDC1049BDDD5 /* DamerauLevenshtein.swift in Sources */,
 				371ADBAC635CEB63CA0A4A1E /* SwiftDashSDKWalletRuntime.swift in Sources */,
 				915115B56A2B097590AE3797 /* SwiftDashSDKHost.swift in Sources */,
+				DA5A00000000000000000002 /* DWDashPayIdentityKeys.swift in Sources */,
 				ACAB47BF67F9E00D253166D4 /* DWRegistrationPhaseAdapter.swift in Sources */,
 				E4165429FE629AE7E9CB7E22 /* DWIdentityRegistrationController.swift in Sources */,
 				A15ED0B9E7AAF29C694E4E16 /* DWIdentityAuthorizer.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -580,21 +580,14 @@ final class SwiftDashSDKContactsService: ObservableObject {
 
     // MARK: - Contact-request eligibility
 
-    /// Check whether identities can participate in DashPay contact
-    /// requests: an enabled ECDSA_SECP256K1 key with purpose
-    /// ENCRYPTION *and* one with purpose DECRYPTION. The ENCRYPTION
-    /// predicate mirrors the SDK send path verbatim
-    /// (`rs-platform-wallet/…/contact_requests.rs`: `purpose ==
-    /// ENCRYPTION && key_type == ECDSA_SECP256K1 &&
-    /// disabled_at.is_none()`, over the identity's plain public keys —
-    /// deliberately NO contract-bounds requirement; a contract-keys
-    /// query false-negatives identities whose DashPay keys aren't
-    /// contract-bound). DECRYPTION is additionally required so the
-    /// recipient can actually open incoming requests. Identities
-    /// registered before DashPay keys existed fail `sendContactRequest`
-    /// with "Identity has no enabled ECDSA_SECP256K1 encryption key" —
-    /// checking up front lets the add-contact UI mark them instead of
-    /// letting the user hit the PIN gate and a network error.
+    /// Check whether identities can receive a DashPay contact request:
+    /// an enabled ECDSA_SECP256K1 DECRYPTION key (preferred by the SDK)
+    /// or ENCRYPTION key (the supported mobile-cohort fallback).
+    /// Deliberately NO contract-bounds requirement; a contract-keys
+    /// query false-negatives identities whose compatible keys aren't
+    /// contract-bound. Identities with neither compatible key fail the
+    /// SDK's recipient-key selector, so checking up front lets the UI
+    /// explain the state before the PIN gate.
     ///
     /// Returns eligibility per requested id; an id whose key query
     /// fails is omitted — callers treat absent as "unknown" and leave
@@ -614,15 +607,9 @@ final class SwiftDashSDKContactsService: ObservableObject {
                 // requested-but-missing key id.
                 let keys = try await sdk.identityGetKeys(identityId: base58)
                 let usable = keys.values.compactMap { $0 as? [String: Any] }
-                func hasEnabledECDSAKey(purpose: Int) -> Bool {
-                    usable.contains { key in
-                        (key["purpose"] as? Int) == purpose
-                            && (key["type"] as? Int) == 0  // ECDSA_SECP256K1
-                            && (key["disabledAt"] == nil || key["disabledAt"] is NSNull)
-                    }
+                if let eligible = DWDashPayIdentityKeys.recipientEligibility(from: usable) {
+                    result[id] = eligible
                 }
-                result[id] = hasEnabledECDSAKey(purpose: 1)  // ENCRYPTION
-                    && hasEnabledECDSAKey(purpose: 2)        // DECRYPTION
             } catch {
                 Self.logger.error("👥 CONTACTS :: key eligibility query failed for \(base58, privacy: .public): \(String(describing: error), privacy: .public)")
             }
@@ -669,14 +656,14 @@ final class SwiftDashSDKContactsService: ObservableObject {
         return (wallet, modelContainer, ownerId)
     }
 
-    /// Lazily bring the current identity up to the DashPay key set
-    /// before its first contact action: dashwallet's registration
-    /// derives AUTHENTICATION keys only, and both `sendContactRequest`
-    /// and the reciprocal request inside `acceptContactRequest` need
-    /// our own enabled ECDSA ENCRYPTION key for the DIP-15 ECDH.
-    /// No-op once the keys exist; called after the PIN gate so the
-    /// IdentityUpdate broadcast is covered by the same user approval
-    /// as the contact action it unblocks.
+    /// Lazily repair an incomplete identity before a contact action.
+    /// New registrations include the full DashPay key pair, but the
+    /// fallback remains for earlier/development identities because
+    /// both `sendContactRequest` and the reciprocal request inside
+    /// `acceptContactRequest` need our own enabled ECDSA ENCRYPTION
+    /// key for DIP-15 ECDH. No-op once both keys exist; called after
+    /// the PIN gate so any IdentityUpdate is covered by the same user
+    /// approval as the contact action it unblocks.
     private func ensureOwnDashPayKeys(
         wallet: ManagedPlatformWallet,
         ownerId: Data,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWDashPayIdentityKeys.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWDashPayIdentityKeys.swift
@@ -1,0 +1,153 @@
+//
+//  DWDashPayIdentityKeys.swift
+//  DashWallet
+//
+//  Shared DashPay identity-key policy for registration-time creation
+//  and the lazy IdentityUpdate fallback.
+//
+
+import Foundation
+import SwiftDashSDK
+
+enum DWDashPayIdentityKeys {
+
+    /// DashPay system contract id — `dashpay_contract::ID_BYTES` in
+    /// the platform repo (base58
+    /// `Bwr4WHCPz5rFVAD87RqTs3izo4zpzwsEdKPWUT1NS1C7`).
+    static let dashPayContractId = Data([
+        162, 161, 180, 172, 111, 239, 34, 234,
+        42, 26, 104, 232, 18, 54, 68, 179,
+        87, 135, 95, 107, 65, 44, 24, 16,
+        146, 129, 193, 70, 231, 178, 113, 188,
+    ])
+
+    static let contactRequestDocumentType = "contactRequest"
+
+    struct KeySpecification: Equatable, Sendable {
+        let keyId: UInt32
+        let purpose: KeyPurpose
+        let keyType: KeyType = .ecdsaSecp256k1
+        let securityLevel: SecurityLevel = .medium
+
+        var contractBounds: ManagedPlatformWallet.ContractBounds {
+            .singleContractDocumentType(
+                id: DWDashPayIdentityKeys.dashPayContractId,
+                documentTypeName: DWDashPayIdentityKeys.contactRequestDocumentType)
+        }
+    }
+
+    enum KeyError: LocalizedError {
+        case noIdentityRow
+        case derivationMismatch
+        case keychainWriteFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .noIdentityRow:
+                return NSLocalizedString("No DashPay identity is registered", comment: "DashPay")
+            case .derivationMismatch:
+                return "Derived key didn't match its public key — refusing to broadcast."
+            case .keychainWriteFailed:
+                return "Could not persist new key to the iOS Keychain — aborted before broadcast."
+            }
+        }
+    }
+
+    /// The registration-time pair appended after the SDK's four base
+    /// keys (AUTHENTICATION/MASTER, AUTHENTICATION/CRITICAL,
+    /// AUTHENTICATION/HIGH, TRANSFER/CRITICAL).
+    static func registrationSpecifications(firstKeyId: UInt32) -> [KeySpecification] {
+        [
+            KeySpecification(keyId: firstKeyId, purpose: .encryption),
+            KeySpecification(keyId: firstKeyId + 1, purpose: .decryption),
+        ]
+    }
+
+    /// Match Platform's recipient-key selector: prefer DECRYPTION,
+    /// but accept ENCRYPTION for the established mobile cohort.
+    ///
+    /// `nil` means the key query was unavailable and callers must
+    /// leave the identity actionable so the send path can surface the
+    /// authoritative error.
+    static func recipientEligibility(from keys: [[String: Any]]?) -> Bool? {
+        guard let keys else { return nil }
+        return keys.contains { key in
+            guard (key["type"] as? Int) == Int(KeyType.ecdsaSecp256k1.rawValue) else {
+                return false
+            }
+            guard key["disabledAt"] == nil || key["disabledAt"] is NSNull else {
+                return false
+            }
+            guard let purpose = key["purpose"] as? Int else { return false }
+            return purpose == Int(KeyPurpose.decryption.rawValue)
+                || purpose == Int(KeyPurpose.encryption.rawValue)
+        }
+    }
+
+    /// Derive, validate, and Keychain-persist the requested DashPay
+    /// keys, then return the public rows for IdentityCreate or
+    /// IdentityUpdate.
+    ///
+    /// `identityIdString` is empty before IdentityCreate. The SDK
+    /// persister replaces that placeholder once the identity lands;
+    /// update flows pass the existing identity's base58 id.
+    @MainActor
+    static func deriveAndPersist(
+        wallet: ManagedPlatformWallet,
+        identityIdString: String,
+        identityIndex: UInt32,
+        specifications: [KeySpecification],
+        network: Network
+    ) throws -> [ManagedPlatformWallet.IdentityPubkey] {
+        var rows: [ManagedPlatformWallet.IdentityPubkey] = []
+        rows.reserveCapacity(specifications.count)
+
+        for specification in specifications {
+            let preview = try wallet.deriveIdentityAuthKeyAtSlot(
+                identityIndex: identityIndex,
+                keyId: specification.keyId,
+                network: network)
+
+            guard KeyValidation.validatePrivateKeyForPublicKey(
+                privateKeyHex: preview.privateKeyData.toHexString(),
+                publicKeyHex: preview.publicKeyHex,
+                keyType: specification.keyType,
+                network: network)
+            else {
+                throw KeyError.derivationMismatch
+            }
+
+            let pubKeyHashHex = SwiftDashSDK.KeychainManager.computePublicKeyHashHex(
+                preview.publicKeyData)
+            let metadata = IdentityPrivateKeyMetadata(
+                identityId: identityIdString,
+                keyId: specification.keyId,
+                walletId: wallet.walletId.toHexString(),
+                identityIndex: identityIndex,
+                keyIndex: specification.keyId,
+                derivationPath: preview.derivationPath,
+                publicKey: preview.publicKeyHex,
+                publicKeyHash: pubKeyHashHex,
+                keyType: specification.keyType.rawValue,
+                purpose: specification.purpose.rawValue,
+                securityLevel: specification.securityLevel.rawValue)
+            guard KeychainManager.shared.storeIdentityPrivateKey(
+                preview.privateKeyData,
+                derivationPath: preview.derivationPath,
+                metadata: metadata) != nil
+            else {
+                throw KeyError.keychainWriteFailed
+            }
+
+            rows.append(ManagedPlatformWallet.IdentityPubkey(
+                keyId: specification.keyId,
+                keyType: specification.keyType,
+                purpose: specification.purpose,
+                securityLevel: specification.securityLevel,
+                pubkeyBytes: preview.publicKeyData,
+                contractBounds: specification.contractBounds))
+        }
+
+        return rows
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityKeyUpgrader.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityKeyUpgrader.swift
@@ -5,22 +5,12 @@
 //  Adds missing DashPay ENCRYPTION / DECRYPTION keys to the current
 //  identity via an IdentityUpdate transition (migration Row #18).
 //
-//  Why this exists: dashwallet's registration flow
-//  (`prePersistIdentityKeysForRegistration`) derives AUTHENTICATION
-//  keys only — the Rust ladder is pinned to
-//  `(ECDSA_SECP256K1, AUTHENTICATION, MASTER|HIGH)` — so identities
-//  registered here can't send contact requests: the SDK's
-//  `select_own_encryption_key` fails with "Identity has no enabled
-//  ECDSA_SECP256K1 encryption key". This upgrader runs lazily before
-//  the first contact action and brings the identity up to the DashPay
-//  key set (ENCRYPTION + DECRYPTION, MEDIUM security, ECDSA — the
-//  same shape SwiftExampleApp's add-key flow produces, verified
-//  working on testnet).
+//  New registrations include both keys in IdentityCreate. This
+//  upgrader remains as a lazy fallback for identities created before
+//  that policy or whose Platform key set is otherwise incomplete.
 //
-//  The derive → validate → persist → updateIdentity sequence is a
-//  port of SwiftExampleApp's `IdentityKeyAddition.prepareKeys`
-//  (packages/swift-sdk/SwiftExampleApp/Views/IdentityKeyAddition.swift),
-//  narrowed to the two ECDSA DashPay purposes.
+//  Key derivation/persistence is shared with the registration flow
+//  through `DWDashPayIdentityKeys`.
 //
 //  dashpay target only.
 //
@@ -37,31 +27,7 @@ enum DWIdentityKeyUpgrader {
         subsystem: "org.dashfoundation.dash",
         category: "swift-sdk-migration.identity-key-upgrader")
 
-    /// DashPay system contract id — `dashpay_contract::ID_BYTES` in
-    /// the platform repo (base58 `Bwr4WHCPz5rFVAD87RqTs3izo4zpzwsEdKPWUT1NS1C7`).
-    private static let dashPayContractId = Data([
-        162, 161, 180, 172, 111, 239, 34, 234,
-        42, 26, 104, 232, 18, 54, 68, 179,
-        87, 135, 95, 107, 65, 44, 24, 16,
-        146, 129, 193, 70, 231, 178, 113, 188,
-    ])
-
-    enum UpgradeError: LocalizedError {
-        case noIdentityRow
-        case derivationMismatch
-        case keychainWriteFailed
-
-        var errorDescription: String? {
-            switch self {
-            case .noIdentityRow:
-                return NSLocalizedString("No DashPay identity is registered", comment: "DashPay")
-            case .derivationMismatch:
-                return "Derived key didn't match its public key — refusing to broadcast."
-            case .keychainWriteFailed:
-                return "Could not persist new key to the iOS Keychain — aborted before broadcast."
-            }
-        }
-    }
+    typealias UpgradeError = DWDashPayIdentityKeys.KeyError
 
     /// Ensure the identity has enabled ECDSA_SECP256K1 keys with
     /// purposes ENCRYPTION and DECRYPTION, broadcasting one
@@ -110,76 +76,19 @@ enum DWIdentityKeyUpgrader {
         let localMaxId = identityRow.identityPublicKeys.map(\.id).max()
         var nextKeyId = (max(networkMaxId ?? 0, localMaxId ?? 0)) + 1
 
-        var rows: [ManagedPlatformWallet.IdentityPubkey] = []
+        var specifications: [DWDashPayIdentityKeys.KeySpecification] = []
         for purpose in missingPurposes {
             let chosenKeyId = nextKeyId
             nextKeyId += 1
-
-            // 1. Derive the keypair at the slot (path build + secp256k1
-            //    derive happen Rust-side; mnemonic stays behind the
-            //    resolver trampoline).
-            let preview = try wallet.deriveIdentityAuthKeyAtSlot(
-                identityIndex: identityRow.identityIndex,
-                keyId: chosenKeyId,
-                network: network)
-
-            // 2. Defence against derivation drift before anything is
-            //    persisted or broadcast.
-            guard KeyValidation.validatePrivateKeyForPublicKey(
-                privateKeyHex: preview.privateKeyData.toHexString(),
-                publicKeyHex: preview.publicKeyHex,
-                keyType: .ecdsaSecp256k1,
-                network: network)
-            else {
-                throw UpgradeError.derivationMismatch
-            }
-
-            // 3. Persist the private scalar so the KeychainSigner
-            //    trampoline can use the key later (and sign the
-            //    update transition's proof-of-possession if required).
-            let pubKeyHashHex = SwiftDashSDK.KeychainManager.computePublicKeyHashHex(preview.publicKeyData)
-            let metadata = IdentityPrivateKeyMetadata(
-                identityId: identityRow.identityIdString,
-                keyId: chosenKeyId,
-                walletId: wallet.walletId.toHexString(),
-                identityIndex: identityRow.identityIndex,
-                keyIndex: chosenKeyId,
-                derivationPath: preview.derivationPath,
-                publicKey: preview.publicKeyHex,
-                publicKeyHash: pubKeyHashHex,
-                keyType: KeyType.ecdsaSecp256k1.rawValue,
-                purpose: purpose.rawValue,
-                securityLevel: SecurityLevel.medium.rawValue)
-            guard KeychainManager.shared.storeIdentityPrivateKey(
-                preview.privateKeyData,
-                derivationPath: preview.derivationPath,
-                metadata: metadata) != nil
-            else {
-                throw UpgradeError.keychainWriteFailed
-            }
-
-            // 4. The on-chain key row. MEDIUM security. Drive REQUIRES
-            //    contract bounds on Encryption/Decryption keys added
-            //    via IdentityUpdate, and DashPay's contract config only
-            //    declares the bounds requirement at the DOCUMENT-TYPE
-            //    level — `SingleContract` (kind 1) is rejected, it must
-            //    be `SingleContractDocumentType(DashPay, "contactRequest")`
-            //    (kind 2). See rs-drive-abci
-            //    `validate_identity_public_key_contract_bounds/v0/mod.rs`
-            //    and SwiftExampleApp's AddIdentityKeyView, whose added
-            //    keys (this exact shape) verifiably work on testnet.
-            //    The send path's own-key selector checks purpose/type/
-            //    enabled only, so the bound doesn't affect selection.
-            rows.append(ManagedPlatformWallet.IdentityPubkey(
-                keyId: chosenKeyId,
-                keyType: .ecdsaSecp256k1,
-                purpose: purpose,
-                securityLevel: .medium,
-                pubkeyBytes: preview.publicKeyData,
-                contractBounds: .singleContractDocumentType(
-                    id: Self.dashPayContractId,
-                    documentTypeName: "contactRequest")))
+            specifications.append(.init(keyId: chosenKeyId, purpose: purpose))
         }
+
+        let rows = try DWDashPayIdentityKeys.deriveAndPersist(
+            wallet: wallet,
+            identityIdString: identityRow.identityIdString,
+            identityIndex: identityRow.identityIndex,
+            specifications: specifications,
+            network: network)
 
         let signer = KeychainSigner(modelContainer: modelContainer)
         try await wallet.updateIdentity(

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -66,8 +66,10 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// DashPay identity per wallet.
     private static let pinnedIdentityIndex: UInt32 = 0
 
-    /// Number of identity keys to pre-derive. Matches the
-    /// `SwiftExampleApp` reference (`Self.defaultKeyCount`).
+    /// Number of SDK base keys to pre-derive: AUTHENTICATION/MASTER,
+    /// AUTHENTICATION/CRITICAL, AUTHENTICATION/HIGH, and
+    /// TRANSFER/CRITICAL. The DashPay ENCRYPTION/DECRYPTION pair is
+    /// appended separately at ids 4 and 5 below.
     private static let defaultKeyCount: UInt32 = 4
 
     /// BIP44 account index used for asset-lock funding. dashwallet
@@ -327,13 +329,21 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         // to Keychain. Synchronous on the FFI side; the resolver
         // callback reads the mnemonic via WalletStorage.
         newController.enterPreparingKeys()
-        let pubkeys: [ManagedPlatformWallet.IdentityPubkey]
+        var pubkeys: [ManagedPlatformWallet.IdentityPubkey]
         do {
             pubkeys = try wallet.prePersistIdentityKeysForRegistration(
                 identityIndex: Self.pinnedIdentityIndex,
                 keyCount: Self.defaultKeyCount,
                 network: network)
-            Self.logger.info("🪪 IDENT-COORD :: pre-derived \(pubkeys.count, privacy: .public) keys")
+            let dashPaySpecifications = DWDashPayIdentityKeys.registrationSpecifications(
+                firstKeyId: Self.defaultKeyCount)
+            pubkeys.append(contentsOf: try DWDashPayIdentityKeys.deriveAndPersist(
+                wallet: wallet,
+                identityIdString: "",
+                identityIndex: Self.pinnedIdentityIndex,
+                specifications: dashPaySpecifications,
+                network: network))
+            Self.logger.info("🪪 IDENT-COORD :: pre-derived \(pubkeys.count, privacy: .public) keys including DashPay contact pair")
         } catch {
             Self.logger.error("🪪 IDENT-COORD :: key derivation failed: \(String(describing: error), privacy: .public)")
             failedAtPhase = .processingPayment

--- a/DashWallet/Sources/UI/Auth/PinPromptPresenter.swift
+++ b/DashWallet/Sources/UI/Auth/PinPromptPresenter.swift
@@ -48,19 +48,93 @@ enum PinPromptPresenter {
             // and the send screen stays visible behind the card.
             host.view.backgroundColor = .clear
             anchor.present(host, animated: true)
+
+            // UIKit can reject a presentation without calling a completion
+            // handler (for example when a SwiftUI sheet is being replaced).
+            // Do not leak the continuation and leave AuthenticationGate
+            // waiting for its watchdog in that case.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                guard !didResume else { return }
+                guard host.presentingViewController != nil,
+                      host.viewIfLoaded?.window != nil else {
+                    NSLog("🔐 PINPROMPT :: presentation rejected — resolving .failed")
+                    resume(.failed, dismiss: nil)
+                    return
+                }
+            }
         }
     }
 
     /// The controller a modal should be presented from: the top of the key
     /// window's presentation stack.
     private static func topPresentedController() -> UIViewController? {
-        let scene = UIApplication.shared.connectedScenes
+        let foregroundScenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState == .foregroundActive }
-            ?? UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first
+            .filter { $0.activationState == .foregroundActive }
 
-        let keyWindow = scene?.windows.first(where: { $0.isKeyWindow }) ?? scene?.windows.first
-        guard let root = keyWindow?.rootViewController else { return nil }
-        return root.topController()
+        // Prefer the app delegate's long-lived DWWindow. While a SwiftUI text
+        // field resigns first responder, a transient presentation/keyboard
+        // window can briefly become `isKeyWindow`; resolving from it produced
+        // a detached PresentationHostingController and UIKit dropped the PIN.
+        var windows: [UIWindow] = []
+        if let appWindow = UIApplication.shared.delegate?.window ?? nil {
+            windows.append(appWindow)
+        }
+        windows.append(contentsOf: foregroundScenes.flatMap(\.windows))
+
+        var seen = Set<ObjectIdentifier>()
+        for window in windows where seen.insert(ObjectIdentifier(window)).inserted {
+            guard !window.isHidden,
+                  window.alpha > 0,
+                  window.windowLevel == .normal,
+                  let root = window.rootViewController,
+                  let anchor = attachedTopController(from: root, in: window)
+            else {
+                continue
+            }
+            return anchor
+        }
+        return nil
+    }
+
+    /// Walk only the visible, attached presentation/container path. The
+    /// generic `topController()` intentionally follows every
+    /// `presentedViewController`, including a SwiftUI presentation host that
+    /// is already being removed. Such a controller is not a valid presenter.
+    private static func attachedTopController(
+        from controller: UIViewController,
+        in window: UIWindow
+    ) -> UIViewController? {
+        guard controller.viewIfLoaded?.window === window,
+              !controller.isBeingDismissed else {
+            return nil
+        }
+
+        if let presented = controller.presentedViewController,
+           let top = attachedTopController(from: presented, in: window) {
+            return top
+        }
+
+        if let tab = controller as? UITabBarController,
+           let selected = tab.selectedViewController,
+           let top = attachedTopController(from: selected, in: window) {
+            return top
+        }
+
+        if let navigation = controller as? UINavigationController,
+           let visible = navigation.visibleViewController,
+           let top = attachedTopController(from: visible, in: window) {
+            return top
+        }
+
+        if let split = controller as? UISplitViewController {
+            for child in split.viewControllers.reversed() {
+                if let top = attachedTopController(from: child, in: window) {
+                    return top
+                }
+            }
+        }
+
+        return controller
     }
 }

--- a/DashWalletTests/DashPayIdentityKeysTests.swift
+++ b/DashWalletTests/DashPayIdentityKeysTests.swift
@@ -1,0 +1,96 @@
+//
+//  DashPayIdentityKeysTests.swift
+//  DashWalletTests
+//
+
+import Foundation
+import SwiftDashSDK
+import XCTest
+@testable import dashwallet
+
+final class DashPayIdentityKeysTests: XCTestCase {
+
+    func testRegistrationSpecificationsMatchDashPayContractPolicy() {
+        let specifications = DWDashPayIdentityKeys.registrationSpecifications(firstKeyId: 4)
+
+        XCTAssertEqual(specifications.count, 2)
+        XCTAssertEqual(specifications.map(\.keyId), [4, 5])
+        XCTAssertEqual(specifications.map(\.purpose), [.encryption, .decryption])
+        XCTAssertTrue(specifications.allSatisfy { $0.keyType == .ecdsaSecp256k1 })
+        XCTAssertTrue(specifications.allSatisfy { $0.securityLevel == .medium })
+        XCTAssertTrue(specifications.allSatisfy {
+            $0.contractBounds == .singleContractDocumentType(
+                id: DWDashPayIdentityKeys.dashPayContractId,
+                documentTypeName: "contactRequest")
+        })
+    }
+
+    func testRecipientWithBothKeysIsEligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .encryption),
+                key(purpose: .decryption),
+            ]),
+            true)
+    }
+
+    func testEncryptionOnlyMobileRecipientIsEligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .encryption),
+            ]),
+            true)
+    }
+
+    func testDecryptionOnlyRecipientIsEligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .decryption),
+            ]),
+            true)
+    }
+
+    func testRecipientWithNeitherCompatiblePurposeIsIneligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .authentication),
+                key(purpose: .transfer),
+            ]),
+            false)
+    }
+
+    func testDisabledCompatibleKeyIsIneligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .encryption, disabledAt: 42),
+            ]),
+            false)
+    }
+
+    func testNonECDSACompatiblePurposeIsIneligible() {
+        XCTAssertEqual(
+            DWDashPayIdentityKeys.recipientEligibility(from: [
+                key(purpose: .decryption, keyType: .bls12_381),
+            ]),
+            false)
+    }
+
+    func testUnavailableQueryRemainsUnknown() {
+        XCTAssertNil(DWDashPayIdentityKeys.recipientEligibility(from: nil))
+    }
+
+    private func key(
+        purpose: KeyPurpose,
+        keyType: KeyType = .ecdsaSecp256k1,
+        disabledAt: Int? = nil
+    ) -> [String: Any] {
+        var key: [String: Any] = [
+            "purpose": Int(purpose.rawValue),
+            "type": Int(keyType.rawValue),
+        ]
+        if let disabledAt {
+            key["disabledAt"] = disabledAt
+        }
+        return key
+    }
+}


### PR DESCRIPTION
## Summary
- present the DashPay PIN prompt from the active application window
- register ENCRYPTION and DECRYPTION keys during identity creation
- keep the lazy key upgrader for existing incomplete identities
- accept recipients with either compatible DashPay contact key

## Testing
- manually verified the contact-request flow on two iOS 26.3 simulators
- verified the ENCRYPTION/DECRYPTION key changes in the app
- git diff --check
- plutil -lint DashWallet.xcodeproj/project.pbxproj
- full build not run