### PR TITLE
fix(crowdnode): unwrap the published error before reading localizedDescription

### DIFF
--- a/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountEmailController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountEmailController.swift
@@ -100,9 +100,10 @@ final class OnlineAccountEmailController: UIViewController {
         viewModel.$error
             .receive(on: DispatchQueue.main)
             .sink { [weak self] error in
-                if error is CrowdNode.Error {
+                if let error, error is CrowdNode.Error {
                     self?.viewModel.clearError()
-                    self?.navigationController?.toErrorScreen(error: error as? CrowdNode.Error ?? .messageStatus(error: error.localizedDescription))
+                    self?.navigationController?.toErrorScreen(
+                        error: error as? CrowdNode.Error ?? .messageStatus(error: error.localizedDescription))
                 }
             }
             .store(in: &cancellableBag)

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift
@@ -185,9 +185,10 @@ extension CrowdNodePortalController {
             .receive(on: DispatchQueue.main)
             .filter { error in error != nil }
             .sink(receiveValue: { [weak self] error in
-                if error is CrowdNode.Error {
+                if let error, error is CrowdNode.Error {
                     self?.viewModel.clearError()
-                    self?.navigationController?.toErrorScreen(error: error as? CrowdNode.Error ?? .messageStatus(error: error.localizedDescription))
+                    self?.navigationController?.toErrorScreen(
+                        error: error as? CrowdNode.Error ?? .messageStatus(error: error.localizedDescription))
                 }
             })
             .store(in: &cancellableBag)


### PR DESCRIPTION
## Issue being fixed or feature implemented

`swift-sdk-integration` does not build. #910 replaced `error as! CrowdNode.Error` with
`error as? CrowdNode.Error ?? .messageStatus(error: error.localizedDescription)` at both CrowdNode
error sinks. The force-cast implicitly unwrapped the optional; `as?` does not, so the fallback's
`error.localizedDescription` is read off `Optional<any Error>` — the element type of
`@Published var error: Error?`:

```
value of optional type 'Published<(any Error)?>.Publisher.Output' (aka 'Optional<any Error>')
must be unwrapped to refer to member 'localizedDescription' of wrapped base type 'any Error'
```

It was not caught before merging #910 because the SwiftDashSDK package in `../platform` was not
compiling locally at the time, so the app target was never reached — as that PR's test section
recorded. It surfaced as soon as the local sandbox was repaired with `pod install` (the
post-unlink `Podfile.lock` had gone out of sync with `Pods/`).

## What was done?

Bind the optional in the existing `if` at both sites:

- `DashWallet/Sources/UI/CrowdNode/Online/OnlineAccountEmailController.swift:103`
- `DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift:188`

Behaviour is unchanged — the `error is CrowdNode.Error` test already excluded nil, so the binding
only makes that explicit to the type checker.

## How Has This Been Tested?

`xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` → **BUILD SUCCEEDED**.

No behavioural testing: this restores compilation of code whose runtime behaviour #910 already
left unchanged.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)