### PR TITLE
fix(dashpay): scope upgrade state to active network

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -133,6 +133,7 @@ public final class DWCurrentUserIdentityInfo: NSObject {
     private var cachedSnapshot: Snapshot = .empty
     private var cachedRevision: Int = -1
     private var currentRevision: Int = 0
+    private var cachedNetwork: Network?
 
     private override init() {
         super.init()
@@ -187,6 +188,20 @@ public final class DWCurrentUserIdentityInfo: NSObject {
     /// `DWDashPayProtocol.hasIdentity` semantics from Row #17 stage A.
     @objc public var hasIdentity: Bool {
         snapshot.identityId != nil
+    }
+
+    /// True only after the SDK host has rebound to the network currently
+    /// selected by the app. During a network switch the persisted selection
+    /// changes before the old host is stopped, so destination UI must not
+    /// consume that old host's identity.
+    @objc public var isCurrentNetworkContextReady: Bool {
+        guard let selectedNetwork = WalletEnvironment.network else {
+            return false
+        }
+        let host = SwiftDashSDKHost.shared
+        return host.runningNetwork == selectedNetwork
+            && host.wallet != nil
+            && host.modelContainer != nil
     }
 
     /// First DPNS label for the current identity, or
@@ -263,6 +278,7 @@ public final class DWCurrentUserIdentityInfo: NSObject {
         currentRevision &+= 1
         cachedSnapshot = .empty
         cachedRevision = currentRevision
+        cachedNetwork = nil
         Self.logger.info(
             "🪪 IDENT-INFO :: wallet-context reset; revision → \(self.currentRevision, privacy: .public)")
     }
@@ -304,10 +320,21 @@ public final class DWCurrentUserIdentityInfo: NSObject {
     }
 
     private var snapshot: Snapshot {
-        if cachedRevision != currentRevision {
+        // Never serve or recompute the previous network's snapshot while the
+        // selected network and the still-running SDK host disagree. That
+        // transition window previously leaked a Testnet identity into Mainnet
+        // and repopulated the cleared global username mirror.
+        guard isCurrentNetworkContextReady,
+              let selectedNetwork = WalletEnvironment.network
+        else {
+            return .empty
+        }
+
+        if cachedNetwork != selectedNetwork || cachedRevision != currentRevision {
             if let computed = computeSnapshot() {
                 cachedSnapshot = computed
                 cachedRevision = currentRevision
+                cachedNetwork = selectedNetwork
             }
             // else: host wasn't ready (wallet/container hydrating).
             // Don't bump cachedRevision so the next read retries

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -309,6 +309,13 @@ final class SwiftDashSDKWalletRuntime: NSObject {
                 currentNetwork = network
                 if trigger == .walletMaterialChanged {
                     publishActiveWalletDidChange(reason: "wallet-started")
+                } else if trigger == .networkDidChange {
+                    // The same walletId can exist on both networks, but its
+                    // SwiftData container and identity set are network-scoped.
+                    // Publish only after the destination runtime is fully
+                    // bound so identity/banner consumers re-read destination
+                    // state instead of the cleared transition mirror.
+                    publishActiveWalletDidChange(reason: "network-changed")
                 }
             } catch {
                 Self.logger.error("🧭 RUNTIME :: start failed: \(String(describing: error), privacy: .public)")

--- a/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
+++ b/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
@@ -32,7 +32,7 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
     private var model = SyncModelImpl()
     @objc private(set) var state: CurrentUserProfileModelState = .none
     @objc let updateModel: DWDPUpdateProfileModel
-    @Published private(set) var showJoinDashpay: Bool = true
+    @Published private(set) var showJoinDashpay: Bool = false
     
     @objc var blockchainIdentity: DSBlockchainIdentity? {
         if MOCK_DASHPAY.boolValue {
@@ -65,6 +65,25 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
             }
             .store(in: &cancellableBag)
 
+        // Re-evaluate only after the SDK host has rebound to the destination
+        // network. This prevents the menu banner from inheriting the previous
+        // network's global username mirror.
+        NotificationCenter.default.publisher(
+            for: SwiftDashSDKWalletState.activeWalletDidChangeNotification
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.updateShowJoinDashpay()
+        }
+        .store(in: &cancellableBag)
+
+        NotificationCenter.default.publisher(for: NSNotification.Name.DWCurrentNetworkDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.showJoinDashpay = false
+            }
+            .store(in: &cancellableBag)
+
         updateShowJoinDashpay()
     }
 
@@ -77,13 +96,23 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
     /// install, which kept the banner up on a wallet that already has a
     /// username.
     private func updateShowJoinDashpay() {
-        var hasUsername = DWGlobalOptions.sharedInstance().dashpayUsername?.isEmpty == false
-        if !hasUsername {
-            hasUsername = MainActor.assumeIsolated {
-                DWCurrentUserIdentityInfo.shared.username?.isEmpty == false
-            }
+        let identityState = MainActor.assumeIsolated {
+            let identity = DWCurrentUserIdentityInfo.shared
+            return (
+                contextReady: identity.isCurrentNetworkContextReady,
+                hasIdentity: identity.hasIdentity,
+                username: identity.username
+            )
         }
-        showJoinDashpay = model.state == .syncDone && !hasUsername
+        let options = DWGlobalOptions.sharedInstance()
+        let hasUsername = JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+            hasIdentity: identityState.hasIdentity,
+            sdkUsername: identityState.username,
+            legacyRegistrationCompleted: options.dashpayRegistrationCompleted,
+            legacyUsername: options.dashpayUsername)
+        showJoinDashpay = identityState.contextReady
+            && model.state == .syncDone
+            && !hasUsername
     }
     
     @objc func update() {

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -82,7 +82,7 @@ class HomeViewModel: ObservableObject {
     @Published var showTimeSkewAlertDialog: Bool = false
     @Published var showCoinJoinSweepDialog: Bool = false
     @Published private(set) var timeSkew: TimeInterval = 0
-    @Published private(set) var showJoinDashpay: Bool = true
+    @Published private(set) var showJoinDashpay: Bool = false
     /// Selected filter categories (multi-select checkboxes). Defaults to every
     /// category — i.e. "All". Never empty: the dialog blocks unchecking the
     /// last box.
@@ -180,6 +180,12 @@ class HomeViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.clearCachedData()
+#if DASHPAY
+                // The selected network changes before its SDK runtime is
+                // ready. Keep the banner hidden during that transition; the
+                // post-ready wallet-context notification re-evaluates it.
+                self?.showJoinDashpay = false
+#endif
             }
             .store(in: &cancellableBag)
 
@@ -194,6 +200,16 @@ class HomeViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.clearCachedData()
+#if DASHPAY
+                // The runtime posts this only after the destination
+                // network's wallet + SwiftData container are bound. Defer
+                // one main-queue turn so DWCurrentUserIdentityInfo's
+                // notification observer invalidates its old-network snapshot
+                // before the banner asks for the destination username.
+                DispatchQueue.main.async { [weak self] in
+                    self?.checkJoinDashPay()
+                }
+#endif
             }
             .store(in: &cancellableBag)
     }
@@ -1401,26 +1417,65 @@ private struct HomeViewModelPreviewTransactionSource: TransactionSource {
 }
 #endif
 
+/// SDK identity data is authoritative for Join DashPay visibility. The
+/// DWGlobalOptions fields are a legacy UI mirror and are deliberately cleared
+/// at the start of every network switch; requiring that mirror before reading
+/// the SDK username creates a short-circuit where the mirror can never
+/// self-heal after returning to a network with an existing identity.
+enum JoinDashPayRegistrationPolicy {
+    static func hasRegisteredUsername(
+        hasIdentity: Bool,
+        sdkUsername: String?,
+        legacyRegistrationCompleted: Bool,
+        legacyUsername: String?
+    ) -> Bool {
+        // The legacy mirror is global, while identities are network-scoped.
+        // It can only be a fallback for an identity that exists in the
+        // currently-bound SDK context.
+        guard hasIdentity else {
+            return false
+        }
+        if sdkUsername?.isEmpty == false {
+            return true
+        }
+        return legacyRegistrationCompleted && legacyUsername?.isEmpty == false
+    }
+}
+
 // MARK: - DashPay
 
 #if DASHPAY
 extension HomeViewModel {
     func checkJoinDashPay() {
         let options = DWGlobalOptions.sharedInstance()
-        var hasRegisteredUsername =
-            options.dashpayRegistrationCompleted &&
-            options.dashpayUsername?.isEmpty == false
-        if !hasRegisteredUsername {
-            hasRegisteredUsername = MainActor.assumeIsolated {
-                options.dashpayRegistrationCompleted &&
-                DWCurrentUserIdentityInfo.shared.username?.isEmpty == false
-            }
+        // Read the network-scoped SDK truth unconditionally.
+        let identityState = MainActor.assumeIsolated {
+            let identity = DWCurrentUserIdentityInfo.shared
+            return (
+                contextReady: identity.isCurrentNetworkContextReady,
+                hasIdentity: identity.hasIdentity,
+                username: identity.username
+            )
         }
+        let hasRegisteredUsername = JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+            hasIdentity: identityState.hasIdentity,
+            sdkUsername: identityState.username,
+            legacyRegistrationCompleted: options.dashpayRegistrationCompleted,
+            legacyUsername: options.dashpayUsername)
+        // Dismissal and registration-progress prefs predate network-scoped
+        // identity storage. They may still describe the previous network, so
+        // they can suppress the banner only when this network has an identity.
+        let identityScopedDismissal =
+            identityState.hasIdentity && UsernamePrefs.shared.joinDashPayDismissed
+        let identityScopedRegistrationState =
+            identityState.hasIdentity &&
+            (joinDashPayState == .voting || joinDashPayState == .registered)
 
-        self.showJoinDashpay = syncModel.state == .syncDone &&
-            !UsernamePrefs.shared.joinDashPayDismissed &&
+        self.showJoinDashpay = identityState.contextReady &&
+            syncModel.state == .syncDone &&
+            !identityScopedDismissal &&
             !hasRegisteredUsername &&
-            joinDashPayState != .voting && joinDashPayState != .registered
+            !identityScopedRegistrationState
     }
     
     private func observeDashPay() {

--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -142,6 +142,17 @@ class MainTabbarController: UITabBarController {
                 self?.reconfigureDashPayTabsForActiveWalletChange()
             }
             .store(in: &cancellableBag)
+
+        // Remove destination-inappropriate tabs immediately when the selected
+        // network flips. `DWCurrentUserIdentityInfo` deliberately reports no
+        // identity until the destination SDK runtime is bound; the post-ready
+        // active-wallet notification above rebuilds again with final state.
+        NotificationCenter.default.publisher(for: NSNotification.Name.DWCurrentNetworkDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reconfigureDashPayTabsForActiveWalletChange()
+            }
+            .store(in: &cancellableBag)
         #endif
     }
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -92,3 +92,50 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertFalse(mainnetFirst.value === testnet.value)
     }
 }
+
+final class JoinDashPayRegistrationPolicyTests: XCTestCase {
+    func testSDKUsernameWinsWhenLegacyMirrorWasClearedByNetworkSwitch() {
+        XCTAssertTrue(
+            JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+                hasIdentity: true,
+                sdkUsername: "alice",
+                legacyRegistrationCompleted: false,
+                legacyUsername: nil))
+    }
+
+    func testLegacyMirrorRemainsACompatibleFallback() {
+        XCTAssertTrue(
+            JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+                hasIdentity: true,
+                sdkUsername: nil,
+                legacyRegistrationCompleted: true,
+                legacyUsername: "alice"))
+    }
+
+    func testIdentityWithoutOwnedUsernameStillShowsJoinFlow() {
+        XCTAssertFalse(
+            JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+                hasIdentity: false,
+                sdkUsername: nil,
+                legacyRegistrationCompleted: false,
+                legacyUsername: nil))
+    }
+
+    func testLegacyUsernameWithoutCompletionDoesNotSuppressJoinFlow() {
+        XCTAssertFalse(
+            JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+                hasIdentity: true,
+                sdkUsername: nil,
+                legacyRegistrationCompleted: false,
+                legacyUsername: "stale"))
+    }
+
+    func testLegacyMirrorCannotLeakAcrossNetworkWithoutIdentity() {
+        XCTAssertFalse(
+            JoinDashPayRegistrationPolicy.hasRegisteredUsername(
+                hasIdentity: false,
+                sdkUsername: nil,
+                legacyRegistrationCompleted: true,
+                legacyUsername: "testnet-alice"))
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes BUG-6 and the related network-switch aspect of BUG-9.

Switching Testnet → Mainnet → Testnet could leak the previous network's DashPay identity state into the destination UI. Mainnet could retain Contacts/Explore tabs and hide the Join DashPay banner despite having no identity, while returning to a registered Testnet wallet could show the upgrade banner again.

## What was done?

- Publish an active-wallet context notification after a network runtime is fully rebound.
- Make `DWCurrentUserIdentityInfo` refuse cached identity snapshots from a different network.
- Gate the Home and More Join DashPay banners on the current network's ready SDK context and identity.
- Reset DashPay-only tabs at network-transition start and rebuild them from the destination identity state after runtime readiness.
- Keep the legacy username mirror only as a fallback when the current network actually has an identity.
- Add regression coverage for cleared, stale, and cross-network legacy mirror states.

## How Has This Been Tested?

- Built the `dashpay` scheme successfully for an arm64 iOS Simulator:
  `xcodebuild -quiet -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/dashwallet-bug06-derived ARCHS=arm64 build`
- Manually verified on iPhone 17 Pro Simulator, iOS 26.5:
  - Mainnet without an identity shows the Join/Upgrade DashPay entry and the base three-tab layout.
  - Testnet with a registered identity hides the upgrade banner and restores DashPay tabs.
  - Testnet → Mainnet → Testnet preserves the correct per-network UI state.
- Added five unit regression cases for the Join DashPay registration policy.
- Targeted XCTest execution is currently blocked by pre-existing test-scheme issues: repository-wide SwiftLint failures, concurrent BartyCrouch mutation, and a non-DashPay test host configuration.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
