### PR TITLE
fix(wallet): pin the protocol version per network instead of globally

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -158,6 +158,51 @@ final class SwiftDashSDKHost {
         network == .mainnet ? 200_000 : 0
     }
 
+    // MARK: - Platform protocol version
+
+    /// The `DashSDKConfig.platform_version` to build the SDK with, per network.
+    ///
+    /// **Testnet stays pinned to 13.** Testnet Drive moved past v12 to v13,
+    /// whose validation set changed the shielded identity-create exit
+    /// denominations (v12/V8 `[0.1, 0.3, 0.5, 1.0]` → v13/V9 `[0.03, 0.1,
+    /// 0.25, 0.5, 1.0]`). Staying at v12 made the client build shielded
+    /// transitions against the old set, so a contested (0.25 DASH) shielded
+    /// username create failed client-side ("denomination 25000000000 is not a
+    /// member …") even though the server requires exactly 0.25. Pinning
+    /// explicitly also avoids a race where the shielded build runs before the
+    /// SDK has ratcheted to the network version. Bump this when the agreed
+    /// testnet protocol moves past v13.
+    ///
+    /// **Mainnet uses `0` — auto-detect.** The pin above was chosen for
+    /// testnet but applied to every network, which put the client two versions
+    /// ahead of mainnet. Platform v13 (`DRIVE_VERSION_V8`) switches the
+    /// compacted address-balance proof to the two-proof
+    /// `CompactedAddressBalanceProof` bincode envelope, while "nodes and
+    /// clients on v12 and below keep the legacy single GroveDB proof"
+    /// (rs-platform-version `version/v13.rs`). A v13 client therefore decodes
+    /// mainnet's legacy proof as the envelope, consumes the structure and
+    /// trips on the remainder:
+    ///
+    ///     proof: corrupted error: compacted address balance proof contains trailing bytes
+    ///
+    /// — observed 20× across three nodes on a mainnet device (2026-07-31),
+    /// with testnet clean, and it retries then gives up, so the Platform
+    /// address balance never populates there.
+    ///
+    /// `0` is what the SDK is designed for: it seeds at the per-network
+    /// `min_protocol_version` floor (mainnet 11, testnet 12) with auto-detect
+    /// on, ratcheting up as the network reports newer versions — "so this
+    /// picks the right wire without a Swift-side network→version map"
+    /// (`SDK.init(network:platformVersion:)`). A hard pin also disables
+    /// `refreshProtocolVersion()`, which is documented as a no-op while
+    /// pinned, so the client could never learn the network's real version.
+    ///
+    /// Devnet/regtest follow mainnet's auto-detect: no shielded-denomination
+    /// contract is pinned for them, and `makeRuntime` rejects regtest anyway.
+    static func platformVersion(for network: Network) -> UInt32 {
+        network == .testnet ? 13 : 0
+    }
+
     // MARK: - Wallet presence
 
     /// True when at least one SDK wallet mnemonic is persisted in
@@ -550,25 +595,10 @@ final class SwiftDashSDKHost {
 
         let newSDK: SDK
         do {
-            // Pin Platform protocol version 13. Testnet Drive has moved past
-            // v12 to v13, whose validation set changed the shielded
-            // identity-create exit denominations (v12/V8 `[0.1, 0.3, 0.5,
-            // 1.0]` → v13/V9 `[0.03, 0.1, 0.25, 0.5, 1.0]`). Staying pinned at
-            // v12 made the client build shielded transitions against the old
-            // set, so a contested (0.25 DASH) shielded username create failed
-            // client-side ("denomination 25000000000 is not a member …") even
-            // though the server (v13) requires exactly 0.25. v13 is a superset
-            // of v12's shielded fee logic, so the reason v11→v12 was pinned
-            // (correct `ShieldFromAssetLock` / `Shield` fees) still holds.
-            // Pinning explicitly rather than the auto-detect default
-            // (`platformVersion: 0`, floor + ratchet) avoids a race where the
-            // shielded build runs before the SDK has ratcheted to the network
-            // version. The knob is `DashSDKConfig.platform_version`
-            // (dashpay/platform #3751); bump this when the agreed protocol
-            // moves past v13.
-            let pinnedPlatformVersion: UInt32 = 13
-            newSDK = try SDK(network: network, platformVersion: pinnedPlatformVersion)
-            Self.logger.info("🪺 HOST :: stage 1/4 SDK created for \(network.rawValue, privacy: .public), pinned protocol v\(pinnedPlatformVersion, privacy: .public)")
+            let platformVersion = Self.platformVersion(for: network)
+            newSDK = try SDK(network: network, platformVersion: platformVersion)
+            Self.logger.info(
+                "🪺 HOST :: stage 1/4 SDK created for \(network.rawValue, privacy: .public), protocol \(platformVersion == 0 ? "auto-detect" : "pinned v\(platformVersion)", privacy: .public)")
         } catch {
             Self.logger.error("🪺 HOST :: SDK init failed: \(String(describing: error), privacy: .public)")
             throw HostError.sdkInitFailed(error)


### PR DESCRIPTION
## Issue being fixed or feature implemented

BUG-22. The Platform-address balance never populates on **mainnet**. The SDK logs, per sync cycle, retried across three separate nodes and then given up on:

```
ExecutionError { inner: Proof(DriveError { error:
  "proof: corrupted error: compacted address balance proof contains trailing bytes" }) }
```

Root cause: the SDK was built with `platformVersion: 13` for **every** network. That value was picked for testnet — v13 changed the shielded identity-create exit denominations, and pinning it fixed contested username creation — but it was applied unconditionally.

Platform v13 (`DRIVE_VERSION_V8`) switches the compacted address-balance proof to the two-proof `CompactedAddressBalanceProof` bincode envelope, while "nodes and clients on **v12 and below** keep the legacy single GroveDB proof" (rs-platform-version `version/v13.rs`). The verifier dispatches on that same feature version (`verify_compacted_address_balance_changes/mod.rs`). So a pinned-v13 client decodes mainnet's legacy proof as the envelope, consumes the structure, and trips on what is left.

**Measured on device with this change applied:**

```
2026-08-03T22:25:23  dash_sdk::protocol_version:
    ratcheting protocol version upward from=11 to=12
```

Mainnet reports **protocol version 12** — one below the format boundary. That confirms the mismatch directly rather than by inference.

Worth noting the hard pin was also suppressing this very diagnostic: `refreshProtocolVersion()` is documented as a no-op while pinned, so the client never ratcheted and never logged the network's real version.

## What was done?

`SwiftDashSDKHost` now chooses the version per network:

```swift
static func platformVersion(for network: Network) -> UInt32 {
    network == .testnet ? 13 : 0
}
```

- **Testnet keeps the explicit 13**, so the shielded-denomination fix and the ratchet-race avoidance it was introduced for are unchanged.
- **Mainnet passes `0`** — what the SDK is designed for: it seeds at the per-network `min_protocol_version` floor (mainnet 11, testnet 12) with auto-detect on and ratchets up as the network reports newer versions, "so this picks the right wire without a Swift-side network→version map" (`SDK.init(network:platformVersion:)`).
- Devnet follows mainnet's auto-detect; regtest is rejected by `makeRuntime` regardless.

The stage-1 log now reports which mode is in effect.

## How Has This Been Tested?

`xcodebuild … -scheme dashpay … ARCHS=arm64 build` → **BUILD SUCCEEDED**.

Run on a mainnet device (iPhone 13 Pro, iOS 18.7.8), session covering both networks:

```
HOST :: stage 1/4 SDK created for 0, protocol auto-detect   ← mainnet
HOST :: stage 1/4 SDK created for 1, protocol pinned v13    ← testnet
dash_sdk::protocol_version: ratcheting protocol version upward from=11 to=12
```

Mainnet negotiated v12 and matched the network; testnet behaviour is untouched. No new errors — the `Failed to find quorum: Quorum not found for type 4` warnings present in that run also appear on the older pinned build (2026-07-31 mainnet export), so they are pre-existing and unrelated.

**Not yet exercised end-to-end:** the compacted query itself did not run in that session. `need_compacted` is only true when the recent proof's last boundary is below the checkpoint height, or boundary extraction fails (`rs-sdk/src/platform/address_sync/mod.rs:602-643`); the recent tree was empty, so the path was skipped. To close that last step: Menu → Sync Info → Platform Sync → **Clear**, then **Sync Now** on mainnet, and confirm the compacted phase completes without the decode error.

## Breaking Changes

None for testnet — the pin it depends on is preserved verbatim. Mainnet changes from a hard v13 to the SDK's intended auto-detect, which is what makes it interoperate.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
