### PR TITLE
refactor(dashsync): migrate app notification names

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -31,11 +31,11 @@ DashSync is still linked for four bounded tails:
    observed; `DWEnvironment` mirrors the active SDK wallet when switching
    networks.
 4. **Pod-unlink mechanics and compatibility surfaces** — Uphold networking,
-   DashSync keychain helpers used outside wallet migration, app-internal
-   `DS*` notifications, `DSLocalizedString`/`DSUtils`, AppDelegate setup, and
-   project/Podfile link entries.
+   DashSync keychain helpers used outside wallet migration,
+   `DSLocalizedString`/`DSUtils`, AppDelegate setup, and project/Podfile link
+   entries.
 
-As of this audit, 27 app source files directly import DashSync. Counts of all
+As of this audit, 25 app source files directly import DashSync. Counts of all
 `DS*` tokens are not a useful progress metric because app-owned names such as
 `DSTransactionDirection`, comments, and frozen compatibility contracts are
 included.
@@ -99,7 +99,7 @@ Status meanings:
 | 8 | Send Dash | Done | None. Money movement goes through `WalletSendService` / `SwiftDashSDKTransactionSender`. |
 | 9 | Fee estimation | Done | None. Confirmation uses the transaction builder's fee. |
 | 10 | PIN / biometrics | Done; teardown tail | Remove incidental DashSync imports/constants and retain the byte-compatible app-owned keychain contract. |
-| 11 | SPV sync | Done; teardown tail | Core restart/peer rotation is serialized `stopSpv → startSpv` on the existing manager, preserving Platform sync, wallet state and the process-cached per-network `ModelContainer`; clear-and-resync deletes the chain store off MainActor on the next process launch. Remove `setupDashSyncOnce` / `DSOptionsManager` and remaining legacy notification names at unlink. |
+| 11 | SPV sync | Done; teardown tail | Core restart/peer rotation is serialized `stopSpv → startSpv` on the existing manager, preserving Platform sync, wallet state and the process-cached per-network `ModelContainer`; clear-and-resync deletes the chain store off MainActor on the next process launch. Remove `setupDashSyncOnce` / `DSOptionsManager` at unlink; the chain-wallet notification is removed separately with C6-E. |
 | 12 | Network switch | Done; teardown tail | Remove the temporary DashSync wallet-registry mirror with C6-E. |
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
 | 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state and the in-memory identity snapshot for retry. After a successful wipe the stopped runtime installs an empty identity snapshot and publishes the wallet-context change; a newly started wallet publishes the same event, rebuilding the DashPay tab bar as 3 or 5 items from that wallet's identity state. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |

--- a/DASHSYNC_TEARDOWN_PLAN.md
+++ b/DASHSYNC_TEARDOWN_PLAN.md
@@ -33,6 +33,9 @@ picker DTO and Confirm Username fiat formatter.
 About now reports app/network information without a DashSync commit resource
 or CocoaPods generation hook.
 
+Permission and termination notifications are app-owned. Receive-address
+refresh no longer observes the dead DashSync transaction-manager notification.
+
 The contacts rebuild in PR #787 is complete. Do not describe C10 as “contacts
 pending”; the remaining C10 scope is invitations plus legacy identity/profile
 compatibility types.
@@ -118,7 +121,6 @@ These are active repo tasks, not externally assigned work:
 |---|---|---|
 | Uphold/profile HTTP | `HTTPLoaderManager`, `HTTPLoaderFactory`, `DSNetworkingCoordinator` | App-owned URLSession/Moya boundary preserving bearer and OTP behavior. |
 | Generic keychain helpers | `getKeychainData`, `setKeychainData`, `getKeychainInt` in Coinbase, Uphold, global options | App-owned compatibility shim preserving service/account/accessibility bytes. |
-| App-internal notifications | `DSWillRequestOSPermissionNotification`, `DSApplicationTerminationRequestNotification`, residual transaction notification names | App-owned typed notification names; migrate posters and observers together. |
 | Localization/utilities | `DSLocalizedString`, `UIWindow+DSUtils`, umbrella-only constants such as `DUFFS` | Foundation/app helpers and app-owned constants. |
 | Logger compatibility | `dwLogLevel` workaround | Revert to normal CocoaLumberjack `ddLogLevel` after DashSync headers disappear. |
 | App startup | `setupDashSyncOnce`, `DSOptionsManager` | Delete once every required service has an app/SDK owner. |
@@ -196,6 +198,7 @@ xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay \
 - Watch payload compatibility if retained;
 - Uphold/Coinbase sessions survive the keychain-helper replacement;
 - local-currency picker and About diagnostics after unlink.
+- camera/push permission handoff and app-termination alerts.
 
 Before the final release build, also verify that CrowdNode is unavailable as
 intended and that `../platform` is on `v4.1-dev` rather than the temporary local

--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -125,8 +125,8 @@ NS_ASSUME_NONNULL_BEGIN
     [SwapTrackingServiceObjcWrapper start];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(dsApplicationTerminationRequestNotification:)
-                                                 name:DSApplicationTerminationRequestNotification
+                                             selector:@selector(applicationTerminationRequestNotification:)
+                                                 name:DWApp.applicationTerminationRequestNotification
                                                object:nil];
     
     [CLMCloudInAppMessaging setupWithCloudKitContainerIdentifier:@"iCloud.org.dash.dashwallet"];
@@ -369,7 +369,7 @@ performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionH
 
 #pragma mark - Notifications
 
-- (void)dsApplicationTerminationRequestNotification:(NSNotification *)sender {
+- (void)applicationTerminationRequestNotification:(NSNotification *)sender {
     CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication); // force NSUserDefaults to save
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{

--- a/DashWallet/Sources/Application/App.swift
+++ b/DashWallet/Sources/Application/App.swift
@@ -33,6 +33,15 @@ class AppObjcWrapper: NSObject {
     static let fiatCurrencyDidChangeNotification = Notification.Name.fiatCurrencyDidChange
 
     @objc
+    static let willRequestOSPermissionNotification = Notification.Name.willRequestOSPermission
+
+    @objc
+    static let didRequestOSPermissionNotification = Notification.Name.didRequestOSPermission
+
+    @objc
+    static let applicationTerminationRequestNotification = Notification.Name.applicationTerminationRequest
+
+    @objc
     static var dashFormatter: NumberFormatter {
         NumberFormatter.dashFormatter
     }
@@ -112,4 +121,7 @@ private let kFiatCurrencyDidChange = "FiatCurrencyDidChange"
 
 extension Notification.Name {
     static let fiatCurrencyDidChange = Notification.Name(kFiatCurrencyDidChange)
+    static let willRequestOSPermission = Notification.Name("org.dash.will-request-permission-notification")
+    static let didRequestOSPermission = Notification.Name("org.dash.did-request-permission-notification")
+    static let applicationTerminationRequest = Notification.Name("DWApplicationTerminationRequestNotification")
 }

--- a/DashWallet/Sources/Models/Transactions/BalanceNotifier.swift
+++ b/DashWallet/Sources/Models/Transactions/BalanceNotifier.swift
@@ -57,11 +57,11 @@ class DWBalanceNotifier: NSObject {
 
     @objc
     func registerForPushNotifications() {
-        NotificationCenter.default.post(name: NSNotification.Name("org.dash.will-request-permission-notification"), object: nil)
+        NotificationCenter.default.post(name: .willRequestOSPermission, object: nil)
         let options: UNAuthorizationOptions = [.badge, .sound, .alert]
         UNUserNotificationCenter.current().requestAuthorization(options: options) { granted, error in
             DispatchQueue.main.async {
-                NotificationCenter.default.post(name: NSNotification.Name("org.dash.did-request-permission-notification"), object: nil)
+                NotificationCenter.default.post(name: .didRequestOSPermission, object: nil)
             }
             DWGlobalOptions.sharedInstance().localNotificationsEnabled = granted
             DWLogger.log("DWBalanceNotifier: register for notifications result \(granted), error \(String(describing: error))")
@@ -133,4 +133,3 @@ class DWBalanceNotifier: NSObject {
         cancellableBag.removeAll()
     }
 }
-

--- a/DashWallet/Sources/UI/Home/HomeViewController+JailbreakCheck.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+JailbreakCheck.swift
@@ -35,7 +35,7 @@ extension HomeViewController: DWRecoverViewControllerDelegate {
         } else {
             message = NSLocalizedString("DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash).", comment: "")
             mainAction = UIAlertAction(title: NSLocalizedString("Close App", comment: ""), style: .default) { action in
-                NotificationCenter.default.post(name: NSNotification.Name.DSApplicationTerminationRequest, object: nil)
+                NotificationCenter.default.post(name: .applicationTerminationRequest, object: nil)
             }
         }
 

--- a/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModel.m
+++ b/DashWallet/Sources/UI/Payments/Receive/Models/DWReceiveModel.m
@@ -47,11 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
 
         [self updateReceivingInfo];
 
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(transactionReceivedNotification)
-                                                     name:DSTransactionManagerTransactionReceivedNotification
-                                                   object:nil];
-
         // Re-fetch the receive address as SwiftDashSDK's SPV catches up.
         // Rust's persister writes PersistentTransaction rows on every Core
         // SPV / BLAST batch and SwiftData posts NSManagedObjectContextDidSave

--- a/DashWallet/Sources/UI/Payments/ScanQR/DWQRScanViewController.m
+++ b/DashWallet/Sources/UI/Payments/ScanQR/DWQRScanViewController.m
@@ -25,7 +25,7 @@
 
 #import "DWQRScanModel.h"
 #import "DWQRScanView.h"
-#import <DashSync/DSPermissionNotification.h>
+#import "dashwallet-Swift.h"
 
 #import "DWQRScanViewController.h"
 
@@ -60,7 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
     self.view.model = self.model;
 
     if (!self.model.isCameraDeniedOrRestricted) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:DSWillRequestOSPermissionNotification object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:DWApp.willRequestOSPermissionNotification
+                                                            object:nil];
         __weak typeof(self) weakSelf = self;
         [self.model startPreviewCompletion:^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -68,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
                 return;
             }
 
-            [[NSNotificationCenter defaultCenter] postNotificationName:DSDidRequestOSPermissionNotification
+            [[NSNotificationCenter defaultCenter] postNotificationName:DWApp.didRequestOSPermissionNotification
                                                                 object:nil];
 
             [strongSelf.view connectCaptureSession];

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -481,7 +481,8 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
         actionWithTitle:NSLocalizedString(@"Close App", nil)
                   style:UIAlertActionStyleDefault
                 handler:^(UIAlertAction *action) {
-                    [[NSNotificationCenter defaultCenter] postNotificationName:DSApplicationTerminationRequestNotification object:nil];
+                    [[NSNotificationCenter defaultCenter] postNotificationName:DWApp.applicationTerminationRequestNotification
+                                                                        object:nil];
                 }];
     [alert addAction:closeButton];
     [self presentViewController:alert animated:NO completion:nil];

--- a/DashWallet/Sources/UI/Views/SharedViews/DWWindow.m
+++ b/DashWallet/Sources/UI/Views/SharedViews/DWWindow.m
@@ -17,7 +17,7 @@
 
 #import "DWWindow.h"
 
-#import <DashSync/DSPermissionNotification.h>
+#import "dashwallet-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,11 +46,11 @@ NSString *const DWDeviceDidShakeNotification = @"DWDeviceDidShakeNotification";
                                  object:nil];
         [notificationCenter addObserver:self
                                selector:@selector(willRequestOSPermissionNotification)
-                                   name:DSWillRequestOSPermissionNotification
+                                   name:DWApp.willRequestOSPermissionNotification
                                  object:nil];
         [notificationCenter addObserver:self
                                selector:@selector(didRequestOSPermissionNotification)
-                                   name:DSDidRequestOSPermissionNotification
+                                   name:DWApp.didRequestOSPermissionNotification
                                  object:nil];
     }
     return self;


### PR DESCRIPTION
## Summary

- replace DashSync permission and termination notification symbols with app-owned typed names
- preserve permission raw values during the remaining DashSync biometrics transition
- remove the dead DashSync transaction-received observer from the receive model
- update migration and teardown ledgers; direct DashSync imports drop from 27 to 25

## Testing

- git diff --check
- plutil -lint DashWallet.xcodeproj/project.pbxproj
- verified no production references to the four removed DashSync notification symbols
- dashpay Debug arm64 iOS Simulator build with code signing disabled: succeeded
- dashwallet reaches the WatchApp asset catalog, then is blocked by the known local watchOS runtime mismatch: runtime 23S303 vs SDK 23T570

## Manual smoke tests

- camera and push permission handoff
- app-termination security alerts
- receive-address refresh after an incoming transaction