### PR TITLE
fix(coinbase): Fix Coinbase metadata wallet context

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -20,7 +20,8 @@ DashSync is still linked for three bounded tails:
 1. **Apple Watch phone bridge** — the targets and bridge remain; transaction
    payload formatting still reads `DSAccount`/`DSTransaction`. The watch app is
    not embedded by either app target on this branch. Watch was deliberately
-   untouched and is out of scope for the invitation/profile tail.
+   untouched and still requires the remove-or-port decision described in the
+   teardown plan.
 2. **C6-E wallet-registry teardown** — create/recover still dual-write a
    `DSWallet`; wipe clears both stores; `WalletEnvironment.hasWallet` includes
    the DashSync registry; `DSChainWalletsDidChangeNotification` is still
@@ -29,9 +30,10 @@ DashSync is still linked for three bounded tails:
    `DSBlockchainIdentity` registration compatibility path; active profile UI
    no longer consumes that object.
 3. **Pod-unlink mechanics and compatibility surfaces** — AppDelegate setup,
-   a dormant `DSAccount` spent-input category, one stale payment import, and
-   project/Podfile link entries. Coinbase/Uphold keychain access, reachable
-   Uphold HTTP flows, and profile-avatar networking are app-owned.
+   the `DSTransaction.h` bridging exposure retained solely for
+   `DSTransactionDirection`, non-wallet exported helpers, and project/Podfile
+   link entries. Coinbase/Uphold keychain access, reachable Uphold HTTP flows,
+   profile-avatar networking, and Coinbase transaction metadata are app-owned.
 
 As of this audit, three app source files directly import DashSync. Counts of all
 `DS*` tokens are not a useful progress metric because app-owned names such as

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKReceiveAddressReader.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKReceiveAddressReader.swift
@@ -56,7 +56,14 @@ final class SwiftDashSDKReceiveAddressReader: NSObject {
     /// network at the time `start(network:)` ran.
     @objc
     static func receiveAddress() -> String? {
-        onMain { readOnMain() }
+        receiveDestination()?.address
+    }
+
+    /// The receive address and wallet id captured from the same host-bound
+    /// wallet. Swift callers that retain work across wallet switches use this
+    /// to keep the destination tied to its originating wallet.
+    static func receiveDestination() -> (address: String, walletId: Data)? {
+        onMain { readDestinationOnMain() }
     }
 
     // MARK: Request-amount receive detection (DWReceiveModel)
@@ -121,13 +128,14 @@ final class SwiftDashSDKReceiveAddressReader: NSObject {
     }
 
     @MainActor
-    private static func readOnMain() -> String? {
+    private static func readDestinationOnMain() -> (address: String, walletId: Data)? {
         guard let wallet = SwiftDashSDKHost.shared.wallet else {
             Self.logger.warning("📬 RECVADDR :: host has no wallet yet")
             return nil
         }
         do {
-            return try wallet.coreWallet().nextReceiveAddress(accountIndex: 0)
+            let address = try wallet.coreWallet().nextReceiveAddress(accountIndex: 0)
+            return (address, wallet.walletId)
         } catch {
             Self.logger.warning(
                 "📬 RECVADDR :: nextReceiveAddress failed: \(String(describing: error), privacy: .public)")

--- a/DashWallet/Sources/Models/Coinbase/Accounts/Account/CBAccount.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/Account/CBAccount.swift
@@ -104,9 +104,11 @@ extension CBAccount {
 
 // MARK: Transfer
 extension CBAccount {
-    public func send(amount: UInt64, verificationCode: String?, idem: UUID?) async throws -> CoinbaseTransaction {
+    public func send(amount: UInt64,
+                     verificationCode: String?,
+                     idem: UUID?) async throws -> (transaction: CoinbaseTransaction, walletId: Data) {
         // NOTE: Maybe better to get the address once and use it during the tx flow
-        guard let dashWalletAddress = SwiftDashSDKReceiveAddressReader.receiveAddress() else {
+        guard let destination = SwiftDashSDKReceiveAddressReader.receiveDestination() else {
             fatalError("No wallet")
         }
 
@@ -132,7 +134,7 @@ extension CBAccount {
         do {
             try await authInterop.refreshTokenIfNeeded()
             let dto = CoinbaseTransactionsRequest(type: .send,
-                                                  to: dashWalletAddress,
+                                                  to: destination.address,
                                                   amount: coinbaseAmount,
                                                   currency: kDashCurrency,
                                                   idem: currentIdem.uuidString.lowercased(),
@@ -142,7 +144,7 @@ extension CBAccount {
                 .request(.sendCoinsToWallet(accountId: accountId, verificationCode: verificationCode, dto: dto))
             let _ = try? await refreshAccount() // Ignore if fails
 
-            return result.data
+            return (result.data, destination.walletId)
         } catch HTTPClientError.statusCode(let r) where r.statusCode == 400 {
             DWLogger.log("Tranfer from coinbase: transferToWallet - failure - statusCode - 400")
             if let err = r.error?.errors.first {

--- a/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/AccountService.swift
@@ -57,11 +57,13 @@ class AccountService {
         return try await account.retrieveAddress()
     }
 
-    public func send(from accountName: String, amount: UInt64, verificationCode: String?, idem: UUID?) async throws -> CoinbaseTransaction {
+    public func send(from accountName: String,
+                     amount: UInt64,
+                     verificationCode: String?,
+                     idem: UUID?) async throws -> (transaction: CoinbaseTransaction, walletId: Data) {
         let account = try await account(by: accountName)
 
-        let tx = try await account.send(amount: amount, verificationCode: verificationCode, idem: idem)
-        return tx
+        return try await account.send(amount: amount, verificationCode: verificationCode, idem: idem)
     }
 
     public func placeBuyOrder(for accountName: String, amount: UInt64) async throws -> CoinbasePlaceBuyOrder {

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -163,9 +163,15 @@ extension Coinbase {
                                                  verificationCode: String?,
                                                  idem: UUID?) async throws -> CoinbaseTransaction {
         do {
-            let tx = try await accountService.send(from: kDashAccount, amount: amount, verificationCode: verificationCode, idem: idem)
+            let (tx, walletId) = try await accountService.send(
+                from: kDashAccount,
+                amount: amount,
+                verificationCode: verificationCode,
+                idem: idem)
 
-            CoinbaseTransactionMetadataTagger.shared.track(receivedTransfer: tx)
+            CoinbaseTransactionMetadataTagger.shared.track(
+                receivedTransfer: tx,
+                walletId: walletId)
 
             if let address = tx.to?.address {
                 Taxes.shared.mark(address: address, with: .transferIn)
@@ -450,36 +456,45 @@ final class CoinbaseTransactionMetadataTagger {
             .store(in: &cancellables)
     }
 
-    func track(receivedTransfer transaction: CoinbaseTransaction) {
+    func track(receivedTransfer transaction: CoinbaseTransaction, walletId: Data) {
         if let walletTxHash = Self.walletTxHashData(from: transaction.network?.hash) {
             markCoinbaseTransaction(txHash: walletTxHash)
             return
         }
 
-        guard let address = transaction.to?.address?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !address.isEmpty,
-              let amount = coinbaseDashAmount(from: transaction.amount),
-              amount > 0 else {
-            return
-        }
-
-        let minimumTimestamp = coinbaseTimestamp(from: transaction.createdAt)
-            ?? (Date().timeIntervalSince1970 - Self.receiveLookbackWindow)
-
-        guard let walletId = CoinbaseWalletTransactionSnapshot.current()?.walletId else {
+        guard let pendingTransfer = Self.pendingReceiveTransfer(
+            from: transaction,
+            walletId: walletId) else {
             return
         }
 
         queue.async { [weak self] in
             guard let self else { return }
-            self.pendingReceiveTransfers.append(
-                CoinbasePendingReceiveTransfer(
-                    walletId: walletId,
-                    address: address,
-                    amount: amount,
-                    minimumTimestamp: minimumTimestamp))
+            self.pendingReceiveTransfers.append(pendingTransfer)
             self.resolvePendingReceiveTransfersOnQueue()
         }
+    }
+
+    static func pendingReceiveTransfer(
+        from transaction: CoinbaseTransaction,
+        walletId: Data,
+        now: Date = Date()
+    ) -> CoinbasePendingReceiveTransfer? {
+        guard let address = transaction.to?.address?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !address.isEmpty,
+              let amount = coinbaseDashAmount(from: transaction.amount),
+              amount > 0 else {
+            return nil
+        }
+
+        let minimumTimestamp = coinbaseTimestamp(from: transaction.createdAt)
+            ?? (now.timeIntervalSince1970 - Self.receiveLookbackWindow)
+
+        return CoinbasePendingReceiveTransfer(
+            walletId: walletId,
+            address: address,
+            amount: amount,
+            minimumTimestamp: minimumTimestamp)
     }
 
     // txidWire follows the `Transaction.txHashData` convention (wire-order txid),
@@ -526,7 +541,7 @@ final class CoinbaseTransactionMetadataTagger {
         return Data(data.reversed())
     }
 
-    private func coinbaseDashAmount(from amount: Amount?) -> UInt64? {
+    private static func coinbaseDashAmount(from amount: Amount?) -> UInt64? {
         guard let amountString = amount?.amount,
               let decimal = Decimal(string: amountString, locale: Locale(identifier: "en_US_POSIX")) else {
             return nil
@@ -535,7 +550,7 @@ final class CoinbaseTransactionMetadataTagger {
         return decimal.plainDashAmount
     }
 
-    private func coinbaseTimestamp(from createdAt: String?) -> TimeInterval? {
+    private static func coinbaseTimestamp(from createdAt: String?) -> TimeInterval? {
         guard let createdAt = createdAt?.trimmingCharacters(in: .whitespacesAndNewlines),
               !createdAt.isEmpty else {
             return nil

--- a/DashWallet/Sources/UI/Home/Tx Metadata/CoinbaseMetadataProvider.swift
+++ b/DashWallet/Sources/UI/Home/Tx Metadata/CoinbaseMetadataProvider.swift
@@ -72,6 +72,7 @@ final class CoinbaseMetadataProvider: MetadataProvider, @unchecked Sendable {
 
         NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
             .receive(on: DispatchQueue.main)
+            .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] _ in
                 Task {
                     await self?.refreshMetadata()

--- a/DashWalletTests/CoinbaseTransactionMetadataTests.swift
+++ b/DashWalletTests/CoinbaseTransactionMetadataTests.swift
@@ -91,9 +91,23 @@ final class CoinbaseTransactionMetadataTests: XCTestCase {
         XCTAssertEqual(resolution.unresolved, [pending])
     }
 
-    func testUnmatchedTransferCanResolveOnLaterSnapshot() {
+    func testFallbackTransferKeepsOriginatingWalletIdUntilLaterSnapshot() throws {
         let walletId = Data([0x01])
-        let pending = makePending(walletId: walletId)
+        let response = Data(
+            """
+            {
+              "amount": { "amount": "0.00000100", "currency": "DASH" },
+              "created_at": "1970-01-01T00:01:40Z",
+              "to": { "address": "Xreceive" }
+            }
+            """.utf8)
+        let transaction = try JSONDecoder().decode(CoinbaseTransaction.self, from: response)
+        let pending = try XCTUnwrap(
+            CoinbaseTransactionMetadataTagger.pendingReceiveTransfer(
+                from: transaction,
+                walletId: walletId))
+        XCTAssertEqual(pending.walletId, walletId)
+
         let emptySnapshot = CoinbaseWalletTransactionSnapshot(
             walletId: walletId,
             transactions: [])


### PR DESCRIPTION
## Summary

- capture the Dash receive address and wallet ID atomically, then carry that wallet context through the Coinbase send response
- retain fallback Coinbase transfers for their originating wallet across runtime rebuilds without fetching a full snapshot while tracking
- throttle metadata refreshes triggered by Core Data saves and correct the migration ledger left stale by #902

Follow-up to #902. The public `transferFromCoinbaseToDashWallet` API and direct `network.hash` behavior remain unchanged.

## Validation

- `git diff --check`
- `plutil -lint DashWallet.xcodeproj/project.pbxproj`
- `dashpay` Debug build for arm64 iOS Simulator
- Focused `CoinbaseTransactionMetadataTests` and the `dashwallet` build are blocked before app compilation by the local watchOS runtime mismatch: runtime `23S303` is unavailable for watch simulator SDK `23T570`.
