### PR TITLE
Migrate passive wallet state UI tail from DashSync

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -99,18 +99,18 @@ Status meanings:
 
 | # | Capability | Current status | Remaining work |
 |---|---|---|---|
-| 1 | Receive address | Done | None. Reads the active SDK wallet/account. |
+| 1 | Receive address | Done | None. Reads the active SDK wallet/account; Explore resolves the testnet faucet address from the active SDK wallet at action time. |
 | 2 | Address validation | Done | None. Uses SwiftDashSDK address validation through app-owned parsing helpers. |
 | 3 | Mnemonic generation / create wallet | Done; teardown tail | SDK-owned mnemonic storage is verified before a wallet becomes live in `PlatformWalletManager`; remove the adjacent `DSWallet standardWalletWithSeedPhrase` dual-write in C6-E. |
 | 4 | Mnemonic validation | Done | None. Uses `Mnemonic.validate`. |
-| 5 | Wallet balance | Done | None. Production balance reads use `SwiftDashSDKWalletState`; Coinbase transfer amount refreshes from its SDK-backed model balance and uses the fee-aware active-wallet maximum for its leftover warning. |
+| 5 | Wallet balance | Done | None. Production balance reads use `SwiftDashSDKWalletState`; Home reloads transaction projections only for distinct post-subscription balance changes, while `BalanceModel` binds directly to the SDK publisher. Coinbase transfer amount refreshes from its SDK-backed model balance and uses the fee-aware active-wallet maximum for its leftover warning. |
 | 6 | Transaction list | Done | None. History and Coinbase transaction metadata/tagging use active-wallet-scoped SDK-persisted SwiftData rows. The obsolete `DSTransaction` UI category and spent-input `DSAccount` category are removed. |
 | 7 | Transaction detail | Done | None. Uses SDK snapshots and recent-send resolution. |
 | 8 | Send Dash | Done | None. Money movement goes through `WalletSendService` / `SwiftDashSDKTransactionSender`. |
 | 9 | Fee estimation | Done | None. Confirmation uses the transaction builder's fee. |
 | 10 | PIN / biometrics | Done; teardown tail | Authentication, lockout copy/duration formatting, and secure mnemonic allocation are app-owned; retain the byte-compatible keychain contract through pod unlink. |
 | 11 | SPV sync | Done; teardown tail | Core restart/peer rotation is serialized `stopSpv → startSpv` on the existing manager, preserving Platform sync, wallet state and the process-cached per-network `ModelContainer`; clear-and-resync deletes the chain store off MainActor on the next process launch. Remove `setupDashSyncOnce` / `DSOptionsManager` at unlink; the chain-wallet notification is removed separately with C6-E. |
-| 12 | Network switch | Done; teardown tail | Remove the temporary DashSync wallet-registry mirror with C6-E. |
+| 12 | Network switch | Done; teardown tail | Explore and Buy/Sell gating use app-owned `WalletEnvironment` network state. Remove the temporary DashSync wallet-registry mirror with C6-E. |
 | 13 | Backup seed phrase | Done | Reads the active SDK wallet mnemonic from host-owned storage. |
 | 14 | Wipe wallet | Done; teardown tail | Reinstall recovery and Settings Debug Reset both gate onboarding behind the background wipe executor's explicit success result; per-wallet SDK deletion remains synchronous, and a failed delete preserves mnemonic/runtime state and the in-memory identity snapshot for retry. After a successful wipe the stopped runtime installs an empty identity snapshot and publishes the wallet-context change; a newly started wallet publishes the same event, rebuilding the DashPay tab bar as 3 or 5 items from that wallet's identity state. Remove the DashSync registry/Core Data wipe arm after all consumers are gone. |
 | 15 | Provider-key derivation | Done | All four families are SDK-native: Owner/Voting via the key-wallet path surface, Operator (BLS) and Evonode Operator (Ed25519) via `ManagedPlatformWallet.providerKeyAtIndex` (`platform_wallet_provider_key_at_index` grew per-index BLS/EdDSA public-key export, removing the earlier blocker). Overview counts and per-keypair “used at” restored from the Rust masternode aggregation (`PlatformWalletManager.masternodes(for:)`). |

--- a/DASHSYNC_TEARDOWN_PLAN.md
+++ b/DASHSYNC_TEARDOWN_PLAN.md
@@ -67,6 +67,12 @@ its amount model and uses the active wallet's fee-aware maximum for the
 CrowdNode leftover warning. Its dead `DWEnvironment.currentAccount` protocol
 fallback and legacy balance notification observer were removed.
 
+The passive Home, Explore, and Buy/Sell UI tail is app/SDK-owned. Home and its
+balance model consume `SwiftDashSDKWalletState`; Explore resolves the active SDK
+receive address at faucet action time; and Explore/Buy-Sell network gating uses
+`WalletEnvironment`. Their scoped legacy balance and `DWEnvironment` consumers
+were removed without changing network/wallet lifecycle notifications.
+
 `DWUploadAvatarModel` keeps its public Objective-C/KVO contract and automatic
 start, but delegates Imgur delete/upload to an internal Moya/`HTTPClient`
 client. It preserves resize/JPEG settings, delete retries, delete-before-upload,
@@ -111,9 +117,11 @@ but it is not an acceptable final migration or release pin.
 
 **Decision:** remove or port.
 
-The Watch targets still exist, but the phone app does not embed WatchApp on
-this branch. `DWPhoneWCSessionManager` and `DSWatchTransactionDataObject` still
-depend on frozen DashSync account/transaction state.
+The Watch targets still exist. `dashwallet` still has and builds a WatchApp
+target dependency, although its Embed Watch Content phase is empty; `dashpay`
+has no Watch dependency. `DWPhoneWCSessionManager` and
+`DSWatchTransactionDataObject` still depend on frozen DashSync
+account/transaction state.
 
 - **Remove:** delete Watch targets, `Sources/AppleWatch`, Podfile watch targets,
   and phone hooks.

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1159,6 +1159,7 @@
 		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
 		CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */; };
 		CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */; };
+		CB9200022FE3000000000002 /* PassiveWalletStateUITailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9200012FE3000000000001 /* PassiveWalletStateUITailTests.swift */; };
 		C124DF94278D4238FAE0975D /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		C1A0B2C3D4E5F60718293A02 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
 		C1A0B2C3D4E5F60718293A03 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
@@ -3152,6 +3153,7 @@
 		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
 		CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransactionMetadataTests.swift; sourceTree = "<group>"; };
 		CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransferAmountTests.swift; sourceTree = "<group>"; };
+		CB9200012FE3000000000001 /* PassiveWalletStateUITailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassiveWalletStateUITailTests.swift; sourceTree = "<group>"; };
 		C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsBarView.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D8E9F01234 /* TransferAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountView.swift; sourceTree = "<group>"; };
 		C3DAD266246AA6F10001624F /* DWScreenshotWarningViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWScreenshotWarningViewController.h; sourceTree = "<group>"; };
@@ -7075,6 +7077,7 @@
 				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
 				CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */,
 				CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */,
+				CB9200012FE3000000000001 /* PassiveWalletStateUITailTests.swift */,
 				AA0003032CA0F58E00A1B402 /* SwapAddressValidatorTests.swift */,
 				AA00F1002FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift */,
 				AA00100D2CA0B10001A0B10D /* SwapKitQuoteDecodingTests.swift */,
@@ -10232,6 +10235,7 @@
 				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
 				CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */,
 				CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */,
+				CB9200022FE3000000000002 /* PassiveWalletStateUITailTests.swift in Sources */,
 				AA0003042CA0F58E00A1B402 /* SwapAddressValidatorTests.swift in Sources */,
 				AA00F1012FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift in Sources */,
 				AA00100E2CA0B10001A0B10E /* SwapKitQuoteDecodingTests.swift in Sources */,

--- a/DashWallet/Sources/UI/Buy Sell/BuySellPortalViewController.swift
+++ b/DashWallet/Sources/UI/Buy Sell/BuySellPortalViewController.swift
@@ -142,7 +142,10 @@ final class BuySellPortalViewController: UIViewController, NavigationBarDisplaya
             showCoinbase: CoinbaseDataSource.shouldShow(),
             // Dash DEX swaps real assets — mainnet only, and only when the SwapKit API key
             // is configured. Mirrors ServiceDataProvider.shouldShow(.swapKit).
-            showSwapKit: DWEnvironment.sharedInstance().currentChain.isMainnet() && SwapKitConstants.isConfigured,
+            showSwapKit: ServiceDataProviderImpl.shouldShow(
+                service: .swapKit,
+                isMainnet: WalletEnvironment.isMainnet,
+                swapKitConfigured: SwapKitConstants.isConfigured),
             model: model,
             onBack: { [weak self] in
                 guard let self else { return }

--- a/DashWallet/Sources/UI/Buy Sell/Model/BuySellPortalModel.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Model/BuySellPortalModel.swift
@@ -94,18 +94,6 @@ class BuySellPortalModel: ObservableObject, NetworkReachabilityHandling {
 
     @Published var items: [ServiceItem] = []
 
-    var services: [Service] {
-        Service.allCases.filter { service in
-            switch service {
-            case .swapKit:
-                return DWEnvironment.sharedInstance().currentChain.isMainnet() && SwapKitConstants.isConfigured
-            case .maya:
-                return DWEnvironment.sharedInstance().currentChain.isMainnet()
-            default:
-                return true
-            }
-        }
-    }
     private var upholdDashCard: DWUpholdCardObject?
 
     private var serviceItemDataProvider: ServiceDataProvider

--- a/DashWallet/Sources/UI/Buy Sell/Model/ServiceDataProvider.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Model/ServiceDataProvider.swift
@@ -89,9 +89,20 @@ class ServiceDataProviderImpl: ServiceDataProvider {
     }
 
     private func shouldShow(service: Service) -> Bool {
+        Self.shouldShow(
+            service: service,
+            isMainnet: WalletEnvironment.isMainnet,
+            swapKitConfigured: SwapKitConstants.isConfigured)
+    }
+
+    static func shouldShow(
+        service: Service,
+        isMainnet: Bool,
+        swapKitConfigured: Bool
+    ) -> Bool {
         switch service {
         case .swapKit:
-            return DWEnvironment.sharedInstance().currentChain.isMainnet() && SwapKitConstants.isConfigured
+            return isMainnet && swapKitConfigured
         case .maya:
             // Hidden from Buy & Sell — Dash DEX (SwapKit) replaces the standalone Maya entry.
             return false

--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -25,12 +25,14 @@ struct ExploreMenuScreen: View {
     private let onShowSendPayment: () -> Void
     private let onShowReceivePayment: () -> Void
     private let onShowGiftCard: (Data) -> Void
+    private let isTestnetProvider: () -> Bool
+    private let receiveAddressProvider: () -> String?
 
     @ObservedObject private var balanceReminder = CrowdNodeBalanceReminder.shared
     @State private var showSyncingAlert = false
 
-    private var isTestnet: Bool {
-        DWEnvironment.sharedInstance().currentChain.isTestnet()
+    var shouldShowGetTestDash: Bool {
+        isTestnetProvider()
     }
 
     private var hasCrowdNodeAccount: Bool {
@@ -42,12 +44,16 @@ struct ExploreMenuScreen: View {
          showBackButton: Bool = true,
          onShowSendPayment: @escaping () -> Void,
          onShowReceivePayment: @escaping () -> Void,
-         onShowGiftCard: @escaping (Data) -> Void) {
+         onShowGiftCard: @escaping (Data) -> Void,
+         isTestnetProvider: @escaping () -> Bool = { WalletEnvironment.isTestnet },
+         receiveAddressProvider: @escaping () -> String? = { SwiftDashSDKReceiveAddressReader.receiveAddress() }) {
         self.vc = vc
         self.showBackButton = showBackButton
         self.onShowSendPayment = onShowSendPayment
         self.onShowReceivePayment = onShowReceivePayment
         self.onShowGiftCard = onShowGiftCard
+        self.isTestnetProvider = isTestnetProvider
+        self.receiveAddressProvider = receiveAddressProvider
     }
 
     var body: some View {
@@ -69,7 +75,7 @@ struct ExploreMenuScreen: View {
 
             // Menu list
             VStack(spacing: 2) {
-                if isTestnet {
+                if shouldShowGetTestDash {
                     MenuItem(
                         title: NSLocalizedString("Get Test Dash", comment: ""),
                         subtitle: NSLocalizedString("Test Dash is free and can be obtained from what is called a faucet.", comment: ""),
@@ -154,13 +160,16 @@ struct ExploreMenuScreen: View {
     }
 
     private func getTestDashAction() {
-        let account = DWEnvironment.sharedInstance().currentAccount
-        if let paymentAddress = account.receiveAddress {
+        if let paymentAddress = currentTestDashReceiveAddress() {
             UIPasteboard.general.string = paymentAddress
         }
         if let url = URL(string: "http://faucet.testnet.networks.dash.org/") {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
+    }
+
+    func currentTestDashReceiveAddress() -> String? {
+        receiveAddressProvider()
     }
 
     private func showWhereToSpend() {

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
@@ -46,12 +46,8 @@ final class BalanceModel: ObservableObject {
         isBalanceHidden = DWGlobalOptions.sharedInstance().balanceHidden
         SyncingActivityMonitor.shared.add(observer: self)
 
-        // Subscribe to SwiftDashSDKWalletState's balance publisher.
         // After M6 retired DashSync's SPV, this is the authoritative source
-        // for the home screen balance — DSWallet.balance is frozen at
-        // whatever was cached pre-M6. The DSWalletBalanceDidChange observer
-        // in `observeWallet()` is kept as a backstop and now harmlessly
-        // re-fires `reloadBalance()` (which also reads from this publisher).
+        // for the home screen balance.
         SwiftDashSDKWalletState.shared.$balance
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
@@ -67,7 +63,7 @@ final class BalanceModel: ObservableObject {
             .store(in: &cancellableBag)
 
         reloadBalance()
-        observeWallet()
+        observeAppLifecycle()
     }
 
     func hideBalanceIfNeeded() {
@@ -119,18 +115,11 @@ final class BalanceModel: ObservableObject {
 }
 
 extension BalanceModel {
-    func observeWallet() {
+    func observeAppLifecycle() {
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.hideBalanceIfNeeded()
-            }
-            .store(in: &cancellableBag)
-        
-        NotificationCenter.default.publisher(for: NSNotification.Name.DSWalletBalanceDidChange)
-            .removeDuplicates()
-            .sink { [weak self] _ in
-                self?.reloadBalance()
             }
             .store(in: &cancellableBag)
     }
@@ -177,4 +166,3 @@ extension BalanceModel {
         CurrencyExchanger.shared.fiatAmountString(for: duffs.dashAmount)
     }
 }
-

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -76,6 +76,20 @@ class HomeViewModel: ObservableObject {
     /// Throttled in `observeWallet()` so the save/balance notification storm
     /// during sync coalesces into at most one full reload per interval.
     private let txReloadRequests = PassthroughSubject<Void, Never>()
+
+    /// Converts the SDK's current-value balance publisher into actual balance
+    /// changes. The initial snapshot is already covered by the eager Home load,
+    /// while `removeDuplicates()` prevents the coordinator's repeated 1 Hz
+    /// snapshots from requesting redundant transaction-list reloads.
+    static func distinctBalanceChanges<P: Publisher>(
+        from publisher: P
+    ) -> AnyPublisher<Void, Never> where P.Output == WalletBalance?, P.Failure == Never {
+        publisher
+            .removeDuplicates()
+            .dropFirst()
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
     
     @Published private(set) var txItems: [TransactionGroup] = []
     @Published var shortcutItems: [ShortcutAction] = []
@@ -321,10 +335,11 @@ class HomeViewModel: ObservableObject {
             }
             .store(in: &cancellableBag)
 
-        // Balance changes often indicate new transactions, so reload the full
-        // transaction list, not just shortcuts. This ensures newly received or
-        // sent transactions appear in the UI promptly.
-        NotificationCenter.default.publisher(for: NSNotification.Name.DSWalletBalanceDidChange)
+        // Balance changes can precede or arrive without a SwiftData save (for
+        // example seed/clear transitions), so retain an independent trigger.
+        // Equal snapshots are filtered and the initial current-value emission
+        // is skipped because init already starts an eager full reload.
+        Self.distinctBalanceChanges(from: SwiftDashSDKWalletState.shared.$balance)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.txReloadRequests.send()

--- a/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
+++ b/DashWallet/Sources/UI/Payment Controller/Enter Amount/ProvideAmountViewController.swift
@@ -161,10 +161,6 @@ extension ProvideAmountViewController {
     }
 }
 
-extension Notification.Name {
-    static var balanceChangeNotification: NSNotification.Name { .init("DSWalletBalanceChangedNotification") }
-}
-
 struct ProvideAmountIntro<Content: View>: View {
     var destination: String? = nil
     var balanceLabel: String

--- a/DashWalletTests/PassiveWalletStateUITailTests.swift
+++ b/DashWalletTests/PassiveWalletStateUITailTests.swift
@@ -1,0 +1,154 @@
+//
+//  PassiveWalletStateUITailTests.swift
+//  DashWalletTests
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+
+import Combine
+import XCTest
+@testable import dashwallet
+
+@MainActor
+final class PassiveWalletStateUITailTests: XCTestCase {
+
+    func testHomeBalanceChangesSkipInitialAndDuplicateSnapshots() {
+        let balances = CurrentValueSubject<WalletBalance?, Never>(nil)
+        var reloadCount = 0
+        let cancellable = HomeViewModel.distinctBalanceChanges(from: balances)
+            .sink { reloadCount += 1 }
+
+        XCTAssertEqual(reloadCount, 0)
+
+        balances.send(WalletBalance(confirmed: 9_000))
+        XCTAssertEqual(reloadCount, 1)
+
+        balances.send(WalletBalance(confirmed: 9_000))
+        XCTAssertEqual(reloadCount, 1)
+
+        balances.send(WalletBalance(confirmed: 4_000))
+        XCTAssertEqual(reloadCount, 2)
+
+        balances.send(nil)
+        XCTAssertEqual(reloadCount, 3)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testBalanceModelAppliesClearsAndReseedsWithoutChangingDisplayContract() async {
+        let options = DWGlobalOptions.sharedInstance()
+        let originalBalanceHidden = options.balanceHidden
+        let originalWalletNeedsBackup = options.walletNeedsBackup
+        let originalUserHasBalance = options.userHasBalance
+        let originalBalanceChangedDate = options.balanceChangedDate
+        defer {
+            SwiftDashSDKWalletState.shared.clearAllState()
+            options.balanceHidden = originalBalanceHidden
+            options.walletNeedsBackup = originalWalletNeedsBackup
+            options.userHasBalance = originalUserHasBalance
+            options.balanceChangedDate = originalBalanceChangedDate
+        }
+
+        SwiftDashSDKWalletState.shared.clearAllState()
+        options.balanceHidden = true
+        options.walletNeedsBackup = true
+        options.userHasBalance = false
+        options.balanceChangedDate = nil
+
+        let model = BalanceModel()
+        XCTAssertTrue(model.isBalanceHidden)
+
+        await applyBalance(9_000, expecting: 9_000, in: model)
+        XCTAssertTrue(options.userHasBalance)
+        XCTAssertNotNil(options.balanceChangedDate)
+        XCTAssertTrue(model.isBalanceHidden)
+
+        let backupReminderDate = options.balanceChangedDate
+        await clearBalance(expecting: model)
+        XCTAssertFalse(options.userHasBalance)
+        XCTAssertEqual(options.balanceChangedDate, backupReminderDate)
+        XCTAssertTrue(model.isBalanceHidden)
+
+        await applyBalance(4_000, expecting: 4_000, in: model)
+        XCTAssertEqual(model.value, 4_000)
+        XCTAssertTrue(options.userHasBalance)
+        XCTAssertTrue(model.isBalanceHidden)
+    }
+
+    func testExploreUsesCurrentNetworkAndResolvesAddressForEveryAction() {
+        var isTestnet = false
+        var activeAddress: String? = "first-address"
+        let screen = ExploreMenuScreen(
+            vc: UINavigationController(),
+            onShowSendPayment: {},
+            onShowReceivePayment: {},
+            onShowGiftCard: { _ in },
+            isTestnetProvider: { isTestnet },
+            receiveAddressProvider: { activeAddress })
+
+        XCTAssertFalse(screen.shouldShowGetTestDash)
+        isTestnet = true
+        XCTAssertTrue(screen.shouldShowGetTestDash)
+        XCTAssertEqual(screen.currentTestDashReceiveAddress(), "first-address")
+
+        activeAddress = "second-address"
+        XCTAssertEqual(screen.currentTestDashReceiveAddress(), "second-address")
+    }
+
+    func testBuySellVisibilityUsesAppOwnedNetworkState() {
+        XCTAssertFalse(
+            ServiceDataProviderImpl.shouldShow(
+                service: .maya,
+                isMainnet: true,
+                swapKitConfigured: true))
+        XCTAssertFalse(
+            ServiceDataProviderImpl.shouldShow(
+                service: .maya,
+                isMainnet: false,
+                swapKitConfigured: true))
+        XCTAssertFalse(
+            ServiceDataProviderImpl.shouldShow(
+                service: .swapKit,
+                isMainnet: false,
+                swapKitConfigured: true))
+        XCTAssertFalse(
+            ServiceDataProviderImpl.shouldShow(
+                service: .swapKit,
+                isMainnet: true,
+                swapKitConfigured: false))
+        XCTAssertTrue(
+            ServiceDataProviderImpl.shouldShow(
+                service: .swapKit,
+                isMainnet: true,
+                swapKitConfigured: true))
+    }
+
+    private func applyBalance(
+        _ confirmed: UInt64,
+        expecting expectedBalance: UInt64,
+        in model: BalanceModel
+    ) async {
+        let expectation = expectation(description: "Balance becomes \(expectedBalance)")
+        let cancellable = model.$value
+            .filter { $0 == expectedBalance }
+            .prefix(1)
+            .sink { _ in expectation.fulfill() }
+
+        SwiftDashSDKWalletState.shared.applyBalance(WalletBalance(confirmed: confirmed))
+
+        await fulfillment(of: [expectation], timeout: 2)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    private func clearBalance(expecting model: BalanceModel) async {
+        let expectation = expectation(description: "Balance clears")
+        let cancellable = model.$value
+            .filter { $0 == 0 }
+            .prefix(1)
+            .sink { _ in expectation.fulfill() }
+
+        SwiftDashSDKWalletState.shared.clearAllState()
+
+        await fulfillment(of: [expectation], timeout: 2)
+        withExtendedLifetime(cancellable) {}
+    }
+}


### PR DESCRIPTION
## Summary

- drive Home transaction reload requests from distinct SwiftDashSDK balance changes and remove the redundant BalanceModel legacy observer
- move Explore faucet/network and Buy/Sell visibility reads to existing app-owned WalletEnvironment and SwiftDashSDK boundaries
- remove dead passive consumers, add focused regression tests, and update the DashSync migration/teardown docs including the current Watch target dependency

## Tests

- `git diff --check`
- `plutil -lint DashWallet.xcodeproj/project.pbxproj`
- full DashSync import, DS type, balance-notification, DWEnvironment, Pod/project, source-membership, and forbidden-scope audits
- `dashpay` arm64 Simulator build without signing: passed
- focused `DashWalletTests/PassiveWalletStateUITailTests` and the `dashwallet` build are locally blocked before test compilation because the installed Watch simulator runtime `23S303` does not match the Watch SDK runtime `23T570`

## Scope

No Watch implementation/graph, Podfile, storage/keychain, SDK/platform, Coinbase, CrowdNode, `DASHSYNC_KEY_MIGRATION.md`, or `DWUpholdMainnetConstants.m` changes.