### PR TITLE
feat(ui): allow any-to-any internal transfers

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -70,19 +70,11 @@ struct InternalTransferScreen: View {
                             .padding(.horizontal, 20)
                     }
                 }
-                .padding(.bottom, 8)
+                .padding(.bottom, 12)
             }
             .scrollBounceBehavior(.basedOnSize)
 
-            NumericKeyboardView(
-                value: keypadBinding,
-                showDecimalSeparator: true,
-                actionButtonText: NSLocalizedString("Continue", comment: ""),
-                actionEnabled: viewModel.canContinue,
-                inProgress: false,
-                actionHandler: { showConfirm = true })
-                .padding(.horizontal, 16)
-                .padding(.bottom, 12)
+            keyboardSection
         }
         .background(Color.dash.primaryBackground)
         .sheet(isPresented: $showConfirm) {
@@ -116,13 +108,38 @@ struct InternalTransferScreen: View {
     // MARK: - Amount row
 
     private var amountRow: some View {
-        TransferAmountRow(
-            unit: $viewModel.unit,
-            amountText: viewModel.amountText,
-            secondaryText: viewModel.secondaryDisplayString,
-            currencySymbol: viewModel.primaryCurrencySymbol,
-            fiatCurrencyCode: viewModel.fiatCurrencyCode,
-            onMax: { viewModel.fillMaxFromWallet() })
+        EnterAmountView(
+            primaryAmount: dashAmountText,
+            secondaryAmount: fiatAmountText,
+            primaryCurrency: .dash,
+            secondaryCurrency: .fiat(viewModel.fiatCurrencyCode),
+            isPrimarySelected: isDashInputSelected,
+            currencyCodes: amountCurrencyCodes,
+            selectedCurrencyCode: selectedAmountCurrencyCode,
+            onMax: { viewModel.fillMaxFromWallet() },
+            onSwap: toggleAmountUnit,
+            onCurrencyTap: toggleAmountUnit,
+            onSelectInputType: selectAmountCurrency
+        )
+    }
+
+    // MARK: - Keyboard
+
+    private var keyboardSection: some View {
+        NumericKeyboardView(
+            value: keypadBinding,
+            showDecimalSeparator: true,
+            actionButtonText: NSLocalizedString("Continue", comment: ""),
+            actionEnabled: viewModel.canContinue,
+            inProgress: false,
+            actionHandler: { showConfirm = true }
+        )
+        .padding(.top, 12)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+        .background(Color.dash.secondaryBackground)
+        .clipShape(.rect(cornerRadius: 20))
+        .background(Color.dash.secondaryBackground, ignoresSafeAreaEdges: .bottom)
     }
 
     // MARK: - From / To cards
@@ -143,43 +160,27 @@ struct InternalTransferScreen: View {
     /// badge — the source is fixed by the tapped balance row.
     @ViewBuilder
     private func sendCards(source: ChainNetwork) -> some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 12) {
             pinnedCard(source, caption: NSLocalizedString("From", comment: ""))
-            switch source {
-            case .core:
-                sendTargetRow(.shielded)
-                sendTargetRow(.platform)
-            case .platform:
-                sendTargetRow(.shielded)
-                sendTargetRow(.core)
-            case .shielded:
-                sendTargetRow(.core)
-                sendTargetRow(.platform)
-            }
+            selectionGroup(
+                caption: NSLocalizedString("To", comment: ""),
+                networks: availableTargets(for: source),
+                selected: sanitizedTarget(for: source, proposed: viewModel.sendTarget),
+                onSelect: viewModel.selectSendTarget)
         }
-    }
-
-    /// Selectable To row of the send sheet, bound to `viewModel.sendTarget`.
-    private func sendTargetRow(_ network: ChainNetwork) -> some View {
-        let display = networkDisplay(network)
-        return sourceRow(
-            iconSystemName: display.icon,
-            caption: NSLocalizedString("To", comment: ""),
-            title: display.title,
-            balanceTrailing: dashBalanceTrailing(display.balance),
-            selected: viewModel.sendTarget == network,
-            action: { viewModel.sendTarget = network })
     }
 
     /// Non-tappable pinned endpoint card (the fixed From of the send sheet).
     private func pinnedCard(_ network: ChainNetwork, caption: String) -> some View {
         let display = networkDisplay(network)
-        return directionCard(
+        return sourceRow(
             iconSystemName: display.icon,
-            iconColor: .blue,
             caption: caption,
             title: display.title,
-            balanceTrailing: dashBalanceTrailing(display.balance))
+            balanceTrailing: dashBalanceTrailing(display.balance),
+            selected: false,
+            showsRadio: false,
+            action: {})
     }
 
     /// Icon / title / formatted balance for a balance row, one source of
@@ -202,26 +203,18 @@ struct InternalTransferScreen: View {
     }
 
     private var swappableCards: some View {
-        ZStack {
-            VStack(spacing: 8) {
-                switch viewModel.direction {
-                case .toShielded:
-                    coreSourceCard
-                    platformSourceCard
-                    toCard
-                case .fromShielded:
-                    fromShieldedCard
-                    coreSourceCard
-                    platformSourceCard
-                }
-            }
+        VStack(spacing: 12) {
+            selectionGroup(
+                caption: NSLocalizedString("From", comment: ""),
+                networks: ChainNetwork.allCases,
+                selected: viewModel.source,
+                onSelect: viewModel.selectStandaloneSource)
 
-            // Tappable swap badge — toggles the transfer direction. Sits over
-            // the boundary between the From and To sides. Forward (2 source rows
-            // above the To card) nudges it down (y:32); reverse (1 From card
-            // above 2 destination rows) nudges it up (y:-32).
-            swapBadge
-                .offset(y: viewModel.direction == .toShielded ? 32 : -32)
+            selectionGroup(
+                caption: NSLocalizedString("To", comment: ""),
+                networks: availableTargets(for: viewModel.source),
+                selected: sanitizedTarget(for: viewModel.source, proposed: viewModel.sendTarget),
+                onSelect: viewModel.selectStandaloneTarget)
         }
     }
 
@@ -230,54 +223,15 @@ struct InternalTransferScreen: View {
     /// No swap badge — the destination is fixed by the tapped balance row.
     @ViewBuilder
     private func receiveCards(target: ChainNetwork) -> some View {
-        VStack(spacing: 8) {
-            switch target {
-            case .shielded:
-                coreSourceCard
-                platformSourceCard
-                toCard
-            case .core:
-                receiveSourceRow(.shielded)
-                receiveSourceRow(.platform)
-                toTransparentCard
-            case .platform:
-                receiveSourceRow(.shielded)
-                receiveSourceRow(.core)
-                toPlatformCard
-            }
+        VStack(spacing: 12) {
+            selectionGroup(
+                caption: NSLocalizedString("From", comment: ""),
+                networks: availableSources(for: target),
+                selected: sanitizedSource(into: target, proposed: viewModel.receiveSource),
+                onSelect: viewModel.selectReceiveSource)
+
+            pinnedCard(target, caption: NSLocalizedString("To", comment: ""))
         }
-    }
-
-    /// Selectable From row of the receive sheet, bound to
-    /// `viewModel.receiveSource` (the .shielded target reuses the legacy
-    /// `source`-bound cards instead).
-    private func receiveSourceRow(_ network: ChainNetwork) -> some View {
-        let display = networkDisplay(network)
-        return sourceRow(
-            iconSystemName: display.icon,
-            caption: NSLocalizedString("From", comment: ""),
-            title: display.title,
-            balanceTrailing: dashBalanceTrailing(display.balance),
-            selected: viewModel.receiveSource == network,
-            action: { viewModel.receiveSource = network })
-    }
-
-    private var toTransparentCard: some View {
-        directionCard(
-            iconSystemName: "d.circle.fill",
-            iconColor: .blue,
-            caption: NSLocalizedString("To", comment: ""),
-            title: NSLocalizedString("Transparent", comment: "Balance breakdown"),
-            balanceTrailing: dashBalanceTrailing(viewModel.coreBalanceFormatted))
-    }
-
-    private var toPlatformCard: some View {
-        directionCard(
-            iconSystemName: "creditcard.fill",
-            iconColor: .blue,
-            caption: NSLocalizedString("To", comment: ""),
-            title: NSLocalizedString("Platform", comment: "Dash Platform chain"),
-            balanceTrailing: dashBalanceTrailing(viewModel.platformCreditsFormatted))
     }
 
     /// Trailing balance amount + Dash currency glyph, shared by every card.
@@ -285,61 +239,24 @@ struct InternalTransferScreen: View {
         TransferSourceRow.dashBalanceTrailing(formatted)
     }
 
-    private var coreSourceCard: some View {
-        sourceRow(
-            iconSystemName: "d.circle.fill",
-            caption: sourceCaption,
-            title: NSLocalizedString("Transparent", comment: "Balance breakdown"),
-            balanceTrailing: dashBalanceTrailing(viewModel.coreBalanceFormatted),
-            selected: viewModel.source == .core,
-            action: { viewModel.source = .core })
-    }
-
-    private var platformSourceCard: some View {
-        sourceRow(
-            iconSystemName: "creditcard.fill",
-            caption: sourceCaption,
-            title: NSLocalizedString("Platform", comment: "Dash Platform chain"),
-            balanceTrailing: dashBalanceTrailing(viewModel.platformCreditsFormatted),
-            selected: viewModel.source == .platform,
-            action: { viewModel.source = .platform })
-    }
-
-    private var toCard: some View {
-        directionCard(
-            iconSystemName: "shield.fill",
-            iconColor: .blue,
-            caption: NSLocalizedString("To", comment: ""),
-            title: NSLocalizedString("Shielded", comment: ""),
-            balanceTrailing: AnyView(
-                Text(viewModel.shieldedBalanceFormatted)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.dash.primaryText)))
-    }
-
-    // MARK: - Reverse-direction From card
-
-    /// "From" card in reverse mode — the shielded balance (non-tappable). The
-    /// reverse *destination* is chosen via the reused `coreSourceCard` /
-    /// `platformSourceCard` radio rows rendered below it.
-    private var fromShieldedCard: some View {
-        directionCard(
-            iconSystemName: "shield.fill",
-            iconColor: .blue,
-            caption: NSLocalizedString("From", comment: ""),
-            title: NSLocalizedString("Shielded", comment: ""),
-            balanceTrailing: AnyView(
-                Text(viewModel.shieldedBalanceFormatted)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.dash.primaryText)))
-    }
-
-    /// Caption for the reusable source rows: "From" in the forward direction,
-    /// "To" in reverse (where they act as the destination picker).
-    private var sourceCaption: String {
-        viewModel.direction == .toShielded
-            ? NSLocalizedString("From", comment: "")
-            : NSLocalizedString("To", comment: "")
+    private func selectionGroup(
+        caption: String,
+        networks: [ChainNetwork],
+        selected: ChainNetwork,
+        onSelect: @escaping (ChainNetwork) -> Void
+    ) -> some View {
+        VStack(spacing: 8) {
+            ForEach(networks, id: \.self) { network in
+                let display = networkDisplay(network)
+                sourceRow(
+                    iconSystemName: display.icon,
+                    caption: caption,
+                    title: display.title,
+                    balanceTrailing: dashBalanceTrailing(display.balance),
+                    selected: selected == network,
+                    action: { onSelect(network) })
+            }
+        }
     }
 
     /// Tappable source row with a trailing radio indicator — rendered by the
@@ -350,6 +267,7 @@ struct InternalTransferScreen: View {
         title: String,
         balanceTrailing: AnyView,
         selected: Bool,
+        showsRadio: Bool = true,
         action: @escaping () -> Void
     ) -> some View {
         TransferSourceRow(
@@ -358,58 +276,42 @@ struct InternalTransferScreen: View {
             title: title,
             balanceTrailing: balanceTrailing,
             selected: selected,
+            showsRadio: showsRadio,
             action: action)
     }
 
-    private func directionCard(
-        iconSystemName: String,
-        iconColor: Color,
-        caption: String,
-        title: String,
-        balanceTrailing: AnyView
-    ) -> some View {
-        HStack(spacing: 14) {
-            Image(systemName: iconSystemName)
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(iconColor)
-                .frame(width: 36, height: 36)
-                .background(Color.dash.blue.opacity(0.08))
-                .clipShape(Circle())
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(caption)
-                    .font(.system(size: 11))
-                    .foregroundColor(Color.dash.secondaryText)
-                Text(title)
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(.dash.primaryText)
-            }
-
-            Spacer()
-
-            balanceTrailing
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 12)
-        .background(Color.dash.secondaryBackground)
-        .cornerRadius(12)
+    private func availableTargets(for source: ChainNetwork) -> [ChainNetwork] {
+        ChainNetwork.allCases.filter { $0 != source }
     }
 
-    private var swapBadge: some View {
-        Button(action: toggleDirection) {
-            Image(systemName: "arrow.up.arrow.down")
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundColor(.dash.primaryText)
-                .frame(width: 28, height: 28)
-                .background(Color.dash.primaryBackground)
-                .clipShape(Circle())
-                .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
-        }
-        .buttonStyle(.plain)
+    private func availableSources(for target: ChainNetwork) -> [ChainNetwork] {
+        ChainNetwork.allCases.filter { $0 != target }
     }
 
-    private func toggleDirection() {
-        viewModel.direction = viewModel.direction == .toShielded ? .fromShielded : .toShielded
+    private func sanitizedTarget(for source: ChainNetwork, proposed target: ChainNetwork) -> ChainNetwork {
+        source == target ? defaultTarget(for: source) : target
+    }
+
+    private func sanitizedSource(into target: ChainNetwork, proposed source: ChainNetwork) -> ChainNetwork {
+        source == target ? defaultSource(for: target) : source
+    }
+
+    private func defaultTarget(for source: ChainNetwork) -> ChainNetwork {
+        switch source {
+        case .core, .platform:
+            return .shielded
+        case .shielded:
+            return .core
+        }
+    }
+
+    private func defaultSource(for target: ChainNetwork) -> ChainNetwork {
+        switch target {
+        case .shielded:
+            return .core
+        case .core, .platform:
+            return .shielded
+        }
     }
 
     // MARK: - Transfer preview
@@ -433,6 +335,54 @@ struct InternalTransferScreen: View {
     }
 
     // MARK: - Helpers
+
+    private var isDashInputSelected: Bool {
+        viewModel.unit == .dash
+    }
+
+    private var dashAmountText: String {
+        switch viewModel.unit {
+        case .dash:
+            return keypadBinding.wrappedValue
+        case .fiat:
+            guard viewModel.parsedDashAmount > 0 else { return "" }
+            return InternalTransferViewModel.formatTyped(
+                viewModel.parsedDashAmount,
+                fractionDigits: 8)
+        }
+    }
+
+    private var fiatAmountText: String {
+        switch viewModel.unit {
+        case .dash:
+            guard viewModel.parsedDashAmount > 0,
+                  let fiatAmount = try? CurrencyExchanger.shared.convertDash(
+                    amount: viewModel.parsedDashAmount,
+                    to: viewModel.fiatCurrencyCode)
+            else { return "" }
+            return InternalTransferViewModel.formatTyped(
+                fiatAmount,
+                fractionDigits: 2)
+        case .fiat:
+            return keypadBinding.wrappedValue
+        }
+    }
+
+    private var amountCurrencyCodes: [String] {
+        ["DASH", viewModel.fiatCurrencyCode]
+    }
+
+    private var selectedAmountCurrencyCode: String {
+        isDashInputSelected ? "DASH" : viewModel.fiatCurrencyCode
+    }
+
+    private func toggleAmountUnit() {
+        viewModel.unit = isDashInputSelected ? .fiat : .dash
+    }
+
+    private func selectAmountCurrency(_ currencyCode: String) {
+        viewModel.unit = currencyCode.caseInsensitiveCompare("DASH") == .orderedSame ? .dash : .fiat
+    }
 
     private var keypadBinding: Binding<String> {
         Binding(

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -13,28 +13,10 @@ enum InternalTransferUnit: String {
     case fiat
 }
 
-/// Source bucket the user is funding the shielded transfer from. Decides
-/// which SDK route the `ShieldedTransferCoordinator` runs (asset-lock vs
-/// transparent shield) and which balance the screen validates against.
-enum InternalTransferSource: String {
-    case core
-    case platform
-}
-
-/// Direction of the transfer, toggled by the swap badge. `.toShielded`
-/// funds the shielded balance from Core/Platform (forward); `.fromShielded`
-/// withdraws from the shielded balance back to the transparent Dash Wallet
-/// (reverse, via `PlatformWalletManager.shieldedWithdraw`).
-enum InternalTransferDirection {
-    case toShielded
-    case fromShielded
-}
-
 /// Every balance-to-balance route the transfer engine can execute. The
 /// canonical read for validation, fees, and execution — derived from the
-/// receive sheet's (source, target) pair when pinned, otherwise from the
-/// standalone screen's legacy (direction, source) pair (which can only
-/// express the four shielded-centric routes).
+/// current explicit (from, to) pair, whether the screen is standalone or
+/// one side is pinned by the send/receive sheet host.
 enum InternalTransferRoute: Equatable {
     /// BIP44 UTXOs → asset lock → Type 18 shield.
     case coreToShielded
@@ -94,42 +76,38 @@ final class InternalTransferViewModel: ObservableObject {
         }
     }
 
-    /// Which "From" bucket the user picked on the source rows. Defaults to
-    /// `.core` because most users have BIP44 balance before they have
-    /// Platform Payment credits. Only meaningful while `.toShielded`.
-    @Published var source: InternalTransferSource = .core
-
-    /// Forward (Core/Platform → Shielded) vs reverse (Shielded → Dash Wallet),
-    /// toggled by the swap badge. Reverse has a single fixed destination
-    /// (Dash Wallet), so `source` is ignored while `.fromShielded`.
-    @Published var direction: InternalTransferDirection = .toShielded
+    /// Standalone screen's selected source balance. Defaults to `.core`
+    /// because most users have BIP44 funds before they have Platform or
+    /// Shielded balance.
+    @Published var source: ChainNetwork = .core {
+        didSet { guard oldValue != source else { return }; routeDidChange() }
+    }
 
     /// Fixed destination when this VM drives the receive sheet's embedded
-    /// form: the balance being received into. `nil` = the standalone
-    /// swappable screen (legacy direction/source model).
-    @Published private(set) var receiveTarget: ChainNetwork? = nil
+    /// form: the balance being received into. `nil` = the standalone form.
+    @Published private(set) var receiveTarget: ChainNetwork? = nil {
+        didSet { guard oldValue != receiveTarget else { return }; routeDidChange() }
+    }
 
     /// Fixed source when this VM drives the send sheet's embedded form
     /// (the balance-row out arrows): the balance being sent FROM. The To
     /// rows pick `sendTarget` among the other two balances. Mutually
     /// exclusive with `receiveTarget`; `nil` = not the send sheet.
-    @Published private(set) var sendSource: ChainNetwork? = nil
+    @Published private(set) var sendSource: ChainNetwork? = nil {
+        didSet { guard oldValue != sendSource else { return }; routeDidChange() }
+    }
 
     /// The destination balance picked on the send sheet's To rows. Only
-    /// meaningful while `sendSource` is set. Changing it re-derives `route`
-    /// and kicks the withdrawal preflight when Platform → Core becomes
-    /// active.
+    /// meaningful while `sendSource` is set, but reused by the standalone
+    /// screen as the selected To balance as well.
     @Published var sendTarget: ChainNetwork = .shielded {
-        didSet { routeDidChange() }
+        didSet { guard oldValue != sendTarget else { return }; routeDidChange() }
     }
 
     /// The source balance picked on the receive sheet's From rows. Only
-    /// meaningful for `receiveTarget` .core / .platform (the .shielded
-    /// target reuses the legacy `source` picker). Changing it re-derives
-    /// `route`, and kicks the withdrawal preflight when the full-balance
-    /// Platform → Core route becomes active.
+    /// meaningful while `receiveTarget` is set.
     @Published var receiveSource: ChainNetwork = .shielded {
-        didSet { routeDidChange() }
+        didSet { guard oldValue != receiveSource else { return }; routeDidChange() }
     }
 
     /// Live result of `preflightWithdrawal()` for the Platform → Core route:
@@ -140,24 +118,11 @@ final class InternalTransferViewModel: ObservableObject {
     private var preflightTask: Task<Void, Never>?
 
     /// Pins the route for the receive sheet: a transfer INTO `target`.
-    /// The From rows pick the source among the other two balances —
-    /// `source` for the .shielded target (legacy-expressible routes),
-    /// `receiveSource` for .core/.platform targets.
+    /// The From rows then pick the source among the other two balances.
     func applyReceiveRoute(into target: ChainNetwork) {
+        sendSource = nil
         receiveTarget = target
-        switch target {
-        case .shielded:
-            direction = .toShielded
-            // `source` keeps the user's pick (.core default).
-        case .core:
-            // Valid sources: shielded (withdraw) or platform (full-balance
-            // address withdrawal). Reset an out-of-range carryover.
-            if receiveSource != .platform { receiveSource = .shielded }
-        case .platform:
-            // Valid sources: shielded (unshield) or core (asset-lock fund).
-            if receiveSource != .core { receiveSource = .shielded }
-        }
-        routeDidChange()
+        receiveSource = Self.sanitizedSource(into: target, proposed: receiveSource)
     }
 
     /// Pins the route for the send sheet: a transfer OUT OF `from`. The To
@@ -166,43 +131,83 @@ final class InternalTransferViewModel: ObservableObject {
     /// Platform default to Shielded (privacy-forward); Shielded defaults
     /// to Core.
     func applySendRoute(from source: ChainNetwork) {
+        receiveTarget = nil
         sendSource = source
-        switch source {
-        case .core, .platform:
-            if sendTarget == source { sendTarget = .shielded }
-        case .shielded:
-            if sendTarget == .shielded { sendTarget = .core }
-        }
-        routeDidChange()
+        sendTarget = Self.sanitizedDestination(from: source, proposed: sendTarget)
+    }
+
+    func selectStandaloneSource(_ network: ChainNetwork) {
+        source = network
+        sendTarget = Self.sanitizedDestination(from: network, proposed: sendTarget)
+    }
+
+    func selectStandaloneTarget(_ network: ChainNetwork) {
+        sendTarget = Self.sanitizedDestination(from: source, proposed: network)
+    }
+
+    func selectSendTarget(_ network: ChainNetwork) {
+        let from = sendSource ?? source
+        sendTarget = Self.sanitizedDestination(from: from, proposed: network)
+    }
+
+    func selectReceiveSource(_ network: ChainNetwork) {
+        guard let receiveTarget else { return }
+        receiveSource = Self.sanitizedSource(into: receiveTarget, proposed: network)
     }
 
     /// The canonical route for validation/fees/execution.
     var route: InternalTransferRoute {
         if let source = sendSource {
-            switch (source, sendTarget) {
-            case (.core, .platform): return .coreToPlatform
-            case (.platform, .core): return .platformToCore
-            case (.platform, _): return .platformToShielded
-            case (.shielded, .platform): return .shieldedToPlatform
-            case (.shielded, _): return .shieldedToCore
-            case (.core, _): return .coreToShielded
-            }
+            return Self.route(
+                from: source,
+                to: Self.sanitizedDestination(from: source, proposed: sendTarget))
         }
         if let target = receiveTarget {
-            switch target {
-            case .shielded:
-                return source == .core ? .coreToShielded : .platformToShielded
-            case .core:
-                return receiveSource == .platform ? .platformToCore : .shieldedToCore
-            case .platform:
-                return receiveSource == .core ? .coreToPlatform : .shieldedToPlatform
-            }
+            return Self.route(
+                from: Self.sanitizedSource(into: target, proposed: receiveSource),
+                to: target)
         }
-        switch (direction, source) {
-        case (.toShielded, .core): return .coreToShielded
-        case (.toShielded, .platform): return .platformToShielded
-        case (.fromShielded, .core): return .shieldedToCore
-        case (.fromShielded, .platform): return .shieldedToPlatform
+        return Self.route(
+            from: source,
+            to: Self.sanitizedDestination(from: source, proposed: sendTarget))
+    }
+
+    private static func defaultDestination(for source: ChainNetwork) -> ChainNetwork {
+        switch source {
+        case .core, .platform:
+            return .shielded
+        case .shielded:
+            return .core
+        }
+    }
+
+    private static func defaultSource(for target: ChainNetwork) -> ChainNetwork {
+        switch target {
+        case .shielded:
+            return .core
+        case .core, .platform:
+            return .shielded
+        }
+    }
+
+    private static func sanitizedDestination(from source: ChainNetwork, proposed target: ChainNetwork) -> ChainNetwork {
+        source == target ? defaultDestination(for: source) : target
+    }
+
+    private static func sanitizedSource(into target: ChainNetwork, proposed source: ChainNetwork) -> ChainNetwork {
+        source == target ? defaultSource(for: target) : source
+    }
+
+    private static func route(from source: ChainNetwork, to target: ChainNetwork) -> InternalTransferRoute {
+        switch (source, target) {
+        case (.core, .shielded): return .coreToShielded
+        case (.core, .platform): return .coreToPlatform
+        case (.platform, .shielded): return .platformToShielded
+        case (.platform, .core): return .platformToCore
+        case (.shielded, .core): return .shieldedToCore
+        case (.shielded, .platform): return .shieldedToPlatform
+        case (.core, .core), (.platform, .platform), (.shielded, .shielded):
+            return route(from: source, to: defaultDestination(for: source))
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
The Internal Transfer screen was built around **Shielded as a fixed pivot** — a `toShielded` / `fromShielded` direction toggle plus a Core/Platform source picker. That model could only express the four shielded-centric routes, so **Transparent ↔ Platform transfers were unreachable from the UI** even though the transfer engine (`InternalTransferRoute`) already supports all six directed routes. Users tapping to move funds directly between Transparent and Platform had no path (BUG-21).

## What was done?
Replaced the shielded-pivot model with an explicit **(from, to) selection over every `ChainNetwork` pair**:
- Removed `InternalTransferSource` and `InternalTransferDirection`; the route is now derived purely from the selected from/to networks, with any same-network pick sanitized to a sensible default (`sanitizedDestination` / `sanitizedSource`, centralized `route(from:to:)`).
- From/To render as uniform **selection groups** (radio rows) across the standalone, send-pinned, and receive-pinned layouts; the pinned endpoint is a non-tappable row (`showsRadio: false`). Dropped the bespoke `directionCard` / swap-badge machinery.
- Swapped the local `TransferAmountRow` for the shared **DashUIKit `EnterAmountView`**, wiring DASH/fiat input toggling through the view-model `unit`.

All six routes — `coreToShielded`, `coreToPlatform`, `platformToShielded`, `platformToCore`, `shieldedToCore`, `shieldedToPlatform` — are now selectable, including the previously unreachable **Transparent ↔ Platform** pair.

## How Has This Been Tested?
Manual, on testnet: exercised the standalone screen and both pinned hosts (send sheet / receive sheet), confirming each of the six from/to combinations resolves to the correct route and that same-network selections snap to the default counterpart. Amount entry verified in both DASH and fiat units. Clean `dashpay` build verified in Xcode. (The unit-test target is pre-existing broken; not run.)

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone