### PR TITLE
feat(ui): show insufficient shielded spendable balance

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -65,6 +65,44 @@ enum CoreToShieldedAmountPolicy {
     }
 }
 
+/// Shared affordability boundary for every route that spends Orchard notes.
+///
+/// Shielded spends debit both the requested amount and a route-specific fee.
+/// Keeping the calculation here makes the inline validation, Continue gate,
+/// and Max amount describe the same spendable envelope.
+enum ShieldedSpendAmountPolicy {
+    static func spendableCredits(
+        balanceCredits: UInt64,
+        feeReserveCredits: UInt64
+    ) -> UInt64 {
+        balanceCredits > feeReserveCredits
+            ? balanceCredits - feeReserveCredits
+            : 0
+    }
+
+    static func insufficientBalanceMessage(
+        requestedCredits: UInt64,
+        balanceCredits: UInt64,
+        feeReserveCredits: UInt64
+    ) -> String? {
+        let spendableCredits = spendableCredits(
+            balanceCredits: balanceCredits,
+            feeReserveCredits: feeReserveCredits)
+        guard requestedCredits > spendableCredits else { return nil }
+
+        // The amount input supports duff precision, so report the largest
+        // value the user can actually enter rather than rounding credits up.
+        let spendableDuffs = spendableCredits / 1000
+        let formattedSpendable =
+            "\(spendableDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Insufficient Shielded balance. Available to spend: %@",
+                comment: "Shielded send amount exceeds spendable balance"),
+            formattedSpendable)
+    }
+}
+
 @MainActor
 final class InternalTransferViewModel: ObservableObject {
 
@@ -358,24 +396,43 @@ final class InternalTransferViewModel: ObservableObject {
             poolFeeCredits: poolFeeCredits)
     }
 
-    /// Inline, user-facing explanation for a Core → Shielded amount rejected
-    /// before Confirm. Zero stays quiet while the user has not entered an
-    /// amount; a fee-estimation failure fails closed with a generic retry.
+    /// Inline, user-facing explanation for an amount rejected before Confirm.
+    /// Zero stays quiet while the user has not entered an amount; a
+    /// fee-estimation failure fails closed with a generic retry.
     var amountValidationMessage: String? {
-        guard route == .coreToShielded, dashDuffsUnsigned > 0 else { return nil }
-        guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-            return NSLocalizedString(
-                "There was an error, please try again later",
-                comment: "Internal transfer fee estimate unavailable")
-        }
-        guard dashDuffsUnsigned < minimumDuffs else { return nil }
+        guard dashDuffsUnsigned > 0 else { return nil }
 
-        let formattedMinimum = "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-        return String.localizedStringWithFormat(
-            NSLocalizedString(
-                "The minimum amount you can send is %@",
-                comment: "Internal transfer minimum amount"),
-            formattedMinimum)
+        switch route {
+        case .coreToShielded:
+            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
+                return NSLocalizedString(
+                    "There was an error, please try again later",
+                    comment: "Internal transfer fee estimate unavailable")
+            }
+            guard dashDuffsUnsigned < minimumDuffs else { return nil }
+
+            let formattedMinimum =
+                "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "The minimum amount you can send is %@",
+                    comment: "Internal transfer minimum amount"),
+                formattedMinimum)
+
+        case .shieldedToCore, .shieldedToPlatform:
+            guard let reserve = feeReserveCredits else {
+                return NSLocalizedString(
+                    "There was an error, please try again later",
+                    comment: "Shielded transfer fee estimate unavailable")
+            }
+            return ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+                requestedCredits: creditsPreview,
+                balanceCredits: shieldedBalance,
+                feeReserveCredits: reserve)
+
+        default:
+            return nil
+        }
     }
 
     var canContinue: Bool {
@@ -466,7 +523,9 @@ final class InternalTransferViewModel: ObservableObject {
     /// amount. Fails closed (returns 0) when the reserve is unavailable.
     private func creditsMinusFeeReserve(_ balanceCredits: UInt64) -> UInt64 {
         guard let fee = feeReserveCredits else { return 0 }
-        return balanceCredits > fee ? balanceCredits - fee : 0
+        return ShieldedSpendAmountPolicy.spendableCredits(
+            balanceCredits: balanceCredits,
+            feeReserveCredits: fee)
     }
 
     /// `parsedDashAmount` expressed as Int64 duffs, for `DashAmount` views.

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -422,7 +422,9 @@ final class SendViewModel: ObservableObject {
 
     private func creditsMinusFeeReserve(_ balanceCredits: UInt64) -> UInt64 {
         guard let fee = feeReserveCredits else { return 0 }
-        return balanceCredits > fee ? balanceCredits - fee : 0
+        return ShieldedSpendAmountPolicy.spendableCredits(
+            balanceCredits: balanceCredits,
+            feeReserveCredits: fee)
     }
 
     /// Net payout of the full-balance Platform → Core withdrawal (duffs);
@@ -473,23 +475,42 @@ final class SendViewModel: ObservableObject {
             poolFeeCredits: poolFeeCredits)
     }
 
-    /// Inline explanation for a Core → external Shielded amount that cannot
-    /// cover the Type-18 pool fee. Keep zero quiet until the user types.
+    /// Inline explanation for an amount rejected before Confirm. Keep zero
+    /// quiet until the user types.
     var amountValidationMessage: String? {
-        guard route == .coreToShielded, dashDuffsUnsigned > 0 else { return nil }
-        guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-            return NSLocalizedString(
-                "There was an error, please try again later",
-                comment: "External shielded send fee estimate unavailable")
-        }
-        guard dashDuffsUnsigned < minimumDuffs else { return nil }
+        guard dashDuffsUnsigned > 0, let route else { return nil }
 
-        let formattedMinimum = "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-        return String.localizedStringWithFormat(
-            NSLocalizedString(
-                "The minimum amount you can send is %@",
-                comment: "External shielded send minimum amount"),
-            formattedMinimum)
+        switch route {
+        case .coreToShielded:
+            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
+                return NSLocalizedString(
+                    "There was an error, please try again later",
+                    comment: "External shielded send fee estimate unavailable")
+            }
+            guard dashDuffsUnsigned < minimumDuffs else { return nil }
+
+            let formattedMinimum =
+                "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "The minimum amount you can send is %@",
+                    comment: "External shielded send minimum amount"),
+                formattedMinimum)
+
+        case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
+            guard let reserve = feeReserveCredits else {
+                return NSLocalizedString(
+                    "There was an error, please try again later",
+                    comment: "External Shielded send fee estimate unavailable")
+            }
+            return ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+                requestedCredits: creditsPreview,
+                balanceCredits: shieldedBalance,
+                feeReserveCredits: reserve)
+
+        default:
+            return nil
+        }
     }
 
     /// Gate for advancing from the address step to the amount step: the

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -215,6 +215,36 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
                 poolFeeCredits: 212_851_000),
             212_852)
     }
+
+    func testShieldedSpendableBalanceSubtractsFeeReserve() {
+        XCTAssertEqual(
+            ShieldedSpendAmountPolicy.spendableCredits(
+                balanceCredits: 10_000_000_000,
+                feeReserveCredits: 2_000_000_000),
+            8_000_000_000)
+        XCTAssertEqual(
+            ShieldedSpendAmountPolicy.spendableCredits(
+                balanceCredits: 1_000_000_000,
+                feeReserveCredits: 2_000_000_000),
+            0)
+    }
+
+    func testShieldedInsufficientBalanceMessageUsesSpendableAmount() {
+        let message = ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+            requestedCredits: 8_000_000_001,
+            balanceCredits: 10_000_000_000,
+            feeReserveCredits: 2_000_000_000)
+
+        XCTAssertNotNil(message)
+        XCTAssertTrue(
+            message?.contains("0.08 DASH") == true
+                || message?.contains("0,08 DASH") == true)
+        XCTAssertNil(
+            ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+                requestedCredits: 8_000_000_000,
+                balanceCredits: 10_000_000_000,
+                feeReserveCredits: 2_000_000_000))
+    }
 }
 
 final class JoinDashPayRegistrationPolicyTests: XCTestCase {


### PR DESCRIPTION
## Issue being fixed or feature implemented

SB-2: Shielded sends and internal withdrawals that exceed the remaining fee-aware spendable balance were blocked without a clear explanation. This was especially confusing after earlier spends reduced the usable note balance.

## What was done?

- Added one shared Shielded spendability policy that subtracts the route-specific fee reserve without underflow.
- Show the same inline `Insufficient Shielded balance` message for internal and external Shielded spends before the confirmation/proving flow.
- Include the actual fee-aware amount available to spend in the message.
- Kept Continue and Max aligned with the same spendable-balance calculation.
- Added boundary coverage for fee subtraction, insufficient balance, and the exact spendable limit.

## How Has This Been Tested?

- `xcodebuild` for the `dashwallet-dashpay` scheme targeting a generic arm64 iOS Simulator: **BUILD SUCCEEDED**.
- Added unit tests in `SwiftDashSDKCoreLifecycleTests`.
- A targeted test run was attempted, but the repository's existing WatchApp Extension SwiftLint phase fails on unrelated pre-existing lint violations before XCTest starts.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
