### PR TITLE
fix(wallet): full 8-decimal Dash amounts, and accept `&` as a URI query separator

### DIFF
--- a/DashWallet/Sources/Application/Tools.swift
+++ b/DashWallet/Sources/Application/Tools.swift
@@ -23,11 +23,24 @@ private var _cachedFormatters: [String: NumberFormatter] = [:]
 private var _decimalFormatter: NumberFormatter!
 private var _fiatFormatter: NumberFormatter!
 private var _dashFormatter: NumberFormatter = {
-    let maximumFractionDigits = 5
+    // Dash is divisible to 8 decimal places (1 duff = 1e-8 DASH). Anything
+    // narrower silently truncates: a scanned `dash:…?amount=0.23243214`
+    // rendered as "0.23243", dropping 214 duffs. `cryptoFormatter` leaves
+    // `minimumFractionDigits` at 0, so whole amounts still render as "1"
+    // rather than "1.00000000".
+    //
+    // The paste path already clamps Dash input to 8
+    // (`BaseAmountModel.updateFromPasteboard`) and
+    // `DashAmountFormatterTests.testGeneralDashFormatterSupportsEightFractionDigits…`
+    // already asserts 8 here, so 5 was an oversight rather than a display cap.
+    let maximumFractionDigits = 8
 
     var dashFormat = NumberFormatter.cryptoFormatter(currencyCode: kDashCurrency, exponent: maximumFractionDigits)
     dashFormat.locale = Locale.current
-    dashFormat.maximum = (Decimal(kMaxDashSupplyDuffs)/pow(10, maximumFractionDigits)) as NSNumber
+    // Max supply expressed in DASH. Derived from the duffs-per-Dash constant
+    // rather than the display precision above — the two only happened to agree
+    // once the precision reached 8, and at 5 this evaluated to 21,000,000,000.
+    dashFormat.maximum = NSDecimalNumber(value: kMaxDashSupplyDuffs / kOneDash)
 
     return dashFormat
 }()

--- a/DashWallet/Sources/Models/PaymentProtocol/BIP70URI.swift
+++ b/DashWallet/Sources/Models/PaymentProtocol/BIP70URI.swift
@@ -71,9 +71,15 @@ struct BIP70URI {
         var rest = String(trimmed[trimmed.index(after: colon)...])
         if rest.hasPrefix("//") { rest = String(rest.dropFirst(2)) }
 
+        // BIP21 introduces the query with `?`, but wallets and payment pages in
+        // the wild also emit `dash:<address>&amount=…`. Splitting only on `?`
+        // left the whole tail inside the address, which then failed validation
+        // and the scan was rejected outright rather than losing just the amount.
+        // Accept whichever separator comes first; `&` is already the pair
+        // separator below, so a leading one yields the same key/value list.
         let addressPart: String
         let queryPart: String?
-        if let q = rest.firstIndex(of: "?") {
+        if let q = rest.firstIndex(where: { $0 == "?" || $0 == "&" }) {
             addressPart = String(rest[..<q])
             queryPart = String(rest[rest.index(after: q)...])
         } else {

--- a/DashWalletTests/PaymentProtocolTests.swift
+++ b/DashWalletTests/PaymentProtocolTests.swift
@@ -780,6 +780,31 @@ final class BIP70PaymentServiceTests: XCTestCase {
         XCTAssertEqual(BIP70URI("dash:X?amount=1e2")?.amount, 10_000_000_000)
     }
 
+    /// BUG-25: a scanned `dash:<address>&amount=…` (no `?`) used to put the whole
+    /// tail into the address, so the request was rejected instead of paying.
+    func testURIAcceptsAmpersandAsQuerySeparator() {
+        let uri = BIP70URI("dash:ybt3gVM6cM9WprG7bRTMst1YR2GnAbWGLr&amount=0.23243214")
+
+        XCTAssertEqual(uri?.address, "ybt3gVM6cM9WprG7bRTMst1YR2GnAbWGLr")
+        XCTAssertEqual(uri?.amount, 23_243_214)
+    }
+
+    /// The `&` form must still parse every following pair, exactly like `?`.
+    func testURIAmpersandSeparatorParsesRemainingPairs() {
+        let uri = BIP70URI("dash:Xabc&amount=1.5&label=Coffee&sender=ctx")
+
+        XCTAssertEqual(uri?.address, "Xabc")
+        XCTAssertEqual(uri?.amount, 150_000_000)
+        XCTAssertEqual(uri?.label, "Coffee")
+        XCTAssertEqual(uri?.callbackScheme, "ctx")
+    }
+
+    /// BUG-25/BUG-26: a full-precision amount must survive the URI parse. The
+    /// display side is covered by `DashAmountFormatterTests`.
+    func testURIKeepsAllEightDecimals() {
+        XCTAssertEqual(BIP70URI("dash:X?amount=0.23243214")?.amount, 23_243_214)
+    }
+
     // MARK: - L5 URI — paymentString init (bare address / BIP73)
 
     func testPaymentStringBareAddress() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two carry-over bugs from 2026-08-03 testing, both about amount precision on the send path.

**BUG-26** — `NumberFormatter.dashFormatter` capped `maximumFractionDigits` at 5, so
`0.23243214` DASH rendered as `0.23243`: 214 duffs dropped on screen.

**BUG-25** — a scanned payment request misbehaved. Retested with four generated QRs:

| QR | Encoded | Before |
|---|---|---|
| 1 | `dash:<addr>?amount=0.23243214` | glitched |
| 2 | `dash:<addr>&amount=0.23243214` | rejected with an error |
| 3 | `dash:<addr>?amount=0.25` | ✅ pre-filled 0.25 DASH |
| 4 | `<addr>` (bare) | ✅ accepted, amount 0 |

3 and 4 passing means the prefill path was never broken — the original "amount isn't
auto-populated" framing was wrong. That leaves two separate defects, one per commit here.

## What was done?

**`fix(amount)` — 5 → 8 decimal places.** Five was an oversight, not a display cap:

- the paste path already clamps Dash input to 8 (`BaseAmountModel.updateFromPasteboard`);
- `formattedDashAmountWithoutCurrencySymbol` already goes through the 8-digit
  `_dashDecimalFormatter`, so the same amount rendered differently with and without the symbol;
- `DashAmountFormatterTests` already asserts `dashFormatter.maximumFractionDigits == 8` and has
  been failing against this;
- `Numbers+Dash.swift`'s own doc comment advertises `12345678 -> "1.2345678"`.

`cryptoFormatter` leaves `minimumFractionDigits` at 0, so whole amounts still render as "1", not
"1.00000000" — only amounts that actually carry sub-5-decimal precision get longer.

This also decouples `dashFormat.maximum` from the display precision. It was
`kMaxDashSupplyDuffs / pow(10, maximumFractionDigits)`, which at 5 evaluated to 21,000,000,000
instead of the 21,000,000 DASH max supply; it now divides by `kOneDash`, the way
`BaseAmountModel` already does.

**`fix(payments)` — accept `&` as the query separator.** BIP21 introduces the query with `?` and
the parser split only on that, so for QR 2 the entire tail stayed in `addressPart`; the address
then failed validation and the whole request was refused. It now splits on whichever of `?` or `&`
comes first — `&` is already the pair separator for the rest of the query, so following pairs keep
parsing unchanged.

That accounts for QR 2. QR 1 is the display side: the internal value already kept full precision
(`AmountObject.dashInputString` uses the 8-digit `dashDecimalFormatter`) while `mainFormatted` was
rendered through the 5-digit `dashFormatter`, falling back to the literal `"Invalid Input"` on
failure — which the first commit fixes.

## How Has This Been Tested?

`xcodebuild … -scheme dashpay … ARCHS=arm64 build` → **BUILD SUCCEEDED** (verified with #913
applied on top, since that hotfix is what currently unblocks the branch's build).

Added to `PaymentProtocolTests`: the `&` form parses address and amount, following pairs still
parse, and all 8 decimals survive the parse. The unit-test target remains unrunnable per
`CLAUDE.md`, so these are compile-ready rather than executed.

**Still owed — a device retest of QR 1** to confirm the 8-decimal send screen is clean. If it is,
BUG-25 closes entirely.

## Breaking Changes

None. Amounts with more than 5 decimals now display in full; nothing that was previously shown
changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
