### PR TITLE
fix(dashpay): balance, transfer, avatar and username-registration QA fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ TODO.md
 */Coinbase-Info.plist
 */ZenLedger-Info.plist
 */SwapKit-Info.plist
+*/Imgur-Info.plist
 **/Uphold-Info.plist
 
 # SQLite temporary files

--- a/DashPay/Presentation/Profile/EditProfile/DWCropAvatarViewController.m
+++ b/DashPay/Presentation/Profile/EditProfile/DWCropAvatarViewController.m
@@ -47,7 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 static CGFloat const PADDING = 38.0;
 
-@interface DWCropAvatarViewController () <DWUploadAvatarViewControllerDelegate, DWImgurInfoViewControllerDelegate>
+@interface DWCropAvatarViewController () <DWUploadAvatarViewControllerDelegate,
+                                          DWImgurInfoViewControllerDelegate,
+                                          UIAdaptivePresentationControllerDelegate>
 
 @property (nullable, nonatomic, strong) DWFaceDetector *faceDetector;
 
@@ -179,7 +181,16 @@ NS_ASSUME_NONNULL_END
     DWImgurInfoViewController *controller = [[DWImgurInfoViewController alloc] init];
     controller.croppedImage = croppedImage;
     controller.delegate = self;
+    controller.presentationController.delegate = self;
     [self presentViewController:controller animated:YES completion:nil];
+}
+
+/// Bring the crop chrome back. Hiding it is how the sheets get an unobstructed
+/// backdrop; every path that closes one has to undo it, or the screen is left
+/// showing the cropped photo alone with no way forward or back.
+- (void)restoreCropChrome {
+    self.titleLabel.hidden = NO;
+    self.buttonsStackView.hidden = NO;
 }
 
 - (void)cancelButtonAction:(UIButton *)sender {
@@ -199,13 +210,13 @@ NS_ASSUME_NONNULL_END
 
                                DWUploadAvatarViewController *controller = [[DWUploadAvatarViewController alloc] initWithImage:croppedImage];
                                controller.delegate = self;
+                               controller.presentationController.delegate = self;
                                [self presentViewController:controller animated:YES completion:nil];
                            }];
 }
 
 - (void)imgurInfoViewControllerDidCancel:(DWImgurInfoViewController *)controller {
-    self.titleLabel.hidden = NO;
-    self.buttonsStackView.hidden = NO;
+    [self restoreCropChrome];
 
     [controller dismissViewControllerAnimated:YES completion:nil];
 }
@@ -213,10 +224,25 @@ NS_ASSUME_NONNULL_END
 #pragma mark - DWUploadAvatarViewControllerDelegate
 
 - (void)uploadAvatarViewControllerDidCancel:(DWUploadAvatarViewController *)controller {
-    self.titleLabel.hidden = NO;
-    self.buttonsStackView.hidden = NO;
+    [self restoreCropChrome];
 
     [controller dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - UIAdaptivePresentationControllerDelegate
+
+/// A swipe-down on either sheet dismisses it without going through the
+/// delegate methods above, so restore the chrome here too — otherwise the
+/// crop screen stays stripped of its title and buttons with the sheet gone.
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    UIViewController *dismissed = presentationController.presentedViewController;
+    if ([dismissed isKindOfClass:DWUploadAvatarViewController.class]) {
+        // The sheet is already gone; drop the in-flight request so its
+        // completion cannot finish an upload the user walked away from.
+        [(DWUploadAvatarViewController *)dismissed cancelUpload];
+    }
+
+    [self restoreCropChrome];
 }
 
 - (void)uploadAvatarViewController:(DWUploadAvatarViewController *)controller didFinishWithURLString:(NSString *)urlString {

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarChildView.m
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarChildView.m
@@ -195,17 +195,24 @@ NS_ASSUME_NONNULL_END
                                   [self.animationView startAnimating];
 
                                   break;
-                              case DWUploadAvatarModelState_Error:
+                              case DWUploadAvatarModelState_Error: {
+                                  // Cancel stays available: hiding it left the
+                                  // sheet with nothing but "Try again", trapping
+                                  // the user on a failure they cannot clear.
+                                  const BOOL retryable = self.model.failureIsRetryable;
+                                  NSString *reason = self.model.failureMessage;
                                   self.titleLabel.text = NSLocalizedString(@"Upload Error", nil);
-                                  self.subtitleLabel.text = NSLocalizedString(@"Unable to upload your picture. Please try again.", nil);
-                                  self.retryButton.hidden = NO;
-                                  self.cancelButton.hidden = YES;
+                                  self.subtitleLabel.text = reason
+                                                                ?: NSLocalizedString(@"Unable to upload your picture. Please try again.", nil);
+                                  self.retryButton.hidden = !retryable;
+                                  self.cancelButton.hidden = NO;
                                   self.errorImageView.hidden = NO;
 
                                   [self.animationView stopAnimating];
                                   self.animationView.hidden = YES;
 
                                   break;
+                              }
                               case DWUploadAvatarModelState_Success:
                                   [self.delegate uploadAvatarChildViewDidFinish:self];
                                   break;

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.h
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.h
@@ -34,6 +34,14 @@ typedef NS_ENUM(NSUInteger, DWUploadAvatarModelState) {
 
 @property (readonly, nullable, nonatomic, copy) NSString *resultURLString;
 
+/// The failed attempt's user-facing reason, or nil when the last failure
+/// carried no specific one (generic transport failure).
+@property (readonly, nullable, nonatomic, copy) NSString *failureMessage;
+
+/// NO when retrying cannot possibly succeed (e.g. the build ships no upload
+/// credentials). The error UI then offers only a way out.
+@property (readonly, nonatomic, assign) BOOL failureIsRetryable;
+
 - (instancetype)initWithImage:(UIImage *)image;
 
 - (void)retry;

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.m
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.m
@@ -81,13 +81,16 @@ NS_ASSUME_NONNULL_END
 
              NSAssert([NSThread isMainThread], @"Avatar state is UI-observable and must update on main");
              if (error != nil) {
-                 // A build without upload credentials can never succeed, so the
-                 // error UI must not offer a retry that is guaranteed to fail.
-                 const BOOL notConfigured =
+                 // Missing credentials, or a host that refused the action
+                 // outright: neither can succeed on a retry, so the error UI
+                 // must not offer one. Everything else (rate limits, 5xx,
+                 // transport) stays retryable.
+                 const BOOL permanent =
                      [error.domain isEqualToString:DWAvatarUploadClient.errorDomain] &&
-                     error.code == DWAvatarUploadClient.errorCodeNotConfigured;
-                 strongSelf.failureIsRetryable = !notConfigured;
-                 strongSelf.failureMessage = notConfigured ? error.localizedDescription : nil;
+                     (error.code == DWAvatarUploadClient.errorCodeNotConfigured ||
+                      error.code == DWAvatarUploadClient.errorCodeRefused);
+                 strongSelf.failureIsRetryable = !permanent;
+                 strongSelf.failureMessage = permanent ? error.localizedDescription : nil;
                  strongSelf.state = DWUploadAvatarModelState_Error;
                  return;
              }

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.m
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarModel.m
@@ -29,6 +29,8 @@ NSString *const ImageDeleteHash = @"ImgurImageDeleteHash";
 
 @property (nonatomic, assign) BOOL cancelled;
 @property (nullable, nonatomic, copy) NSString *resultURLString;
+@property (nullable, nonatomic, copy) NSString *failureMessage;
+@property (nonatomic, assign) BOOL failureIsRetryable;
 @property (nonatomic, strong) DWAvatarUploadClient *client;
 @property (nullable, nonatomic, strong) id<DWAvatarUploadCancelling> uploadOperation;
 @property (nonatomic, assign) NSUInteger attemptGeneration;
@@ -62,6 +64,8 @@ NS_ASSUME_NONNULL_END
     self.attemptGeneration += 1;
     const NSUInteger generation = self.attemptGeneration;
     self.cancelled = NO;
+    self.failureMessage = nil;
+    self.failureIsRetryable = YES;
     self.state = DWUploadAvatarModelState_Loading;
     NSString *deleteHash = [[NSUserDefaults standardUserDefaults] stringForKey:ImageDeleteHash];
 
@@ -77,6 +81,13 @@ NS_ASSUME_NONNULL_END
 
              NSAssert([NSThread isMainThread], @"Avatar state is UI-observable and must update on main");
              if (error != nil) {
+                 // A build without upload credentials can never succeed, so the
+                 // error UI must not offer a retry that is guaranteed to fail.
+                 const BOOL notConfigured =
+                     [error.domain isEqualToString:DWAvatarUploadClient.errorDomain] &&
+                     error.code == DWAvatarUploadClient.errorCodeNotConfigured;
+                 strongSelf.failureIsRetryable = !notConfigured;
+                 strongSelf.failureMessage = notConfigured ? error.localizedDescription : nil;
                  strongSelf.state = DWUploadAvatarModelState_Error;
                  return;
              }

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarViewController.h
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarViewController.h
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithImage:(UIImage *)image;
 
+/// Abandon an in-flight upload without routing through the delegate. For the
+/// interactive-dismissal path, where the sheet is already gone and the
+/// presenter restores its own chrome.
+- (void)cancelUpload;
+
 - (instancetype)initWithNibName:(nullable NSString *)nibNameOrNil bundle:(nullable NSBundle *)nibBundleOrNil NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;

--- a/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarViewController.m
+++ b/DashPay/Presentation/Profile/EditProfile/Upload/DWUploadAvatarViewController.m
@@ -57,6 +57,10 @@ NS_ASSUME_NONNULL_END
     return self.model.image;
 }
 
+- (void)cancelUpload {
+    [self.model cancel];
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
@@ -19,10 +19,14 @@ import UIKit
 /// request up front instead of letting Imgur reject an invalid Client-ID and
 /// presenting it to the user as a retryable network error.
 enum DWAvatarUploadConfiguration {
+    /// Only the Client-ID is read. Imgur's anonymous upload endpoint
+    /// authenticates with `Authorization: Client-ID <id>`; the client SECRET
+    /// belongs to the OAuth flows we do not use, and must never be put on a
+    /// request from the app.
     static let clientID: String = {
         guard let path = Bundle.main.path(forResource: "Imgur-Info", ofType: "plist"),
               let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
-              let clientID = dict["CLIENT_ID"] as? String
+              let clientID = dict["IMGUR_CLIENT_ID"] as? String
         else { return "" }
         return clientID
     }()

--- a/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
@@ -174,6 +174,7 @@ final class DWAvatarUploadClient: NSObject {
         let task = DWAvatarUploadTask()
 
         guard DWAvatarUploadConfiguration.isConfigured else {
+            DWLogger.log("AvatarUpload: no Imgur CLIENT_ID in this build — upload refused up front")
             finish(
                 task: task,
                 link: nil,
@@ -275,6 +276,12 @@ final class DWAvatarUploadClient: NSObject {
                         guard let json = object as? [String: Any],
                               (json["success"] as? NSNumber)?.boolValue == true
                         else {
+                            // The status code and Imgur's own error string are the
+                            // only way to tell a bad Client-ID from a rate limit or
+                            // a rejected image, and neither reaches the UI.
+                            DWLogger.log(
+                                "AvatarUpload: Imgur rejected the upload — status \(response.statusCode), "
+                                    + "body \(String(data: response.data, encoding: .utf8) ?? "<non-utf8>")")
                             throw Self.error("Imgur rejected the avatar upload")
                         }
                         let data = json["data"] as? [String: Any]
@@ -293,6 +300,7 @@ final class DWAvatarUploadClient: NSObject {
                             completion: completion)
                     }
                 case .failure(let error):
+                    DWLogger.log("AvatarUpload: transport failure — \(error.localizedDescription)")
                     self.finish(
                         task: task,
                         link: nil,

--- a/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
@@ -138,6 +138,13 @@ final class DWAvatarUploadClient: NSObject {
     /// "Try again" that is guaranteed to fail.
     @objc static let errorCodeNotConfigured = 2
 
+    /// Imgur accepted the request and refused the action — a 4xx that is not a
+    /// rate limit, e.g. `{"error":"These actions are forbidden."}` when the
+    /// registered application is not authorised for anonymous uploads. The
+    /// wallet cannot fix this from the device, so the UI must not invite a
+    /// retry; only a rate limit (429) is worth trying again.
+    @objc static let errorCodeRefused = 3
+
     // Internal test seam used by DWUploadAvatarModel tests. Production callers
     // always get the normal HTTPClient and image queue.
     static var testingHTTPClient: HTTPClient<DWAvatarEndpoint>?
@@ -315,7 +322,7 @@ final class DWAvatarUploadClient: NSObject {
                         task: task,
                         link: nil,
                         deleteHash: nil,
-                        error: error as NSError,
+                        error: Self.uploadError(from: error),
                         completion: completion)
                 }
             }
@@ -348,6 +355,25 @@ final class DWAvatarUploadClient: NSObject {
             return "status \(response.statusCode), body \(body)"
         }
         return error.localizedDescription
+    }
+
+    /// Classify a failed upload. A 4xx other than 429 is Imgur declining the
+    /// action itself — the app's API authorisation, not anything the device can
+    /// change — so it is reported as non-retryable. A 429 is a rate limit and a
+    /// 5xx is transient: both stay retryable, as does anything without a status.
+    private static func uploadError(from error: Error) -> NSError {
+        guard let clientError = error as? HTTPClientError,
+              case .statusCode(let response) = clientError,
+              (400..<500).contains(response.statusCode),
+              response.statusCode != 429
+        else {
+            return error as NSError
+        }
+        return self.error(
+            NSLocalizedString(
+                "Imgur refused the upload, so picture upload is unavailable right now.",
+                comment: "Avatar upload rejected by the image host"),
+            code: errorCodeRefused)
     }
 
     private static func error(_ description: String, code: Int = 1) -> NSError {

--- a/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
@@ -10,8 +10,25 @@ import Foundation
 import Moya
 import UIKit
 
-// TODO(avatar-upload): Replace the legacy placeholder with a configured Imgur client ID.
-private let avatarClientID = "imgurId"
+/// Imgur anonymous-upload credentials.
+///
+/// Read from a bundled `Imgur-Info.plist`, mirroring how `SwapKitConstants` and
+/// `Coinbase+Constants` read theirs: drop the (git-ignored) plist next to the
+/// others and add it to the dashwallet/dashpay targets. Absent credentials mean
+/// avatar upload is unavailable in this build — `DWAvatarUploadClient` fails the
+/// request up front instead of letting Imgur reject an invalid Client-ID and
+/// presenting it to the user as a retryable network error.
+enum DWAvatarUploadConfiguration {
+    static let clientID: String = {
+        guard let path = Bundle.main.path(forResource: "Imgur-Info", ofType: "plist"),
+              let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
+              let clientID = dict["CLIENT_ID"] as? String
+        else { return "" }
+        return clientID
+    }()
+
+    static var isConfigured: Bool { !clientID.isEmpty }
+}
 
 enum DWAvatarEndpoint: TargetType {
     case delete(deleteHash: String)
@@ -55,7 +72,7 @@ enum DWAvatarEndpoint: TargetType {
     }
 
     var headers: [String: String]? {
-        ["Authorization": "Client-ID \(avatarClientID)"]
+        ["Authorization": "Client-ID \(DWAvatarUploadConfiguration.clientID)"]
     }
 }
 
@@ -111,6 +128,12 @@ private final class DWAvatarUploadTask: NSObject, DWAvatarUploadCancelling {
 final class DWAvatarUploadClient: NSObject {
     typealias UploadCompletion = (String?, String?, NSError?) -> Void
 
+    @objc static let errorDomain = "DWAvatarUploadClient"
+    /// This build ships no Imgur credentials, so no amount of retrying can make
+    /// the upload succeed. The UI uses this to offer an exit instead of a
+    /// "Try again" that is guaranteed to fail.
+    @objc static let errorCodeNotConfigured = 2
+
     // Internal test seam used by DWUploadAvatarModel tests. Production callers
     // always get the normal HTTPClient and image queue.
     static var testingHTTPClient: HTTPClient<DWAvatarEndpoint>?
@@ -149,6 +172,21 @@ final class DWAvatarUploadClient: NSObject {
         completion: @escaping UploadCompletion
     ) -> DWAvatarUploadCancelling {
         let task = DWAvatarUploadTask()
+
+        guard DWAvatarUploadConfiguration.isConfigured else {
+            finish(
+                task: task,
+                link: nil,
+                deleteHash: nil,
+                error: Self.error(
+                    NSLocalizedString(
+                        "Picture upload is not available in this build.",
+                        comment: "Avatar upload has no configured credentials"),
+                    code: Self.errorCodeNotConfigured),
+                completion: completion)
+            return task
+        }
+
         let startUpload = { [weak self, weak task] in
             guard let self, let task, !task.isCancelled else { return }
             self.prepareAndUpload(image: image, task: task, completion: completion)
@@ -280,10 +318,10 @@ final class DWAvatarUploadClient: NSObject {
         }
     }
 
-    private static func error(_ description: String) -> NSError {
+    private static func error(_ description: String, code: Int = 1) -> NSError {
         NSError(
-            domain: "DWAvatarUploadClient",
-            code: 1,
+            domain: errorDomain,
+            code: code,
             userInfo: [NSLocalizedDescriptionKey: description])
     }
 }

--- a/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/DWAvatarUploadClient.swift
@@ -224,7 +224,13 @@ final class DWAvatarUploadClient: NSObject {
             switch result {
             case .success:
                 completion()
-            case .failure:
+            case .failure(let error):
+                // Logged separately from the upload: the delete runs first and
+                // retries four times, so without its own tag a stale delete
+                // hash is indistinguishable from a failing upload in the log.
+                DWLogger.log(
+                    "AvatarUpload: DELETE /3/image failed (\(attemptsRemaining) attempt(s) left) — "
+                        + Self.failureDetail(error))
                 if attemptsRemaining > 1 {
                     self.deletePreviousImage(
                         deleteHash: deleteHash,
@@ -304,7 +310,7 @@ final class DWAvatarUploadClient: NSObject {
                             completion: completion)
                     }
                 case .failure(let error):
-                    DWLogger.log("AvatarUpload: transport failure — \(error.localizedDescription)")
+                    DWLogger.log("AvatarUpload: POST /3/upload failed — \(Self.failureDetail(error))")
                     self.finish(
                         task: task,
                         link: nil,
@@ -328,6 +334,20 @@ final class DWAvatarUploadClient: NSObject {
             guard !task.isCancelled else { return }
             completion(link, deleteHash, error)
         }
+    }
+
+    /// Imgur states the reason for a refusal in the response BODY. `HTTPClient`
+    /// maps a non-2xx into `.statusCode(response)`, which carries it — but
+    /// `localizedDescription` renders only "Status Code: 400, Data Length: 78",
+    /// which is exactly enough to know something is wrong and nothing about
+    /// what. Pull the body out whenever it is there.
+    private static func failureDetail(_ error: Error) -> String {
+        if let clientError = error as? HTTPClientError,
+           case .statusCode(let response) = clientError {
+            let body = String(data: response.data, encoding: .utf8) ?? "<non-utf8 body>"
+            return "status \(response.statusCode), body \(body)"
+        }
+        return error.localizedDescription
     }
 
     private static func error(_ description: String, code: Int = 1) -> NSError {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -864,6 +864,31 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         }
     }
 
+    /// Whether a previous contest for `label` ended in a masternode LOCK.
+    ///
+    /// A locked label reads as AVAILABLE to `dpnsCheckAvailability` — no
+    /// identity owns the domain document, because the vote decided that nobody
+    /// gets it — but the vote poll rejects every new submission, so the state
+    /// transition fails at broadcast with `vote_poll_status: Locked`. Only a
+    /// contested-eligible label can be in this state.
+    ///
+    /// Returns false when the state cannot be determined: the submit-time
+    /// transition stays the authority, and a failed query must not block a name
+    /// that is very likely fine.
+    func isContestedNameLocked(_ label: String) async -> Bool {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return false }
+        do {
+            // `winner` is "LOCKED", a base58 identity id, or absent/null while
+            // the contest is unresolved (rs-sdk-ffi `dpns/queries/contested.rs`).
+            let state = try await sdk.dpnsGetContestedVoteState(name: label)
+            return (state["winner"] as? String) == "LOCKED"
+        } catch {
+            Self.logger.info(
+                "🪪 IDENT-COORD :: contested lock check unavailable for \(label, privacy: .public): \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
     /// Whether the active wallet has already paid for a Core-funded
     /// identity registration that still needs to finish. Used by the
     /// create-username screen to bypass the balance gate and present a

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -650,6 +650,39 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         }
     }
 
+    /// Cancel every subscription/task that writes the published mirrors. Pure
+    /// Swift-side teardown (no FFI call), so it is safe to run ahead of the
+    /// serialized stop — `performStop` and `prepareForNetworkSwitch` share it
+    /// rather than keeping two lists of cancellables in step by hand.
+    private func detachSyncSubscriptions() {
+        syncEventCancellable?.cancel()
+        syncEventCancellable = nil
+        syncStateCancellable?.cancel()
+        syncStateCancellable = nil
+        shieldedEventCancellable?.cancel()
+        shieldedEventCancellable = nil
+        shieldedForegroundCancellable?.cancel()
+        shieldedForegroundCancellable = nil
+        shieldedFreshnessTask?.cancel()
+        shieldedFreshnessTask = nil
+        shieldedRefreshGeneration &+= 1
+        shieldedRefreshTask?.cancel()
+        shieldedRefreshTask = nil
+        lastFullShieldedSyncAt = nil
+    }
+
+    /// Drop the outgoing network's Platform and Shielded balances the moment a
+    /// network switch is requested, ahead of the runtime's serialized stop.
+    ///
+    /// `performStop` only runs once the lifecycle queue reaches it, and BLAST /
+    /// shielded events from the previous network keep repainting the mirrors
+    /// until then — so the home screen would otherwise show the old network's
+    /// funds for the whole transition.
+    public func prepareForNetworkSwitch() {
+        detachSyncSubscriptions()
+        clearDisplay()
+    }
+
     /// Clear the UI counters/display without tearing down the sync loop.
     public func clearDisplay() {
         shieldedReconciliationTask?.cancel()
@@ -847,20 +880,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
             deletePersistedWalletIfAny()
         }
 
-        syncEventCancellable?.cancel()
-        syncEventCancellable = nil
-        syncStateCancellable?.cancel()
-        syncStateCancellable = nil
-        shieldedEventCancellable?.cancel()
-        shieldedEventCancellable = nil
-        shieldedForegroundCancellable?.cancel()
-        shieldedForegroundCancellable = nil
-        shieldedFreshnessTask?.cancel()
-        shieldedFreshnessTask = nil
-        shieldedRefreshGeneration &+= 1
-        shieldedRefreshTask?.cancel()
-        shieldedRefreshTask = nil
-        lastFullShieldedSyncAt = nil
+        detachSyncSubscriptions()
 
         if let manager = walletManager {
             do {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
@@ -274,7 +274,25 @@ final class SwiftDashSDKKeyMigrator: NSObject {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess, let items = result as? [[String: Any]] else {
+            // Distinguish "the keychain would not talk to us" from "no chain
+            // claims this wallet": both used to surface as the same silent nil,
+            // and the caller's log line ("chain unresolved/unsupported") reads
+            // as the second while an upgrade on a locked device produces the
+            // first. `errSecInteractionNotAllowed` (-25308) is that case — this
+            // query asks for kSecValueData, which the enumeration pass does
+            // not, so it can fail where enumeration just succeeded.
+            logger.error(
+                "🔑 KEYMIG :: chain-wallets keychain query failed, status \(status, privacy: .public)")
             return nil
+        }
+
+        let chainItems = items.filter {
+            ($0[kSecAttrAccount as String] as? String)?
+                .hasPrefix(dashSyncChainWalletsKeyPrefix) == true
+        }
+        if chainItems.isEmpty {
+            logger.error(
+                "🔑 KEYMIG :: no \(dashSyncChainWalletsKeyPrefix, privacy: .public)* items among \(items.count, privacy: .public) keychain item(s) — cannot map any wallet to a chain")
         }
 
         for item in items {
@@ -297,9 +315,20 @@ final class SwiftDashSDKKeyMigrator: NSObject {
                 if chainSuffix == mainnetGenesisShortHex { return .mainnet }
                 if chainSuffix == testnetGenesisShortHex { return .testnet }
                 // Unknown chain (devnet/regtest/evonet) — defer in v1.
+                logger.error(
+                    "🔑 KEYMIG :: \(walletID, privacy: .public) belongs to unsupported chain \(chainSuffix, privacy: .public)")
                 return nil
             }
         }
+        // The wallet has a mnemonic but no chain list claims it. Name the
+        // suffixes that were present, so a prefix/format change in the source
+        // keychain is distinguishable from a genuinely orphaned wallet.
+        let suffixes = chainItems
+            .compactMap { ($0[kSecAttrAccount as String] as? String) }
+            .map { String($0.dropFirst(dashSyncChainWalletsKeyPrefix.count)) }
+            .joined(separator: ",")
+        logger.error(
+            "🔑 KEYMIG :: \(walletID, privacy: .public) not listed by any chain; chains present: [\(suffixes, privacy: .public)]")
         return nil
     }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKSPVCoordinator.swift
@@ -304,14 +304,35 @@ public final class SwiftDashSDKSPVCoordinator: NSObject, ObservableObject {
         return .success(())
     }
 
+    /// Detach every publisher that feeds published state, without touching the
+    /// FFI. Shared by `performStop` and `prepareForNetworkSwitch` so the
+    /// pre-switch silencing can never drift from the real teardown.
     @MainActor
-    private func performStop(lastError: String?, clearBalance: Bool) throws {
+    private func detachManagerSubscriptions() {
         progressCancellable?.cancel()
         progressCancellable = nil
         peersCancellable?.cancel()
         peersCancellable = nil
         balanceRefreshCancellable?.cancel()
         balanceRefreshCancellable = nil
+    }
+
+    /// Drop the outgoing network's balance the moment a network switch is
+    /// requested, ahead of the runtime's serialized stop.
+    ///
+    /// `performStop` only runs once the lifecycle queue reaches it (after the
+    /// seed-migrator wait and the BLAST teardown), and until then the 1 Hz
+    /// progress tick keeps re-publishing the previous network's balance — which
+    /// the home screen renders as the newly selected network's funds.
+    @MainActor
+    func prepareForNetworkSwitch() {
+        detachManagerSubscriptions()
+        SwiftDashSDKWalletState.shared.clearAllState()
+    }
+
+    @MainActor
+    private func performStop(lastError: String?, clearBalance: Bool) throws {
+        detachManagerSubscriptions()
 
         if let manager = SwiftDashSDKHost.shared.manager {
             do {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -432,6 +432,14 @@ final class SwiftDashSDKWalletRuntime: NSObject {
             queue: nil
         ) { _ in
             Task { @MainActor in
+                // The home screen's funds are three published mirrors: the core
+                // balance plus BLAST's Platform and Shielded totals. `refresh`
+                // clears all three, but only once the serial lifecycle queue
+                // reaches `fullReset` — behind the seed-migrator wait and the
+                // BLAST/SPV stops. Silence and zero them here so the previously
+                // selected network's balances never render as the new one's.
+                SwiftDashSDKSPVCoordinator.shared.prepareForNetworkSwitch()
+                PlatformAddressSyncCoordinator.shared.prepareForNetworkSwitch()
                 Self.shared.enqueueRefresh(trigger: .networkDidChange)
             }
         }

--- a/DashWallet/Sources/Models/DWDateFormatter.swift
+++ b/DashWallet/Sources/Models/DWDateFormatter.swift
@@ -74,6 +74,16 @@ class DWDateFormatter: NSObject {
         return longDateFormatter.string(from: date)
     }
 
+    /// Date and time together, for deadlines where the hour matters. A
+    /// contested-name vote closes ~90 minutes after submission on testnet, so
+    /// a bare date tells the user nothing about when to look again.
+    func dateAndTime(from date: Date) -> String {
+        String.localizedStringWithFormat(
+            NSLocalizedString("%1$@ at %2$@", comment: "A date followed by a time of day"),
+            dateOnly(from: date),
+            timeOnly(from: date))
+    }
+
     func iso8601String(from date: Date) -> String {
         return iso8601DateFormatter.string(from: date)
     }

--- a/DashWallet/Sources/Models/Voting/VotingConstants.swift
+++ b/DashWallet/Sources/Models/Voting/VotingConstants.swift
@@ -18,6 +18,8 @@
 @objcMembers
 class VotingConstants: NSObject {
     static let maxVotes = 5 // max allowed by Platform for a masternode
-    // TODO: replace
-    static let votingEndTime = TimeInterval(1702695521)
+    // A contest's close time is per-submission, not a constant: read it from
+    // `DWContestedNameStatusService.pendingVotingEndTime`, which holds the
+    // submission-time estimate until Platform's `ContestVoteState.endTime`
+    // replaces it.
 }

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -19,6 +19,10 @@ struct SDKIdentityProfileSheet: View {
     @State private var dpnsNames: [String] = []
     @State private var hasIdentity: Bool = false
     @State private var pendingContestedName: String? = nil
+    /// Best-known close time of the pending contest. Starts as the
+    /// submission-time estimate and is replaced by Platform's
+    /// `ContestVoteState.endTime` once the contest is indexed.
+    @State private var pendingVotingEndTime: Date? = nil
     @State private var copyToast: String? = nil
 
     /// Callback invoked when the user taps Edit. Owner (HomeViewController)
@@ -78,6 +82,7 @@ struct SDKIdentityProfileSheet: View {
                 dpnsNames = DWCurrentUserIdentityInfo.shared.usernames
                 hasIdentity = DWCurrentUserIdentityInfo.shared.hasIdentity
                 pendingContestedName = DWContestedNameStatusService.shared.pendingLabel
+                pendingVotingEndTime = DWContestedNameStatusService.shared.pendingVotingEndTime
             }
         }
     }
@@ -120,11 +125,20 @@ struct SDKIdentityProfileSheet: View {
                 .fontWeight(.semibold)
                 .foregroundColor(.dash.primaryText)
             if pendingContestedName != nil {
-                Label(
-                    NSLocalizedString("Voting in progress", comment: "Usernames"),
-                    systemImage: "clock")
-                    .font(.caption)
-                    .foregroundColor(.orange)
+                VStack(spacing: 2) {
+                    Label(
+                        NSLocalizedString("Voting in progress", comment: "Usernames"),
+                        systemImage: "clock")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                    if let pendingVotingEndTime {
+                        Text(String.localizedStringWithFormat(
+                            NSLocalizedString("Ends around %@", comment: "Usernames"),
+                            DWDateFormatter.sharedInstance.dateAndTime(from: pendingVotingEndTime)))
+                            .font(.caption2)
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                }
             }
         }
         .frame(maxWidth: .infinity)

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -326,11 +326,7 @@ struct CreateUsernameView: View {
         ) {
             Button(NSLocalizedString("OK", comment: "")) { finish() }
         } message: {
-            Text(String.localizedStringWithFormat(
-                NSLocalizedString(
-                    "“%@” has been submitted for voting. It is not registered to you yet. We will notify you when voting ends.",
-                    comment: "Usernames"),
-                viewModel.username))
+            Text(votingSubmittedMessage)
         }
         .alert(
             NSLocalizedString("Contact request failed", comment: "DashPay Invitations"),
@@ -538,6 +534,27 @@ struct CreateUsernameView: View {
                 registrationErrorMessage = message
             }
         }
+    }
+
+    /// Post-submit copy for a contested name. The deadline is a conservative
+    /// submission-time estimate until Platform indexes the contest and
+    /// `checkPendingContestResolution` swaps in `ContestVoteState.endTime`,
+    /// hence "around". Falls back to the date-less wording when no pending
+    /// bookmark exists rather than inventing a deadline.
+    private var votingSubmittedMessage: String {
+        guard let endTime = DWContestedNameStatusService.shared.pendingVotingEndTime else {
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "“%@” has been submitted for voting. It is not registered to you yet. We will notify you when voting ends.",
+                    comment: "Usernames"),
+                viewModel.username)
+        }
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "“%1$@” has been submitted for voting. It is not registered to you yet. Voting ends around %2$@ — we will notify you with the result.",
+                comment: "Usernames"),
+            viewModel.username,
+            DWDateFormatter.sharedInstance.dateAndTime(from: endTime))
     }
 
     /// Viable funding sources in privacy-descending priority order.

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -640,6 +640,14 @@ struct CreateUsernameView: View {
         case .valid:
             return NSLocalizedString("Username available", comment: "Usernames")
         case .invalidCritical:
+            // A locked contest is not "taken" — nobody owns the name, and
+            // nobody can. Saying "taken" would send the user off to wait for
+            // it to free up, which never happens.
+            if viewModel.isLockedContestedName {
+                return NSLocalizedString(
+                    "Username locked by masternode vote — it cannot be registered",
+                    comment: "Usernames")
+            }
             return NSLocalizedString("Username taken", comment: "Usernames")
         case .error:
             return NSLocalizedString("Validating username failed", comment: "Usernames")

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -358,7 +358,12 @@ class CreateUsernameViewModel: ObservableObject {
         // pool) all pass. The picker in `CreateUsernameView` lets the
         // user choose among the viable sources; the form is unblocked
         // as soon as any one is.
-        let coreBalance = SwiftDashSDKWalletState.shared.balance?.total ?? 0
+        // Fee-aware spendable, NOT the displayed total: the funding transaction
+        // is an ordinary L1 spend, so it can only draw on confirmed UTXOs and
+        // still needs room for the miner fee. Gating on the total let a wallet
+        // whose coins were unconfirmed (or whose whole balance was the exact
+        // cost) reach Continue on a registration the SDK must then reject.
+        let coreBalance = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
         let hasEnoughCore = coreBalance >= requiredCost
         let hasEnoughPlatform = PlatformPaymentIdentityFundingPolicy
             .canFundCurrentWallet(
@@ -498,7 +503,10 @@ class CreateUsernameViewModel: ObservableObject {
     }
 
     private func checkBalance() {
-        let balance = SwiftDashSDKWalletState.shared.balance?.total ?? 0
+        // Same envelope `validateUsername` gates on — the Core picker row must
+        // show the amount that can actually fund the registration, not a total
+        // that includes coins the funding transaction cannot spend.
+        let balance = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
         let platformDuffs = SwiftDashSDKWalletState.shared.platformPaymentCreditsAsDuffs
         let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
         let requiredDuffs = trimmedUsername.isEmpty

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -89,6 +89,13 @@ class CreateUsernameViewModel: ObservableObject {
     /// `dash_sdk_dpns_is_contested_username` — no network call.
     @Published private(set) var isContestedCandidate: Bool = false
 
+    /// The typed label lost an earlier contest to a masternode LOCK, so nobody
+    /// can register it. It still reports as available (no owner holds the
+    /// domain document), which is why this needs its own flag: the rule row
+    /// would otherwise say "Username taken", and the user would keep retrying
+    /// a name that can only fail at broadcast.
+    @Published private(set) var isLockedContestedName: Bool = false
+
     /// Per-funding-source eligibility flags. `hasMinimumRequiredBalance`
     /// (above) is kept as the legacy OR-of-both flag for any existing
     /// consumer; the new picker UI reads these to decide whether to
@@ -237,7 +244,8 @@ class CreateUsernameViewModel: ObservableObject {
             } catch DWIdentityRegistrationCoordinator.CoordinatorError.authCancelled {
                 return .cancelled
             } catch {
-                return .failure(error.localizedDescription)
+                return .failure(
+                    Self.registrationFailureMessage(error, username: submittedUsername))
             }
         }
 
@@ -259,11 +267,38 @@ class CreateUsernameViewModel: ObservableObject {
                     if error.domain == NSCocoaErrorDomain && error.code == NSUserCancelledError {
                         continuation.resume(returning: .cancelled)
                     } else {
-                        continuation.resume(returning: .failure(error.localizedDescription))
+                        continuation.resume(
+                            returning: .failure(
+                                Self.registrationFailureMessage(error, username: submittedUsername)))
                     }
                 }
             }
         }
+    }
+
+    /// Human wording for a failed registration. Platform surfaces its refusals
+    /// as a Rust debug dump of the whole state transition — hundreds of
+    /// characters of `ContestedDocumentResourceVotePoll { … }` that fill the
+    /// alert and tell the user nothing. Recognised causes get a sentence; an
+    /// unrecognised one is passed through unchanged rather than swallowed, and
+    /// the raw text always reaches the log.
+    private static func registrationFailureMessage(
+        _ error: Error,
+        username: String
+    ) -> String {
+        let raw = error.localizedDescription
+        DWLogger.log("CreateUsername: registration failed for '\(username)': \(raw)")
+
+        // The vote poll ended in a LOCK: masternodes decided nobody gets the
+        // name. Re-submitting can only fail the same way.
+        if raw.contains("vote_poll_status: Locked") || raw.contains("is currently already locked") {
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "“%@” was locked by a masternode vote, so it cannot be registered by anyone. Please choose a different username.",
+                    comment: "Usernames"),
+                username)
+        }
+        return raw
     }
 
     private func registrationOutcome(for username: String) -> UsernameRegistrationOutcome {
@@ -324,6 +359,8 @@ class CreateUsernameViewModel: ObservableObject {
         // Kill any in-flight availability check — its result belongs to
         // an input the user has already changed (including changed-to-empty).
         availabilityCheckTask?.cancel()
+
+        isLockedContestedName = false
 
         guard !username.isEmpty else {
             uiState = CreateUsernameUIState()
@@ -429,10 +466,20 @@ class CreateUsernameViewModel: ObservableObject {
         guard !Task.isCancelled else { return }
 
         let result: UsernameValidationRuleResult
+        var locked = false
         do {
             let available = try await DWIdentityRegistrationCoordinator.shared.dpnsCheckAvailability(username)
             if available {
-                result = .valid
+                // "Available" only means no identity owns the domain document.
+                // A contested label whose vote ended in a LOCK is exactly that
+                // — and unregisterable: the transition is refused at broadcast.
+                // Scope the extra query to contested candidates, the only
+                // labels that can reach a locked poll.
+                if isContestedCandidate {
+                    locked = await DWIdentityRegistrationCoordinator.shared
+                        .isContestedNameLocked(username)
+                }
+                result = locked ? .invalidCritical : .valid
             } else if let pending = DWContestedNameStatusService.shared.pendingLabel,
                       pending.caseInsensitiveCompare(username) == .orderedSame {
                 // Our own contested submission — reads as taken on-chain
@@ -452,6 +499,7 @@ class CreateUsernameViewModel: ObservableObject {
               self.username.trimmingCharacters(in: .whitespacesAndNewlines) == username
         else { return }
 
+        isLockedContestedName = locked
         uiState.usernameBlockedRule = result
         uiState.canContinue = (result == .valid)
     }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -382,6 +382,20 @@ class CreateUsernameViewModel: ObservableObject {
         let hasEnoughBalance = recoveryFunded || voucherFunded || hasEnoughCore || hasEnoughPlatform || hasReadyShieldedFunding
         let canContinue = lengthValid && !hasIllegalCharacters && !startsOrEndsWithHyphen && hasEnoughBalance
 
+        // The cost rule is an OR across four funding sources, so a green rule
+        // on a wallet the user knows is short reads as a bug with no way to
+        // tell WHICH source claimed it can pay. Record the verdicts and the
+        // numbers behind them — this lands in the exported diagnostic log.
+        if hasEnoughBalance {
+            DWLogger.log(
+                "CreateUsername: cost rule satisfied for '\(username)' "
+                    + "(contested=\(isContested), required=\(requiredCost) duffs) — "
+                    + "core=\(hasEnoughCore) [spendable \(coreBalance) duffs], "
+                    + "platform=\(hasEnoughPlatform), "
+                    + "shielded=\(hasReadyShieldedFunding), "
+                    + "recovery=\(recoveryFunded), voucher=\(voucherFunded)")
+        }
+
         uiState = CreateUsernameUIState(
             lengthRule: lengthValid ? .valid : .invalid,
             allowedCharactersRule: hasIllegalCharacters || startsOrEndsWithHyphen ? .invalid : .valid,

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
@@ -159,7 +159,7 @@ struct JoinDashPayView: View {
             }
         case .voting:
             if let endTime = DWContestedNameStatusService.shared.pendingVotingEndTime {
-                let endDate = DWDateFormatter.sharedInstance.longString(from: endTime)
+                let endDate = DWDateFormatter.sharedInstance.dateAndTime(from: endTime)
                 return String.localizedStringWithFormat(
                     NSLocalizedString(
                         "Username %@ has been submitted for voting. Voting ends around %@.",

--- a/DashWallet/Sources/UI/DashPay/Usernames/RequestDetailsViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Usernames/RequestDetailsViewController.swift
@@ -44,10 +44,19 @@ class RequestDetailsViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configureLayout()
         configureObservers()
         viewModel.fetchUsernameRequestData()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // The deadline starts as a submission-time estimate and is replaced by
+        // Platform's `ContestVoteState.endTime` once `checkPendingContestResolution`
+        // (Home appear / app foreground) indexes the contest, so re-read it on
+        // every appearance instead of only at load.
+        updateResultsDate()
     }
     
     @IBAction
@@ -70,10 +79,8 @@ extension RequestDetailsViewController {
         linkLabel.text = NSLocalizedString("Link", comment: "Usernames")
         identityLabel.text = NSLocalizedString("Identity", comment: "Usernames")
         resultsLabel.text = NSLocalizedString("Results", comment: "Usernames")
-        let endDate = Date(timeIntervalSince1970: VotingConstants.votingEndTime) // TODO replace
-        let endDateStr = DWDateFormatter.sharedInstance.dateOnly(from: endDate)
-        resultsDateText.text = endDateStr
-        
+        updateResultsDate()
+
         var configuration = UIButton.Configuration.configuration(from: .tinted())
         configuration.baseBackgroundColor = .dw_red().withAlphaComponent(0.08)
         configuration.baseForegroundColor = .dw_red()
@@ -84,6 +91,17 @@ extension RequestDetailsViewController {
         continueButton.setAttributedTitle(NSAttributedString(string: NSLocalizedString("Cancel Request", comment: ""), attributes: attributes), for: .normal)
     }
     
+    /// Show the real close time of OUR pending contested submission. Nil means
+    /// there is no submission bookmark for the active network — say so rather
+    /// than print a date we do not have.
+    private func updateResultsDate() {
+        guard let endTime = DWContestedNameStatusService.shared.pendingVotingEndTime else {
+            resultsDateText.text = NSLocalizedString("Not available yet", comment: "Usernames")
+            return
+        }
+        resultsDateText.text = DWDateFormatter.sharedInstance.dateAndTime(from: endTime)
+    }
+
     private func configureObservers() {
         viewModel.$currentUsernameRequest
             .receive(on: DispatchQueue.main)

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -331,12 +331,14 @@ struct HomeViewContent<Content: View>: View {
                                     viewModel.checkJoinDashPay()
                                 } else {
                                     // TODO: ? MOCK_DASHPAY if failed, maybe need to call model?.dashPayModel.retry()
-                                    if viewModel.shouldShowDashPayInfo {
-                                        UsernamePrefs.shared.joinDashPayInfoShown = true
-                                        self.shouldShowJoinDashPayInfo = true
-                                    } else {
-                                        delegate?.homeViewRequestUsername()
-                                    }
+                                    // Always open the info dialog. It carries the
+                                    // only "Have an invitation?" entry in the app,
+                                    // so latching it to the first-ever tap left an
+                                    // invited user with no way to reach the redeem
+                                    // path once they had dismissed it — which is
+                                    // every user whose invitation arrived after
+                                    // they first looked at DashPay.
+                                    self.shouldShowJoinDashPayInfo = true
                                 }
                             }, onDismissButton: { _ in
                                 joinDPViewModel.markAsDismissed()

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -142,13 +142,6 @@ class HomeViewModel: ObservableObject {
         }
     }
     
-    #if DASHPAY
-    var shouldShowDashPayInfo: Bool {
-        get { !UsernamePrefs.shared.joinDashPayInfoShown }
-        set(value) { UsernamePrefs.shared.joinDashPayInfoShown = !value }
-    }
-    #endif
-    
     init(transactionSource: TransactionSource) {
         self.transactionSource = transactionSource
         syncModel.networkStatusDidChange = { status in

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -423,14 +423,11 @@ struct MainMenuScreen: View {
     }
     
     private func handleJoinButtonAction() {
-        let shouldShowDashPayInfo = !UsernamePrefs.shared.joinDashPayInfoShown
-
-        if shouldShowDashPayInfo {
-            UsernamePrefs.shared.joinDashPayInfoShown = true
-            showDashPayInfo = true
-        } else {
-            joinDashPay()
-        }
+        // Always open the info dialog — same reason as HomeView: it is the
+        // only surface carrying "Have an invitation?", and the one-shot latch
+        // hid the redeem path for good from anyone who had already tapped
+        // Upgrade before their invitation arrived.
+        showDashPayInfo = true
     }
     #endif
     

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -580,6 +580,17 @@ struct IdentityDetailScreen: View {
                     icon: "clock",
                     color: .orange)
             }
+            // A "Voting" badge with no end time leaves the user with nothing
+            // to act on. The deadline is known from submission onward — an
+            // estimate first, Platform's own `endTime` once it indexes the
+            // contest — so show it here too.
+            if let endTime = row.pendingVotingEndTime {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("Voting ends around %@", comment: "Usernames"),
+                    DWDateFormatter.sharedInstance.dateAndTime(from: endTime)))
+                    .font(.caption)
+                    .foregroundColor(.dash.secondaryText)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -61,6 +61,10 @@ struct IdentityRowModel: Identifiable {
     /// Kept separate from `dpnsNames` so every identities surface can
     /// render it explicitly as voting rather than as a confirmed name.
     let pendingContestedName: String?
+    /// Best-known close time of that contest — the submission-time estimate
+    /// until Platform's `ContestVoteState.endTime` replaces it. nil only when
+    /// there is no pending submission for this identity.
+    let pendingVotingEndTime: Date?
     /// True when this identity is the wallet's resolved MAIN identity —
     /// the one `DWCurrentUserIdentityInfo` reads, i.e. the owner of
     /// DashPay mode (username, avatar, contacts). Resolution = stored
@@ -272,6 +276,9 @@ final class IdentitiesViewModel: ObservableObject {
             publicKeyCount: identity.publicKeys.count,
             dpnsNames: ownedNames,
             pendingContestedName: pendingBelongsToIdentity ? pendingLabel : nil,
+            pendingVotingEndTime: pendingBelongsToIdentity
+                ? DWContestedNameStatusService.shared.pendingVotingEndTime
+                : nil,
             isMainIdentity: mainIdentityId != nil && identity.identityId == mainIdentityId)
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -189,17 +189,11 @@ struct InternalTransferScreen: View {
     private func networkDisplay(_ network: ChainNetwork) -> (icon: String, title: String, balance: String) {
         switch network {
         case .core:
-            return ("d.circle.fill",
-                    NSLocalizedString("Transparent", comment: "Balance breakdown"),
-                    viewModel.coreBalanceFormatted)
+            return ("d.circle.fill", network.balanceName, viewModel.coreBalanceFormatted)
         case .platform:
-            return ("creditcard.fill",
-                    NSLocalizedString("Platform", comment: "Dash Platform chain"),
-                    viewModel.platformCreditsFormatted)
+            return ("creditcard.fill", network.balanceName, viewModel.platformCreditsFormatted)
         case .shielded:
-            return ("shield.fill",
-                    NSLocalizedString("Shielded", comment: ""),
-                    viewModel.shieldedBalanceFormatted)
+            return ("shield.fill", network.balanceName, viewModel.shieldedBalanceFormatted)
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -31,6 +31,16 @@ enum InternalTransferRoute: Equatable {
     /// FULL-BALANCE address-credit withdrawal → L1 payout. The SDK has no
     /// partial-amount form for this route.
     case platformToCore
+
+    /// The balance this route spends from — the one an insufficient-funds
+    /// message has to name, and the one Max draws its ceiling from.
+    var source: ChainNetwork {
+        switch self {
+        case .coreToShielded, .coreToPlatform: return .core
+        case .platformToShielded, .platformToCore: return .platform
+        case .shieldedToCore, .shieldedToPlatform: return .shielded
+        }
+    }
 }
 
 /// Shared Type-18 amount boundary for Core → Shielded transfers.
@@ -65,12 +75,14 @@ enum CoreToShieldedAmountPolicy {
     }
 }
 
-/// Shared affordability boundary for every route that spends Orchard notes.
+/// Shared affordability boundary for every transfer route, whichever balance
+/// it spends.
 ///
-/// Shielded spends debit both the requested amount and a route-specific fee.
-/// Keeping the calculation here makes the inline validation, Continue gate,
-/// and Max amount describe the same spendable envelope.
-enum ShieldedSpendAmountPolicy {
+/// A spend debits both the requested amount and a route-specific fee/selection
+/// reserve. Keeping the calculation here makes the inline validation, the
+/// Continue gate, and the Max amount describe the same spendable envelope, and
+/// makes every "you don't have that much" line read the same way.
+enum TransferSpendAmountPolicy {
     static func spendableCredits(
         balanceCredits: UInt64,
         feeReserveCredits: UInt64
@@ -80,7 +92,12 @@ enum ShieldedSpendAmountPolicy {
             : 0
     }
 
+    /// Insufficient-balance line for a credit-denominated source (Shielded
+    /// notes, DIP-17 Platform credits). `balanceName` is the user-facing name
+    /// of the balance being spent, so a three-balance screen says which one is
+    /// short. `nil` when the amount fits.
     static func insufficientBalanceMessage(
+        balanceName: String,
         requestedCredits: UInt64,
         balanceCredits: UInt64,
         feeReserveCredits: UInt64
@@ -92,13 +109,29 @@ enum ShieldedSpendAmountPolicy {
 
         // The amount input supports duff precision, so report the largest
         // value the user can actually enter rather than rounding credits up.
-        let spendableDuffs = spendableCredits / 1000
+        return message(balanceName: balanceName, spendableDuffs: spendableCredits / 1000)
+    }
+
+    /// Insufficient-balance line for a duff-denominated source (the BIP44 Core
+    /// balance). `spendableDuffs` is the route's real ceiling, fee reserve
+    /// already deducted.
+    static func insufficientBalanceMessage(
+        balanceName: String,
+        requestedDuffs: UInt64,
+        spendableDuffs: UInt64
+    ) -> String? {
+        guard requestedDuffs > spendableDuffs else { return nil }
+        return message(balanceName: balanceName, spendableDuffs: spendableDuffs)
+    }
+
+    private static func message(balanceName: String, spendableDuffs: UInt64) -> String {
         let formattedSpendable =
             "\(spendableDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
         return String.localizedStringWithFormat(
             NSLocalizedString(
-                "Insufficient Shielded balance. Available to spend: %@",
-                comment: "Shielded send amount exceeds spendable balance"),
+                "Insufficient %1$@ balance. Available to send: %2$@",
+                comment: "Transfer amount exceeds the source balance"),
+            balanceName,
             formattedSpendable)
     }
 }
@@ -106,22 +139,25 @@ enum ShieldedSpendAmountPolicy {
 @MainActor
 final class InternalTransferViewModel: ObservableObject {
 
-    private var isApplyingShieldedMax = false
+    private var isApplyingMax = false
     @Published var amountText: String = "0" {
         didSet {
-            guard !isApplyingShieldedMax else { return }
-            clearShieldedMaxSelection()
+            guard !isApplyingMax else { return }
+            clearMaxSelection()
         }
     }
     @Published private(set) var isFullShieldedSweep = false
-    @Published private(set) var shieldedMaxNotice: String?
+    /// Why Max produced the amount it did — a held-back fee, a pending sweep
+    /// remainder, or why it could not produce one at all. Surfaced through
+    /// `amountValidationMessage` so tapping Max is never a silent no-op.
+    @Published private(set) var maxNotice: String?
     private var shieldedSweepAmountCredits: UInt64?
     @Published var unit: InternalTransferUnit = .dash {
         didSet {
             guard oldValue != unit else { return }
-            let preserveShieldedMax = isFullShieldedSweep
-            isApplyingShieldedMax = preserveShieldedMax
-            defer { isApplyingShieldedMax = false }
+            let preserveMax = isFullShieldedSweep
+            isApplyingMax = preserveMax
+            defer { isApplyingMax = false }
             convertAmountText(from: oldValue, to: unit)
         }
     }
@@ -266,19 +302,13 @@ final class InternalTransferViewModel: ObservableObject {
     /// partial withdrawal, and for the net payout a Max (full-balance,
     /// AUTO-path) withdrawal pays out.
     private func routeDidChange() {
-        clearShieldedMaxSelection()
+        clearMaxSelection()
         guard route == .platformToCore else {
             preflightTask?.cancel()
             preflightTask = nil
             return
         }
-        guard preflightTask == nil else { return }
-        preflightTask = Task { [weak self] in
-            let result = try? await PlatformAddressSyncCoordinator.shared.preflightWithdrawal()
-            guard let self, !Task.isCancelled else { return }
-            self.withdrawalPreflight = result
-            self.preflightTask = nil
-        }
+        startWithdrawalPreflightIfNeeded()
     }
 
     /// Net payout of the full-balance (Max) Platform → Core withdrawal, in
@@ -314,6 +344,18 @@ final class InternalTransferViewModel: ObservableObject {
     /// drawing from BIP44 UTXOs only).
     @Published private(set) var coreBalanceDuffs: UInt64 = 0
 
+    /// The most a Core-funded route can actually lock, in duffs: the fee-aware
+    /// spendable balance (confirmed − InstantSend-locked − the L1 fee reserve).
+    ///
+    /// NOT `coreBalanceDuffs`, which is the displayed total and includes
+    /// unconfirmed/immature coins the asset lock cannot spend. Validation, the
+    /// Continue gate and Max all read this one number so the screen can't offer
+    /// an amount the transaction builder must then reject.
+    ///
+    /// Recomputed on each published balance instead of per view render — the
+    /// underlying reserve estimate walks the account's UTXO set over the FFI.
+    @Published private(set) var coreSpendableDuffs: UInt64 = 0
+
     /// DIP-17 Platform Payment credits (1e11 per DASH). Sourced from
     /// `PlatformAddressSyncCoordinator.platformBalance`. Used to validate
     /// `.platform` source transfers (which go through `shieldedShield`,
@@ -341,12 +383,14 @@ final class InternalTransferViewModel: ObservableObject {
     init() {
         SyncingActivityMonitor.shared.add(observer: self)
         coreBalanceDuffs = SwiftDashSDKWalletState.shared.balance?.total ?? 0
+        coreSpendableDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
         platformCredits = PlatformAddressSyncCoordinator.shared.platformBalance
 
         SwiftDashSDKWalletState.shared.$balance
             .receive(on: RunLoop.main)
             .sink { [weak self] balance in
                 self?.coreBalanceDuffs = balance?.total ?? 0
+                self?.coreSpendableDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
             }
             .store(in: &cancellables)
 
@@ -413,41 +457,104 @@ final class InternalTransferViewModel: ObservableObject {
     /// Zero stays quiet while the user has not entered an amount; a
     /// fee-estimation failure fails closed with a generic retry.
     var amountValidationMessage: String? {
-        if let shieldedMaxNotice { return shieldedMaxNotice }
+        if let maxNotice { return maxNotice }
         guard dashDuffsUnsigned > 0 else { return nil }
 
-        switch route {
-        case .coreToShielded:
+        // Route minimum first: below the Type-18 pool fee the SDK refuses the
+        // asset lock however much Core balance backs it.
+        if route == .coreToShielded {
             guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-                return NSLocalizedString(
-                    "There was an error, please try again later",
-                    comment: "Internal transfer fee estimate unavailable")
+                return Self.feeEstimateUnavailableMessage
             }
-            guard dashDuffsUnsigned < minimumDuffs else { return nil }
+            if dashDuffsUnsigned < minimumDuffs {
+                let formattedMinimum =
+                    "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "The minimum amount you can send is %@",
+                        comment: "Internal transfer minimum amount"),
+                    formattedMinimum)
+            }
+        }
 
-            let formattedMinimum =
-                "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-            return String.localizedStringWithFormat(
-                NSLocalizedString(
-                    "The minimum amount you can send is %@",
-                    comment: "Internal transfer minimum amount"),
-                formattedMinimum)
+        return insufficientBalanceMessage
+    }
+
+    /// "You don't have that much" for the ACTIVE route, named after the balance
+    /// it spends. Mirrors `canContinue`'s envelope route by route, so a Continue
+    /// button disabled on affordability is never left unexplained.
+    private var insufficientBalanceMessage: String? {
+        let balanceName = route.source.balanceName
+
+        switch route {
+        case .coreToShielded, .coreToPlatform:
+            // Asset-lock routes carve their pool fee from the locked value, but
+            // the funding transaction is still an L1 spend — only confirmed
+            // UTXOs, and the miner fee comes off the top.
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: coreSpendableDuffs)
+
+        case .platformToShielded:
+            guard let reserve = feeReserveCredits else {
+                return Self.feeEstimateUnavailableMessage
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedCredits: creditsPreview,
+                balanceCredits: platformCredits,
+                feeReserveCredits: reserve)
 
         case .shieldedToCore, .shieldedToPlatform:
+            // A Max sweep is planned against the real note set rather than the
+            // amount+reserve envelope, so it is affordable by construction.
+            if isFullShieldedSweep { return nil }
             guard let reserve = feeReserveCredits else {
-                return NSLocalizedString(
-                    "There was an error, please try again later",
-                    comment: "Shielded transfer fee estimate unavailable")
+                return Self.feeEstimateUnavailableMessage
             }
-            return ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
                 feeReserveCredits: reserve)
 
-        default:
-            return nil
+        case .platformToCore:
+            // Stay quiet while the preflight is still resolving: Continue is
+            // disabled, but the amount is not yet known to be unaffordable.
+            guard let preflight = withdrawalPreflight else { return nil }
+            guard preflight.canWithdraw else {
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "Your %@ balance is too low to cover the withdrawal fee.",
+                        comment: "Platform withdrawal cannot fund its own fee"),
+                    balanceName)
+            }
+            if isFullPlatformWithdrawal { return nil }
+            guard creditsPreview > partialWithdrawCapCredits else { return nil }
+
+            // A partial withdrawal spends a single address, so it is bounded by
+            // the largest address balance. Amounts above that are reachable
+            // only through the full-balance (Max) withdrawal over every address.
+            let formattedCap =
+                "\((partialWithdrawCapCredits / 1000).formattedDashAmountWithoutCurrencySymbol) DASH"
+            if let fullDuffs = platformWithdrawableDuffs, dashDuffsUnsigned <= fullDuffs {
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "A partial withdrawal is limited to %@. Tap Max to withdraw the full balance.",
+                        comment: "Platform partial withdrawal cap"),
+                    formattedCap)
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: platformWithdrawableDuffs ?? partialWithdrawCapCredits / 1000)
         }
     }
+
+    private static let feeEstimateUnavailableMessage = NSLocalizedString(
+        "There was an error, please try again later",
+        comment: "Internal transfer fee estimate unavailable")
 
     var canContinue: Bool {
         // Gate on duffs, not raw DASH: a sub-duff amount (e.g. 1e-9 DASH)
@@ -463,13 +570,13 @@ final class InternalTransferViewModel: ObservableObject {
             guard let minimumDuffs = coreToShieldedMinimumAmountDuffs,
                   dashDuffsUnsigned >= minimumDuffs
             else { return false }
-            return dashDuffsUnsigned <= coreBalanceDuffs
+            return dashDuffsUnsigned <= coreSpendableDuffs
         case .coreToPlatform:
             // Asset-lock routes: the pool/processing fee is carved from the
-            // locked value (not charged on top of the Core balance) and the
-            // Rust side rejects an undersized lock, so no source-balance fee
-            // headroom is reserved here.
-            return dashDuffsUnsigned <= coreBalanceDuffs
+            // locked value rather than charged on top. What still bounds them
+            // is the funding spend itself — confirmed UTXOs minus the L1 fee
+            // reserve, which is exactly `coreSpendableDuffs`.
+            return dashDuffsUnsigned <= coreSpendableDuffs
         case .platformToShielded:
             // Shield (Type 15): the SDK's input selection requires
             // balance ≥ amount + reserve. Fail closed if the reserve is
@@ -540,7 +647,7 @@ final class InternalTransferViewModel: ObservableObject {
     /// amount. Fails closed (returns 0) when the reserve is unavailable.
     private func creditsMinusFeeReserve(_ balanceCredits: UInt64) -> UInt64 {
         guard let fee = feeReserveCredits else { return 0 }
-        return ShieldedSpendAmountPolicy.spendableCredits(
+        return TransferSpendAmountPolicy.spendableCredits(
             balanceCredits: balanceCredits,
             feeReserveCredits: fee)
     }
@@ -627,14 +734,19 @@ final class InternalTransferViewModel: ObservableObject {
     }
 
     /// Card-row balance display: plain decimal, no grouping, at most 5
-    /// fraction digits (rounded) so long balances don't wrap the card.
+    /// fraction digits so long balances don't wrap the card.
     /// Internal — the Send screen's source cards use the same format.
+    ///
+    /// Truncates rather than rounds: half-even rounding would render 0.39999999
+    /// as "0.4", so the card would claim more than Max can ever fill and the
+    /// difference reads as a broken Max button.
     static func cardBalanceString(duffs: UInt64) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.usesGroupingSeparator = false
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 5
+        formatter.roundingMode = .down
         return formatter.string(from: NSDecimalNumber(decimal: duffs.dashAmount))
             ?? duffs.formattedDashAmountWithoutCurrencySymbol
     }
@@ -642,18 +754,35 @@ final class InternalTransferViewModel: ObservableObject {
     /// Source-aware Max fill. Keeps the same unit semantics — DASH or fiat —
     /// but draws the upper bound from whichever bucket the user picked.
     func fillMaxFromWallet() {
-        clearShieldedMaxSelection()
+        clearMaxSelection()
         let sourceDuffs: UInt64
         switch route {
         case .coreToShielded, .coreToPlatform:
             // Fee-aware max: spendable minus the send fee reserve (mirrors
             // DSAccount.maxOutputAmount), never the raw total — the asset-lock
             // spends core UTXOs and still needs room for the L1 fee.
-            sourceDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
+            sourceDuffs = coreSpendableDuffs
+            if sourceDuffs == 0 {
+                maxNotice = Self.coreZeroMaxMessage(
+                    totalDuffs: coreBalanceDuffs,
+                    confirmedSpendableDuffs: SwiftDashSDKWalletState.shared.balance?.spendable ?? 0)
+            } else if sourceDuffs < coreBalanceDuffs {
+                // The balance card shows the total, so a Max that lands below
+                // it reads as a bug unless the held-back part is accounted for.
+                maxNotice = Self.coreHeldBackMessage(coreBalanceDuffs - sourceDuffs)
+            }
         case .platformToShielded:
             // Reserve the fee the SDK charges on top of the amount so Max
             // stays sendable (credits → duffs: integer divide by 1000).
-            sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
+            let spendableCredits = creditsMinusFeeReserve(platformCredits)
+            sourceDuffs = spendableCredits / 1000
+            if sourceDuffs == 0 {
+                maxNotice = platformCredits > 0
+                    ? Self.feeReserveExceedsBalanceMessage(route.source)
+                    : Self.emptyBalanceMessage(route.source)
+            } else if platformCredits > spendableCredits {
+                maxNotice = Self.feeHeldBackMessage(platformCredits - spendableCredits)
+            }
         case .shieldedToCore, .shieldedToPlatform:
             let feeKind: PlatformWalletManager.ShieldedFeeKind =
                 route == .shieldedToCore ? .withdrawal : .unshield
@@ -662,26 +791,38 @@ final class InternalTransferViewModel: ObservableObject {
                 isFullShieldedSweep = true
                 shieldedSweepAmountCredits = plan.amountCredits
                 if plan.remainingCredits > 0 {
-                    shieldedMaxNotice = Self.shieldedRemainderMessage(plan.remainingCredits)
+                    maxNotice = Self.shieldedRemainderMessage(plan.remainingCredits)
                 }
                 sourceDuffs = plan.amountCredits / 1000
             case .waitingForConfirmation(let credits):
-                shieldedMaxNotice = Self.shieldedConfirmingMessage(credits)
+                maxNotice = Self.shieldedConfirmingMessage(credits)
                 sourceDuffs = 0
             case .unavailable:
-                shieldedMaxNotice = NSLocalizedString(
+                maxNotice = NSLocalizedString(
                     "Your Shielded balance is not ready to withdraw. Sync and try Max again.",
                     comment: "Shielded Max unavailable")
                 sourceDuffs = 0
             }
         case .platformToCore:
             // Max = the full-balance net payout (executed via the AUTO,
-            // all-addresses path); 0 until the preflight resolves.
+            // all-addresses path). The preflight is a network round trip, so
+            // say so rather than silently filling 0 — and re-arm it, since a
+            // failed attempt would otherwise only retry on a route change.
             sourceDuffs = platformWithdrawableDuffs ?? 0
+            if sourceDuffs == 0 {
+                if withdrawalPreflight?.canWithdraw == false {
+                    maxNotice = Self.feeReserveExceedsBalanceMessage(route.source)
+                } else {
+                    maxNotice = NSLocalizedString(
+                        "Still calculating the withdrawable amount. Tap Max again in a moment.",
+                        comment: "Platform withdrawal preflight not resolved")
+                    startWithdrawalPreflightIfNeeded()
+                }
+            }
         }
 
-        isApplyingShieldedMax = true
-        defer { isApplyingShieldedMax = false }
+        isApplyingMax = true
+        defer { isApplyingMax = false }
         switch unit {
         case .dash:
             amountText = sourceDuffs.formattedDashAmountWithoutCurrencySymbol
@@ -699,10 +840,77 @@ final class InternalTransferViewModel: ObservableObject {
         }
     }
 
-    private func clearShieldedMaxSelection() {
+    private func clearMaxSelection() {
         isFullShieldedSweep = false
         shieldedSweepAmountCredits = nil
-        shieldedMaxNotice = nil
+        maxNotice = nil
+    }
+
+    /// Kick off (or re-arm) the Platform → Core withdrawal preflight. Split out
+    /// of `routeDidChange` so Max can retry a preflight that failed, instead of
+    /// leaving the route stuck at 0 until the user toggles the route.
+    private func startWithdrawalPreflightIfNeeded() {
+        guard route == .platformToCore, preflightTask == nil else { return }
+        preflightTask = Task { [weak self] in
+            let result = try? await PlatformAddressSyncCoordinator.shared.preflightWithdrawal()
+            guard let self, !Task.isCancelled else { return }
+            self.withdrawalPreflight = result
+            self.preflightTask = nil
+        }
+    }
+
+    /// The part of the Core balance Max cannot offer: unconfirmed/immature
+    /// coins plus the reserved L1 fee.
+    private static func coreHeldBackMessage(_ duffs: UInt64) -> String {
+        let formatted = duffs.formattedDashAmountWithoutCurrencySymbol
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "%@ DASH is held back for the network fee and unconfirmed coins.",
+                comment: "Core Max holds back fee and unconfirmed funds"),
+            formatted)
+    }
+
+    /// Why a Core Max produced nothing, told apart by the three states that
+    /// reach it: no funds at all, funds that are still confirming, and a
+    /// confirmed balance too small to also cover the L1 fee.
+    private static func coreZeroMaxMessage(
+        totalDuffs: UInt64,
+        confirmedSpendableDuffs: UInt64
+    ) -> String {
+        guard totalDuffs > 0 else { return emptyBalanceMessage(.core) }
+        guard confirmedSpendableDuffs > 0 else {
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "None of your %@ DASH is spendable yet — it is still confirming.",
+                    comment: "Core Max has nothing confirmed to spend"),
+                totalDuffs.formattedDashAmountWithoutCurrencySymbol)
+        }
+        return feeReserveExceedsBalanceMessage(.core)
+    }
+
+    private static func feeHeldBackMessage(_ credits: UInt64) -> String {
+        let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "%@ DASH is reserved for the transfer fee.",
+                comment: "Max reserves the transfer fee"),
+            formatted)
+    }
+
+    private static func feeReserveExceedsBalanceMessage(_ source: ChainNetwork) -> String {
+        String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Your %@ balance is too low to cover the transfer fee.",
+                comment: "Max cannot fund the fee"),
+            source.balanceName)
+    }
+
+    private static func emptyBalanceMessage(_ source: ChainNetwork) -> String {
+        String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Your %@ balance is empty.",
+                comment: "Max pressed with no funds"),
+            source.balanceName)
     }
 
     private static func shieldedConfirmingMessage(_ credits: UInt64) -> String {

--- a/DashWallet/Sources/UI/Payments/Pay/ChainNetworkToggle.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/ChainNetworkToggle.swift
@@ -22,6 +22,19 @@ enum ChainNetwork: String, CaseIterable, Identifiable {
         case .shielded: return NSLocalizedString("Shielded", comment: "")
         }
     }
+
+    /// User-facing name of the BALANCE this chain holds. The home balance rows
+    /// and the transfer screens call the Core balance "Transparent"; `title`
+    /// stays the chain's own name for the Send/Receive segmented toggle. One
+    /// source of truth so a row label and its insufficient-funds message can't
+    /// name the same balance differently.
+    var balanceName: String {
+        switch self {
+        case .core: return NSLocalizedString("Transparent", comment: "Balance breakdown")
+        case .platform: return NSLocalizedString("Platform", comment: "Dash Platform chain")
+        case .shielded: return NSLocalizedString("Shielded", comment: "")
+        }
+    }
 }
 
 struct ChainNetworkToggle: View {

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -425,7 +425,7 @@ final class SendViewModel: ObservableObject {
 
     private func creditsMinusFeeReserve(_ balanceCredits: UInt64) -> UInt64 {
         guard let fee = feeReserveCredits else { return 0 }
-        return ShieldedSpendAmountPolicy.spendableCredits(
+        return TransferSpendAmountPolicy.spendableCredits(
             balanceCredits: balanceCredits,
             feeReserveCredits: fee)
     }
@@ -484,38 +484,96 @@ final class SendViewModel: ObservableObject {
         if let shieldedMaxNotice { return shieldedMaxNotice }
         guard dashDuffsUnsigned > 0, let route else { return nil }
 
-        switch route {
-        case .coreToShielded:
+        // Route minimum first: below the Type-18 pool fee the SDK refuses the
+        // asset lock however much Core balance backs it.
+        if route == .coreToShielded {
             guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-                return NSLocalizedString(
-                    "There was an error, please try again later",
-                    comment: "External shielded send fee estimate unavailable")
+                return Self.feeEstimateUnavailableMessage
             }
-            guard dashDuffsUnsigned < minimumDuffs else { return nil }
+            if dashDuffsUnsigned < minimumDuffs {
+                let formattedMinimum =
+                    "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "The minimum amount you can send is %@",
+                        comment: "External shielded send minimum amount"),
+                    formattedMinimum)
+            }
+        }
 
-            let formattedMinimum =
-                "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-            return String.localizedStringWithFormat(
-                NSLocalizedString(
-                    "The minimum amount you can send is %@",
-                    comment: "External shielded send minimum amount"),
-                formattedMinimum)
+        return insufficientBalanceMessage
+    }
+
+    /// "You don't have that much" for the ACTIVE route, named after the balance
+    /// it spends. Mirrors `canContinue`'s envelope route by route so a Continue
+    /// button disabled on affordability is never left unexplained.
+    private var insufficientBalanceMessage: String? {
+        guard let route else { return nil }
+        let balanceName = source.balanceName
+
+        switch route {
+        case .coreToCore, .coreToShielded:
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: coreBalanceDuffs)
+
+        case .platformToPlatform:
+            guard let reserve = feeReserveCredits else {
+                return Self.feeEstimateUnavailableMessage
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedCredits: creditsPreview,
+                balanceCredits: platformCredits,
+                feeReserveCredits: reserve)
 
         case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
+            // A Max sweep is planned against the real note set rather than the
+            // amount+reserve envelope, so it is affordable by construction.
+            if isFullShieldedSweep { return nil }
             guard let reserve = feeReserveCredits else {
-                return NSLocalizedString(
-                    "There was an error, please try again later",
-                    comment: "External Shielded send fee estimate unavailable")
+                return Self.feeEstimateUnavailableMessage
             }
-            return ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
                 feeReserveCredits: reserve)
 
-        default:
-            return nil
+        case .platformToCore:
+            // Stay quiet while the preflight is still resolving: Continue is
+            // disabled, but the amount is not yet known to be unaffordable.
+            guard let preflight = withdrawalPreflight else { return nil }
+            guard preflight.canWithdraw else {
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "Your %@ balance is too low to cover the withdrawal fee.",
+                        comment: "Platform withdrawal cannot fund its own fee"),
+                    balanceName)
+            }
+            if isFullPlatformWithdrawal { return nil }
+            guard creditsPreview > partialWithdrawCapCredits else { return nil }
+
+            let formattedCap =
+                "\((partialWithdrawCapCredits / 1000).formattedDashAmountWithoutCurrencySymbol) DASH"
+            if let fullDuffs = platformWithdrawableDuffs, dashDuffsUnsigned <= fullDuffs {
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "A partial withdrawal is limited to %@. Tap Max to withdraw the full balance.",
+                        comment: "Platform partial withdrawal cap"),
+                    formattedCap)
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: platformWithdrawableDuffs ?? partialWithdrawCapCredits / 1000)
         }
     }
+
+    private static let feeEstimateUnavailableMessage = NSLocalizedString(
+        "There was an error, please try again later",
+        comment: "External send fee estimate unavailable")
 
     /// Gate for advancing from the address step to the amount step: the
     /// entered address decodes to a known destination and — on the balance-row

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -337,32 +337,53 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
 
     func testShieldedSpendableBalanceSubtractsFeeReserve() {
         XCTAssertEqual(
-            ShieldedSpendAmountPolicy.spendableCredits(
+            TransferSpendAmountPolicy.spendableCredits(
                 balanceCredits: 10_000_000_000,
                 feeReserveCredits: 2_000_000_000),
             8_000_000_000)
         XCTAssertEqual(
-            ShieldedSpendAmountPolicy.spendableCredits(
+            TransferSpendAmountPolicy.spendableCredits(
                 balanceCredits: 1_000_000_000,
                 feeReserveCredits: 2_000_000_000),
             0)
     }
 
     func testShieldedInsufficientBalanceMessageUsesSpendableAmount() {
-        let message = ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+        let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
+            balanceName: "Shielded",
             requestedCredits: 8_000_000_001,
             balanceCredits: 10_000_000_000,
             feeReserveCredits: 2_000_000_000)
 
         XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("Shielded") == true)
         XCTAssertTrue(
             message?.contains("0.08 DASH") == true
                 || message?.contains("0,08 DASH") == true)
         XCTAssertNil(
-            ShieldedSpendAmountPolicy.insufficientBalanceMessage(
+            TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: "Shielded",
                 requestedCredits: 8_000_000_000,
                 balanceCredits: 10_000_000_000,
                 feeReserveCredits: 2_000_000_000))
+    }
+
+    func testDuffDenominatedInsufficientBalanceMessageNamesTheBalance() {
+        let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
+            balanceName: "Transparent",
+            requestedDuffs: 50_000_000,
+            spendableDuffs: 40_000_000)
+
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("Transparent") == true)
+        XCTAssertTrue(
+            message?.contains("0.4 DASH") == true
+                || message?.contains("0,4 DASH") == true)
+        XCTAssertNil(
+            TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: "Transparent",
+                requestedDuffs: 40_000_000,
+                spendableDuffs: 40_000_000))
     }
 
     func testUniqueWithdrawalAddressMatchesDespiteRestoreTimeAndAmountSkew() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

A batch of QA findings across the balance, internal-transfer, avatar and
DashPay-username surfaces. Each one had the app either showing a number it
could not honour, or leaving the user with no way forward.

- Switching networks left the previous network's funds on the home screen for
  the whole transition.
- Entering more than the source balance showed nothing at all on the Platform
  and Core transfer routes — Continue just stayed dead with no explanation.
- Max under-filled with no explanation, and on the Core routes it disagreed
  with the very balance the screen was showing.
- Avatar upload could never succeed, then refused to let the user out of the
  failure.
- Contested-username Continue was enabled on wallets that could not pay.
- A contest in progress never said when voting closes; one screen printed a
  hardcoded date in 2023.
- The "Have an invitation?" entry disappeared permanently after the first tap
  on Upgrade, so an invited user could not redeem.
- A username locked by an earlier masternode vote passed the availability
  check and failed at broadcast with a raw Rust debug dump.

## What was done?

**Network switch clears the balance mirrors immediately.** The home header
sums three published mirrors (core balance, BLAST Platform and Shielded
totals). All three were only cleared inside the runtime's serialized
`refresh`, behind the seed-migrator wait and the BLAST/SPV stops — and until
then the 1 Hz SPV progress tick and BLAST sync events kept repainting them.
Both coordinators now expose `prepareForNetworkSwitch()`, which detaches those
feeds and zeroes the mirrors synchronously from the network-change observer,
before the refresh is enqueued. The cancellable teardown is shared with
`performStop` rather than duplicated.

**Every transfer route explains a rejected amount.**
`amountValidationMessage` covered only Core→Shielded minimums and Shielded
spends; everything else fell through to `default: return nil`. It now mirrors
`canContinue`'s envelope route by route and names the balance that is short,
including the Platform→Core partial-withdrawal cap, which points at Max.
`ShieldedSpendAmountPolicy` becomes `TransferSpendAmountPolicy` with a
duff-denominated form; the Send screen had the identical gap and uses it too.

**Max and its gate now describe the same money.** The Core routes validated
against the displayed total but filled from the fee-aware spendable amount, so
any unconfirmed coin silently shrank Max — and the gate let through amounts
the builder must reject. `coreSpendableDuffs` is the single ceiling for
validation, Continue and Max. Max also reports why it held funds back or
produced nothing, and re-arms a Platform→Core preflight that had failed
instead of leaving the route stuck at 0. Balance cards truncate instead of
rounding up, so a card can no longer claim more than Max can fill.

**Avatar upload is honest and no longer a trap.** The Imgur Client-ID was the
literal placeholder `"imgurId"`, carried over from the pre-migration Obj-C
model's `//TODO: DashPay`. It now reads `Imgur-Info.plist` the same way
SwapKit and Coinbase read theirs (gitignored alongside them), and an
unconfigured build fails up front with a message that says so. The error state
kept Cancel hidden, leaving "Try again" as the only control on a failure the
user could not clear; and swiping either sheet away skipped the delegate that
un-hides the crop screen's chrome, stranding the user on a bare photo. Both
are fixed, and the client now logs the refusal, Imgur's status code and body,
and transport failures.

**Username cost gates on spendable funds.** The registration's funding
transaction is an ordinary L1 spend — confirmed UTXOs only, miner fee on top —
but the gate read the displayed total. A diagnostic line now records which of
the four funding sources satisfied the cost rule, since a green rule on a
wallet the user knows is short is otherwise indistinguishable between them.

**A locked contested name is refused before submit.**
`dpnsCheckAvailability` reports a locked label as AVAILABLE — no identity owns
the domain document, because the vote decided nobody gets it — so the form
said "Username available" and let Platform do the rejecting. The check now
also reads the contest's vote state (`winner == "LOCKED"`), scoped to
contested-eligible labels, and fails the rule with wording of its own:
"taken" would send the user off to wait for a name that never frees up. A
failed query does not block the name — the transition stays the authority.
Registration failures are no longer surfaced raw; the locked case gets a
sentence, anything unrecognised passes through unchanged, and the raw text
always reaches the log.

**The vote deadline is shown wherever a contest is in progress.** The close
time was already known — a conservative submission-time estimate, replaced by
Platform's `ContestVoteState.endTime` once the contest is indexed — but only
the home banner rendered it. It now also appears in the post-submit alert, the
identity profile sheet, Request details and the identity detail card. Request
details previously printed `VotingConstants.votingEndTime = 1702695521`, i.e.
16 December 2023, behind a `// TODO replace`; that constant is gone. All
surfaces format through a new `DWDateFormatter.dateAndTime`, because a testnet
contest closes ~90 minutes after submission and the date-only wording said
nothing useful.

**The invitation redeem path stays reachable.** "Have an invitation?" lives
only on the Join DashPay info dialog, and both surfaces that open it latched
it to `joinDashPayInfoShown` on the first ever tap. After that, Upgrade went
straight to the username form and the redeem entry was gone for good — so
anyone whose invitation arrived after they first looked at DashPay could never
open it. Both surfaces now always open the dialog. This is the cheap
stopgap agreed with QA; the durable fix is a permanent entry point elsewhere,
after which the latch can come back.

## How Has This Been Tested?

Clean `dashpay` build after every change (`xcodebuild -workspace
DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator ARCHS=arm64`),
per the branch's standing verification while the unit-test target is broken.
Two compile-ready assertions were added to
`SwiftDashSDKCoreLifecycleTests` covering the renamed policy's credit- and
duff-denominated message forms.

Testnet smoke of the touched flows on device, driven by QA screenshots and
exported diagnostic logs:

- network switch: home balance drops to zero immediately instead of holding
  the previous network's totals;
- internal transfer: over-balance entry now names the short balance, Max
  states what it held back;
- avatar: the failure sheet is escapable, and swiping it away returns to a
  usable crop screen;
- contested username: a locked label (`asd`) is refused at the rule instead of
  at broadcast, and the failure alert reads as a sentence;
- vote deadline visible on all five surfaces.

Not verified end to end: a successful avatar upload, which needs a real Imgur
Client-ID in `Imgur-Info.plist` — the file is gitignored and must be added to
the dashwallet and dashpay targets locally.

## Breaking Changes

None. `ShieldedSpendAmountPolicy` is renamed to `TransferSpendAmountPolicy`
and its message function takes a `balanceName`; both call sites and the test
are updated in this branch. `VotingConstants.votingEndTime` is removed — it
had a single consumer, which now reads the real per-submission deadline.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
