### PR TITLE
docs: rightsize CLAUDE.md (cut derivable sections, Figma guidance → skill)

### DIFF
--- a/.claude/skills/figma-assets/SKILL.md
+++ b/.claude/skills/figma-assets/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: figma-assets
+description: Set up the Figma Dev Mode MCP server and clean Figma-exported SVG assets for iOS. Use when pulling designs or icons from Figma, adding assets to AppAssets.xcassets, or when an added SVG icon renders blank.
+---
+
+# Figma MCP setup & asset cleaning
+
+## MCP / Figma Setup
+
+This project uses the Figma Dev Mode MCP server, configured in `.mcp.json` (`http://127.0.0.1:3845/mcp`). To use it:
+
+1. Run Figma Desktop, enable Dev Mode (`Shift+D`), and click "Enable desktop MCP server" in the inspect panel.
+2. Restart Claude Code — MCP servers connect only at startup.
+3. Verify the server responds: `curl -s http://127.0.0.1:3845/mcp`
+
+## Figma MCP assets need cleaning for iOS
+
+Figma MCP serves assets at ephemeral `http://localhost:3845/assets/{hash}.svg` URLs (valid only while Figma Desktop + Dev Mode are running). Download them into the asset catalog (`DashWallet/Resources/AppAssets.xcassets/...`) — never reference localhost URLs in code. Then strip web-only SVG features iOS can't render:
+
+- `fill="var(--fill-0, #78C4F5)"` → `fill="#78C4F5"` (CSS variables render invisible)
+- `width="100%" height="100%"` → explicit pixel dimensions from the viewBox
+- remove `preserveAspectRatio="none"`, `style="display: block;"`, `overflow="visible"`
+
+If icons appear blank after adding an SVG, check for `var(--fill-0, ...)` or `width="100%"` first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,36 +45,13 @@ cd ../platform/packages/swift-sdk && ./build_ios.sh --target ios --target sim
 ```
 If the app fails with missing SDK symbols (e.g. "no member …"), `../platform` is on the wrong branch — check the branch/commit pins recorded in `DASHSYNC_MIGRATION.md`.
 
-## MCP / Figma Setup
+## Figma
 
-This project uses the Figma Dev Mode MCP server, configured in `.mcp.json` (`http://127.0.0.1:3845/mcp`). To use it:
-
-1. Run Figma Desktop, enable Dev Mode (`Shift+D`), and click "Enable desktop MCP server" in the inspect panel.
-2. Restart Claude Code — MCP servers connect only at startup.
-3. Verify the server responds: `curl -s http://127.0.0.1:3845/mcp`
+Figma Dev Mode MCP setup and cleaning Figma-exported SVG assets for iOS are covered by the `figma-assets` skill (`.claude/skills/figma-assets/SKILL.md`).
 
 ## Architecture
 
-### Languages
-- **Objective-C**: legacy wallet functionality, core models, some view controllers
-- **Swift**: modern UI, SwiftUI, new features. Many view controllers bridge ObjC ↔ Swift.
-
-### Key directories
-- `DashWallet/Sources/Application/` — app lifecycle, constants, configuration
-- `DashWallet/Sources/UI/` — UI components, organized by feature
-- `DashWallet/Sources/Models/` — business logic, data models, services
-- `DashWallet/Sources/Infrastructure/` — core services (networking, database, currency)
 - `DashWallet/Sources/Infrastructure/SwiftDashSDK/` — the SwiftDashSDK adapter layer (host, wallet runtime/state, SPV coordinator, transaction sender, identity coordinators) — the app-side boundary to the Rust SDK
-
-### Targets
-Main app, `TodayExtension` (widget), and `WatchApp`, with shared code in `Shared/`. Each target has its own deployment target and capabilities.
-
-### Patterns
-- **MVVM** — ViewModels for SwiftUI views and modern controllers
-- **Protocol-based dependency injection**
-- **Service layer** — dedicated services for major functionality (e.g. `SendCoinsService`, `CurrencyExchanger`)
-- **Repository / DAO** — data access objects over SQLite
-- **Coordinator** — `DWAppRootViewController` manages navigation flow
 
 ### Notable services & files
 - `WalletSendService.swift` — the send boundary: auth → build+sign (`SwiftDashSDKTransactionSender`) → user confirm → broadcast. `SendCoinsService.swift` is a thin programmatic wrapper over it.
@@ -170,11 +147,3 @@ iOS `*.lproj/Localizable.strings` files are UTF-16 little-endian, so plain `grep
 iconv -f UTF-16LE -t UTF-8 DashWallet/de.lproj/Localizable.strings | grep '"Spend"'
 ```
 Translations sync via Transifex: `tx push -s` (push source) / `tx pull -a` (pull all). Let Xcode and BartyCrouch manage the files; keep them UTF-16LE.
-
-### Figma MCP assets need cleaning for iOS
-Figma MCP serves assets at ephemeral `http://localhost:3845/assets/{hash}.svg` URLs (valid only while Figma Desktop + Dev Mode are running). Download them into the asset catalog (`DashWallet/Resources/AppAssets.xcassets/...`) — never reference localhost URLs in code. Then strip web-only SVG features iOS can't render:
-- `fill="var(--fill-0, #78C4F5)"` → `fill="#78C4F5"` (CSS variables render invisible)
-- `width="100%" height="100%"` → explicit pixel dimensions from the viewBox
-- remove `preserveAspectRatio="none"`, `style="display: block;"`, `overflow="visible"`
-
-If icons appear blank after adding an SVG, check for `var(--fill-0, ...)` or `width="100%"` first.


### PR DESCRIPTION
## What

Context-engineering cleanup of `CLAUDE.md`, per the current guidance for Claude 5 models (keep memory files to gotchas and contracts; lazy-load task-specific guidance):

1. **Cut sections derivable from the codebase** — *Languages*, the generic *Key directories* bullets, *Targets*, and *Patterns*. A fresh session reconstructs these with `ls` and a glance at the code. The `Sources/Infrastructure/SwiftDashSDK/` adapter-layer pointer is kept — that one carries real boundary knowledge.
2. **Move Figma guidance to a lazy-loaded skill** — the Figma Dev Mode MCP setup and the "Figma SVG assets need cleaning for iOS" gotcha now live in `.claude/skills/figma-assets/SKILL.md` (loaded only during design work); `CLAUDE.md` keeps a one-line pointer.

All migration contracts, guardrails, and gotchas stay in `CLAUDE.md` unchanged. Net effect: ~600 est. tokens less resident context per session, zero information lost.

## Why base = `codex/dashsync-coinbase-uphold-tail`

The rightsized `CLAUDE.md` lives on the migration branch line; `master` still has the pre-migration version, so this targets the branch where the edits apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)