### PR TITLE
fix(dashpay): refresh contact request state across screens

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -107,6 +107,7 @@ final class SwiftDashSDKContactsService: ObservableObject {
     private let authorizer = DWIdentityAuthorizer()
     private var saveObserverCancellable: AnyCancellable?
     private var activeWalletCancellable: AnyCancellable?
+    private var repairingIgnoredSenderIds: Set<Data> = []
 
     /// Last run of the payments projection (see
     /// `refreshPaymentsProjection`). Throttles the piggyback call in
@@ -169,15 +170,31 @@ final class SwiftDashSDKContactsService: ObservableObject {
 
         let requestRows: [PersistentDashpayContactRequest]
         let profileRows: [PersistentDashpayContactProfile]
+        let ignoredSenderRows: [PersistentDashpayIgnoredSender]
         do {
             requestRows = try context.fetch(FetchDescriptor<PersistentDashpayContactRequest>(
                 predicate: PersistentDashpayContactRequest.predicate(ownerIdentityId: ownerId)))
             profileRows = try context.fetch(FetchDescriptor<PersistentDashpayContactProfile>(
                 predicate: PersistentDashpayContactProfile.predicate(ownerIdentityId: ownerId)))
+            ignoredSenderRows = try context.fetch(FetchDescriptor<PersistentDashpayIgnoredSender>(
+                predicate: PersistentDashpayIgnoredSender.predicate(ownerIdentityId: ownerId)))
         } catch {
             Self.logger.error("👥 CONTACTS :: SwiftData fetch failed: \(String(describing: error), privacy: .public)")
             return
         }
+
+        // An ignored sender cannot also be someone we sent a request to:
+        // the outgoing row means we deliberately established or initiated
+        // that relationship. This contradictory state can only be produced
+        // by a stale incoming-row action. Repair it so an already-established
+        // contact is not permanently downgraded to "outgoing".
+        let outgoingIds = Set(
+            requestRows.lazy.filter(\.isOutgoing).map(\.contactIdentityId))
+        let contradictoryIgnoredIds = Set(
+            ignoredSenderRows.map(\.ignoredSenderId)).intersection(outgoingIds)
+        repairContradictoryIgnoredSenders(
+            contradictoryIgnoredIds,
+            ownerId: ownerId)
 
         let profilesByContact = Dictionary(
             profileRows.map { ($0.contactIdentityId, $0) },
@@ -249,6 +266,42 @@ final class SwiftDashSDKContactsService: ObservableObject {
         if Date().timeIntervalSince(lastPaymentsProjection) > 60 {
             lastPaymentsProjection = Date()
             refreshPaymentsProjection()
+        }
+    }
+
+    private func repairContradictoryIgnoredSenders(
+        _ senderIds: Set<Data>,
+        ownerId: Data
+    ) {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return }
+        let pendingIds = senderIds.filter {
+            repairingIgnoredSenderIds.insert($0).inserted
+        }
+        guard !pendingIds.isEmpty else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.repairingIgnoredSenderIds.subtract(pendingIds)
+            }
+
+            var repairedAny = false
+            for senderId in pendingIds {
+                do {
+                    try await wallet.unignoreContactSender(
+                        ourIdentityId: ownerId,
+                        contactIdentityId: senderId)
+                    repairedAny = true
+                    Self.logger.info(
+                        "👥 CONTACTS :: repaired stale ignored+outgoing state for \(senderId.prefix(4).map { String(format: "%02x", $0) }.joined(), privacy: .public)…")
+                } catch {
+                    Self.logger.error(
+                        "👥 CONTACTS :: stale ignore repair failed: \(String(describing: error), privacy: .public)")
+                }
+            }
+            if repairedAny {
+                await self.syncNow()
+            }
         }
     }
 
@@ -370,6 +423,18 @@ final class SwiftDashSDKContactsService: ObservableObject {
     func acceptContactRequest(from senderId: Data) async throws {
         let (wallet, modelContainer, ownerId) = try requireContext()
 
+        // UI actions can arrive from a SwiftUI row that was rendered for an
+        // older relationship snapshot. Treat them as idempotent no-ops once
+        // the request has already moved to established/outgoing.
+        guard incomingRequests.contains(where: {
+            $0.contactIdentityId == senderId
+        }) else {
+            Self.logger.info(
+                "👥 CONTACTS :: ignored stale accept — sender is no longer pending incoming")
+            refresh()
+            return
+        }
+
         // Resolve the live ContactRequest handle from the SDK's
         // in-memory state. That state is PER-SESSION — the SwiftData row
         // the UI acted on may have been persisted by an earlier session's
@@ -429,6 +494,19 @@ final class SwiftDashSDKContactsService: ObservableObject {
     /// via `unignoreContactSender`.
     func ignoreSender(_ senderId: Data) async throws {
         let (wallet, _, ownerId) = try requireContext()
+
+        // Never let an obsolete incoming row mute an established contact.
+        // Besides avoiding a misleading action, this preserves the invariant
+        // that ignored senders have no outgoing request from us.
+        guard incomingRequests.contains(where: {
+            $0.contactIdentityId == senderId
+        }) else {
+            Self.logger.info(
+                "👥 CONTACTS :: ignored stale ignore — sender is no longer pending incoming")
+            refresh()
+            return
+        }
+
         do {
             try await wallet.ignoreContactSender(
                 ourIdentityId: ownerId,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -107,7 +107,6 @@ final class SwiftDashSDKContactsService: ObservableObject {
     private let authorizer = DWIdentityAuthorizer()
     private var saveObserverCancellable: AnyCancellable?
     private var activeWalletCancellable: AnyCancellable?
-    private var repairingIgnoredSenderIds: Set<Data> = []
 
     /// Last run of the payments projection (see
     /// `refreshPaymentsProjection`). Throttles the piggyback call in
@@ -170,31 +169,15 @@ final class SwiftDashSDKContactsService: ObservableObject {
 
         let requestRows: [PersistentDashpayContactRequest]
         let profileRows: [PersistentDashpayContactProfile]
-        let ignoredSenderRows: [PersistentDashpayIgnoredSender]
         do {
             requestRows = try context.fetch(FetchDescriptor<PersistentDashpayContactRequest>(
                 predicate: PersistentDashpayContactRequest.predicate(ownerIdentityId: ownerId)))
             profileRows = try context.fetch(FetchDescriptor<PersistentDashpayContactProfile>(
                 predicate: PersistentDashpayContactProfile.predicate(ownerIdentityId: ownerId)))
-            ignoredSenderRows = try context.fetch(FetchDescriptor<PersistentDashpayIgnoredSender>(
-                predicate: PersistentDashpayIgnoredSender.predicate(ownerIdentityId: ownerId)))
         } catch {
             Self.logger.error("👥 CONTACTS :: SwiftData fetch failed: \(String(describing: error), privacy: .public)")
             return
         }
-
-        // An ignored sender cannot also be someone we sent a request to:
-        // the outgoing row means we deliberately established or initiated
-        // that relationship. This contradictory state can only be produced
-        // by a stale incoming-row action. Repair it so an already-established
-        // contact is not permanently downgraded to "outgoing".
-        let outgoingIds = Set(
-            requestRows.lazy.filter(\.isOutgoing).map(\.contactIdentityId))
-        let contradictoryIgnoredIds = Set(
-            ignoredSenderRows.map(\.ignoredSenderId)).intersection(outgoingIds)
-        repairContradictoryIgnoredSenders(
-            contradictoryIgnoredIds,
-            ownerId: ownerId)
 
         let profilesByContact = Dictionary(
             profileRows.map { ($0.contactIdentityId, $0) },
@@ -266,42 +249,6 @@ final class SwiftDashSDKContactsService: ObservableObject {
         if Date().timeIntervalSince(lastPaymentsProjection) > 60 {
             lastPaymentsProjection = Date()
             refreshPaymentsProjection()
-        }
-    }
-
-    private func repairContradictoryIgnoredSenders(
-        _ senderIds: Set<Data>,
-        ownerId: Data
-    ) {
-        guard let wallet = SwiftDashSDKHost.shared.wallet else { return }
-        let pendingIds = senderIds.filter {
-            repairingIgnoredSenderIds.insert($0).inserted
-        }
-        guard !pendingIds.isEmpty else { return }
-
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer {
-                self.repairingIgnoredSenderIds.subtract(pendingIds)
-            }
-
-            var repairedAny = false
-            for senderId in pendingIds {
-                do {
-                    try await wallet.unignoreContactSender(
-                        ourIdentityId: ownerId,
-                        contactIdentityId: senderId)
-                    repairedAny = true
-                    Self.logger.info(
-                        "👥 CONTACTS :: repaired stale ignored+outgoing state for \(senderId.prefix(4).map { String(format: "%02x", $0) }.joined(), privacy: .public)…")
-                } catch {
-                    Self.logger.error(
-                        "👥 CONTACTS :: stale ignore repair failed: \(String(describing: error), privacy: .public)")
-                }
-            }
-            if repairedAny {
-                await self.syncNow()
-            }
         }
     }
 

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -38,7 +38,7 @@ struct AddContactScreen: View {
     @State private var errorMessage: String? = nil
     @State private var sentToast = false
 
-    private let service = SwiftDashSDKContactsService.shared
+    @ObservedObject private var service = SwiftDashSDKContactsService.shared
 
     var body: some View {
         NavigationStack {

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -15,7 +15,7 @@ import SwiftUI
 import DashUIKit
 
 struct ContactProfileSheet: View {
-    let contact: ContactItem
+    @State private var contact: ContactItem
 
     @Environment(\.dismiss) private var dismiss
     @State private var isProcessing = false
@@ -46,6 +46,10 @@ struct ContactProfileSheet: View {
     @State private var showContactSettings = false
 
     private let service = SwiftDashSDKContactsService.shared
+
+    init(contact: ContactItem) {
+        _contact = State(initialValue: contact)
+    }
 
     var body: some View {
         NavigationStack {
@@ -112,7 +116,24 @@ struct ContactProfileSheet: View {
             .onReceive(NotificationCenter.default.publisher(
                 for: SwiftDashSDKContactsService.contactsDidChangeNotification)
             ) { _ in
-                if contact.relationship == .established {
+                guard let latestContact = service.contactItem(
+                    for: contact.contactIdentityId)
+                else {
+                    // The request was removed (ignored) or the active wallet
+                    // changed. Do not leave an actionable stale profile open.
+                    dismiss()
+                    return
+                }
+
+                let becameEstablished =
+                    contact.relationship != .established &&
+                    latestContact.relationship == .established
+                contact = latestContact
+
+                if latestContact.relationship == .established {
+                    if becameEstablished {
+                        service.refreshPaymentsProjection()
+                    }
                     loadPayments()
                 }
             }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -91,6 +91,34 @@ final class ContactsViewModel: ObservableObject {
 
 // MARK: - ContactsScreen
 
+/// SwiftUI otherwise reuses a contact row by `ContactItem.id` when the same
+/// identity moves between incoming / established / outgoing sections. That
+/// can preserve the old row type and its action closures (for example an
+/// Accept button rendered inside the Pending section).
+private struct ContactListEntry: Identifiable {
+    enum Section: Hashable {
+        case incoming
+        case established
+        case outgoing
+        case hidden
+    }
+
+    struct ID: Hashable {
+        let section: Section
+        let contactIdentityId: Data
+    }
+
+    let item: ContactItem
+    let id: ID
+
+    init(item: ContactItem, section: Section) {
+        self.item = item
+        id = ID(
+            section: section,
+            contactIdentityId: item.contactIdentityId)
+    }
+}
+
 struct ContactsScreen: View {
     @StateObject private var viewModel = ContactsViewModel()
     @State private var filterText = ""
@@ -159,7 +187,8 @@ struct ContactsScreen: View {
                             format: NSLocalizedString("Contact Requests (%d)", comment: "DashPay Contacts"),
                             filteredIncoming.count),
                         size: 15)
-                    ForEach(filteredIncoming) { item in
+                    ForEach(entries(filteredIncoming, section: .incoming)) { entry in
+                        let item = entry.item
                         cardRow {
                             IncomingRequestRow(
                                 item: item,
@@ -174,7 +203,8 @@ struct ContactsScreen: View {
 
                 if !filteredContacts.isEmpty {
                     sectionHeader(NSLocalizedString("My Contacts", comment: "DashPay Contacts"), size: 17)
-                    ForEach(filteredContacts) { item in
+                    ForEach(entries(filteredContacts, section: .established)) { entry in
+                        let item = entry.item
                         cardRow {
                             ContactRow(item: item)
                         }
@@ -184,7 +214,8 @@ struct ContactsScreen: View {
 
                 if !filteredOutgoing.isEmpty {
                     sectionHeader(NSLocalizedString("Pending Requests", comment: "DashPay Contacts"), size: 15)
-                    ForEach(filteredOutgoing) { item in
+                    ForEach(entries(filteredOutgoing, section: .outgoing)) { entry in
+                        let item = entry.item
                         cardRow {
                             ContactRow(item: item, showPendingBadge: true)
                         }
@@ -195,7 +226,8 @@ struct ContactsScreen: View {
 
                 if !filteredHidden.isEmpty {
                     sectionHeader(NSLocalizedString("Hidden", comment: "DashPay Contacts"), size: 15)
-                    ForEach(filteredHidden) { item in
+                    ForEach(entries(filteredHidden, section: .hidden)) { entry in
+                        let item = entry.item
                         cardRow {
                             ContactRow(item: item)
                         }
@@ -284,6 +316,13 @@ struct ContactsScreen: View {
     private var filteredHidden: [ContactItem] { viewModel.contacts.filter { $0.isHidden && matches($0) } }
     private var filteredIncoming: [ContactItem] { viewModel.incomingRequests.filter(matches) }
     private var filteredOutgoing: [ContactItem] { viewModel.outgoingRequests.filter(matches) }
+
+    private func entries(
+        _ items: [ContactItem],
+        section: ContactListEntry.Section
+    ) -> [ContactListEntry] {
+        items.map { ContactListEntry(item: $0, section: section) }
+    }
 }
 
 // MARK: - Rows (Android dashpay_contact_row: 70pt, avatar 36, name 17sb)

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
@@ -57,7 +57,7 @@ struct NotificationsScreen: View {
 
     // MARK: Events
 
-    private enum EventKind {
+    private enum EventKind: Hashable {
         /// Pending incoming request — actionable.
         case incomingRequest
         /// Pending outgoing request we sent — awaiting their acceptance.
@@ -69,9 +69,18 @@ struct NotificationsScreen: View {
     }
 
     private struct Event: Identifiable {
+        struct ID: Hashable {
+            let contactIdentityId: Data
+            let kind: EventKind
+        }
+
         let item: ContactItem
         let kind: EventKind
-        var id: Data { item.contactIdentityId }
+        var id: ID {
+            ID(
+                contactIdentityId: item.contactIdentityId,
+                kind: kind)
+        }
         var date: Date { item.createdAt }
     }
 


### PR DESCRIPTION
## Summary
- give contact rows relationship-scoped identities so SwiftUI does not reuse stale Accept/Pending views
- refresh an open contact profile when the relationship changes
- make stale Accept and Ignore actions safe no-ops
- repair contradictory ignored + outgoing state left by a stale action
- observe contact snapshots from Add Contact so Pending changes to Already a contact

## Testing
- manually verified the accepting side updates from incoming to established
- verified through simulator logs that the sending peer reaches established with zero outgoing requests
- xcrun swiftc -frontend -parse for the five changed Swift files
- git diff --check
- plutil -lint DashWallet.xcodeproj/project.pbxproj
- full build not run