### PR TITLE
fix: correct Platform activity after shielded unshield

### DIFF
--- a/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
+++ b/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
@@ -77,7 +77,8 @@ extension DatabaseConnection {
             AddProviderToGiftCardsTable(),
             AddRedeemUrlChallengeToGiftCardsTable(),
             AddSwapOrdersTable(),
-            AddPlatformAddressActivityTables()
+            AddPlatformAddressActivityTables(),
+            NormalizePlatformAddressActivityUnits()
         ]
     }
 

--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -51,6 +51,47 @@ extension Notification.Name {
     static let platformAddressActivityRecorded = Notification.Name("DWPlatformAddressActivityRecorded")
 }
 
+// MARK: - Units
+
+/// Platform-address balances arrive from the SDK in credits (1e11/DASH),
+/// while the app's transaction/history presentation uses duffs (1e8/DASH).
+/// Convert once at the recorder boundary so every persisted baseline and
+/// activity value has the unit promised by its API.
+struct PlatformAddressActivityUnitPolicy {
+    static let creditsPerDuff: UInt64 = 1_000
+
+    static func duffs(fromCredits credits: UInt64) -> Int64 {
+        Int64(clamping: credits / creditsPerDuff)
+    }
+
+    static func unshieldMatches(
+        creditedAmountCredits: UInt64,
+        observedDeltaDuffs: Int64
+    ) -> Bool {
+        duffs(fromCredits: creditedAmountCredits) == observedDeltaDuffs
+    }
+
+    static func isOwnUnshieldCandidate(
+        kindTag: Int,
+        counterpartyLength: Int
+    ) -> Bool {
+        counterpartyLength == 21
+            && kindTag == ShieldedActivityItem.Kind.unshield.rawValue
+    }
+
+    static func exactUnshieldMatches(
+        destinationAddress: String,
+        observedAddress: String,
+        creditedAmountCredits: UInt64,
+        observedDeltaDuffs: Int64
+    ) -> Bool {
+        destinationAddress == observedAddress
+            && unshieldMatches(
+                creditedAmountCredits: creditedAmountCredits,
+                observedDeltaDuffs: observedDeltaDuffs)
+    }
+}
+
 // MARK: - Record
 
 struct PlatformAddressActivityRecord: Identifiable {
@@ -108,6 +149,30 @@ struct AddPlatformAddressActivityTables: Migration {
             t.column(S.colObservedAt)
         })
         try db.run(S.activity.createIndex(S.colWalletId, S.colNetwork, ifNotExists: true))
+    }
+}
+
+/// Correct the first recorder schema, which stored SDK credits in columns
+/// documented and rendered as duffs.
+///
+/// Dividing existing observations is lossless for wallet-originated amounts
+/// (all public transfer amounts are whole duffs). A fresh install runs this
+/// immediately after creating empty activity tables.
+///
+/// Keep this version stable: prerelease builds briefly used the same migration
+/// for an app-owned reconciliation table. Reusing the version prevents those
+/// test installs from dividing their activity rows a second time; the now-dead
+/// table is harmless and no longer read.
+struct NormalizePlatformAddressActivityUnits: Migration {
+    var version: Int64 = 20260727140000
+
+    func migrateDatabase(_ db: Connection) throws {
+        try db.run("UPDATE platform_address_baseline SET balance = balance / 1000")
+        try db.run("""
+            UPDATE platform_address_activity
+            SET amount = amount / 1000,
+                balance_after = balance_after / 1000
+            """)
     }
 }
 
@@ -213,7 +278,9 @@ enum PlatformAddressActivityRecorder {
             for entry in addresses where entry.balance > 0 {
                 dao.upsertBaseline(
                     walletId: walletId, networkRaw: networkRaw,
-                    address: entry.address, balanceDuffs: Int64(entry.balance))
+                    address: entry.address,
+                    balanceDuffs: PlatformAddressActivityUnitPolicy.duffs(
+                        fromCredits: entry.balance))
             }
             return
         }
@@ -221,7 +288,7 @@ enum PlatformAddressActivityRecorder {
         var increases: [(address: String, delta: Int64, after: Int64)] = []
         var netChange: Int64 = 0
         for entry in addresses {
-            let after = Int64(entry.balance)
+            let after = PlatformAddressActivityUnitPolicy.duffs(fromCredits: entry.balance)
             let before = baseline[entry.address] ?? 0
             let delta = after - before
             if delta == 0 { continue }
@@ -270,8 +337,9 @@ enum PlatformAddressActivityRecorder {
     }
 
     /// Exact match against an own internal unshield: same destination
-    /// address, credited amount == entry.amount − fee (the recipient
-    /// receives the principal net of the pool fee).
+    /// address and credited principal. The unshield builder reserves the fee
+    /// in addition to `amount`; the Platform address receives `amount`
+    /// exactly, while the shielded pool is debited by amount + fee.
     private static func matchesOwnUnshield(
         address: String,
         deltaDuffs: Int64,
@@ -280,19 +348,27 @@ enum PlatformAddressActivityRecorder {
         container: ModelContainer
     ) -> Bool {
         let cutoffMs = UInt64(max(0, Date().timeIntervalSince1970 - ownOperationWindow) * 1000)
-        let unshieldKind = 4
+        let unshieldKind = ShieldedActivityItem.Kind.unshield.rawValue
         let descriptor = FetchDescriptor<PersistentShieldedActivity>(
             predicate: #Predicate {
                 $0.walletId == walletId && $0.kindTag == unshieldKind && $0.createdAtMs >= cutoffMs
             })
         guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
         for row in rows {
-            guard row.counterparty.count == 21 else { continue }
+            guard PlatformAddressActivityUnitPolicy.isOwnUnshieldCandidate(
+                kindTag: row.kindTag,
+                counterpartyLength: row.counterparty.count)
+            else { continue }
             let destination = AddressTransformer.formatAddress(
-                row.counterparty, asBech32m: true, isTestnet: network != .mainnet)
-            guard destination == address else { continue }
-            let creditedCredits = row.amount - (row.hasFee ? row.fee : 0)
-            if Int64(creditedCredits / 1000) == deltaDuffs {
+                row.counterparty,
+                asBech32m: true,
+                isTestnet: network != .mainnet)
+            if PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+                destinationAddress: destination,
+                observedAddress: address,
+                creditedAmountCredits: row.amount,
+                observedDeltaDuffs: deltaDuffs)
+            {
                 return true
             }
         }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -492,16 +492,19 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // transfer, the wallet's own next receive address. Resolve before
         // advancing the phase.
         let platformAddress: String
+        let isOwnPlatformDestination: Bool
         if let destinationOverride, !destinationOverride.isEmpty {
             platformAddress = destinationOverride
+            isOwnPlatformDestination = false
         } else {
-            guard let ownAddress = PlatformAddressSyncCoordinator.shared
-                    .derivedAddresses.nextReceiveAddress?.address,
-                  !ownAddress.isEmpty else {
+            guard let ownDestination = PlatformAddressSyncCoordinator.shared
+                    .derivedAddresses.nextReceiveAddress,
+                  !ownDestination.address.isEmpty else {
                 handleFailure(CoordinatorError.noPlatformAddress)
                 return
             }
-            platformAddress = ownAddress
+            platformAddress = ownDestination.address
+            isOwnPlatformDestination = true
         }
 
         do {
@@ -522,6 +525,13 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 toPlatformAddress: platformAddress,
                 amount: amountCredits)
         } catch {
+            // The transition may already have credited our Platform address.
+            // There is no proof height on this ambiguous path, so never invent
+            // an absolute balance; let the height-aware BLAST sync reconcile it.
+            if isOwnPlatformDestination,
+               case PlatformWalletError.shieldedSpendUnconfirmed = error {
+                schedulePlatformResync()
+            }
             handleSpendError(error, manager: env.manager)
             return
         }
@@ -530,9 +540,8 @@ final class ShieldedTransferCoordinator: ObservableObject {
         phase = .broadcasting
         phase = .success
         scheduleShieldedResync(manager: env.manager)
-        // Unshield credits the Platform-address balance; the shielded resync
-        // above only refreshes the shielded side, so kick the Platform-address
-        // (BLAST) sync to surface the credit promptly.
+        // Refresh the Platform side after the backend accepts the transition.
+        // BLAST remains the source of truth for the persisted balance.
         schedulePlatformResync()
     }
 
@@ -909,11 +918,14 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// `performPlatformSend` relies on the same kick after a Platform send.
     private func schedulePlatformResync() {
         Task {
-            for delayNanos in [UInt64(0), 4_000_000_000, 12_000_000_000] {
-                if delayNanos > 0 {
-                    try? await Task.sleep(nanoseconds: delayNanos)
+            var previousDelaySeconds: UInt64 = 0
+            for delaySeconds in [UInt64(0), 4, 12] {
+                let intervalSeconds = delaySeconds - previousDelaySeconds
+                if intervalSeconds > 0 {
+                    try? await Task.sleep(nanoseconds: intervalSeconds * 1_000_000_000)
                 }
                 await PlatformAddressSyncCoordinator.shared.syncNow()
+                previousDelaySeconds = delaySeconds
             }
         }
     }

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -205,6 +205,52 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             refreshInFlight: true))
     }
 
+    func testPlatformActivityConvertsCreditsToDuffsBeforeMatchingUnshield() {
+        let creditedAmount: UInt64 = 10_000_000_000
+
+        XCTAssertEqual(
+            PlatformAddressActivityUnitPolicy.duffs(fromCredits: creditedAmount),
+            10_000_000)
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldMatches(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: 10_000_000))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldMatches(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: Int64(creditedAmount)))
+    }
+
+    func testOwnUnshieldSuppressionAcceptsOnlyLiveUnshieldWithPlatformCounterparty() {
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.isOwnUnshieldCandidate(
+            kindTag: ShieldedActivityItem.Kind.unshield.rawValue,
+            counterpartyLength: 21))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.isOwnUnshieldCandidate(
+            kindTag: ShieldedActivityItem.Kind.shieldedSpend.rawValue,
+            counterpartyLength: 21))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.isOwnUnshieldCandidate(
+            kindTag: ShieldedActivityItem.Kind.shieldedSpend.rawValue,
+            counterpartyLength: 43))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.isOwnUnshieldCandidate(
+            kindTag: ShieldedActivityItem.Kind.received.rawValue,
+            counterpartyLength: 21))
+    }
+
+    func testOwnUnshieldSuppressionDoesNotMatchAnExternalReceive() {
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+            destinationAddress: "tdash1own",
+            observedAddress: "tdash1external",
+            creditedAmountCredits: 10_000_000_000,
+            observedDeltaDuffs: 10_000_000))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+            destinationAddress: "tdash1own",
+            observedAddress: "tdash1own",
+            creditedAmountCredits: 10_000_000_000,
+            observedDeltaDuffs: 9_999_999))
+    }
+
+    func testPlatformActivityUnitMigrationKeepsPrereleaseVersion() {
+        XCTAssertEqual(NormalizePlatformAddressActivityUnits().version, 20260727140000)
+    }
+
     func testCoreToShieldedMinimumIsFirstWholeDuffStrictlyAbovePoolFee() {
         XCTAssertEqual(
             CoreToShieldedAmountPolicy.minimumAmountDuffs(


### PR DESCRIPTION
## Summary

- normalize Platform-address activity baselines and received amounts from SDK credits to duffs
- suppress a wallet's own unshield from generic Received history only when the live operation has a 21-byte Platform counterparty and its address and amount match exactly
- treat the unshield amount as the credited principal; the shielded fee is reserved separately
- kick Platform BLAST sync after an ambiguous submitted-unconfirmed result and run retries at the intended elapsed times of 0/4/12 seconds

## Scope

This PR no longer changes or predicts the Platform balance and has no dependency on a Platform/Rust PR. Backend-only testnet verification on clean Platform v4.2-dev confirmed that the balance issue is already resolved.

There are no direct PersistentPlatformAddress writes, expected-balance policies, reconciliation jobs, retry tables, or cleanup that deletes existing Received rows.

## Migration

The existing prerelease migration version is preserved. Builds that already ran the earlier draft's combined migration do not divide activity values a second time.

## Validation

- dashpay Debug arm64 simulator build: BUILD SUCCEEDED
- git diff --check: passed
- focused SwiftDashSDKCoreLifecycleTests were attempted through the dashwallet-dashpay scheme, but Xcode cancelled before execution because the local watchOS simulator runtime (23S303) does not match the installed watchsimulator SDK (23T570)
- manual Shielded → Platform test on clean v4.2-dev: Platform balance updated without the abandoned client-side reconciliation