### PR TITLE
refactor(dashsync): migrate transaction direction compatibility

### DIFF
--- a/DASHSYNC_MIGRATION.md
+++ b/DASHSYNC_MIGRATION.md
@@ -31,16 +31,16 @@ DashSync is still linked for three bounded tails:
    `DSBlockchainIdentity` registration compatibility path; active profile UI
    no longer consumes that object.
 3. **Pod-unlink mechanics and compatibility surfaces** — AppDelegate setup,
-   the `DSTransaction.h` bridging exposure retained solely for
-   `DSTransactionDirection`, non-wallet exported helpers, and project/Podfile
-   link entries. Coinbase/Uphold keychain access, reachable Uphold HTTP flows,
-   profile-avatar networking, and Coinbase transaction/balance integration are
-   app-owned.
+   non-wallet exported helpers, and project/Podfile link entries.
+   Coinbase/Uphold keychain access, reachable Uphold HTTP flows,
+   profile-avatar networking, Coinbase transaction/balance integration, and
+   the shared transaction-direction model are app-owned.
 
 As of this audit, three app source files directly import DashSync. Counts of all
-`DS*` tokens are not a useful progress metric because app-owned names such as
-`DSTransactionDirection`, comments, and frozen compatibility contracts are
-included.
+`DS*` tokens are not a useful progress metric because comments and frozen
+compatibility contracts are included. The app bridging header no longer
+exposes `DSTransaction.h`; functional `DSTransaction` references are confined
+to the Apple Watch phone bridge.
 
 ## Platform pin
 
@@ -104,7 +104,7 @@ Status meanings:
 | 3 | Mnemonic generation / create wallet | Done; teardown tail | SDK-owned mnemonic storage is verified before a wallet becomes live in `PlatformWalletManager`; remove the adjacent `DSWallet standardWalletWithSeedPhrase` dual-write in C6-E. |
 | 4 | Mnemonic validation | Done | None. Uses `Mnemonic.validate`. |
 | 5 | Wallet balance | Done | None. Production balance reads use `SwiftDashSDKWalletState`; Coinbase transfer amount refreshes from its SDK-backed model balance and uses the fee-aware active-wallet maximum for its leftover warning. |
-| 6 | Transaction list | Done | None. History and Coinbase transaction metadata/tagging use active-wallet-scoped SDK-persisted SwiftData rows. The obsolete `DSTransaction` UI category and spent-input `DSAccount` category are removed. |
+| 6 | Transaction list | Done | None. History and Coinbase transaction metadata/tagging use active-wallet-scoped SDK-persisted SwiftData rows. Direction mapping and UI formatting use app-owned `TransactionDirection`; the obsolete `DSTransaction` UI category, spent-input `DSAccount` category, and `DSTransaction.h` bridging exposure are removed. |
 | 7 | Transaction detail | Done | None. Uses SDK snapshots and recent-send resolution. |
 | 8 | Send Dash | Done | None. Money movement goes through `WalletSendService` / `SwiftDashSDKTransactionSender`. |
 | 9 | Fee estimation | Done | None. Confirmation uses the transaction builder's fee. |

--- a/DASHSYNC_TEARDOWN_PLAN.md
+++ b/DASHSYNC_TEARDOWN_PLAN.md
@@ -67,6 +67,11 @@ its amount model and uses the active wallet's fee-aware maximum for the
 CrowdNode leftover warning. Its dead `DWEnvironment.currentAccount` protocol
 fallback and legacy balance notification observer were removed.
 
+Shared transaction direction is app-owned. `TransactionDirection` preserves
+the SDK FFI mapping, self-send promotion, DashPay override, UI formatting,
+metadata categories, and CrowdNode matching without exposing
+`DSTransaction.h` through the app bridging header.
+
 `DWUploadAvatarModel` keeps its public Objective-C/KVO contract and automatic
 start, but delegates Imgur delete/upload to an internal Moya/`HTTPClient`
 client. It preserves resize/JPEG settings, delete retries, delete-before-upload,
@@ -176,7 +181,7 @@ The remaining T4 work can run independently before the Watch decision. T3 must
 wait until the Watch bridge and legacy registration consumer of `DWEnvironment`
 have a final shape.
 
-### Direct DashSync import classification after T1
+### Direct DashSync import classification after transaction-direction cleanup
 
 | Source | Classification |
 |---|---|
@@ -184,12 +189,11 @@ have a final shape.
 | `DashWallet/Sources/Models/DWEnvironment.h` | C6-E wallet-registry compatibility owner. |
 | `DashWallet/Sources/AppleWatch/DSWatchTransactionDataObject.h` | Apple Watch tail, deliberately untouched/out of scope. |
 
-These are three source files. The app bridging header still exposes
-`DSTransaction.h` solely for the widely used `DSTransactionDirection` enum; it
-does not expose a live DashSync transaction object path. Migrating that enum is
-a separate compatibility cleanup. The only functional `DSBlockchainIdentity` matches
-outside comments are internal to `DWDashPayModel`'s legacy registration path;
-there are no functional `DSBlockchainInvitation` matches.
+These are three source files. The app bridging header no longer exposes
+`DSTransaction.h`, and functional `DSTransaction` references are confined to
+the Apple Watch phone bridge. The only functional `DSBlockchainIdentity`
+matches outside comments are internal to `DWDashPayModel`'s legacy registration
+path; there are no functional `DSBlockchainInvitation` matches.
 
 The non-blocking CrowdNode suspension and platform-upstream work can run in
 parallel with T1-T4. They do not change the order of the DashSync unlink.

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1159,6 +1159,7 @@
 		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
 		CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */; };
 		CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */; };
+		7A30000230A1000000000002 /* TransactionDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A30000130A1000000000001 /* TransactionDirectionTests.swift */; };
 		C124DF94278D4238FAE0975D /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		C1A0B2C3D4E5F60718293A02 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
 		C1A0B2C3D4E5F60718293A03 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
@@ -3152,6 +3153,7 @@
 		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
 		CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransactionMetadataTests.swift; sourceTree = "<group>"; };
 		CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinbaseTransferAmountTests.swift; sourceTree = "<group>"; };
+		7A30000130A1000000000001 /* TransactionDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDirectionTests.swift; sourceTree = "<group>"; };
 		C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsBarView.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D8E9F01234 /* TransferAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountView.swift; sourceTree = "<group>"; };
 		C3DAD266246AA6F10001624F /* DWScreenshotWarningViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWScreenshotWarningViewController.h; sourceTree = "<group>"; };
@@ -7075,6 +7077,7 @@
 				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
 				CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */,
 				CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */,
+				7A30000130A1000000000001 /* TransactionDirectionTests.swift */,
 				AA0003032CA0F58E00A1B402 /* SwapAddressValidatorTests.swift */,
 				AA00F1002FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift */,
 				AA00100D2CA0B10001A0B10D /* SwapKitQuoteDecodingTests.swift */,
@@ -10232,6 +10235,7 @@
 				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
 				CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */,
 				CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */,
+				7A30000230A1000000000002 /* TransactionDirectionTests.swift in Sources */,
 				AA0003042CA0F58E00A1B402 /* SwapAddressValidatorTests.swift in Sources */,
 				AA00F1012FF0A10000A1B402 /* ExchangeAddressLookupContextTests.swift in Sources */,
 				AA00100E2CA0B10001A0B10E /* SwapKitQuoteDecodingTests.swift in Sources */,

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -341,7 +341,7 @@ struct CoinbaseWalletTransactionRecord: Equatable {
             direction = .received
         case .sent:
             direction = .sent
-        default:
+        case .moved, .notAccountFunds:
             direction = .other
         }
 

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/CrowdNodeTopUpTx.swift
@@ -21,7 +21,7 @@ public final class CrowdNodeTopUpTx: CoinsToAddressTxFilter {
     }
 
     override func matches(_ tx: ObservedTransaction) -> Bool {
-        tx.direction == DSTransactionDirection.moved &&
+        tx.direction == .moved &&
             super.matches(tx)
     }
 }

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
@@ -132,7 +132,7 @@ final class FullCrowdNodeSignUpTxSet: GroupedTransactions, TransactionWrapper {
                 _amount -= Int64(dashAmount)
             case .received:
                 _amount += Int64(dashAmount)
-            default:
+            case .moved, .notAccountFunds:
                 break
             }
 

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
@@ -55,11 +55,11 @@ struct ObservedTransaction {
     /// data). SDK-side stand-in for DashSync's `account.transactionIsValid`.
     let isChainAccepted: Bool
     /// Display wrapper; supplies direction/dashAmount with the existing
-    /// FFI → DSTransactionDirection mapping (including the outgoing → moved
+    /// FFI → TransactionDirection mapping (including the outgoing → moved
     /// fee-only promotion the top-up matcher relies on).
     let wrapped: Transaction
 
-    var direction: DSTransactionDirection { wrapped.direction }
+    var direction: TransactionDirection { wrapped.direction }
 }
 
 protocol TransactionFilter {

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -183,13 +183,13 @@ class Transaction: TransactionDataItem, Identifiable {
         return name
     }
 
-    var direction: DSTransactionDirection {
+    var direction: TransactionDirection {
         if let payment = dashPayPayment {
             return payment.isOutgoing ? .sent : .received
         }
         return _direction
     }
-    private lazy var _direction: DSTransactionDirection = {
+    private lazy var _direction: TransactionDirection = {
         // FFI direction encoding: 0=incoming, 1=outgoing, 2=internal,
         // 3=coinjoin. Promote outgoing→moved when the wallet's net
         // change equals just the fee (self-send) — mirrors DashSync's
@@ -383,8 +383,6 @@ class Transaction: TransactionDataItem, Identifiable {
             return 0
         case .notAccountFunds:
             return 0
-        @unknown default:
-            return UInt64(abs(snapshot.netAmount))
         }
     }()
 
@@ -550,8 +548,6 @@ class Transaction: TransactionDataItem, Identifiable {
                 return NSLocalizedString("Received", comment: "")
             case .moved:
                 return NSLocalizedString("Internal Transfer", comment:"Transaction within the wallet, transfer of own funds");
-            default:
-                fatalError()
             }
         case .reward:
             return NSLocalizedString("Mining Reward", comment: "Transaction type: coinbase/masternode mining reward")

--- a/DashWallet/Sources/Models/Tx Metadata/TransactionMetadata.swift
+++ b/DashWallet/Sources/Models/Tx Metadata/TransactionMetadata.swift
@@ -134,7 +134,7 @@ extension TransactionMetadata {
     static var customIconId: SQLite.Expression<Data?> { Expression<Data?>("customIconId") }
 }
 
-extension DSTransactionDirection {
+extension TransactionDirection {
     /// Fallback tax category when the user hasn't classified the transaction.
     var defaultTaxCategory: TxMetadataTaxCategory {
         switch self {
@@ -145,8 +145,6 @@ extension DSTransactionDirection {
         case .received:
             return .transferIn
         case .notAccountFunds:
-            return .unknown
-        @unknown default:
             return .unknown
         }
     }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -943,7 +943,7 @@ extension HomeViewModel {
             if !isShieldedReceipt {
                 categories.insert(.received)
             }
-        default:
+        case .moved, .notAccountFunds:
             break
         }
         return categories

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -45,7 +45,7 @@ class TxDetailModel: NSObject {
         return direction.title
     }
 
-    var direction: DSTransactionDirection {
+    var direction: TransactionDirection {
         transaction.direction
     }
 
@@ -331,8 +331,6 @@ extension TxDetailModel {
             title = NSLocalizedString("Moved from", comment: "");
         case .notAccountFunds:
             title = NSLocalizedString("Registered from", comment: "");
-        @unknown default:
-            title = ""
         }
 
         if hasSourceUser {
@@ -357,8 +355,6 @@ extension TxDetailModel {
         case .moved:
             title = NSLocalizedString("Internally moved to", comment: "")
         case .notAccountFunds: // this should not be possible
-            title = ""
-        @unknown default:
             title = ""
         }
 

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -370,8 +370,6 @@ extension TXDetailViewController {
             }
         case .notAccountFunds:
             break
-        default:
-            break;
         }
 
         currentSnapshot.appendItems([.date(date)], toSection: .info)

--- a/DashWallet/Sources/UI/Views/Transitions/Item/Model/TransactionDataItem.swift
+++ b/DashWallet/Sources/UI/Views/Transitions/Item/Model/TransactionDataItem.swift
@@ -17,6 +17,15 @@
 
 import Foundation
 
+// MARK: - TransactionDirection
+
+enum TransactionDirection: Equatable {
+    case sent
+    case received
+    case moved
+    case notAccountFunds
+}
+
 // MARK: - TransactionDataItem
 
 protocol TransactionDataItem {
@@ -26,19 +35,16 @@ protocol TransactionDataItem {
     var txHashHexString: String { get }
     var dashAmount: UInt64 { get }
     var signedDashAmount: Int64 { get }
-    var direction: DSTransactionDirection { get }
+    var direction: TransactionDirection { get }
     var fiatAmount: String { get }
     var iconName: String { get }
     var stateTitle: String { get }
     var shortDateString: String { get }
 }
 
-// MARK: - DSTransactionDirection UI formatting
-// (Lives here with the rest of the tx-row formatting. The direction enum is
-// still DashSync's — replacing it with an app-owned enum is a separate,
-// repo-wide step tracked in the teardown plan.)
+// MARK: - TransactionDirection UI formatting
 
-extension DSTransactionDirection {
+extension TransactionDirection {
     var title: String {
         switch self {
         case .sent:
@@ -49,8 +55,6 @@ extension DSTransactionDirection {
             return NSLocalizedString("Moved to Address", comment: "");
         case .notAccountFunds:
             return NSLocalizedString("Registered Masternode", comment: "");
-        @unknown default:
-            fatalError()
         }
     }
 
@@ -63,8 +67,6 @@ extension DSTransactionDirection {
         case .moved:
             return .dw_orange()
         case .notAccountFunds:
-            return .dw_label()
-        @unknown default:
             return .dw_label()
         }
     }
@@ -79,8 +81,6 @@ extension DSTransactionDirection {
             return "tx.item.received.icon"
         case .notAccountFunds:
             return "tx.item.received.icon"
-        @unknown default:
-            fatalError()
         }
     }
 
@@ -94,7 +94,7 @@ extension DSTransactionDirection {
             return "+";
         case .sent:
             return "-";
-        default:
+        case .moved, .notAccountFunds:
             return "";
         }
     }
@@ -107,8 +107,6 @@ extension DSTransactionDirection {
             return .dw_darkTitle()
         case .received, .notAccountFunds:
             return .dw_dashBlue()
-        @unknown default:
-            fatalError()
         }
     }
 }

--- a/DashWallet/dashwallet-Bridging-Header.h
+++ b/DashWallet/dashwallet-Bridging-Header.h
@@ -12,7 +12,6 @@ static const bool _SNAPSHOT = 0;
 
 //MARK: DashSync
 #import "DWLogger.h"
-#import "DSTransaction.h"
 #import "DSWallet.h"
 #import "DSPriceOperationProvider.h"
 #import "DSOperation.h"

--- a/DashWalletTests/TransactionDirectionTests.swift
+++ b/DashWalletTests/TransactionDirectionTests.swift
@@ -1,0 +1,133 @@
+//
+//  TransactionDirectionTests.swift
+//  DashWalletTests
+//
+
+import Foundation
+import XCTest
+@testable import dashwallet
+
+final class TransactionDirectionTests: XCTestCase {
+    func testFFIDirectionMapping() {
+        XCTAssertEqual(makeTransaction(directionRaw: 0, netAmount: 100).direction, .received)
+        XCTAssertEqual(makeTransaction(directionRaw: 1, netAmount: -110, fee: 10).direction, .sent)
+        XCTAssertEqual(makeTransaction(directionRaw: 2, netAmount: 0).direction, .moved)
+        XCTAssertEqual(makeTransaction(directionRaw: 3, netAmount: -10, fee: 10).direction, .sent)
+    }
+
+    func testUnknownFFIDirectionFallsBackToNetAmountSign() {
+        XCTAssertEqual(makeTransaction(directionRaw: .max, netAmount: 1).direction, .received)
+        XCTAssertEqual(makeTransaction(directionRaw: .max, netAmount: 0).direction, .received)
+        XCTAssertEqual(makeTransaction(directionRaw: .max, netAmount: -1).direction, .sent)
+    }
+
+    func testOutgoingFeeOnlySelfSendIsMoved() {
+        let transaction = makeTransaction(directionRaw: 1, netAmount: -10, fee: 10)
+
+        XCTAssertEqual(transaction.direction, .moved)
+        XCTAssertEqual(transaction.dashAmount, 0)
+        XCTAssertEqual(transaction.signedDashAmount, 0)
+    }
+
+    func testSentAndReceivedAmountsKeepTheirSigns() {
+        let received = makeTransaction(directionRaw: 0, netAmount: 125)
+        let sent = makeTransaction(directionRaw: 1, netAmount: -125, fee: 25)
+
+        XCTAssertEqual(received.dashAmount, 125)
+        XCTAssertEqual(received.signedDashAmount, 125)
+        XCTAssertEqual(sent.dashAmount, 100)
+        XCTAssertEqual(sent.signedDashAmount, -100)
+    }
+
+    func testPresentationAndDefaultTaxCategories() {
+        assertPresentation(
+            .sent,
+            titleKey: "Amount Sent",
+            symbol: "-",
+            iconName: "tx.item.sent.icon",
+            taxCategory: .transferOut)
+        assertPresentation(
+            .received,
+            titleKey: "Amount received",
+            symbol: "+",
+            iconName: "tx.item.received.icon",
+            taxCategory: .transferIn)
+        assertPresentation(
+            .moved,
+            titleKey: "Moved to Address",
+            symbol: "",
+            iconName: "tx.item.internal.icon",
+            taxCategory: .expense)
+        assertPresentation(
+            .notAccountFunds,
+            titleKey: "Registered Masternode",
+            symbol: "",
+            iconName: "tx.item.received.icon",
+            taxCategory: .unknown)
+    }
+
+    func testCrowdNodeTopUpStillRequiresMovedDirection() {
+        let address = "Xcrowdnode"
+        let output = ObservedTransaction.Output(
+            address: address,
+            amount: CrowdNode.requiredForSignup)
+        let moved = makeObservedTransaction(
+            wrapped: makeTransaction(directionRaw: 1, netAmount: -10, fee: 10),
+            output: output)
+        let sent = makeObservedTransaction(
+            wrapped: makeTransaction(directionRaw: 1, netAmount: -110, fee: 10),
+            output: output)
+
+        XCTAssertTrue(CrowdNodeTopUpTx(address: address).matches(moved))
+        XCTAssertFalse(CrowdNodeTopUpTx(address: address).matches(sent))
+    }
+
+    private func makeTransaction(
+        directionRaw: UInt32,
+        netAmount: Int64,
+        fee: UInt64? = nil
+    ) -> Transaction {
+        Transaction(
+            syntheticTxid: Data(repeating: UInt8(truncatingIfNeeded: directionRaw), count: 32),
+            directionRaw: directionRaw,
+            netAmount: netAmount,
+            fee: fee,
+            contextRaw: 0,
+            date: Date(timeIntervalSince1970: 1))
+    }
+
+    private func makeObservedTransaction(
+        wrapped: Transaction,
+        output: ObservedTransaction.Output
+    ) -> ObservedTransaction {
+        ObservedTransaction(
+            txid: wrapped.txHashData,
+            txidHexDisplay: wrapped.txHashHexString,
+            outputs: [output],
+            inputAddresses: [],
+            timestamp: wrapped.date,
+            ownOutputsAmount: 0,
+            ownOutputAddresses: [],
+            isChainAccepted: true,
+            wrapped: wrapped)
+    }
+
+    private func assertPresentation(
+        _ direction: TransactionDirection,
+        titleKey: String,
+        symbol: String,
+        iconName: String,
+        taxCategory: TxMetadataTaxCategory,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            direction.title,
+            NSLocalizedString(titleKey, comment: ""),
+            file: file,
+            line: line)
+        XCTAssertEqual(direction.directionSymbol, symbol, file: file, line: line)
+        XCTAssertEqual(direction.iconName, iconName, file: file, line: line)
+        XCTAssertEqual(direction.defaultTaxCategory, taxCategory, file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary
- replace `DSTransactionDirection` with the app-owned internal `TransactionDirection`
- preserve SwiftDashSDK FFI mapping, fee-only self-send promotion, DashPay override, UI formatting, metadata, Coinbase, and CrowdNode behavior
- remove `DSTransaction.h` from the app bridging header and update migration documentation
- add focused direction, amount, presentation, tax-category, and CrowdNode tests

## Validation
- `dashpay` Debug arm64 iOS Simulator build: passed
- `git diff --check`: passed
- `plutil -lint DashWallet.xcodeproj/project.pbxproj`: passed
- DashSync ownership audits: passed; remaining functional `DSTransaction` references are Watch-only
- focused tests and `dashwallet` build are blocked before the test/app target by the local Watch runtime mismatch (`23S303` assets vs `23T570` SDK); the identical command fails the same way on untouched `origin/swift-sdk-integration`
- `TransactionDirectionTests.swift` parser check: passed

## Manual smoke
- Home sent/received/internal direction presentation
- transaction details address/fee sections
- DashPay contact-payment direction override
- CrowdNode top-up and tax/export classification