### PR TITLE
fix(wallet): pin Platform protocol v13 for current shielded denominations

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -542,19 +542,25 @@ final class SwiftDashSDKHost {
 
         let newSDK: SDK
         do {
-            // Pin Platform protocol version 12. v12 is the current server
-            // version and the floor for shielded transitions —
-            // `ShieldFromAssetLock` / `Shield` fees were introduced in v12,
-            // and pinning v11 made the client compute a stale, too-low
-            // shielded pool fee (testnet rejected the asset lock as
-            // underfunded, "needs … credits to start processing"). Pinning
-            // explicitly rather than relying on the auto-detect default
-            // (`platformVersion: 0`, which floors at mainnet 11 / testnet 12)
-            // keeps the wire format consistent across networks. The knob is
-            // the `DashSDKConfig.platform_version` field (dashpay/platform
-            // #3751); bump this when the agreed protocol moves past v12.
-            newSDK = try SDK(network: network, platformVersion: 12)
-            Self.logger.info("🪺 HOST :: stage 1/4 SDK created for \(network.rawValue, privacy: .public)")
+            // Pin Platform protocol version 13. Testnet Drive has moved past
+            // v12 to v13, whose validation set changed the shielded
+            // identity-create exit denominations (v12/V8 `[0.1, 0.3, 0.5,
+            // 1.0]` → v13/V9 `[0.03, 0.1, 0.25, 0.5, 1.0]`). Staying pinned at
+            // v12 made the client build shielded transitions against the old
+            // set, so a contested (0.25 DASH) shielded username create failed
+            // client-side ("denomination 25000000000 is not a member …") even
+            // though the server (v13) requires exactly 0.25. v13 is a superset
+            // of v12's shielded fee logic, so the reason v11→v12 was pinned
+            // (correct `ShieldFromAssetLock` / `Shield` fees) still holds.
+            // Pinning explicitly rather than the auto-detect default
+            // (`platformVersion: 0`, floor + ratchet) avoids a race where the
+            // shielded build runs before the SDK has ratcheted to the network
+            // version. The knob is `DashSDKConfig.platform_version`
+            // (dashpay/platform #3751); bump this when the agreed protocol
+            // moves past v13.
+            let pinnedPlatformVersion: UInt32 = 13
+            newSDK = try SDK(network: network, platformVersion: pinnedPlatformVersion)
+            Self.logger.info("🪺 HOST :: stage 1/4 SDK created for \(network.rawValue, privacy: .public), pinned protocol v\(pinnedPlatformVersion, privacy: .public)")
         } catch {
             Self.logger.error("🪺 HOST :: SDK init failed: \(String(describing: error), privacy: .public)")
             throw HostError.sdkInitFailed(error)


### PR DESCRIPTION
## Issue being fixed or feature implemented
The SDK is created pinned to Platform protocol **v12** (`SDK(network:, platformVersion: 12)`). Testnet Drive has since moved to **v13**, whose validation set changed the shielded identity-create exit denominations:

- v12 / validation V8: `[0.1, 0.3, 0.5, 1.0]`
- v13 / validation V9: `[0.03, 0.1, 0.25, 0.5, 1.0]`

The shielded builder validates the chosen denomination against **`sdk.version()`** (not `PlatformVersion::latest()`). A client pinned at v12 therefore built shielded transitions against the retired set, so a **contested (0.25 DASH) shielded username create failed client-side** — *"Shielded build error: denomination 25000000000 is not a member of the allowed exit-denomination set [10000000000, 30000000000, 50000000000, 100000000000]"* — even though the server (v13) requires exactly 0.25. Rebuilding the FFI did **not** help: the explicit `with_version(12)` pin (`version_pinned = true`, ratchet disabled), not the FFI, selected the version.

## What was done?
Bumped the pin to **v13** in `SwiftDashSDKHost` — the existing comment already said to *"bump this when the agreed protocol moves past v12."* v13 is a superset of v12's shielded fee logic, so the original v11→v12 rationale (correct `ShieldFromAssetLock` / `Shield` fees) still holds. Kept the explicit pin rather than the auto-detect default (`platformVersion: 0`, floor + ratchet) so the shielded build can't race a not-yet-ratcheted network version. The pinned version is now logged at SDK creation. Requires a v13-capable FFI (already rebuilt from the current platform checkout).

This is a general SDK-version alignment (affects every transition the client builds), independent of the BUG-24 denomination value (0.25, shipped separately) which stays correct.

## How Has This Been Tested?
Manual, on testnet: a **contested shielded** username (`Gamma`) now **submits and enters the pending-vote state** ("submitted for voting … we will notify you when voting ends") instead of failing at build time. Non-contested shielded / Core / Platform-Payment registrations continue to work. Verified the SDK-create log reports `pinned protocol v13`.

## Breaking Changes
None. Bumps only the client's pinned protocol version to match the network.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone