### PR TITLE
fix(wallet): read masternode owner/voting addresses from the live pool

### DIFF
--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/Models/DerivationPathKeysModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/Models/DerivationPathKeysModel.swift
@@ -186,12 +186,20 @@ extension DerivationPathKeysModel {
 /// its owner/voting address join.
 @MainActor
 final class MasternodeProviderKeyDeriver {
+    /// `AccountTypeTagFFI` discriminants for the two address-carrying provider
+    /// families (`rs-platform-wallet-ffi` `wallet_restore_types.rs`).
+    private static let votingKeysTypeTag: UInt8 = 8
+    private static let ownerKeysTypeTag: UInt8 = 9
+
     private let key: MNKey
     private let masterPath: String
     private let accountType: AccountType
     private let wallet: Wallet
-    private let manager: WalletManager
-    private let walletId: Data
+
+    /// Index → base58 address of the LIVE provider pool, read once from the
+    /// running `PlatformWalletManager` (see `loadLiveAddresses`). Empty when
+    /// the account/pool isn't available.
+    private let liveAddresses: [UInt32: String]
 
     init?(key: MNKey) {
         guard let network = SwiftDashSDKHost.shared.runningNetwork else {
@@ -214,20 +222,51 @@ final class MasternodeProviderKeyDeriver {
             return nil
         }
 
-        guard let (manager, wallet, walletId) = SwiftDashSDKHost.shared.derivationWallet() else {
+        // The derivation stack is a THROWAWAY key-wallet built from the
+        // mnemonic (see `SwiftDashSDKHost.derivationWallet`) — it has never
+        // processed a transaction, so its pools sit at the freshly-created
+        // `DEFAULT_SPECIAL_GAP_LIMIT` depth. It is used ONLY for private-key
+        // derivation, which works at any index; addresses come from the live
+        // pool below.
+        guard let (_, wallet, _) = SwiftDashSDKHost.shared.derivationWallet() else {
             return nil
         }
 
-        // Ensure the provider account exists so the managed collection can vend
-        // its address pool.
+        // Ensure the provider account exists so private-key derivation can
+        // resolve it.
         _ = try? wallet.getAccount(type: type)
 
         self.key = key
         self.masterPath = path
         self.accountType = type
-        self.manager = manager
         self.wallet = wallet
-        self.walletId = walletId
+        self.liveAddresses = Self.loadLiveAddresses(for: key)
+    }
+
+    /// Snapshot the running wallet's provider address pool — the one SPV
+    /// extends as ProRegTx/ProUpRegTx matches mark indexes used, and the one
+    /// the Storage Explorer renders. Read once per deriver: the FFI returns
+    /// the whole pool, so per-index lookups are dictionary hits.
+    private static func loadLiveAddresses(for key: MNKey) -> [UInt32: String] {
+        let typeTag: UInt8
+        switch key {
+        case .voting: typeTag = votingKeysTypeTag
+        case .owner: typeTag = ownerKeysTypeTag
+        case .operator, .evonodeOperator: return [:]
+        }
+        guard let manager = SwiftDashSDKHost.shared.manager,
+              let walletId = SwiftDashSDKHost.shared.wallet?.walletId,
+              let balance = manager.accountBalances(for: walletId)
+                  .first(where: { $0.typeTag == typeTag })
+        else { return [:] }
+
+        var addresses: [UInt32: String] = [:]
+        for pool in manager.accountAddressPools(for: walletId, balance: balance) {
+            for info in pool.addresses where !info.address.isEmpty {
+                addresses[info.addressIndex] = info.address
+            }
+        }
+        return addresses
     }
 
     func wif(at index: UInt32) -> String? {
@@ -240,26 +279,18 @@ final class MasternodeProviderKeyDeriver {
         return data.map { String(format: "%02x", $0) }.joined()
     }
 
+    /// The pool address at `index`, from the running wallet's live provider
+    /// pool. Reading the throwaway derivation wallet here instead would cap
+    /// every consumer at that stack's initial 5-entry pool, hiding every
+    /// masternode whose owner/voting key sits at a deeper index.
     func address(at index: UInt32) -> String? {
-        guard let collection = manager.getManagedAccountCollection(walletId: walletId) else {
-            return nil
-        }
+        liveAddresses[index]
+    }
 
-        let account: ManagedAccount?
-        switch key {
-        case .voting:
-            account = collection.getProviderVotingKeysAccount()
-        case .owner:
-            account = collection.getProviderOwnerKeysAccount()
-        case .operator, .evonodeOperator:
-            account = nil
-        }
-
-        guard let pool = account?.getAddressPool(type: .single) ?? account?.getExternalAddressPool(),
-              let info = try? pool.getAddress(at: index) else {
-            return nil
-        }
-        return info.address
+    /// Highest index the live pool holds, or nil when it's unavailable —
+    /// lets the address-join scan the whole pool instead of a fixed window.
+    var highestAddressIndex: UInt32? {
+        liveAddresses.keys.max()
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/Models/DerivationPathKeysModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/Models/DerivationPathKeysModel.swift
@@ -192,14 +192,18 @@ final class MasternodeProviderKeyDeriver {
     private static let ownerKeysTypeTag: UInt8 = 9
 
     private let key: MNKey
-    private let masterPath: String
+    private let accountRootPath: String
     private let accountType: AccountType
     private let wallet: Wallet
 
-    /// Index → base58 address of the LIVE provider pool, read once from the
-    /// running `PlatformWalletManager` (see `loadLiveAddresses`). Empty when
-    /// the account/pool isn't available.
-    private let liveAddresses: [UInt32: String]
+    /// Index → base58 address of the provider pool, snapshotted once at init.
+    /// Sourced from the running wallet (`loadLiveAddresses`), falling back to
+    /// the derivation wallet's own pool (`loadDerivationAddresses`) when the
+    /// running wallet has no provider account yet — e.g. a just-imported
+    /// wallet whose registration hasn't completed. Empty only when neither
+    /// source has a pool, in which case there are genuinely no addresses to
+    /// join against.
+    private let poolAddresses: [UInt32: String]
 
     init?(key: MNKey) {
         guard let network = SwiftDashSDKHost.shared.runningNetwork else {
@@ -228,19 +232,25 @@ final class MasternodeProviderKeyDeriver {
         // `DEFAULT_SPECIAL_GAP_LIMIT` depth. It is used ONLY for private-key
         // derivation, which works at any index; addresses come from the live
         // pool below.
-        guard let (_, wallet, _) = SwiftDashSDKHost.shared.derivationWallet() else {
+        guard let (derivationManager, wallet, derivationWalletId) =
+                SwiftDashSDKHost.shared.derivationWallet() else {
             return nil
         }
 
-        // Ensure the provider account exists so private-key derivation can
-        // resolve it.
+        // Ensure the provider account exists so private-key derivation — and
+        // the fallback pool read below — can resolve it.
         _ = try? wallet.getAccount(type: type)
 
         self.key = key
-        self.masterPath = path
+        self.accountRootPath = path
         self.accountType = type
         self.wallet = wallet
-        self.liveAddresses = Self.loadLiveAddresses(for: key)
+
+        let live = Self.loadLiveAddresses(for: key)
+        self.poolAddresses = live.isEmpty
+            ? Self.loadDerivationAddresses(
+                key: key, manager: derivationManager, walletId: derivationWalletId)
+            : live
     }
 
     /// Snapshot the running wallet's provider address pool — the one SPV
@@ -269,9 +279,50 @@ final class MasternodeProviderKeyDeriver {
         return addresses
     }
 
+    /// Degraded-path pool read from the derivation wallet itself, used when
+    /// the running wallet can't vend the account. This stack never processes
+    /// transactions, so its pool is only ever the freshly-created
+    /// `DEFAULT_SPECIAL_GAP_LIMIT` depth — enough to keep the low indexes
+    /// resolvable rather than showing nothing at all, but it is NOT a
+    /// substitute for the live pool (that shallowness is precisely the bug
+    /// this class's live read exists to fix).
+    private static func loadDerivationAddresses(
+        key: MNKey,
+        manager: WalletManager,
+        walletId: Data
+    ) -> [UInt32: String] {
+        guard let collection = manager.getManagedAccountCollection(walletId: walletId) else {
+            return [:]
+        }
+        let account: ManagedAccount?
+        switch key {
+        case .voting: account = collection.getProviderVotingKeysAccount()
+        case .owner: account = collection.getProviderOwnerKeysAccount()
+        case .operator, .evonodeOperator: account = nil
+        }
+        guard let pool = account?.getAddressPool(type: .single)
+                ?? account?.getExternalAddressPool() else {
+            return [:]
+        }
+
+        // The pool exposes no count, so walk until it stops vending. The cap
+        // is a runaway guard, not a semantic window: this pool is created at
+        // gap-limit depth and never grows here.
+        var addresses: [UInt32: String] = [:]
+        for index in 0..<Self.derivationPoolProbeCap {
+            guard let info = try? pool.getAddress(at: index) else { break }
+            addresses[index] = info.address
+        }
+        return addresses
+    }
+
+    /// Runaway guard for the fallback pool walk — far above any gap-limit
+    /// depth the derivation wallet can hold.
+    private static let derivationPoolProbeCap: UInt32 = 200
+
     func wif(at index: UInt32) -> String? {
         guard let account = try? wallet.getAccount(type: accountType) else { return nil }
-        return try? account.derivePrivateKeyWIF(wallet: wallet, masterPath: masterPath, index: index)
+        return try? account.derivePrivateKeyWIF(wallet: wallet, masterPath: accountRootPath, index: index)
     }
 
     func privateKeyHex(at index: UInt32) -> String? {
@@ -279,18 +330,20 @@ final class MasternodeProviderKeyDeriver {
         return data.map { String(format: "%02x", $0) }.joined()
     }
 
-    /// The pool address at `index`, from the running wallet's live provider
-    /// pool. Reading the throwaway derivation wallet here instead would cap
-    /// every consumer at that stack's initial 5-entry pool, hiding every
-    /// masternode whose owner/voting key sits at a deeper index.
+    /// The pool address at `index`. Backed by the running wallet's live pool
+    /// whenever it's available: reading the throwaway derivation wallet as
+    /// the primary source would cap every consumer at that stack's initial
+    /// 5-entry pool, hiding every masternode whose owner/voting key sits at
+    /// a deeper index.
     func address(at index: UInt32) -> String? {
-        liveAddresses[index]
+        poolAddresses[index]
     }
 
-    /// Highest index the live pool holds, or nil when it's unavailable —
-    /// lets the address-join scan the whole pool instead of a fixed window.
+    /// Highest index the snapshotted pool holds, or nil when no pool could be
+    /// read — lets the address joins walk the real pool rather than a fixed
+    /// window, and skip entirely when there is nothing to walk.
     var highestAddressIndex: UInt32? {
-        liveAddresses.keys.max()
+        poolAddresses.keys.max()
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/Model/WalletKeysOverviewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/Model/WalletKeysOverviewModel.swift
@@ -66,9 +66,11 @@ struct MasternodeKeyUsage {
         let revoked: Bool
     }
 
-    /// Owner/Voting address-join scan window. Matches the SDK's
-    /// pre-derivation count (`PLATFORM_NODE_KEY_PREDERIVE_COUNT`).
-    private static let scanWindow: UInt32 = 20
+    /// Fallback Owner/Voting address-join scan window, used only when the
+    /// live pool's depth can't be read. The join normally walks the whole
+    /// pool (`MasternodeProviderKeyDeriver.highestAddressIndex`), which SPV
+    /// grows past any fixed window as it marks deeper indexes used.
+    private static let fallbackScanWindow: UInt32 = 20
 
     private let used: [MNKey: [UInt32: KeyUse]]
 
@@ -139,7 +141,11 @@ struct MasternodeKeyUsage {
             }
             guard !useByAddress.isEmpty,
                   let deriver = MasternodeProviderKeyDeriver(key: key) else { continue }
-            for index in 0..<scanWindow {
+            // Walk the live pool's full depth: SPV extends it past any fixed
+            // window as ProRegTx/ProUpRegTx matches mark deeper indexes used,
+            // so a capped scan would silently hide those masternodes.
+            let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? fallbackScanWindow
+            for index in 0..<upperBound {
                 guard let address = deriver.address(at: index),
                       let use = useByAddress[address] else { continue }
                 record(key, index, use)

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/Model/WalletKeysOverviewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/Model/WalletKeysOverviewModel.swift
@@ -66,12 +66,6 @@ struct MasternodeKeyUsage {
         let revoked: Bool
     }
 
-    /// Fallback Owner/Voting address-join scan window, used only when the
-    /// live pool's depth can't be read. The join normally walks the whole
-    /// pool (`MasternodeProviderKeyDeriver.highestAddressIndex`), which SPV
-    /// grows past any fixed window as it marks deeper indexes used.
-    private static let fallbackScanWindow: UInt32 = 20
-
     private let used: [MNKey: [UInt32: KeyUse]]
 
     private init(used: [MNKey: [UInt32: KeyUse]]) {
@@ -141,10 +135,11 @@ struct MasternodeKeyUsage {
             }
             guard !useByAddress.isEmpty,
                   let deriver = MasternodeProviderKeyDeriver(key: key) else { continue }
-            // Walk the live pool's full depth: SPV extends it past any fixed
+            // Walk the pool's full depth: SPV extends it past any fixed
             // window as ProRegTx/ProUpRegTx matches mark deeper indexes used,
-            // so a capped scan would silently hide those masternodes.
-            let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? fallbackScanWindow
+            // so a capped scan would silently hide those masternodes. No pool
+            // means no addresses to join against, so the loop is skipped.
+            let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? 0
             for index in 0..<upperBound {
                 guard let address = deriver.address(at: index),
                       let use = useByAddress[address] else { continue }

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -40,10 +40,6 @@ final class MasternodesViewModel: ObservableObject {
     private var ownerIndexByAddress: [String: UInt32] = [:]
     private var votingIndexByAddress: [String: UInt32] = [:]
 
-    /// Fallback join window, used only when the live pool's depth can't be
-    /// read. Mirrors `MasternodeKeyUsage.fallbackScanWindow`.
-    private static let fallbackScanWindow: UInt32 = 20
-
     func load() {
         defer { loaded = true }
         guard let manager = SwiftDashSDKHost.shared.manager,
@@ -67,8 +63,8 @@ final class MasternodesViewModel: ObservableObject {
         guard !targets.isEmpty,
               let deriver = MasternodeProviderKeyDeriver(key: family) else { return [:] }
         var map: [String: UInt32] = [:]
-        // Whole live pool, not a fixed window — see `MasternodeKeyUsage`.
-        let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? fallbackScanWindow
+        // Whole pool, not a fixed window — see `MasternodeKeyUsage`.
+        let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? 0
         for index in 0..<upperBound {
             guard let address = deriver.address(at: index),
                   targets.contains(address) else { continue }

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -40,8 +40,9 @@ final class MasternodesViewModel: ObservableObject {
     private var ownerIndexByAddress: [String: UInt32] = [:]
     private var votingIndexByAddress: [String: UInt32] = [:]
 
-    /// Matches `MasternodeKeyUsage.scanWindow` / the SDK pre-derivation count.
-    private static let addressScanWindow: UInt32 = 20
+    /// Fallback join window, used only when the live pool's depth can't be
+    /// read. Mirrors `MasternodeKeyUsage.fallbackScanWindow`.
+    private static let fallbackScanWindow: UInt32 = 20
 
     func load() {
         defer { loaded = true }
@@ -66,7 +67,9 @@ final class MasternodesViewModel: ObservableObject {
         guard !targets.isEmpty,
               let deriver = MasternodeProviderKeyDeriver(key: family) else { return [:] }
         var map: [String: UInt32] = [:]
-        for index in 0..<addressScanWindow {
+        // Whole live pool, not a fixed window — see `MasternodeKeyUsage`.
+        let upperBound = deriver.highestAddressIndex.map { $0 + 1 } ?? fallbackScanWindow
+        for index in 0..<upperBound {
             guard let address = deriver.address(at: index),
                   targets.contains(address) else { continue }
             map[address] = index


### PR DESCRIPTION
## The symptom

Masternode Keys showed **Owner 5 keys / 5 used** and **Voting 5 keys / 2 used**, while Operator showed 20/17 — on a wallet whose live pools actually hold 25 owner and 25 voting addresses with 20 and 17 marked used.

## Root cause

`MasternodeProviderKeyDeriver.address(at:)` resolved addresses from `SwiftDashSDKHost.derivationWallet()` — documented in-place as a *"throwaway key-wallet stack"* built fresh from the mnemonic via `addWallet`, for path-based key derivation. That instance has never processed a transaction, so its provider pools sit at the freshly-created `DEFAULT_SPECIAL_GAP_LIMIT` (5) depth forever. Index ≥ 5 returned `nil`.

Both consumers of that lookup are address **joins** — `MasternodeKeyUsage.resolve` (overview counts + detail rows) and `MasternodesScreen.indexByAddress` (ownership labels) — and both `continue` past an index whose address is `nil`. So any masternode whose owner/voting key sits deeper than #4 was silently invisible.

Operator and Evonode Operator were never affected because Rust resolves their indexes directly on the aggregation row (`operatorKeyIndex` / `platformKeyIndex`) instead of joining on an address.

The numbers line up exactly: the live voting pool has #0–#2 unused and #3+ used, so a 5-deep throwaway pool yields precisely the observed "5 keys / 2 used".

## Fix

Addresses now come from the running `PlatformWalletManager` via `accountAddressPools(for:balance:)` — the pool SPV extends as ProRegTx/ProUpRegTx matches mark deeper indexes used, and the same data the Storage Explorer renders. The pool is snapshotted once per deriver, so per-index lookups became dictionary hits rather than an FFI call each.

The fixed 20-index scan windows in both joins are replaced by the live pool's actual depth (`highestAddressIndex`), with the 20 kept only as a fallback when that can't be read — a pool grown past 20 would otherwise hit the same silent cap one size up.

Private-key derivation (`wif` / `privateKeyHex`) still uses the derivation wallet: it needs the mnemonic and derives correctly at any index, pool depth being irrelevant there.

## Verification

- `dashpay` scheme builds clean (arm64 simulator); installed to the QA simulator.
- Evidence gathered from the affected wallet's own SwiftData store: provider voting = 25 addresses / 17 used / max index 24, provider owner = 25 / 20 / 24 — versus the 5 the screen was reporting.
- **Not yet visually confirmed on-device**: the simulator is PIN-gated, so I couldn't drive it to the screen. Expected after unlocking: Owner ≈ 21 keys / 20 used and Voting ≈ 25 / 17, and `Masternodes` ownership labels resolving for nodes previously shown as not-in-wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved masternode owner and voting address discovery using the wallet’s current address pools.
  * Expanded address scanning to cover the full available derivation range instead of limiting checks to 20 addresses.
  * Added fallback scanning when live wallet address data is unavailable.
  * Improved masternode provider key handling while keeping derived private keys isolated from the active wallet.
  * Prevented unsupported key types and unavailable address pools from producing invalid results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->