### PR TITLE
feat(wallet): resolve contact usernames for established contacts after wallet restore

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -242,6 +242,8 @@ final class SwiftDashSDKContactsService: ObservableObject {
         Self.logger.info("👥 CONTACTS :: snapshot rebuilt — \(established.count, privacy: .public) established, \(incoming.count, privacy: .public) incoming, \(outgoing.count, privacy: .public) outgoing")
         NotificationCenter.default.post(name: Self.contactsDidChangeNotification, object: nil)
 
+        backfillMissingUsernames(established + incoming + outgoing)
+
         // Keep the payment-history rows flowing without any screen
         // open: the projection is app-pulled (see
         // refreshPaymentsProjection), so ride the snapshot refresh at
@@ -642,10 +644,49 @@ final class SwiftDashSDKContactsService: ObservableObject {
         return result
     }
 
-    /// Reverse DPNS lookup (identity → label) for incoming-request
-    /// senders, where we only learn the identity ID from the synced
-    /// row. On success the label is cached in the hint store, so the
-    /// next `refresh()` renders it without another network hop.
+    /// Contacts whose reverse lookup is already running, so a `refresh()`
+    /// triggered by one completing does not restart the others.
+    private var usernameBackfillInFlight: Set<Data> = []
+
+    /// Resolve the DPNS label for every contact that has none yet.
+    ///
+    /// `username` is otherwise only populated at add time (from the username
+    /// search) or by the list view's `.onAppear` on the incoming and outgoing
+    /// sections. Established contacts had neither: `ContactsScreen`'s "My
+    /// Contacts" section never called `resolveUsernameIfNeeded`, and a restored
+    /// wallet has no add-time hint because the add happened on the previous
+    /// install. `ContactItem.displayTitle` then fell through to its last
+    /// resort and rendered the contact as `89fd6ddb…` permanently (BUG-27).
+    ///
+    /// Doing it here rather than in the view fixes every surface at once — the
+    /// list, the profile sheet opened straight from a payment, and the
+    /// notifications screen — and does not depend on which row happened to
+    /// scroll into view.
+    ///
+    /// Cost is bounded: `resolveUsername` returns the cached hint without a
+    /// network call once resolved, so this is one lookup per contact per
+    /// install, and contacts that already have a name are skipped entirely.
+    private func backfillMissingUsernames(_ items: [ContactItem]) {
+        let targets = items
+            .filter { $0.username == nil }
+            .map(\.contactIdentityId)
+            .filter { !usernameBackfillInFlight.contains($0) }
+        guard !targets.isEmpty else { return }
+
+        usernameBackfillInFlight.formUnion(targets)
+        Task { @MainActor [weak self] in
+            defer { self?.usernameBackfillInFlight.subtract(targets) }
+            for contactId in targets {
+                _ = await self?.resolveUsername(for: contactId)
+            }
+        }
+    }
+
+    /// Reverse DPNS lookup (identity → label) for any contact we know only by
+    /// identity id — incoming-request senders, and established contacts whose
+    /// add-time hint is gone (a restored wallet). On success the label is
+    /// cached in the hint store, so the next `refresh()` renders it without
+    /// another network hop.
     func resolveUsername(for contactId: Data) async -> String? {
         if let cached = usernameHint(for: contactId) {
             return cached


### PR DESCRIPTION
## Issue being fixed or feature implemented

After restoring a wallet from seed, an established DashPay contact rendered as `89fd6ddb…` with an avatar letter of "8" instead of its username. The condition was permanent, not transient — the name never appeared, on any screen.

The counterpart wallet still displayed the contact correctly, so the DPNS record was intact on Platform. Only the restored device failed to read it.

## What was done?

`ContactItem.displayTitle` falls through alias → profile display name → DPNS label → the first 8 hex chars of the identity id. All three name sources were empty, because `username` is only ever populated two ways:

- captured at add time from the username search, or
- by the contact list's `.onAppear` reverse lookup — which `ContactsScreen` wires onto the incoming-requests and pending-requests sections but **not** onto "My Contacts".

A restored wallet has no add-time hint, because the add happened on the previous install. Nothing then resolved established contacts, so the hex fallback stuck permanently.

Fixed by backfilling in `SwiftDashSDKContactsService` rather than adding a third `.onAppear`: after every snapshot rebuild, resolve the DPNS label for any contact that still has none. That covers the contact list, the profile sheet opened straight from a payment row, and the notifications screen in one place, and does not depend on which row happened to scroll into view.

Cost is bounded — `resolveUsername` already caches the result in the hint store and returns it without a network call afterwards, so this is one lookup per contact per install, and contacts that already have a name are skipped entirely. An in-flight set keeps the `refresh()` that each successful lookup triggers from restarting the others.

## How Has This Been Tested?

Clean `dashpay` arm64-simulator build.

Verified on device against the reproduction that reported it: a wallet restored from a seed whose established contact previously rendered as `89fd6ddb…` now shows "Delta", matching what the original install and the counterpart wallet display.

Note the restored wallet's **payment history** with that contact is still empty. That is a separate defect with a different cause — sent DashPay payments are recorded locally at send time and have no chain-derived reconstruction path (`reconcile_sent_payments` only flips existing Pending entries to Confirmed; its own doc notes that received payments self-heal from receival-account UTXOs while sent payments "have no such ground truth"). It is being raised against `dashpay/platform` separately and is not addressed here.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone