### PR TITLE
fix(wallet): update contested shielded denomination to 0.25 DASH

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -1203,9 +1203,9 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// Drive re-enforces the pool minimum server-side, so an unknown
     /// pool count doesn't block here — the FFI error is the backstop.
     ///
-    /// The denomination is the smallest consensus exit covering the
-    /// name's cost: 0.1 DASH standard, 0.3 DASH for contested names
-    /// (≥ the 0.25 DASH contested requirement). The metered fee is
+    /// The denomination is the smallest current consensus exit covering
+    /// the name's cost: 0.1 DASH standard, 0.25 DASH for contested names.
+    /// The metered fee is
     /// taken FROM the denomination, so the new identity starts at
     /// denomination − fee and no extra headroom is required.
     ///

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/ShieldedIdentityFundingReadiness.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/ShieldedIdentityFundingReadiness.swift
@@ -12,7 +12,8 @@
 //
 //  1. Funding — unspent shielded notes must cover the Type-20 exit
 //     denomination. `IdentityCreateFromShieldedPool` spends a fixed
-//     denomination from the consensus set {0.1, 0.3, 0.5, 1.0} DASH
+//     denomination from the current consensus set
+//     {0.03, 0.1, 0.25, 0.5, 1.0} DASH
 //     (`shielded_identity_create_denominations`, rs-platform-version);
 //     the metered fee is taken FROM the denomination and any excess
 //     spent value returns to the pool as change, so the gate is simply
@@ -68,10 +69,11 @@ final class ShieldedIdentityFundingReadiness: ObservableObject {
     /// the 0.03 DASH the transparent funding paths provision.
     static let standardDenominationCredits: UInt64 = 10_000_000_000
 
-    /// Exit denomination for contested usernames — 0.3 DASH in credits,
-    /// the smallest consensus denomination covering
-    /// `DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME` (0.25 DASH).
-    static let contestedDenominationCredits: UInt64 = 30_000_000_000
+    /// Exit denomination for contested usernames — 0.25 DASH in credits.
+    /// This is both the exact contested-name requirement and a member of
+    /// the current v9 shielded identity-create denomination set. The prior
+    /// 0.3 DASH denomination was retired and is rejected by Drive.
+    static let contestedDenominationCredits: UInt64 = 25_000_000_000
 
     /// How long shielded notes must rest before funding an identity.
     /// DEBUG builds shorten the window so the maturing → ready flip is
@@ -145,7 +147,7 @@ final class ShieldedIdentityFundingReadiness: ObservableObject {
     // MARK: - Evaluation
 
     /// Compute readiness for an arbitrary requirement (contested names
-    /// need the 0.3 DASH denomination). Returns nil while the SDK host
+    /// need the 0.25 DASH denomination). Returns nil while the SDK host
     /// has no hydrated wallet or storage.
     func evaluate(requiredCredits: UInt64, now: Date = Date()) -> Snapshot? {
         wireManagerIfNeeded(rewire: false)

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -59,7 +59,7 @@ class CreateUsernameViewModel: ObservableObject {
     private var availabilityCheckTask: Task<Void, Never>?
     /// One-shot revalidation alarm for a `.maturing` shielded snapshot.
     /// The shared readiness service arms its own flip timer only for
-    /// the STANDARD denomination; a contested name's (0.3 DASH) ready
+    /// the STANDARD denomination; a contested name's (0.25 DASH) ready
     /// moment can be later, so the form re-validates itself at the
     /// snapshot's own `readyAt`. Re-armed on every validation.
     private var shieldedMaturityRevalidationTask: Task<Void, Never>?
@@ -100,7 +100,7 @@ class CreateUsernameViewModel: ObservableObject {
     @Published private(set) var platformPaymentBalance: String = ""
 
     /// Shielded-funding readiness for the CURRENT typed name (contested
-    /// names need the 0.3 DASH exit denomination instead of 0.1).
+    /// names need the 0.25 DASH exit denomination instead of 0.1).
     /// Recomputed by `validateUsername` and on every readiness publish.
     /// nil while the SDK host has no hydrated wallet.
     @Published private(set) var shieldedReadiness: ShieldedIdentityFundingReadiness.Snapshot? = nil

--- a/DashWalletTests/DWRegistrationPhaseAdapterTests.swift
+++ b/DashWalletTests/DWRegistrationPhaseAdapterTests.swift
@@ -292,4 +292,14 @@ final class DWRegistrationPhaseAdapterTests: XCTestCase {
             identifier?.map { String(format: "%02x", $0) }.joined(),
             "993e6ac24139e41ea9a4541bca4e1642bd0832321754c2b4ff60dc4e8b340633")
     }
+
+    func test_contestedShieldedFundingUsesCurrentProtocolDenomination() {
+        XCTAssertEqual(
+            ShieldedIdentityFundingReadiness.contestedDenominationCredits,
+            25_000_000_000)
+        XCTAssertEqual(
+            ShieldedIdentityFundingReadiness.requiredCredits(
+                forContestedName: true),
+            25_000_000_000)
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fix bug #24: Update shielded identity creation to use the current consensus denomination for contested usernames. Platform v9 changed the contested denomination from 0.3 DASH to 0.25 DASH.

## What was done?

- Updated `ShieldedIdentityFundingReadiness.contestedDenominationCredits` from 30_000_000_000 (0.3 DASH) to 25_000_000_000 (0.25 DASH)
- Updated documentation comments in `DWIdentityRegistrationCoordinator` and `ShieldedIdentityFundingReadiness` to reflect the correct current denomination
- Added test case in `DWRegistrationPhaseAdapterTests` to verify the contested denomination is correctly applied
- Updated ViewModel to reference the corrected denomination

## How Has This Been Tested?

- Testnet validation: verified username creation with the new 0.25 DASH contested denomination
- Unit tests verify the denomination constant is correctly set and used in readiness evaluation

## Breaking Changes

None — this is a bug fix aligning the app with current platform consensus.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone