### PR TITLE
refactor: remove DashSync currency dependencies

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -1,8 +1,7 @@
 # DashSync -> SwiftDashSDK migration status
 
-Current-state ledger for the DashSync removal. Updated 2026-07-24 from the
-working tree on `swift-sdk-integration`; historical stage-by-stage detail is
-available in Git history.
+Current-state ledger for the DashSync removal. Updated 2026-07-27 from the
+working tree; historical stage-by-stage detail is available in Git history.
 
 This file answers **what is migrated**. Use
 [`DASHSYNC_TEARDOWN_PLAN.md`](./DASHSYNC_TEARDOWN_PLAN.md) for the remaining
@@ -33,11 +32,10 @@ DashSync is still linked for four bounded tails:
    networks.
 4. **Pod-unlink mechanics and compatibility surfaces** — Uphold networking,
    DashSync keychain helpers used outside wallet migration, app-internal
-   `DS*` notifications, `DashSyncCurrentCommit`, `DSCurrencyPriceObject`,
-   one residual `DSPriceManager` formatter on the Confirm Username screen,
-   `DSLocalizedString`/`DSUtils`, AppDelegate setup, and project/Podfile link entries.
+   `DS*` notifications, `DashSyncCurrentCommit`, `DSLocalizedString`/`DSUtils`,
+   AppDelegate setup, and project/Podfile link entries.
 
-As of this audit, 29 app source files directly import DashSync. Counts of all
+As of this audit, 27 app source files directly import DashSync. Counts of all
 `DS*` tokens are not a useful progress metric because app-owned names such as
 `DSTransactionDirection`, comments, and frozen compatibility contracts are
 included.

--- a/DASHSYNC_TEARDOWN_PLAN.md
+++ b/DASHSYNC_TEARDOWN_PLAN.md
@@ -1,6 +1,6 @@
 # DashSync pod teardown plan
 
-Current unlink plan, audited against the working tree on 2026-07-11. This file
+Current unlink plan, audited against the working tree on 2026-07-27. This file
 answers **what still prevents removing `pod 'DashSync'`**. Functional migration
 status lives in [`DASHSYNC_MIGRATION.md`](./DASHSYNC_MIGRATION.md).
 
@@ -26,6 +26,9 @@ transaction list/detail, receive, standard sends and fees, BIP70, address and
 mnemonic validation, authentication, reachability, the app-owned fiat-rate pipeline, logging, CrowdNode
 signing/APY, network identity/switch ownership, xpub export, DashPay registration
 and contacts, and CoinJoin recovery/sweep.
+
+The local-currency Objective-C boundary is app-owned, including the currency
+picker DTO and Confirm Username fiat formatter.
 
 The contacts rebuild in PR #787 is complete. Do not describe C10 as “contacts
 pending”; the remaining C10 scope is invitations plus legacy identity/profile
@@ -114,8 +117,6 @@ These are active repo tasks, not externally assigned work:
 | Generic keychain helpers | `getKeychainData`, `setKeychainData`, `getKeychainInt` in Coinbase, Uphold, global options | App-owned compatibility shim preserving service/account/accessibility bytes. |
 | App-internal notifications | `DSWillRequestOSPermissionNotification`, `DSApplicationTerminationRequestNotification`, residual transaction notification names | App-owned typed notification names; migrate posters and observers together. |
 | About/build metadata | `DashSyncCurrentCommit`, `scripts/dashsync_version.sh` | Remove resource/script and show app/platform information only. |
-| Local currency DTO | `DSCurrencyPriceObject` | App-owned value/ObjC DTO returned by `CurrencyExchanger`. |
-| Confirm Username fiat amount | Direct `DSPriceManager.localCurrencyStringForDashAmount` call in `DWConfirmUsernameContentView` | Route through `CurrencyExchanger_Objc` / the app-owned exchanger. |
 | Localization/utilities | `DSLocalizedString`, `UIWindow+DSUtils`, umbrella-only constants such as `DUFFS` | Foundation/app helpers and app-owned constants. |
 | Logger compatibility | `dwLogLevel` workaround | Revert to normal CocoaLumberjack `ddLogLevel` after DashSync headers disappear. |
 | App startup | `setupDashSyncOnce`, `DSOptionsManager` | Delete once every required service has an app/SDK owner. |

--- a/DashPay/Presentation/Setup/ConfirmUsername/Views/DWConfirmUsernameContentView.m
+++ b/DashPay/Presentation/Setup/ConfirmUsername/Views/DWConfirmUsernameContentView.m
@@ -20,7 +20,6 @@
 #import "DWCheckbox.h"
 #import "DWUIKit.h"
 #import "dashwallet-Swift.h"
-#import <DashSync/DashSync.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -133,10 +132,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSString *)supplementaryAmountStringForAmount:(uint64_t)amount {
-    DSPriceManager *priceManager = [DSPriceManager sharedInstance];
-    NSString *supplementaryAmount = [priceManager localCurrencyStringForDashAmount:amount];
-
-    return supplementaryAmount;
+    return [CurrencyExchangerObjcWrapper localCurrencyStringForDashAmount:amount];
 }
 
 @end

--- a/DashWallet/Sources/Infrastructure/Currency Exchanger/CurrencyExchanger.swift
+++ b/DashWallet/Sources/Infrastructure/Currency Exchanger/CurrencyExchanger.swift
@@ -17,6 +17,22 @@
 
 import Foundation
 
+// MARK: - CurrencyRateObjc
+
+@objcMembers
+final class CurrencyRateObjc: NSObject {
+    let code: String
+    let name: String
+    let price: NSNumber
+
+    init(code: String, name: String, price: NSNumber) {
+        self.code = code
+        self.name = name
+        self.price = price
+        super.init()
+    }
+}
+
 // MARK: - CurrencyExchangerObjcWrapper
 
 @objc
@@ -32,13 +48,9 @@ class CurrencyExchangerObjcWrapper: NSObject {
         }
     }
 
-    // TODO(PR2b): the last DSCurrencyPriceObject surface — a facade minted for
-    // the ObjC currency picker (DWLocalCurrencyModel/DWCurrencyObject). Swap to
-    // an app-owned DTO after the SwiftUI local-currency rework on master
-    // integrates (deferred 2026-07-08 to avoid colliding with it).
     @objc
-    static var prices: [DSCurrencyPriceObject] {
-        wrapped.currencies.compactMap { .init(code: $0.code, name: $0.name, price: $0.price as NSNumber) }
+    static var prices: [CurrencyRateObjc] {
+        wrapped.currencies.map { .init(code: $0.code, name: $0.name, price: $0.price as NSNumber) }
     }
 
     @objc
@@ -117,10 +129,6 @@ public typealias CurrencyExchangerObserverHandler = (CurrencyExchanger) -> ()
 public final class CurrencyExchanger {
 
     /// All available currencies
-    ///
-    /// - Returns: Array of `DSCurrencyPriceObject`
-    ///
-    ///
     var currencies: [RateObject] = []
 
     private let dataProvider: RatesProvider

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWCurrencyObject.h
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWCurrencyObject.h
@@ -20,13 +20,13 @@
 #import "DWCurrencyItem.h"
 #import "DWCurrencyItemPriceProvider.h"
 
-@class DSCurrencyPriceObject;
+@class CurrencyRateObjc;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DWCurrencyObject : NSObject <DWCurrencyItem>
 
-- (instancetype)initWithPriceObject:(DSCurrencyPriceObject *)object
+- (instancetype)initWithPriceObject:(CurrencyRateObjc *)object
                            flagName:(NSString *)flagName
                            provider:(id<DWCurrencyItemPriceProvider>)provider;
 

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWCurrencyObject.m
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWCurrencyObject.m
@@ -16,7 +16,7 @@
 //
 
 #import "DWCurrencyObject.h"
-#import <DashSync/DSCurrencyPriceObject.h>
+#import "dashwallet-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_END
 @synthesize name = _name;
 @synthesize flagName = _flagName;
 
-- (instancetype)initWithPriceObject:(DSCurrencyPriceObject *)object
+- (instancetype)initWithPriceObject:(CurrencyRateObjc *)object
                            flagName:(NSString *)flagName
                            provider:(id<DWCurrencyItemPriceProvider>)provider {
     self = [super init];

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyModel.m
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyModel.m
@@ -17,10 +17,6 @@
 
 #import "DWLocalCurrencyModel.h"
 
-#import <DashSync/DSCurrencyPriceObject.h>
-#import <DashSync/DashSync.h>
-#import <objc/runtime.h>
-
 #import "DWCurrencyItemPriceProvider.h"
 #import "DWCurrencyObject.h"
 #import "NSPredicate+DWFullTextSearch.h"
@@ -54,11 +50,11 @@ NS_ASSUME_NONNULL_BEGIN
         _numberFormatter = numberFormatter;
 
         NSString *selectedCurrencyCode = currencyCode ?: DWApp.localCurrencyCode;
-        NSArray<DSCurrencyPriceObject *> *prices = [CurrencyExchangerObjcWrapper prices];
+        NSArray<CurrencyRateObjc *> *prices = [CurrencyExchangerObjcWrapper prices];
 
         NSMutableArray<DWCurrencyObject *> *allItems = [NSMutableArray array];
         for (size_t i = 0; i < prices.count; i++) {
-            DSCurrencyPriceObject *priceObject = prices[i];
+            CurrencyRateObjc *priceObject = prices[i];
 
             DWCurrencyObject *object =
                 [[DWCurrencyObject alloc] initWithPriceObject:priceObject
@@ -89,10 +85,10 @@ NS_ASSUME_NONNULL_BEGIN
         DWApp.localCurrencyCode = item.code;
     }
 
-    NSArray<DSCurrencyPriceObject *> *prices = [CurrencyExchangerObjcWrapper prices];
+    NSArray<CurrencyRateObjc *> *prices = [CurrencyExchangerObjcWrapper prices];
 
     for (size_t i = 0; i < prices.count; i++) {
-        DSCurrencyPriceObject *priceObject = prices[i];
+        CurrencyRateObjc *priceObject = prices[i];
         if ([priceObject.code isEqualToString:item.code]) {
             self.selectedIndex = i;
             return;

--- a/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.m
+++ b/DashWallet/Sources/UI/Menu/Settings/LocalCurrency/DWLocalCurrencyViewController.m
@@ -17,8 +17,6 @@
 
 #import "DWLocalCurrencyViewController.h"
 
-#import <DashSync/DashSync.h>
-
 #import "DWLocalCurrencyModel.h"
 
 #import "DWLocalCurrencyTableViewCell.h"

--- a/DashWallet/dashwallet-Bridging-Header.h
+++ b/DashWallet/dashwallet-Bridging-Header.h
@@ -15,7 +15,6 @@ static const bool _SNAPSHOT = 0;
 #import "DSTransaction.h"
 #import "DSCoinbaseTransaction.h"
 #import "DSWallet.h"
-#import "DSCurrencyPriceObject.h"
 #import "DSPriceOperationProvider.h"
 #import "DSOperation.h"
 #import "DSOperationQueue.h"


### PR DESCRIPTION
## Summary
- replace `DSCurrencyPriceObject` with the app-owned Objective-C-visible `CurrencyRateObjc`
- route Confirm Username fiat formatting through `CurrencyExchangerObjcWrapper`
- remove the related DashSync imports and update the migration/teardown ledgers

## Testing
- [x] `plutil -lint DashWallet.xcodeproj/project.pbxproj`
- [x] DashSync import audit: 27 direct importers, down from 31
- [x] no production `DSCurrencyPriceObject` references or active scoped `DSPriceManager` usage
- [x] `dashpay` Debug arm64 iOS Simulator build
