### PR TITLE
feat(wallet): rearm Platform sync without relaunch

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -69,6 +69,31 @@ struct ShieldedSyncFreshnessPolicy {
     }
 }
 
+enum PlatformAccountAvailability: Equatable {
+    case unknown
+    case available
+    case unavailable
+}
+
+struct PlatformAccountAvailabilityPolicy {
+    static func resolve(
+        hasWalletRecord: Bool,
+        hasPlatformPaymentAccount: Bool
+    ) -> PlatformAccountAvailability {
+        guard hasWalletRecord else { return .unknown }
+        return hasPlatformPaymentAccount ? .available : .unavailable
+    }
+}
+
+struct PlatformSyncRearmPolicy {
+    static func requiresRuntimeRearm(
+        isRunning: Bool,
+        hasWalletManager: Bool
+    ) -> Bool {
+        !isRunning || !hasWalletManager
+    }
+}
+
 @MainActor
 @objc(DWPlatformAddressSyncCoordinator)
 public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
@@ -94,6 +119,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     @Published public private(set) var isClearing: Bool = false
     @Published public private(set) var lastSyncTime: Date? = nil
     @Published public private(set) var lastError: String? = nil
+    @Published private(set) var platformAccountAvailability: PlatformAccountAvailability = .unknown
 
     @Published public private(set) var platformBalance: UInt64 = 0
     @Published public private(set) var shieldedBalance: UInt64 = 0
@@ -241,13 +267,41 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
 
     public func syncNow() async {
         guard !isSyncing else { return }
+
+        if PlatformSyncRearmPolicy.requiresRuntimeRearm(
+            isRunning: isRunning,
+            hasWalletManager: walletManager != nil
+        ) {
+            lastError = nil
+            await SwiftDashSDKWalletRuntime.shared.rearmPlatformSync()
+        }
+
         guard let manager = walletManager else {
-            lastError = "Platform wallet not configured"
+            // A missing SDK wallet is a valid post-wipe state, not a Platform
+            // sync failure. When wallet material does exist, the serialized
+            // runtime re-arm above owns the concrete start error and leaves it
+            // in `lastError`. A wallet that exists without a Platform Payment
+            // account is handled by `platformAccountAvailability`.
+            if !WalletEnvironment.hasSDKWallet {
+                platformAccountAvailability = .unavailable
+                lastError = nil
+            } else if platformAccountAvailability != .unavailable && lastError == nil {
+                lastError = "Platform sync could not be started"
+            }
             return
         }
-        isSyncing = true
-        lastError = nil
+
+        // Re-arming starts the background loop as part of binding the runtime.
+        // Its seeded publisher may have flipped this while we were awaiting
+        // the lifecycle queue, so do not launch a competing one-shot sync.
+        guard !isSyncing else { return }
+
         do {
+            if try !manager.isPlatformAddressSyncRunning() {
+                try manager.startPlatformAddressSync()
+            }
+            isSyncing = true
+            lastError = nil
             try await manager.syncPlatformAddressNow()
         } catch {
             isSyncing = false
@@ -654,13 +708,24 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             return
         }
 
-        let addressWallet: ManagedPlatformAddressWallet
+        let accountAvailability = resolvePlatformAccountAvailability(
+            walletId: resolvedWallet.walletId)
+        let addressWallet: ManagedPlatformAddressWallet?
         do {
             addressWallet = try resolvedWallet.platformAddressWallet()
         } catch {
-            Self.logger.error("🛰️ PLATFORM-ADDR :: platformAddressWallet() failed: \(String(describing: error), privacy: .public)")
-            lastError = "platformAddressWallet failed: \(error.localizedDescription)"
-            return
+            if accountAvailability == .unavailable {
+                // A wallet can legitimately have Shielded state without a
+                // DIP-17 Platform Payment account. Keep the shared manager
+                // alive for Shielded/DashPay and expose a neutral UI state.
+                addressWallet = nil
+                Self.logger.info(
+                    "🛰️ PLATFORM-ADDR :: no Platform Payment account; continuing without address wallet")
+            } else {
+                Self.logger.error("🛰️ PLATFORM-ADDR :: platformAddressWallet() failed: \(String(describing: error), privacy: .public)")
+                lastError = "platformAddressWallet failed: \(error.localizedDescription)"
+                return
+            }
         }
 
         // Seed from persisted state before kicking the sync loop, so the UI has
@@ -722,6 +787,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         self.walletManager = manager
         self.wallet = resolvedWallet
         self.platformAddressWallet = addressWallet
+        self.platformAccountAvailability = accountAvailability
         self.runningNetwork = network
         self.isRunning = true
         self.lastError = nil
@@ -839,6 +905,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         sdk = nil
         runningNetwork = nil
         isRunning = false
+        platformAccountAvailability = .unknown
         clearDisplay()
     }
 
@@ -1216,6 +1283,33 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func resolvePlatformAccountAvailability(
+        walletId: Data
+    ) -> PlatformAccountAvailability {
+        guard let container = SwiftDashSDKHost.shared.modelContainer else {
+            return .unknown
+        }
+
+        var descriptor = FetchDescriptor<PersistentWallet>(
+            predicate: #Predicate { $0.walletId == walletId })
+        descriptor.fetchLimit = 1
+
+        do {
+            guard let walletRow = try container.mainContext.fetch(descriptor).first else {
+                return PlatformAccountAvailabilityPolicy.resolve(
+                    hasWalletRecord: false,
+                    hasPlatformPaymentAccount: false)
+            }
+            return PlatformAccountAvailabilityPolicy.resolve(
+                hasWalletRecord: true,
+                hasPlatformPaymentAccount: walletRow.accounts.contains { $0.accountType == 14 })
+        } catch {
+            Self.logger.warning(
+                "🛰️ PLATFORM-ADDR :: platform-account availability lookup failed: \(String(describing: error), privacy: .public)")
+            return .unknown
+        }
+    }
 
     private func resolveCurrentNetwork() -> Network? {
         WalletEnvironment.network

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -121,6 +121,18 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         dispatchOnPipeline { shared.enqueueFullReset(lastError: nil, forWipe: true) }
     }
 
+    /// Rebuild the shared runtime through the same serialized lifecycle used
+    /// at launch and after wallet recovery, then return only when Platform
+    /// sync is bound again (or the start has failed). Sync Info uses this to
+    /// turn "Sync Now" into a real in-session recovery action after Stop or a
+    /// recover-time binding race.
+    func rearmPlatformSync() async {
+        let task = enqueueAwaitable { [weak self] in
+            await self?.refresh(trigger: .platformSyncRearm)
+        }
+        await task.value
+    }
+
     /// Restart Core SPV to dial a fresh peer set ("sync too slow? change
     /// peers"). Shares the exact Core-only restart operation with the
     /// diagnostics screen.
@@ -364,7 +376,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
             // network, so `currentNetwork == network` would otherwise wrongly
             // elide the rebind.
             return false
-        case .startIfReady, .networkDidChange:
+        case .startIfReady, .networkDidChange, .platformSyncRearm:
             // External callers (PlatformSyncStatusScreen, StorageExplorerUnavailableView,
             // the Platform send path) can mutate BLAST without touching
             // `currentNetwork`, so consult the live coordinator state too — otherwise
@@ -432,6 +444,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
         case networkDidChange
         case walletMaterialChanged
         case walletDidChange
+        case platformSyncRearm
     }
 
     enum RuntimeError: LocalizedError {

--- a/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift
@@ -18,6 +18,15 @@ import SwiftUI
 import DashUIKit
 import UIKit
 
+struct PlatformSyncStatusPresentationPolicy {
+    static func visibleError(
+        availability: PlatformAccountAvailability,
+        lastError: String?
+    ) -> String? {
+        availability == .unavailable ? nil : lastError
+    }
+}
+
 struct PlatformSyncStatusScreen: View {
     private let vc: UINavigationController
 
@@ -67,7 +76,10 @@ struct PlatformSyncStatusScreen: View {
                         queriesCard
                     }
                     addressesCard
-                    if let lastError = coordinator.lastError {
+                    if let lastError = PlatformSyncStatusPresentationPolicy.visibleError(
+                        availability: coordinator.platformAccountAvailability,
+                        lastError: coordinator.lastError
+                    ) {
                         errorCard(message: lastError)
                     }
                     controlsCard
@@ -98,7 +110,7 @@ struct PlatformSyncStatusScreen: View {
             } else {
                 Image(systemName: "circle.dashed")
                     .foregroundColor(Color.dash.secondaryText)
-                Text(coordinator.isRunning ? "Not synced yet" : "Idle")
+                Text(stateDescription)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Color.dash.secondaryText)
             }
@@ -112,6 +124,13 @@ struct PlatformSyncStatusScreen: View {
         .padding(16)
         .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
+    }
+
+    private var stateDescription: String {
+        if coordinator.platformAccountAvailability == .unavailable {
+            return "No Platform wallet on this account"
+        }
+        return coordinator.isRunning ? "Not synced yet" : "Idle"
     }
 
     private var balanceCard: some View {

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -205,6 +205,41 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
             refreshInFlight: true))
     }
 
+    func testStoppedPlatformSyncRequiresRuntimeRearm() {
+        XCTAssertTrue(
+            PlatformSyncRearmPolicy.requiresRuntimeRearm(
+                isRunning: false,
+                hasWalletManager: false))
+        XCTAssertTrue(
+            PlatformSyncRearmPolicy.requiresRuntimeRearm(
+                isRunning: true,
+                hasWalletManager: false))
+        XCTAssertFalse(
+            PlatformSyncRearmPolicy.requiresRuntimeRearm(
+                isRunning: true,
+                hasWalletManager: true))
+    }
+
+    func testWalletWithoutPlatformPaymentAccountUsesNeutralState() {
+        let availability = PlatformAccountAvailabilityPolicy.resolve(
+            hasWalletRecord: true,
+            hasPlatformPaymentAccount: false)
+
+        XCTAssertEqual(availability, .unavailable)
+        XCTAssertNil(
+            PlatformSyncStatusPresentationPolicy.visibleError(
+                availability: availability,
+                lastError: "Platform wallet not configured"))
+    }
+
+    func testMissingWalletRecordRemainsUnknownInsteadOfClaimingNoPlatformWallet() {
+        XCTAssertEqual(
+            PlatformAccountAvailabilityPolicy.resolve(
+                hasWalletRecord: false,
+                hasPlatformPaymentAccount: false),
+            .unknown)
+    }
+
     func testPlatformActivityConvertsCreditsToDuffsBeforeMatchingUnshield() {
         let creditedAmount: UInt64 = 10_000_000_000
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes SB-9 and SB-10: Platform sync could not be re-armed in-session after
stopping it or after a wallet recovery binding race. Tapping Sync Now left the
screen idle or displayed a raw "Platform wallet not configured" error until
the application was relaunched.

## What was done?
- Re-arm Platform sync through the same serialized wallet runtime lifecycle
  used at launch and after wallet recovery.
- Restart the Platform address sync loop when required and avoid launching a
  competing one-shot sync when re-arming already started the background loop.
- Detect wallets that genuinely have no Platform Payment account and show the
  neutral "No Platform wallet on this account" state instead of a raw SDK
  configuration error.
- Add lifecycle policy tests for stopped sync and Platform account
  availability.

## How Has This Been Tested?
- Built `dashwallet-dashpay` successfully for a generic arm64 iOS Simulator
  with code signing disabled.
- Attempted the targeted `SwiftDashSDKCoreLifecycleTests` test class. The test
  action was stopped before executing tests by the repository's pre-existing
  SwiftLint build errors (186 repository-wide violations, unrelated to these
  changes).

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
