### PR TITLE
Migrate Coinbase transfer amount balance to SwiftDashSDK

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -18,9 +18,11 @@ selection, and xpub export no longer depend on live DashSync wallet state.
 DashSync is still linked for three bounded tails:
 
 1. **Apple Watch phone bridge** — the targets and bridge remain; transaction
-   payload formatting still reads `DSAccount`/`DSTransaction`. The watch app is
-   not embedded by either app target on this branch. Watch was deliberately
-   untouched and is out of scope for the invitation/profile tail.
+   payload formatting still reads `DSAccount`/`DSTransaction`. `dashwallet`
+   still builds the Watch app dependency (and therefore requires a matching
+   local Watch simulator runtime); `dashpay` does not. Watch was deliberately
+   untouched and still requires the remove-or-port decision described in the
+   teardown plan.
 2. **C6-E wallet-registry teardown** — create/recover still dual-write a
    `DSWallet`; wipe clears both stores; `WalletEnvironment.hasWallet` includes
    the DashSync registry; `DSChainWalletsDidChangeNotification` is still
@@ -29,9 +31,11 @@ DashSync is still linked for three bounded tails:
    `DSBlockchainIdentity` registration compatibility path; active profile UI
    no longer consumes that object.
 3. **Pod-unlink mechanics and compatibility surfaces** — AppDelegate setup,
-   a dormant `DSAccount` spent-input category, one stale payment import, and
-   project/Podfile link entries. Coinbase/Uphold keychain access, reachable
-   Uphold HTTP flows, and profile-avatar networking are app-owned.
+   the `DSTransaction.h` bridging exposure retained solely for
+   `DSTransactionDirection`, non-wallet exported helpers, and project/Podfile
+   link entries. Coinbase/Uphold keychain access, reachable Uphold HTTP flows,
+   profile-avatar networking, and Coinbase transaction/balance integration are
+   app-owned.
 
 As of this audit, three app source files directly import DashSync. Counts of all
 `DS*` tokens are not a useful progress metric because app-owned names such as
@@ -99,7 +103,7 @@ Status meanings:
 | 2 | Address validation | Done | None. Uses SwiftDashSDK address validation through app-owned parsing helpers. |
 | 3 | Mnemonic generation / create wallet | Done; teardown tail | SDK-owned mnemonic storage is verified before a wallet becomes live in `PlatformWalletManager`; remove the adjacent `DSWallet standardWalletWithSeedPhrase` dual-write in C6-E. |
 | 4 | Mnemonic validation | Done | None. Uses `Mnemonic.validate`. |
-| 5 | Wallet balance | Done | None. Uses `SwiftDashSDKWalletState`. |
+| 5 | Wallet balance | Done | None. Production balance reads use `SwiftDashSDKWalletState`; Coinbase transfer amount refreshes from its SDK-backed model balance and uses the fee-aware active-wallet maximum for its leftover warning. |
 | 6 | Transaction list | Done | None. History and Coinbase transaction metadata/tagging use active-wallet-scoped SDK-persisted SwiftData rows. The obsolete `DSTransaction` UI category and spent-input `DSAccount` category are removed. |
 | 7 | Transaction detail | Done | None. Uses SDK snapshots and recent-send resolution. |
 | 8 | Send Dash | Done | None. Money movement goes through `WalletSendService` / `SwiftDashSDKTransactionSender`. |

--- a/DASHSYNC_TEARDOWN_PLAN.md
+++ b/DASHSYNC_TEARDOWN_PLAN.md
@@ -62,6 +62,11 @@ SDK-persisted transaction snapshot and refresh from SwiftData/app-owned wallet
 events. The obsolete `DSTransaction+DashWallet` and spent-input `DSAccount`
 categories plus the stale payment-processor import were removed.
 
+Coinbase transfer amount now refreshes from the SDK-backed balance published by
+its amount model and uses the active wallet's fee-aware maximum for the
+CrowdNode leftover warning. Its dead `DWEnvironment.currentAccount` protocol
+fallback and legacy balance notification observer were removed.
+
 `DWUploadAvatarModel` keeps its public Objective-C/KVO contract and automatic
 start, but delegates Imgur delete/upload to an internal Moya/`HTTPClient`
 client. It preserves resize/JPEG settings, delete retries, delete-before-upload,

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1158,6 +1158,7 @@
 		C05FA6CE3DDE2D0327D334E5 /* CoinJoinRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478AD92C1F1C11D09645DF4 /* CoinJoinRecovery.swift */; };
 		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
 		CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */; };
+		CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */; };
 		C124DF94278D4238FAE0975D /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		C1A0B2C3D4E5F60718293A02 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
 		C1A0B2C3D4E5F60718293A03 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
@@ -3150,6 +3151,7 @@
 		C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderPreviewFeeRow.swift; sourceTree = "<group>"; };
 		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
 		CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransactionMetadataTests.swift; sourceTree = "<group>"; };
+		CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransferAmountTests.swift; sourceTree = "<group>"; };
 		C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsBarView.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D8E9F01234 /* TransferAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountView.swift; sourceTree = "<group>"; };
 		C3DAD266246AA6F10001624F /* DWScreenshotWarningViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWScreenshotWarningViewController.h; sourceTree = "<group>"; };
@@ -7072,6 +7074,7 @@
 				B7C072AA26C7000000000002 /* DWContestedNameStatusServiceTests.swift */,
 				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
 				CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */,
+				CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */,
 				AA0003032CA0F58E00A1B402 /* SwapAddressValidatorTests.swift */,
 				AA00F1002FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift */,
 				AA00100D2CA0B10001A0B10D /* SwapKitQuoteDecodingTests.swift */,
@@ -10228,6 +10231,7 @@
 				B7C072AA26C7000000000001 /* DWContestedNameStatusServiceTests.swift in Sources */,
 				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
 				CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */,
+				CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */,
 				AA0003042CA0F58E00A1B402 /* SwapAddressValidatorTests.swift in Sources */,
 				AA00F1012FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift in Sources */,
 				AA00100E2CA0B10001A0B10E /* SwapKitQuoteDecodingTests.swift in Sources */,

--- a/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountViewModel.swift
+++ b/DashWallet/Sources/UI/Coinbase/Transfer Amount/TransferAmountViewModel.swift
@@ -207,12 +207,14 @@ final class TransferAmountViewModel: ObservableObject, TransferAmountViewModelPr
     // MARK: Private
 
     private func observeWalletBalance() {
-        NotificationCenter.default
-            .publisher(for: NSNotification.Name.DSWalletBalanceDidChange)
+        model.$walletBalance
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.syncCanContinue()
-                self?.refreshSourceItems()
+                guard let self else { return }
+                self.model.rebuildAmounts()
+                self.syncCanContinue()
+                self.syncError()
+                self.refreshSourceItems()
             }
             .store(in: &cancellables)
     }
@@ -302,13 +304,12 @@ final class TransferAmountViewModel: ObservableObject, TransferAmountViewModelPr
     }
 
     private func performLeftoverCheck(completion: @escaping (Bool) -> Void) {
-        if CrowdNodeDefaults.shared.lastKnownBalance <= 0 {
-            completion(true)
-            return
-        }
-        let account = DWEnvironment.sharedInstance().currentAccount
-        let allAvailableFunds = account.maxOutputAmount
-        if (model.amount?.plainAmount ?? 0) + CrowdNode.minimumLeftoverBalance > allAvailableFunds {
+        let requiresWarning = Self.requiresLeftoverWarning(
+            crowdNodeBalance: CrowdNodeDefaults.shared.lastKnownBalance,
+            transferAmount: model.amount?.plainAmount ?? 0,
+            minimumLeftover: CrowdNode.minimumLeftoverBalance,
+            maxSendable: SwiftDashSDKWalletState.shared.feeAwareMaxSendable())
+        if requiresWarning {
             if let handler = onNeedsLeftoverWarning {
                 handler(completion)
             } else {
@@ -317,6 +318,17 @@ final class TransferAmountViewModel: ObservableObject, TransferAmountViewModelPr
         } else {
             completion(true)
         }
+    }
+
+    static func requiresLeftoverWarning(
+        crowdNodeBalance: UInt64,
+        transferAmount: UInt64,
+        minimumLeftover: UInt64,
+        maxSendable: UInt64
+    ) -> Bool {
+        guard crowdNodeBalance > 0 else { return false }
+        guard maxSendable >= minimumLeftover else { return true }
+        return transferAmount > maxSendable - minimumLeftover
     }
 
     private static func makeSourceItem(from provider: SourceViewDataProvider?, dashBalance: Int64, fiat: String) -> TransferSourceItem {

--- a/DashWallet/Sources/UI/Payments/Amount/SendAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/SendAmountViewController.swift
@@ -34,45 +34,6 @@ extension SendAmountFlowSupporting {
 
         return true
     }
-
-    func checkLeftoverBalance(isCrowdNodeTransfer: Bool = false, completion: @escaping (Bool) -> Void) {
-        if CrowdNodeDefaults.shared.lastKnownBalance <= 0 && !isCrowdNodeTransfer {
-            completion(true)
-            return
-        }
-
-        let account = DWEnvironment.sharedInstance().currentAccount
-        let allAvailableFunds = account.maxOutputAmount
-
-        if sendAmountSupportModel.amount.plainAmount + CrowdNode.minimumLeftoverBalance > allAvailableFunds {
-            let title = NSLocalizedString("Looks like you are emptying your Dash Wallet", comment: "Leftover balance warning")
-            let message = String.localizedStringWithFormat(
-                NSLocalizedString(
-                    "Please note, you will not be able to withdraw your funds from CrowdNode to this wallet until you increase your balance to %@ Dash.",
-                    comment: "Leftover balance warning"
-                ),
-                CrowdNode.minimumLeftoverBalance.formattedDashAmountWithoutCurrencySymbol
-            )
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(
-                UIAlertAction(
-                    title: NSLocalizedString("Continue", comment: "Leftover balance warning"),
-                    style: .default,
-                    handler: { _ in completion(true) }
-                )
-            )
-            alert.addAction(
-                UIAlertAction(
-                    title: NSLocalizedString("Cancel", comment: "Leftover balance warning"),
-                    style: .cancel,
-                    handler: { _ in completion(false) }
-                )
-            )
-            present(alert, animated: true)
-        } else {
-            completion(true)
-        }
-    }
 }
 
 // MARK: - SendAmountViewController

--- a/DashWalletTests/CoinbaseTransferAmountTests.swift
+++ b/DashWalletTests/CoinbaseTransferAmountTests.swift
@@ -1,0 +1,123 @@
+//
+//  CoinbaseTransferAmountTests.swift
+//  DashWalletTests
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+
+import Combine
+import XCTest
+@testable import dashwallet
+
+@MainActor
+final class CoinbaseTransferAmountTests: XCTestCase {
+
+    func testNoCrowdNodeBalanceDoesNotRequireWarning() {
+        XCTAssertFalse(
+            TransferAmountViewModel.requiresLeftoverWarning(
+                crowdNodeBalance: 0,
+                transferAmount: UInt64.max,
+                minimumLeftover: 30_000,
+                maxSendable: 0))
+    }
+
+    func testAmountExactlyAtLeftoverThresholdDoesNotRequireWarning() {
+        XCTAssertFalse(
+            TransferAmountViewModel.requiresLeftoverWarning(
+                crowdNodeBalance: 1,
+                transferAmount: 70_000,
+                minimumLeftover: 30_000,
+                maxSendable: 100_000))
+    }
+
+    func testAmountAboveLeftoverThresholdRequiresWarning() {
+        XCTAssertTrue(
+            TransferAmountViewModel.requiresLeftoverWarning(
+                crowdNodeBalance: 1,
+                transferAmount: 70_001,
+                minimumLeftover: 30_000,
+                maxSendable: 100_000))
+    }
+
+    func testMaxSendableBelowMinimumLeftoverRequiresWarning() {
+        XCTAssertTrue(
+            TransferAmountViewModel.requiresLeftoverWarning(
+                crowdNodeBalance: 1,
+                transferAmount: 0,
+                minimumLeftover: 30_000,
+                maxSendable: 29_999))
+    }
+
+    func testLargeTransferAmountDoesNotOverflow() {
+        XCTAssertTrue(
+            TransferAmountViewModel.requiresLeftoverWarning(
+                crowdNodeBalance: 1,
+                transferAmount: UInt64.max,
+                minimumLeftover: 1,
+                maxSendable: UInt64.max))
+    }
+
+    func testSyntheticSDKBalanceRefreshesDisplayedBalanceAndValidation() async {
+        let walletState = SwiftDashSDKWalletState.shared
+        walletState.clearAllState()
+
+        let viewModel = TransferAmountViewModel()
+        viewModel.switchDirection()
+        let separator = Locale.current.decimalSeparator ?? "."
+        viewModel.setInput("0\(separator)00001")
+        XCTAssertFalse(viewModel.canContinue)
+
+        let balanceExpectation = expectation(description: "SDK balance reaches Coinbase transfer UI")
+        let cancellable = viewModel.$fromItem
+            .filter { $0.dashBalance == 2_000 }
+            .prefix(1)
+            .sink { _ in balanceExpectation.fulfill() }
+
+        walletState.applyBalance(WalletBalance(confirmed: 2_000))
+
+        await fulfillment(of: [balanceExpectation], timeout: 2)
+        XCTAssertTrue(viewModel.canContinue)
+        withExtendedLifetime(cancellable) {}
+        walletState.clearAllState()
+    }
+
+    func testClearAndReseedReplacePreviousWalletBalance() async {
+        let walletState = SwiftDashSDKWalletState.shared
+        walletState.clearAllState()
+
+        let viewModel = TransferAmountViewModel()
+        viewModel.switchDirection()
+
+        await applyBalance(9_000, expecting: 9_000, in: viewModel, walletState: walletState)
+
+        let clearExpectation = expectation(description: "Previous wallet balance clears")
+        let clearCancellable = viewModel.$fromItem
+            .filter { $0.dashBalance == 0 }
+            .prefix(1)
+            .sink { _ in clearExpectation.fulfill() }
+        walletState.clearAllState()
+        await fulfillment(of: [clearExpectation], timeout: 2)
+        withExtendedLifetime(clearCancellable) {}
+
+        await applyBalance(4_000, expecting: 4_000, in: viewModel, walletState: walletState)
+        walletState.clearAllState()
+    }
+
+    private func applyBalance(
+        _ confirmed: UInt64,
+        expecting expectedBalance: Int64,
+        in viewModel: TransferAmountViewModel,
+        walletState: SwiftDashSDKWalletState
+    ) async {
+        let expectation = expectation(description: "Displayed balance becomes \(expectedBalance)")
+        let cancellable = viewModel.$fromItem
+            .filter { $0.dashBalance == expectedBalance }
+            .prefix(1)
+            .sink { _ in expectation.fulfill() }
+
+        walletState.applyBalance(WalletBalance(confirmed: confirmed))
+
+        await fulfillment(of: [expectation], timeout: 2)
+        withExtendedLifetime(cancellable) {}
+    }
+}


### PR DESCRIPTION
## Summary

- observe the SDK-backed wallet balance in Coinbase Transfer Amount and revalidate the open screen when it changes
- use the active wallet fee-aware maximum for the CrowdNode leftover warning with overflow-safe threshold logic
- remove the dead DWEnvironment.currentAccount fallback and add focused balance/warning tests
- update the DashSync migration and teardown documentation

## Verification

- git diff --check
- plutil lint for the Xcode project and available Coinbase plist
- Swift parser check for the changed production and test files
- DashSync ownership audit greps
- focused tests/builds were attempted, but local Xcode verification is blocked by the missing Watch runtime 23S303 for SDK 23T570 and missing local ZenLedger/Uphold/Topper plist files; the clean baseline comparison also exhausted local disk before completing

## Manual smoke

- wallet to Coinbase: balance, Max, Continue, and a live balance update
- active-wallet switch clears the previous wallet balance
- CrowdNode warning: no balance, exact threshold, Continue, and Cancel
- Coinbase to wallet and 2FA remain unchanged