### PR TITLE
fix(about): restore shake-to-diagnostics on the SwiftUI About Dash screen

### DIFF
--- a/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
+++ b/DashWallet/Sources/Infrastructure/DiagnosticLogExporter.swift
@@ -179,6 +179,35 @@ struct DiagnosticLogExporter {
         return zipURL
     }
 
+    /// Main-actor entry point: captures the context that must be read on
+    /// the main actor, then runs the blocking staging + zip detached.
+    /// Shared by every caller that offers a log export (Tools menu row,
+    /// About-screen shake gesture) so the capture rules live in one place.
+    @MainActor
+    static func exportArchive() async -> Result<URL, Error> {
+        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
+        let bundle = Bundle.main
+        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let appVersion = "\(short) (\(build))"
+        // Authoritative record of which directory this run is writing
+        // to — timestamp sorting alone can be fooled by a clock
+        // rollback or a stale future-dated directory.
+        let currentSession = LoggingPreferences.currentSessionDirectory
+        let appLogFiles = DWLogger.sharedInstance().logFiles()
+
+        return await Task.detached(priority: .userInitiated) {
+            Result {
+                try export(
+                    network: network,
+                    appVersion: appVersion,
+                    currentSession: currentSession,
+                    appLogFiles: appLogFiles
+                )
+            }
+        }.value
+    }
+
     /// Pure SDK-session selection policy, split out for unit testing.
     ///
     /// The current session (when known) is always first and always

--- a/DashWallet/Sources/UI/Menu/Settings/About/AboutDashView.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/About/AboutDashView.swift
@@ -95,6 +95,50 @@ struct AboutDashView: View {
             }
         }
         .background(Color.dash.primaryBackground)
+        .alert(
+            "",
+            isPresented: Binding(
+                get: { viewModel.techInfo != nil },
+                set: { if !$0 { viewModel.techInfo = nil } }
+            ),
+            presenting: viewModel.techInfo
+        ) { _ in
+            Button(NSLocalizedString("Copy", comment: "")) {
+                viewModel.copyTechInfo()
+                viewModel.techInfo = nil
+            }
+            Button(NSLocalizedString("Copy Logs", comment: "Log export")) {
+                viewModel.techInfo = nil
+                viewModel.exportLogs()
+            }
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {
+                viewModel.techInfo = nil
+            }
+        } message: { techInfo in
+            Text(techInfo)
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { viewModel.exportedLogsURL != nil },
+                set: { if !$0 { viewModel.exportedLogsURL = nil } }
+            )
+        ) {
+            if let url = viewModel.exportedLogsURL {
+                ActivityView(activityItems: [url])
+            }
+        }
+        .alert(
+            NSLocalizedString("Export Logs", comment: "Log export"),
+            isPresented: Binding(
+                get: { viewModel.logExportErrorMessage != nil },
+                set: { if !$0 { viewModel.logExportErrorMessage = nil } }
+            ),
+            presenting: viewModel.logExportErrorMessage
+        ) { _ in
+            Button(NSLocalizedString("OK", comment: "")) { viewModel.logExportErrorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
     }
 
     private var repositoryLink: some View {

--- a/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Settings/About/AboutDashViewModel.swift
@@ -27,9 +27,26 @@ final class AboutDashViewModel: ObservableObject {
     @Published private(set) var lastDeviceSync: String = ""
     @Published private(set) var lastDeviceUpdate: String = ""
 
+    /// Non-nil presents the hidden shake-gesture diagnostics alert, carrying
+    /// the tech-info snapshot taken when the shake landed.
+    @Published var techInfo: String?
+    /// True while the diagnostic-log archive is being staged + zipped.
+    /// Guards re-entry from a second shake.
+    @Published private(set) var isExportingLogs = false
+    /// Non-nil presents the share sheet with the finished zip.
+    @Published var exportedLogsURL: URL?
+    /// Non-nil presents the log-export failure alert.
+    @Published var logExportErrorMessage: String?
+
     let repositoryURL = "https://github.com/dashpay/dashwallet-ios"
 
     private var databaseObserver: NSObjectProtocol?
+    private var shakeObserver: NSObjectProtocol?
+
+    /// The ObjC About model still owns the tech-info status string
+    /// (`status`), which reads DashSync-era + SwiftDashSDK state through
+    /// `DWAboutModel+MasternodeSync`. Reused rather than reimplemented here.
+    private lazy var aboutModel = DWAboutModel()
 
     private static let syncDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -65,11 +82,28 @@ final class AboutDashViewModel: ObservableObject {
                 self?.reloadExploreState()
             }
         }
+
+        // Hidden support gesture: shaking the device on this screen shows a
+        // tech-info snapshot with copy / log-export actions. `DWWindow` posts
+        // the notification; the observer lived on the old
+        // `DWAboutViewController` and was dropped in the SwiftUI rewrite.
+        shakeObserver = NotificationCenter.default.addObserver(
+            forName: .DWDeviceDidShake,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleDeviceShake()
+            }
+        }
     }
 
     deinit {
         if let databaseObserver {
             NotificationCenter.default.removeObserver(databaseObserver)
+        }
+        if let shakeObserver {
+            NotificationCenter.default.removeObserver(shakeObserver)
         }
     }
 
@@ -81,6 +115,39 @@ final class AboutDashViewModel: ObservableObject {
             return
         }
         SKStoreReviewController.requestReview(in: scene)
+    }
+
+    // MARK: - Shake diagnostics
+
+    private func handleDeviceShake() {
+        // A second shake while the alert is up would only re-read the same
+        // state; keep the snapshot the user is looking at.
+        guard techInfo == nil else { return }
+        techInfo = aboutModel.status()
+    }
+
+    func copyTechInfo() {
+        UIPasteboard.general.string = aboutModel.status()
+    }
+
+    /// Zip the recent diagnostic logs (SwiftDashSDK sessions + app
+    /// CocoaLumberjack files) and hand the archive to the share sheet —
+    /// the same export the Tools menu offers.
+    func exportLogs() {
+        guard !isExportingLogs else { return }
+        isExportingLogs = true
+
+        Task { [weak self] in
+            let result = await DiagnosticLogExporter.exportArchive()
+            guard let self else { return }
+            self.isExportingLogs = false
+            switch result {
+            case .success(let url):
+                self.exportedLogsURL = url
+            case .failure(let error):
+                self.logExportErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     // MARK: - Explore Dash state

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -167,11 +167,11 @@ class ToolsMenuViewModel: ObservableObject {
     /// "Move CoinJoin Funds" row self-removes once the balance drops below the
     /// threshold.
     func performCoinJoinSweep() async {
-        DWLogger.log("CJTEST ToolsMenuViewModel: sweep invoked from Tools menu (\(coinJoinLeftoverFormatted))")
+        DWLogger.log("ToolsMenuViewModel: sweep invoked from Tools menu (\(coinJoinLeftoverFormatted))")
         do {
             _ = try await WalletSendService.shared.sweepCoinJoin()
         } catch {
-            DWLogger.log("CJTEST ToolsMenuViewModel: sweep failed: \(error)")
+            DWLogger.log("ToolsMenuViewModel: sweep failed: \(error)")
             // Auth-cancel is an expected no-op (nil message); a real failure
             // surfaces an alert. The row stays visible so the user can retry.
             coinJoinSweepErrorMessage = WalletSendService.coinJoinSweepUserMessage(for: error)
@@ -188,37 +188,15 @@ class ToolsMenuViewModel: ObservableObject {
         guard !isExportingLogs else { return }
         isExportingLogs = true
 
-        // Context captured on the main actor; the detached task only
-        // does file work.
-        let network = SwiftDashSDKHost.shared.runningNetwork.map { String(describing: $0) } ?? "unknown"
-        let bundle = Bundle.main
-        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
-        let appVersion = "\(short) (\(build))"
-        // Authoritative record of which directory this run is writing
-        // to — timestamp sorting alone can be fooled by a clock
-        // rollback or a stale future-dated directory.
-        let currentSession = LoggingPreferences.currentSessionDirectory
-        let appLogFiles = DWLogger.sharedInstance().logFiles()
-
-        Task.detached(priority: .userInitiated) {
-            let result: Result<URL, Error> = Result {
-                try DiagnosticLogExporter.export(
-                    network: network,
-                    appVersion: appVersion,
-                    currentSession: currentSession,
-                    appLogFiles: appLogFiles
-                )
-            }
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                self.isExportingLogs = false
-                switch result {
-                case .success(let url):
-                    self.exportedLogsURL = url
-                case .failure(let error):
-                    self.logExportErrorMessage = error.localizedDescription
-                }
+        Task { [weak self] in
+            let result = await DiagnosticLogExporter.exportArchive()
+            guard let self else { return }
+            self.isExportingLogs = false
+            switch result {
+            case .success(let url):
+                self.exportedLogsURL = url
+            case .failure(let error):
+                self.logExportErrorMessage = error.localizedDescription
             }
         }
     }

--- a/DashWallet/dashwallet-Bridging-Header.h
+++ b/DashWallet/dashwallet-Bridging-Header.h
@@ -24,6 +24,7 @@ static const bool _SNAPSHOT = 0;
 #import "DWGlobalOptions.h"
 #import "DWUIKit.h"
 #import "DWAboutModel.h"
+#import "DashWallet/Sources/UI/Views/SharedViews/DWWindow.h"
 #import "DWBaseActionButtonViewController.h"
 #import "DWNumberKeyboardInputViewAudioFeedback.h"
 #import "DWInputValidator.h"


### PR DESCRIPTION
## Issue being fixed or feature implemented

The About screen's hidden support gesture — shake the device to see a tech-info snapshot and export logs — was lost when the screen moved to SwiftUI. `DWWindow` still posts `DWDeviceDidShakeNotification`, but the observer lived on the deleted `DWAboutViewController` and no replacement was added, so the gesture silently did nothing.

## What was done?

- Re-added the shake observer on `AboutDashViewModel`, with the alert surfaced from `AboutDashView`.
- "Copy Logs" now runs the modern `DiagnosticLogExporter` archive (SDK sessions + app logs + summary) instead of the raw `DWLogger` file list.
- Extracted the Tools-menu export's main-actor capture logic into a shared `DiagnosticLogExporter.exportArchive()` entry point and pointed both call sites at it, rather than copying it into the About screen (guardrail #1).
- Drive-by: dropped the `CJTEST` session tags from `ToolsMenuViewModel`'s log lines (guardrail #6), since that file was already being edited here.

The old alert's "Manage Trusted Node" action is deliberately **not** restored: it drove `DSPeerManager`, which is dead post-M6.

## How Has This Been Tested?

**Not built.** The SwiftDashSDK package in `../platform` is on `feat/platform-wallet-dashconnect-ffi` and fails with `value of type 'EventHandlerCallbacks' has no member 'release_fn'`, so the app target was never reached.

Before merge: `dashpay` arm64-sim build, then on device — open Settings → About Dash, shake, confirm the tech-info alert appears, and confirm "Copy Logs" produces the same archive the Tools-menu export does.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)