### PR TITLE
fix(dashpay): persist Upgrade-to-DashPay banner dismissal (Hide now works)

### DIFF
--- a/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
+++ b/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
@@ -113,10 +113,19 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
         let hasPendingRecoveredName = MainActor.assumeIsolated {
             DWContestedNameStatusService.shared.pendingLabel != nil
         }
-        showJoinDashpay = identityState.contextReady
-            && model.state == .syncDone
-            && !hasUsername
-            && !hasPendingRecoveredName
+        showJoinDashpay = JoinDashPayBannerPolicy.shouldShow(
+            contextReady: identityState.contextReady,
+            syncDone: model.state == .syncDone,
+            dismissed: UsernamePrefs.shared.joinDashPayDismissed,
+            hasRegisteredUsername: hasUsername,
+            hasRegistrationInProgress: hasPendingRecoveredName)
+    }
+
+    /// Re-evaluates the menu banner after a local preference change such as
+    /// tapping Hide. Unlike sync/network notifications, preference writes do
+    /// not otherwise publish an event to this profile model.
+    func refreshJoinDashPayBanner() {
+        updateShowJoinDashpay()
     }
     
     @objc func update() {

--- a/DashWallet/Sources/Models/Usernames/UsernamePrefs.swift
+++ b/DashWallet/Sources/Models/Usernames/UsernamePrefs.swift
@@ -23,6 +23,17 @@ private let kRequestedUsernameId = "requestedUsernameIdKey"
 private let kAlreadyPaid = "alreadyPaidForUsernameKey"
 private let kJoinDashPayDismissed = "joinDashPayDismissed"
 
+/// Keeps the Upgrade-to-DashPay banner dismissal attached to the wallet and
+/// network where the user made that choice. A global flag leaks between
+/// Mainnet and Testnet; an in-memory scalar also serves stale state after a
+/// network round-trip.
+enum JoinDashPayDismissalScope {
+    static func storageKey(networkRawValue: Int, walletIdHex: String?) -> String {
+        let walletScope = walletIdHex.flatMap { $0.isEmpty ? nil : $0 } ?? "unbound"
+        return "\(kJoinDashPayDismissed).v2.\(networkRawValue).\(walletScope)"
+    }
+}
+
 // MARK: - UsernamePrefs
 
 class UsernamePrefs {
@@ -64,12 +75,16 @@ class UsernamePrefs {
         }
     }
     
-    private var _joinDashPayDismissed: Bool? = nil
     var joinDashPayDismissed: Bool {
-        get { _joinDashPayDismissed ?? UserDefaults.standard.bool(forKey: kJoinDashPayDismissed) }
+        get { UserDefaults.standard.bool(forKey: joinDashPayDismissedKey) }
         set(value) {
-            _joinDashPayDismissed = value
-            UserDefaults.standard.set(value, forKey: kJoinDashPayDismissed)
+            UserDefaults.standard.set(value, forKey: joinDashPayDismissedKey)
         }
+    }
+
+    private var joinDashPayDismissedKey: String {
+        JoinDashPayDismissalScope.storageKey(
+            networkRawValue: WalletEnvironment.networkKind.rawValue,
+            walletIdHex: WalletEnvironment.activeWalletIdHex as String?)
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1655,6 +1655,22 @@ enum JoinDashPayRegistrationPolicy {
     }
 }
 
+enum JoinDashPayBannerPolicy {
+    static func shouldShow(
+        contextReady: Bool,
+        syncDone: Bool,
+        dismissed: Bool,
+        hasRegisteredUsername: Bool,
+        hasRegistrationInProgress: Bool
+    ) -> Bool {
+        contextReady &&
+            syncDone &&
+            !dismissed &&
+            !hasRegisteredUsername &&
+            !hasRegistrationInProgress
+    }
+}
+
 // MARK: - DashPay
 
 #if DASHPAY
@@ -1675,20 +1691,19 @@ extension HomeViewModel {
             sdkUsername: identityState.username,
             legacyRegistrationCompleted: options.dashpayRegistrationCompleted,
             legacyUsername: options.dashpayUsername)
-        // Dismissal and registration-progress prefs predate network-scoped
-        // identity storage. They may still describe the previous network, so
-        // they can suppress the banner only when this network has an identity.
-        let identityScopedDismissal =
-            identityState.hasIdentity && UsernamePrefs.shared.joinDashPayDismissed
+        // Dismissal is persisted per active wallet + network. It is valid
+        // before an identity exists and remains valid when readiness is
+        // re-evaluated or the user leaves and returns to this network.
         let identityScopedRegistrationState =
             identityState.hasIdentity &&
             (joinDashPayState == .voting || joinDashPayState == .registered)
 
-        self.showJoinDashpay = identityState.contextReady &&
-            syncModel.state == .syncDone &&
-            !identityScopedDismissal &&
-            !hasRegisteredUsername &&
-            !identityScopedRegistrationState
+        self.showJoinDashpay = JoinDashPayBannerPolicy.shouldShow(
+            contextReady: identityState.contextReady,
+            syncDone: syncModel.state == .syncDone,
+            dismissed: UsernamePrefs.shared.joinDashPayDismissed,
+            hasRegisteredUsername: hasRegisteredUsername,
+            hasRegistrationInProgress: identityScopedRegistrationState)
     }
     
     private func observeDashPay() {

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -232,6 +232,7 @@ struct MainMenuScreen: View {
                         },
                         onDismissButton: { state in
                             joinDPViewModel.markAsDismissed()
+                            viewModel.refreshJoinDashPayBanner()
                         }
                     )
                     .padding(.horizontal, 18)
@@ -417,6 +418,7 @@ struct MainMenuScreen: View {
         default:
             editProfile()
             joinDPViewModel.markAsDismissed()
+            viewModel.refreshJoinDashPayBanner()
         }
     }
     

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -71,6 +71,10 @@ class MainMenuViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .assign(to: &$showJoinDashpay)
     }
+
+    func refreshJoinDashPayBanner() {
+        userProfileModel?.refreshJoinDashPayBanner()
+    }
     #else
     init() {
         buildMenuSections()

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -339,3 +339,45 @@ final class JoinDashPayRegistrationPolicyTests: XCTestCase {
                 legacyUsername: "testnet-alice"))
     }
 }
+
+final class JoinDashPayBannerPolicyTests: XCTestCase {
+    func testDismissalHidesBannerBeforeIdentityExists() {
+        XCTAssertFalse(
+            JoinDashPayBannerPolicy.shouldShow(
+                contextReady: true,
+                syncDone: true,
+                dismissed: true,
+                hasRegisteredUsername: false,
+                hasRegistrationInProgress: false))
+    }
+
+    func testEligibleUndismissedWalletShowsBanner() {
+        XCTAssertTrue(
+            JoinDashPayBannerPolicy.shouldShow(
+                contextReady: true,
+                syncDone: true,
+                dismissed: false,
+                hasRegisteredUsername: false,
+                hasRegistrationInProgress: false))
+    }
+
+    func testDismissalStorageIsScopedByNetworkAndWallet() {
+        let testnetWalletA = JoinDashPayDismissalScope.storageKey(
+            networkRawValue: WalletEnvironment.NetworkKind.testnet.rawValue,
+            walletIdHex: "wallet-a")
+        let mainnetWalletA = JoinDashPayDismissalScope.storageKey(
+            networkRawValue: WalletEnvironment.NetworkKind.mainnet.rawValue,
+            walletIdHex: "wallet-a")
+        let testnetWalletB = JoinDashPayDismissalScope.storageKey(
+            networkRawValue: WalletEnvironment.NetworkKind.testnet.rawValue,
+            walletIdHex: "wallet-b")
+
+        XCTAssertNotEqual(testnetWalletA, mainnetWalletA)
+        XCTAssertNotEqual(testnetWalletA, testnetWalletB)
+        XCTAssertEqual(
+            testnetWalletA,
+            JoinDashPayDismissalScope.storageKey(
+                networkRawValue: WalletEnvironment.NetworkKind.testnet.rawValue,
+                walletIdHex: "wallet-a"))
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Tapping **Hide** on the "Upgrade to DashPay — Your Shielded balance is ready" banner did **nothing** — the banner stayed (reported as SB-8 during shielded-balance testing). Two causes:
1. `UsernamePrefs.joinDashPayDismissed` cached the value in an in-memory scalar and stored it under a **global** key — stale after a network round-trip and leaking between Mainnet/Testnet.
2. `HomeViewModel` only honored the dismissal when the wallet **already had an identity** (`identityScopedDismissal = hasIdentity && dismissed`). But the banner shows precisely when the user has **no** identity yet ("register your username"), so Hide was ignored in exactly the case it's offered.

## What was done?
- **Persist the dismissal per active wallet + network** (`JoinDashPayDismissalScope` → key `joinDashPayDismissed.v2.<network>.<wallet>`), reading/writing `UserDefaults` directly (no stale in-memory scalar). This keeps the choice attached to the wallet/network where it was made and survives readiness re-evaluation and leaving/returning to the network.
- **Honor the dismissal unconditionally** in banner visibility via a testable `JoinDashPayBannerPolicy.shouldShow(contextReady:syncDone:dismissed:hasRegisteredUsername:hasRegistrationInProgress:)` — no longer gated on `hasIdentity`, so Hide works before an identity exists.
- Added `SwiftDashSDKCoreLifecycleTests` cases for the banner policy.

## How Has This Been Tested?
Manual, testnet: tapping Hide on the Upgrade-to-DashPay banner now dismisses it immediately and it stays hidden across shielded-readiness re-evaluations and network round-trips within the session. Upgrade still works; Hide and Upgrade are independent. (Unit-test target is pre-existing broken; the added tests are compile-ready.)

## Breaking Changes
None. New scoped key (`.v2.`) — a prior global dismissal simply isn't read; the banner reappears once and can be re-hidden, now persistently.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone