### PR TITLE
Fix shielded to Platform balance reconciliation

### DIFF
--- a/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
+++ b/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
@@ -77,7 +77,8 @@ extension DatabaseConnection {
             AddProviderToGiftCardsTable(),
             AddRedeemUrlChallengeToGiftCardsTable(),
             AddSwapOrdersTable(),
-            AddPlatformAddressActivityTables()
+            AddPlatformAddressActivityTables(),
+            NormalizePlatformAddressActivityUnitsAndAddCreditReconciliations()
         ]
     }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -69,6 +69,56 @@ struct ShieldedSyncFreshnessPolicy {
     }
 }
 
+/// Bounded retry policy for the direct Platform-address readback performed
+/// after an unshield. BLAST remains the background source of truth, but its
+/// incremental cursor can temporarily miss a just-committed address credit;
+/// querying that one known destination closes the user-visible balance gap.
+struct PlatformCreditReconciliationPolicy {
+    /// Cumulative schedule: immediately, then 2, 6, 14, and 30 seconds.
+    static let retryDelaysNanos: [UInt64] = [
+        0,
+        2_000_000_000,
+        4_000_000_000,
+        8_000_000_000,
+        16_000_000_000,
+    ]
+
+    static func expectedBalance(baseline: UInt64, creditedAmount: UInt64) -> UInt64 {
+        let sum = baseline.addingReportingOverflow(creditedAmount)
+        return sum.overflow ? UInt64.max : sum.partialValue
+    }
+
+    static func isSatisfied(observedBalance: UInt64, expectedBalance: UInt64) -> Bool {
+        observedBalance >= expectedBalance
+    }
+
+    /// A targeted incoming-credit read must never roll a newer local snapshot
+    /// back to a lagging evonode's value. Decreases remain BLAST's job because
+    /// that pipeline has a height with which to order snapshots.
+    static func shouldApply(
+        observedBalance: UInt64,
+        currentBalance: UInt64,
+        expectedBalance: UInt64
+    ) -> Bool {
+        observedBalance >= expectedBalance && observedBalance >= currentBalance
+    }
+
+    /// Jobs created by this app persist their exact pre-transfer expectation.
+    /// This fallback is only for confirmed unshields created before that job
+    /// table existed. A row updated after the operation already passed may
+    /// contain the credit, so adding the principal again would create an
+    /// impossible target and retry forever.
+    static func legacyExpectedBalance(
+        currentBalance: UInt64,
+        rowLastUpdated: Date,
+        activityCreatedAt: Date,
+        creditedAmount: UInt64
+    ) -> UInt64 {
+        guard rowLastUpdated < activityCreatedAt else { return currentBalance }
+        return expectedBalance(baseline: currentBalance, creditedAmount: creditedAmount)
+    }
+}
+
 @MainActor
 @objc(DWPlatformAddressSyncCoordinator)
 public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
@@ -146,6 +196,8 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     private var lastFullShieldedSyncAt: Date?
     private var shieldedReconciliationTask: Task<Void, Never>?
     private var latestObservedShieldedBalance: UInt64 = 0
+    private var platformCreditReconciliationTasks: [String: Task<Void, Never>] = [:]
+    private var platformCreditReconciliationTokens: [String: UUID] = [:]
 
     /// Long-lived resolver for the shielded sub-wallet bind in `performStart`.
     /// Stored (not local) because `MnemonicResolver` hands Rust an unretained
@@ -348,6 +400,360 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             row.lastUpdated = Date()
         }
         try? context.save()
+        // Keep the published balance and address-use flags in lockstep with
+        // the proof-attested rows. In particular, `nextReceiveAddress` must
+        // not keep selecting an address that a just-completed top-up marked
+        // used merely because the next BLAST event has not arrived yet.
+        refreshDerivedAddresses()
+        SwiftDashSDKWalletState.shared.refreshPlatformPaymentCredits()
+    }
+
+    /// Reconcile the one known destination of a successful shielded →
+    /// Platform unshield using an authoritative address-info proof.
+    ///
+    /// The shielded API returns no address-balance changeset, so the regular
+    /// BLAST pass is normally responsible for surfacing the credit. A pass
+    /// that was already in flight can miss the new recent-tree entry and a
+    /// subsequent incremental cursor may keep the persisted row stale. Since
+    /// the operation gives us the exact destination and credited principal,
+    /// directly reading that address is both cheaper and more reliable than
+    /// resetting the wallet-wide BLAST watermark.
+    public func reconcileIncomingCredit(
+        address: String,
+        baselineBalance: UInt64,
+        creditedAmount: UInt64,
+        creditedAtHeight: UInt64? = nil
+    ) {
+        guard
+            let sdk,
+            let container = modelContainer,
+            let walletId = wallet?.walletId,
+            let network = runningNetwork,
+            let parsed = Self.parsePlatformRecipient(bech32m: address)
+        else {
+            Self.logger.warning(
+                "🛰️ PLATFORM-CREDIT :: targeted reconciliation skipped; coordinator/address not ready")
+            return
+        }
+
+        let addressHash = parsed.hash
+        let descriptor = FetchDescriptor<PersistentPlatformAddress>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.addressHash == addressHash
+            })
+        guard (try? container.mainContext.fetch(descriptor).first) != nil else {
+            Self.logger.warning(
+                "🛰️ PLATFORM-CREDIT :: destination is not a persisted wallet address")
+            return
+        }
+
+        let expectedBalance = PlatformCreditReconciliationPolicy.expectedBalance(
+            baseline: baselineBalance,
+            creditedAmount: creditedAmount)
+        let job = PlatformCreditReconciliationDAO.shared.create(
+            walletId: walletId,
+            networkRaw: Int64(network.rawValue),
+            address: address,
+            addressHash: addressHash,
+            amountCredits: creditedAmount,
+            expectedBalanceCredits: expectedBalance,
+            creditedHeight: creditedAtHeight)
+        scheduleCreditReconciliation(job, addressService: sdk.addresses)
+    }
+
+    private func scheduleCreditReconciliation(
+        _ job: PlatformCreditReconciliationRecord,
+        addressService: Addresses
+    ) {
+        guard platformCreditReconciliationTasks[job.id] == nil else { return }
+        let taskToken = UUID()
+        platformCreditReconciliationTokens[job.id] = taskToken
+
+        platformCreditReconciliationTasks[job.id] = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if self.platformCreditReconciliationTokens[job.id] == taskToken {
+                    self.platformCreditReconciliationTasks.removeValue(forKey: job.id)
+                    self.platformCreditReconciliationTokens.removeValue(forKey: job.id)
+                }
+            }
+
+            guard !Task.isCancelled, self.isActiveCreditReconciliation(job) else { return }
+            if self.completeCreditReconciliationFromPersistedStateIfPossible(job) {
+                return
+            }
+
+            for delayNanos in PlatformCreditReconciliationPolicy.retryDelaysNanos {
+                if delayNanos > 0 {
+                    do {
+                        try await Task.sleep(nanoseconds: delayNanos)
+                    } catch {
+                        return
+                    }
+                }
+                guard !Task.isCancelled else { return }
+
+                do {
+                    let info = try await Task.detached(priority: .utility) {
+                        try addressService.getInfo(address: job.address)
+                    }.value
+                    guard !Task.isCancelled, self.isActiveCreditReconciliation(job) else {
+                        return
+                    }
+                    guard let info else {
+                        Self.logger.info(
+                            "🛰️ PLATFORM-CREDIT :: destination not indexed yet; retrying")
+                        continue
+                    }
+
+                    guard self.applyAuthoritativeIncomingCredit(
+                        info,
+                        job: job)
+                    else {
+                        Self.logger.info(
+                            "🛰️ PLATFORM-CREDIT :: observed \(info.balance, privacy: .public), awaiting \(job.expectedBalanceCredits, privacy: .public)")
+                        continue
+                    }
+
+                    self.finishCreditReconciliation(job)
+                    Self.logger.info(
+                        "🛰️ PLATFORM-CREDIT :: reconciled balance=\(info.balance, privacy: .public)")
+                    return
+                } catch {
+                    Self.logger.warning(
+                        "🛰️ PLATFORM-CREDIT :: targeted read failed: \(String(describing: error), privacy: .public)")
+                }
+            }
+        }
+    }
+
+    private func isActiveCreditReconciliation(
+        _ job: PlatformCreditReconciliationRecord
+    ) -> Bool {
+        wallet?.walletId == job.walletId
+            && runningNetwork.map { Int64($0.rawValue) } == job.networkRaw
+            && !isClearing
+    }
+
+    private func completeCreditReconciliationFromPersistedStateIfPossible(
+        _ job: PlatformCreditReconciliationRecord
+    ) -> Bool {
+        guard let container = modelContainer else { return false }
+        let walletId = job.walletId
+        let addressHash = job.addressHash
+        let descriptor = FetchDescriptor<PersistentPlatformAddress>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.addressHash == addressHash
+            })
+        guard let row = try? container.mainContext.fetch(descriptor).first else { return false }
+
+        if let creditedHeight = job.creditedHeight, row.lastSeenHeight >= creditedHeight {
+            finishCreditReconciliation(job)
+            return true
+        }
+        guard row.balance >= job.expectedBalanceCredits else { return false }
+        finishCreditReconciliation(job)
+        return true
+    }
+
+    /// Applies only monotonic incoming-credit observations. An address-info
+    /// response has no height, so a lower balance cannot safely supersede a
+    /// newer BLAST snapshot and is retained only as a retry signal.
+    private func applyAuthoritativeIncomingCredit(
+        _ info: PlatformAddressInfo,
+        job: PlatformCreditReconciliationRecord
+    ) -> Bool {
+        guard let container = modelContainer else { return false }
+        let walletId = job.walletId
+        let addressHash = job.addressHash
+        let descriptor = FetchDescriptor<PersistentPlatformAddress>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.addressHash == addressHash
+            })
+        guard let row = try? container.mainContext.fetch(descriptor).first else { return false }
+        guard PlatformCreditReconciliationPolicy.shouldApply(
+            observedBalance: info.balance,
+            currentBalance: row.balance,
+            expectedBalance: job.expectedBalanceCredits)
+        else { return false }
+
+        row.balance = info.balance
+        row.nonce = max(row.nonce, info.nonce)
+        row.isUsed = row.isUsed || info.balance > 0 || info.nonce > 0
+        if let creditedHeight = job.creditedHeight {
+            if row.firstSeenHeight == 0 {
+                row.firstSeenHeight = UInt32(clamping: creditedHeight)
+            }
+            row.lastSeenHeight = max(row.lastSeenHeight, creditedHeight)
+        }
+        row.lastUpdated = Date()
+        do {
+            try container.mainContext.save()
+        } catch {
+            Self.logger.warning(
+                "🛰️ PLATFORM-CREDIT :: address-row save failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+
+        refreshDerivedAddresses()
+        SwiftDashSDKWalletState.shared.refreshPlatformPaymentCredits()
+        return true
+    }
+
+    private func finishCreditReconciliation(_ job: PlatformCreditReconciliationRecord) {
+        let dao = PlatformCreditReconciliationDAO.shared
+        dao.markCompleted(id: job.id)
+        guard let creditedHeight = job.creditedHeight else { return }
+        if advanceLastSeenHeight(
+            creditedHeight,
+            addressHash: job.addressHash,
+            walletId: job.walletId)
+        {
+            dao.delete(id: job.id)
+        }
+    }
+
+    @discardableResult
+    private func advanceLastSeenHeight(
+        _ height: UInt64,
+        addressHash: Data,
+        walletId: Data
+    ) -> Bool {
+        guard let container = modelContainer else { return false }
+        let descriptor = FetchDescriptor<PersistentPlatformAddress>(
+            predicate: #Predicate {
+                $0.walletId == walletId && $0.addressHash == addressHash
+            })
+        guard let row = try? container.mainContext.fetch(descriptor).first else { return false }
+        if row.firstSeenHeight == 0 {
+            row.firstSeenHeight = UInt32(clamping: height)
+        }
+        row.lastSeenHeight = max(row.lastSeenHeight, height)
+        row.isUsed = true
+        row.lastUpdated = Date()
+        do {
+            try container.mainContext.save()
+            return true
+        } catch {
+            Self.logger.warning(
+                "🛰️ PLATFORM-CREDIT :: height save failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
+    /// Recover confirmed internal unshields that predate the targeted
+    /// readback fix. A confirmed activity carries the destination hash and
+    /// Platform height; if its wallet-owned address row has never reached
+    /// that height, its persisted balance may still be the pre-unshield
+    /// value. Scheduling the same bounded proof read repairs the existing
+    /// balance after an app update/relaunch, not only future transfers.
+    private func reconcileMissedIncomingCredits() {
+        guard
+            let container = modelContainer,
+            let walletId = wallet?.walletId,
+            let network = runningNetwork,
+            let sdk
+        else { return }
+
+        let unshieldKind = ShieldedActivityValue.unshieldKind
+        let confirmedStatus = ShieldedActivityValue.confirmedStatus
+        let activityDescriptor = FetchDescriptor<PersistentShieldedActivity>(
+            predicate: #Predicate {
+                $0.walletId == walletId
+                    && $0.kindTag == unshieldKind
+                    && $0.status == confirmedStatus
+                    && $0.hasBlockHeight
+            },
+            sortBy: [SortDescriptor(\.blockHeight, order: .reverse)])
+
+        guard let activities = try? container.mainContext.fetch(activityDescriptor) else { return }
+        let dao = PlatformCreditReconciliationDAO.shared
+        var jobs = dao.records(walletId: walletId, networkRaw: Int64(network.rawValue))
+
+        for activity in activities {
+            guard activity.counterparty.count == 21 else { continue }
+            let addressHash = activity.counterparty.subdata(in: 1..<21)
+            let addressDescriptor = FetchDescriptor<PersistentPlatformAddress>(
+                predicate: #Predicate {
+                    $0.walletId == walletId && $0.addressHash == addressHash
+                })
+            guard let row = try? container.mainContext.fetch(addressDescriptor).first else { continue }
+
+            let activityDate = Date(
+                timeIntervalSince1970: Double(activity.createdAtMs) / 1_000)
+            let exactIndex = jobs.firstIndex {
+                $0.activityEntryId == activity.entryId
+            }
+            let unlinkedIndex = jobs.enumerated()
+                .filter { _, job in
+                    job.activityEntryId == nil
+                        && job.addressHash == addressHash
+                        && job.amountCredits == activity.amount
+                        && abs(job.createdAt.timeIntervalSince(activityDate))
+                            <= PlatformAddressActivityRecorder.ownOperationWindow
+                }
+                .min {
+                    abs($0.element.createdAt.timeIntervalSince(activityDate))
+                        < abs($1.element.createdAt.timeIntervalSince(activityDate))
+                }?
+                .offset
+
+            if let jobIndex = exactIndex ?? unlinkedIndex {
+                let job = jobs.remove(at: jobIndex)
+                dao.attachActivity(
+                    id: job.id,
+                    entryId: activity.entryId,
+                    creditedHeight: activity.blockHeight)
+                let attachedJob = PlatformCreditReconciliationRecord(
+                    id: job.id,
+                    walletId: job.walletId,
+                    networkRaw: job.networkRaw,
+                    address: job.address,
+                    addressHash: job.addressHash,
+                    amountCredits: job.amountCredits,
+                    expectedBalanceCredits: job.expectedBalanceCredits,
+                    activityEntryId: activity.entryId,
+                    creditedHeight: activity.blockHeight,
+                    isCompleted: job.isCompleted,
+                    createdAt: job.createdAt)
+
+                if row.lastSeenHeight >= activity.blockHeight || job.isCompleted {
+                    finishCreditReconciliation(attachedJob)
+                } else {
+                    scheduleCreditReconciliation(attachedJob, addressService: sdk.addresses)
+                }
+                continue
+            }
+
+            guard row.lastSeenHeight < activity.blockHeight else { continue }
+
+            // One-time upgrade recovery for activity created before durable
+            // jobs existed. `lastUpdated` distinguishes a row already repaired
+            // after the operation from a genuinely pre-credit baseline.
+            let expectedBalance = PlatformCreditReconciliationPolicy.legacyExpectedBalance(
+                currentBalance: row.balance,
+                rowLastUpdated: row.lastUpdated,
+                activityCreatedAt: activityDate,
+                creditedAmount: activity.amount)
+            let legacyJob = dao.create(
+                walletId: walletId,
+                networkRaw: Int64(network.rawValue),
+                address: row.address,
+                addressHash: addressHash,
+                amountCredits: activity.amount,
+                expectedBalanceCredits: expectedBalance,
+                activityEntryId: activity.entryId,
+                creditedHeight: activity.blockHeight,
+                createdAt: activityDate)
+            scheduleCreditReconciliation(legacyJob, addressService: sdk.addresses)
+        }
+
+        // A process may have stopped after creating a durable job but before
+        // the shielded activity reached Confirmed. Resume those exact
+        // expectations without deriving a new baseline.
+        for job in jobs where !job.isCompleted {
+            scheduleCreditReconciliation(job, addressService: sdk.addresses)
+        }
     }
 
     // MARK: - Core ↔ Platform balance movement
@@ -549,6 +955,12 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         }
         isClearing = true
         defer { isClearing = false }
+        cancelPlatformCreditReconciliations()
+        if let walletId = wallet?.walletId, let network = runningNetwork {
+            PlatformCreditReconciliationDAO.shared.markAllPending(
+                walletId: walletId,
+                networkRaw: Int64(network.rawValue))
+        }
 
         do {
             try await manager.resetPlatformAddressSyncState()
@@ -590,6 +1002,8 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
         do {
             try manager.startPlatformAddressSync()
+            refreshDerivedAddresses()
+            reconcileMissedIncomingCredits()
         } catch {
             lastError = "startPlatformAddressSync failed after clear: \(error.localizedDescription)"
             Self.logger.error("🛰️ PLATFORM-ADDR :: post-clear restart failed: \(String(describing: error), privacy: .public)")
@@ -600,6 +1014,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     public func clearDisplay() {
         shieldedReconciliationTask?.cancel()
         shieldedReconciliationTask = nil
+        cancelPlatformCreditReconciliations()
         platformBalance = 0
         shieldedBalance = 0
         latestObservedShieldedBalance = 0
@@ -728,6 +1143,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
         subscribeToManager(manager: manager, walletId: resolvedWallet.walletId)
         refreshDerivedAddresses()
+        reconcileMissedIncomingCredits()
 
         // Hand the shielded diagnostics monitor the new manager generation.
         // Attach AFTER the state above is committed so the monitor's initial
@@ -756,6 +1172,8 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     }
 
     private func performStop(deletingPersistedWallet: Bool) async {
+        cancelPlatformCreditReconciliations()
+
         // Detach the shielded diagnostics monitor before the manager handles
         // drop, so it never observes a manager whose loops are being torn down.
         ShieldedSyncMonitor.shared.detach()
@@ -778,6 +1196,11 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         //      it referenced here means SwiftData contexts captured by
         //      Rust-side persister closures don't dangle while tokio winds down.
         if deletingPersistedWallet {
+            if let walletId = wallet?.walletId, let network = runningNetwork {
+                PlatformCreditReconciliationDAO.shared.deleteAll(
+                    walletId: walletId,
+                    networkRaw: Int64(network.rawValue))
+            }
             deletePersistedWalletIfAny()
         }
 
@@ -840,6 +1263,14 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         runningNetwork = nil
         isRunning = false
         clearDisplay()
+    }
+
+    private func cancelPlatformCreditReconciliations() {
+        for task in platformCreditReconciliationTasks.values {
+            task.cancel()
+        }
+        platformCreditReconciliationTasks.removeAll()
+        platformCreditReconciliationTokens.removeAll()
     }
 
     private func deletePersistedWalletIfAny() {

--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -51,6 +51,32 @@ extension Notification.Name {
     static let platformAddressActivityRecorded = Notification.Name("DWPlatformAddressActivityRecorded")
 }
 
+// MARK: - Units
+
+/// Platform-address balances arrive from the SDK in credits (1e11/DASH),
+/// while the app's transaction/history presentation uses duffs (1e8/DASH).
+/// Convert once at the recorder boundary so every persisted baseline and
+/// activity value has the unit promised by its API.
+struct PlatformAddressActivityUnitPolicy {
+    static let creditsPerDuff: UInt64 = 1_000
+
+    static func duffs(fromCredits credits: UInt64) -> Int64 {
+        Int64(clamping: credits / creditsPerDuff)
+    }
+
+    static func unshieldMatches(
+        creditedAmountCredits: UInt64,
+        observedDeltaDuffs: Int64
+    ) -> Bool {
+        duffs(fromCredits: creditedAmountCredits) == observedDeltaDuffs
+    }
+}
+
+enum ShieldedActivityValue {
+    static let unshieldKind = 4
+    static let confirmedStatus = 1
+}
+
 // MARK: - Record
 
 struct PlatformAddressActivityRecord: Identifiable {
@@ -111,6 +137,183 @@ struct AddPlatformAddressActivityTables: Migration {
     }
 }
 
+/// Correct the first recorder schema, which stored SDK credits in columns
+/// documented and rendered as duffs, and add durable post-unshield jobs.
+///
+/// Dividing existing observations is lossless for wallet-originated amounts
+/// (all public transfer amounts are whole duffs). A fresh install runs this
+/// immediately after creating empty activity tables.
+struct NormalizePlatformAddressActivityUnitsAndAddCreditReconciliations: Migration {
+    var version: Int64 = 20260727140000
+
+    func migrateDatabase(_ db: Connection) throws {
+        try db.run("UPDATE platform_address_baseline SET balance = balance / 1000")
+        try db.run("""
+            UPDATE platform_address_activity
+            SET amount = amount / 1000,
+                balance_after = balance_after / 1000
+            """)
+
+        typealias S = PlatformCreditReconciliationSchema
+        try db.run(S.table.create(ifNotExists: true) { t in
+            t.column(S.colId, primaryKey: true)
+            t.column(S.colWalletId)
+            t.column(S.colNetwork)
+            t.column(S.colAddress)
+            t.column(S.colAddressHash)
+            t.column(S.colAmountCredits)
+            t.column(S.colExpectedBalanceCredits)
+            t.column(S.colActivityEntryId)
+            t.column(S.colCreditedHeight)
+            t.column(S.colCompleted)
+            t.column(S.colCreatedAt)
+            t.column(S.colUpdatedAt)
+        })
+        try db.run(S.table.createIndex(
+            S.colWalletId, S.colNetwork, S.colCompleted, ifNotExists: true))
+    }
+}
+
+// MARK: - Credit reconciliation
+
+struct PlatformCreditReconciliationRecord: Identifiable, Equatable {
+    let id: String
+    let walletId: Data
+    let networkRaw: Int64
+    let address: String
+    let addressHash: Data
+    let amountCredits: UInt64
+    let expectedBalanceCredits: UInt64
+    let activityEntryId: Data?
+    let creditedHeight: UInt64?
+    let isCompleted: Bool
+    let createdAt: Date
+}
+
+enum PlatformCreditReconciliationSchema {
+    static let table = Table("platform_credit_reconciliation")
+
+    static let colId = SQLite.Expression<String>("id")
+    static let colWalletId = SQLite.Expression<Data>("wallet_id")
+    static let colNetwork = SQLite.Expression<Int64>("network")
+    static let colAddress = SQLite.Expression<String>("address")
+    static let colAddressHash = SQLite.Expression<Data>("address_hash")
+    static let colAmountCredits = SQLite.Expression<Int64>("amount_credits")
+    static let colExpectedBalanceCredits = SQLite.Expression<Int64>("expected_balance_credits")
+    static let colActivityEntryId = SQLite.Expression<Data?>("activity_entry_id")
+    static let colCreditedHeight = SQLite.Expression<Int64?>("credited_height")
+    static let colCompleted = SQLite.Expression<Bool>("completed")
+    static let colCreatedAt = SQLite.Expression<Double>("created_at")
+    static let colUpdatedAt = SQLite.Expression<Double>("updated_at")
+}
+
+final class PlatformCreditReconciliationDAO {
+    static let shared = PlatformCreditReconciliationDAO()
+
+    private var db: Connection { DatabaseConnection.shared.db }
+
+    func create(
+        walletId: Data,
+        networkRaw: Int64,
+        address: String,
+        addressHash: Data,
+        amountCredits: UInt64,
+        expectedBalanceCredits: UInt64,
+        activityEntryId: Data? = nil,
+        creditedHeight: UInt64? = nil,
+        createdAt: Date = Date()
+    ) -> PlatformCreditReconciliationRecord {
+        typealias S = PlatformCreditReconciliationSchema
+        let id = UUID().uuidString
+        let now = Date()
+        _ = try? db.run(S.table.insert(
+            S.colId <- id,
+            S.colWalletId <- walletId,
+            S.colNetwork <- networkRaw,
+            S.colAddress <- address,
+            S.colAddressHash <- addressHash,
+            S.colAmountCredits <- Int64(clamping: amountCredits),
+            S.colExpectedBalanceCredits <- Int64(clamping: expectedBalanceCredits),
+            S.colActivityEntryId <- activityEntryId,
+            S.colCreditedHeight <- creditedHeight.map { Int64(clamping: $0) },
+            S.colCompleted <- false,
+            S.colCreatedAt <- createdAt.timeIntervalSince1970,
+            S.colUpdatedAt <- now.timeIntervalSince1970))
+        return PlatformCreditReconciliationRecord(
+            id: id,
+            walletId: walletId,
+            networkRaw: networkRaw,
+            address: address,
+            addressHash: addressHash,
+            amountCredits: amountCredits,
+            expectedBalanceCredits: expectedBalanceCredits,
+            activityEntryId: activityEntryId,
+            creditedHeight: creditedHeight,
+            isCompleted: false,
+            createdAt: createdAt)
+    }
+
+    func records(walletId: Data, networkRaw: Int64) -> [PlatformCreditReconciliationRecord] {
+        typealias S = PlatformCreditReconciliationSchema
+        let query = S.table
+            .filter(S.colWalletId == walletId && S.colNetwork == networkRaw)
+            .order(S.colCreatedAt.asc)
+        guard let rows = try? db.prepare(query) else { return [] }
+        return rows.map { row in
+            PlatformCreditReconciliationRecord(
+                id: row[S.colId],
+                walletId: row[S.colWalletId],
+                networkRaw: row[S.colNetwork],
+                address: row[S.colAddress],
+                addressHash: row[S.colAddressHash],
+                amountCredits: UInt64(max(0, row[S.colAmountCredits])),
+                expectedBalanceCredits: UInt64(max(0, row[S.colExpectedBalanceCredits])),
+                activityEntryId: row[S.colActivityEntryId],
+                creditedHeight: row[S.colCreditedHeight].map { UInt64(max(0, $0)) },
+                isCompleted: row[S.colCompleted],
+                createdAt: Date(timeIntervalSince1970: row[S.colCreatedAt]))
+        }
+    }
+
+    func attachActivity(id: String, entryId: Data, creditedHeight: UInt64) {
+        typealias S = PlatformCreditReconciliationSchema
+        let row = S.table.filter(S.colId == id)
+        _ = try? db.run(row.update(
+            S.colActivityEntryId <- entryId,
+            S.colCreditedHeight <- Int64(clamping: creditedHeight),
+            S.colUpdatedAt <- Date().timeIntervalSince1970))
+    }
+
+    func markCompleted(id: String) {
+        typealias S = PlatformCreditReconciliationSchema
+        let row = S.table.filter(S.colId == id)
+        _ = try? db.run(row.update(
+            S.colCompleted <- true,
+            S.colUpdatedAt <- Date().timeIntervalSince1970))
+    }
+
+    func markAllPending(walletId: Data, networkRaw: Int64) {
+        typealias S = PlatformCreditReconciliationSchema
+        let rows = S.table.filter(
+            S.colWalletId == walletId && S.colNetwork == networkRaw)
+        _ = try? db.run(rows.update(
+            S.colCompleted <- false,
+            S.colUpdatedAt <- Date().timeIntervalSince1970))
+    }
+
+    func delete(id: String) {
+        typealias S = PlatformCreditReconciliationSchema
+        _ = try? db.run(S.table.filter(S.colId == id).delete())
+    }
+
+    func deleteAll(walletId: Data, networkRaw: Int64) {
+        typealias S = PlatformCreditReconciliationSchema
+        let rows = S.table.filter(
+            S.colWalletId == walletId && S.colNetwork == networkRaw)
+        _ = try? db.run(rows.delete())
+    }
+}
+
 // MARK: - DAO
 
 final class PlatformAddressActivityDAO {
@@ -161,6 +364,11 @@ final class PlatformAddressActivityDAO {
             S.colObservedAt <- Date().timeIntervalSince1970))
     }
 
+    func deleteActivity(id: Int64) {
+        typealias S = PlatformAddressActivitySchema
+        _ = try? db.run(S.activity.filter(S.colId == id).delete())
+    }
+
     /// All received-activity rows for the wallet+network, newest first.
     func activities(walletId: Data, networkRaw: Int64) -> [PlatformAddressActivityRecord] {
         typealias S = PlatformAddressActivitySchema
@@ -193,7 +401,7 @@ enum PlatformAddressActivityRecorder {
     /// Suppression window for matching an increase to an own operation.
     /// Wide on purpose: an own unshield's credit may only be OBSERVED
     /// many minutes after the operation (next full rescan).
-    private static let ownOperationWindow: TimeInterval = 6 * 60 * 60
+    static let ownOperationWindow: TimeInterval = 6 * 60 * 60
 
     static func observe(
         addresses: [DerivedPlatformAddress],
@@ -204,6 +412,12 @@ enum PlatformAddressActivityRecorder {
         guard !addresses.isEmpty else { return }
         let networkRaw = Int64(network.rawValue)
         let dao = PlatformAddressActivityDAO.shared
+        cleanupMisclassifiedOwnOperations(
+            dao: dao,
+            walletId: walletId,
+            networkRaw: networkRaw,
+            network: network,
+            container: container)
         let baseline = dao.baselineBalances(walletId: walletId, networkRaw: networkRaw)
 
         // First observation of this wallet+network: seed the baseline
@@ -213,7 +427,9 @@ enum PlatformAddressActivityRecorder {
             for entry in addresses where entry.balance > 0 {
                 dao.upsertBaseline(
                     walletId: walletId, networkRaw: networkRaw,
-                    address: entry.address, balanceDuffs: Int64(entry.balance))
+                    address: entry.address,
+                    balanceDuffs: PlatformAddressActivityUnitPolicy.duffs(
+                        fromCredits: entry.balance))
             }
             return
         }
@@ -221,7 +437,7 @@ enum PlatformAddressActivityRecorder {
         var increases: [(address: String, delta: Int64, after: Int64)] = []
         var netChange: Int64 = 0
         for entry in addresses {
-            let after = Int64(entry.balance)
+            let after = PlatformAddressActivityUnitPolicy.duffs(fromCredits: entry.balance)
             let before = baseline[entry.address] ?? 0
             let delta = after - before
             if delta == 0 { continue }
@@ -270,20 +486,27 @@ enum PlatformAddressActivityRecorder {
     }
 
     /// Exact match against an own internal unshield: same destination
-    /// address, credited amount == entry.amount − fee (the recipient
-    /// receives the principal net of the pool fee).
+    /// address and credited principal. The unshield builder reserves the fee
+    /// in addition to `amount`; the Platform address receives `amount`
+    /// exactly, while the shielded pool is debited by amount + fee.
     private static func matchesOwnUnshield(
         address: String,
         deltaDuffs: Int64,
         walletId: Data,
         network: Network,
-        container: ModelContainer
+        container: ModelContainer,
+        observedAt: Date = Date()
     ) -> Bool {
-        let cutoffMs = UInt64(max(0, Date().timeIntervalSince1970 - ownOperationWindow) * 1000)
-        let unshieldKind = 4
+        let cutoffMs = UInt64(max(0, observedAt.timeIntervalSince1970 - ownOperationWindow) * 1000)
+        let upperBoundMs = UInt64(
+            max(0, observedAt.timeIntervalSince1970 + ownOperationWindow) * 1000)
+        let unshieldKind = ShieldedActivityValue.unshieldKind
         let descriptor = FetchDescriptor<PersistentShieldedActivity>(
             predicate: #Predicate {
-                $0.walletId == walletId && $0.kindTag == unshieldKind && $0.createdAtMs >= cutoffMs
+                $0.walletId == walletId
+                    && $0.kindTag == unshieldKind
+                    && $0.createdAtMs >= cutoffMs
+                    && $0.createdAtMs <= upperBoundMs
             })
         guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
         for row in rows {
@@ -291,8 +514,10 @@ enum PlatformAddressActivityRecorder {
             let destination = AddressTransformer.formatAddress(
                 row.counterparty, asBech32m: true, isTestnet: network != .mainnet)
             guard destination == address else { continue }
-            let creditedCredits = row.amount - (row.hasFee ? row.fee : 0)
-            if Int64(creditedCredits / 1000) == deltaDuffs {
+            if PlatformAddressActivityUnitPolicy.unshieldMatches(
+                creditedAmountCredits: row.amount,
+                observedDeltaDuffs: deltaDuffs)
+            {
                 return true
             }
         }
@@ -308,21 +533,61 @@ enum PlatformAddressActivityRecorder {
         address: String,
         deltaDuffs: Int64,
         walletId: Data,
-        container: ModelContainer
+        container: ModelContainer,
+        observedAt: Date = Date()
     ) -> Bool {
         guard let storageBytes = AddressTransformer.parseAddress(address),
               storageBytes.count == 21 else { return false }
         let addressHash = storageBytes.dropFirst()
-        let cutoff = Date().addingTimeInterval(-ownOperationWindow)
+        let cutoff = observedAt.addingTimeInterval(-ownOperationWindow)
+        let upperBound = observedAt.addingTimeInterval(ownOperationWindow)
         let topUpType = 4 // AssetLockAddressTopUp
         let descriptor = FetchDescriptor<PersistentAssetLock>(
             predicate: #Predicate {
-                $0.walletId == walletId && $0.fundingTypeRaw == topUpType && $0.updatedAt >= cutoff
+                $0.walletId == walletId
+                    && $0.fundingTypeRaw == topUpType
+                    && $0.updatedAt >= cutoff
+                    && $0.updatedAt <= upperBound
             })
         guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
         return rows.contains { lock in
             lock.recipientPlatformAddressHash == Data(addressHash)
                 && deltaDuffs <= lock.amountDuffs
+        }
+    }
+
+    /// Versions before the credits→duffs fix could append an own unshield or
+    /// Core top-up as a generic "Received" row. Remove only rows that match an
+    /// app-owned operation by destination, converted amount, and observation
+    /// window; genuine external receives remain untouched.
+    private static func cleanupMisclassifiedOwnOperations(
+        dao: PlatformAddressActivityDAO,
+        walletId: Data,
+        networkRaw: Int64,
+        network: Network,
+        container: ModelContainer
+    ) {
+        var removedAny = false
+        for record in dao.activities(walletId: walletId, networkRaw: networkRaw) {
+            let isOwnOperation = matchesOwnUnshield(
+                address: record.address,
+                deltaDuffs: record.amountDuffs,
+                walletId: walletId,
+                network: network,
+                container: container,
+                observedAt: record.observedAt)
+                || matchesOwnAssetLockTopUp(
+                    address: record.address,
+                    deltaDuffs: record.amountDuffs,
+                    walletId: walletId,
+                    container: container,
+                    observedAt: record.observedAt)
+            guard isOwnOperation else { continue }
+            dao.deleteActivity(id: record.id)
+            removedAny = true
+        }
+        if removedAny {
+            NotificationCenter.default.post(name: .platformAddressActivityRecorded, object: nil)
         }
     }
 }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -492,16 +492,19 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // transfer, the wallet's own next receive address. Resolve before
         // advancing the phase.
         let platformAddress: String
+        let platformBalanceBefore: UInt64?
         if let destinationOverride, !destinationOverride.isEmpty {
             platformAddress = destinationOverride
+            platformBalanceBefore = nil
         } else {
-            guard let ownAddress = PlatformAddressSyncCoordinator.shared
-                    .derivedAddresses.nextReceiveAddress?.address,
-                  !ownAddress.isEmpty else {
+            guard let ownDestination = PlatformAddressSyncCoordinator.shared
+                    .derivedAddresses.nextReceiveAddress,
+                  !ownDestination.address.isEmpty else {
                 handleFailure(CoordinatorError.noPlatformAddress)
                 return
             }
-            platformAddress = ownAddress
+            platformAddress = ownDestination.address
+            platformBalanceBefore = ownDestination.balance
         }
 
         do {
@@ -531,8 +534,15 @@ final class ShieldedTransferCoordinator: ObservableObject {
         phase = .success
         scheduleShieldedResync(manager: env.manager)
         // Unshield credits the Platform-address balance; the shielded resync
-        // above only refreshes the shielded side, so kick the Platform-address
-        // (BLAST) sync to surface the credit promptly.
+        // above only refreshes the shielded side. Read the exact destination
+        // directly as a reliable postcondition, then retain the BLAST kicks as
+        // the normal wallet-wide background reconciliation.
+        if let platformBalanceBefore {
+            PlatformAddressSyncCoordinator.shared.reconcileIncomingCredit(
+                address: platformAddress,
+                baselineBalance: platformBalanceBefore,
+                creditedAmount: amountCredits)
+        }
         schedulePlatformResync()
     }
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -205,6 +205,77 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             refreshInFlight: true))
     }
 
+    func testPlatformCreditReconciliationWaitsForTheFullCreditedPrincipal() {
+        let baseline: UInt64 = 19_985_113_480
+        let credit: UInt64 = 10_000_000_000
+        let expected = PlatformCreditReconciliationPolicy.expectedBalance(
+            baseline: baseline,
+            creditedAmount: credit)
+
+        XCTAssertEqual(expected, 29_985_113_480)
+        XCTAssertFalse(PlatformCreditReconciliationPolicy.isSatisfied(
+            observedBalance: baseline,
+            expectedBalance: expected))
+        XCTAssertTrue(PlatformCreditReconciliationPolicy.isSatisfied(
+            observedBalance: expected,
+            expectedBalance: expected))
+    }
+
+    func testPlatformCreditExpectedBalanceSaturatesOnOverflow() {
+        XCTAssertEqual(
+            PlatformCreditReconciliationPolicy.expectedBalance(
+                baseline: UInt64.max - 5,
+                creditedAmount: 10),
+            UInt64.max)
+    }
+
+    func testPlatformActivityConvertsCreditsToDuffsBeforeMatchingUnshield() {
+        let creditedAmount: UInt64 = 10_000_000_000
+
+        XCTAssertEqual(
+            PlatformAddressActivityUnitPolicy.duffs(fromCredits: creditedAmount),
+            10_000_000)
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldMatches(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: 10_000_000))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldMatches(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: Int64(creditedAmount)))
+    }
+
+    func testPlatformCreditReadbackNeverRegressesPersistedBalance() {
+        XCTAssertFalse(PlatformCreditReconciliationPolicy.shouldApply(
+            observedBalance: 29_985_113_480,
+            currentBalance: 30_000_000_000,
+            expectedBalance: 29_985_113_480))
+        XCTAssertFalse(PlatformCreditReconciliationPolicy.shouldApply(
+            observedBalance: 19_985_113_480,
+            currentBalance: 19_985_113_480,
+            expectedBalance: 29_985_113_480))
+        XCTAssertTrue(PlatformCreditReconciliationPolicy.shouldApply(
+            observedBalance: 29_985_113_480,
+            currentBalance: 19_985_113_480,
+            expectedBalance: 29_985_113_480))
+    }
+
+    func testLegacyRecoveryDoesNotAddCreditToAlreadyUpdatedRow() {
+        let activityDate = Date(timeIntervalSince1970: 100)
+        XCTAssertEqual(
+            PlatformCreditReconciliationPolicy.legacyExpectedBalance(
+                currentBalance: 29_985_113_480,
+                rowLastUpdated: activityDate.addingTimeInterval(1),
+                activityCreatedAt: activityDate,
+                creditedAmount: 10_000_000_000),
+            29_985_113_480)
+        XCTAssertEqual(
+            PlatformCreditReconciliationPolicy.legacyExpectedBalance(
+                currentBalance: 19_985_113_480,
+                rowLastUpdated: activityDate.addingTimeInterval(-1),
+                activityCreatedAt: activityDate,
+                creditedAmount: 10_000_000_000),
+            29_985_113_480)
+    }
+
     func testCoreToShieldedMinimumIsFirstWholeDuffStrictlyAbovePoolFee() {
         XCTAssertEqual(
             CoreToShieldedAmountPolicy.minimumAmountDuffs(


### PR DESCRIPTION
## Summary

- reconcile wallet-owned Platform address balances directly after successful Shielded → Platform transfers
- persist pending reconciliation expectations so retries survive restarts without double-counting
- prevent lagging address reads from rolling back newer balances or nonces
- normalize Platform activity history from credits to duffs and remove misclassified own-transfer receives
- cancel reconciliation work during clear, wipe, stop, and network changes

## Verification

- `dashpay` simulator build succeeds with and without code signing
- installed and launched on iPhone 17 Pro simulator
- affected address reports `29,985,113,480` credits at Platform height `470273`
- migration leaves zero false received rows and zero pending reconciliation jobs
- `git diff --check` passes

## Tests

Added regression coverage for credit-to-duff conversion, unshield matching, expected-balance saturation, stale-node rollback prevention, and legacy recovery expectations.

The focused XCTest run is currently blocked before test execution by the local Xcode environment: watchsimulator SDK `23T570` is installed, while the available watchOS runtime is `23S303`.