### PR TITLE
feat(ui): group Masternodes and Voting under a Governance menu

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -772,6 +772,10 @@
 		756557B62CE84FFA0060348D /* FeeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756557B42CE84FF70060348D /* FeeInfo.swift */; };
 		7566F4832BB6949E005238D2 /* ToolsMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */; };
 		7566F4842BB6949E005238D2 /* ToolsMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */; };
+		5AGOV0002F9A0000000000S2 /* GovernanceMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AGOV0002F9A0000000000S1 /* GovernanceMenuScreen.swift */; };
+		5AGOV0002F9A0000000000S3 /* GovernanceMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AGOV0002F9A0000000000S1 /* GovernanceMenuScreen.swift */; };
+		5AGOV0002F9A0000000000V2 /* GovernanceMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AGOV0002F9A0000000000V1 /* GovernanceMenuViewModel.swift */; };
+		5AGOV0002F9A0000000000V3 /* GovernanceMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AGOV0002F9A0000000000V1 /* GovernanceMenuViewModel.swift */; };
 		7566F48A2BB6CAF2005238D2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4892BB6CAF2005238D2 /* MenuItem.swift */; };
 		7566F48B2BB6CAF2005238D2 /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7566F4892BB6CAF2005238D2 /* MenuItem.swift */; };
 		7569D6832DE6DA6800768BFF /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7569D6822DE6DA6800768BFF /* ExploreViewController.swift */; };
@@ -2897,6 +2901,8 @@
 		755E6DFD2A99E7A000A42870 /* DWInvitationSetupState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DWInvitationSetupState.h; sourceTree = "<group>"; };
 		756557B42CE84FF70060348D /* FeeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeInfo.swift; sourceTree = "<group>"; };
 		7566F4822BB69498005238D2 /* ToolsMenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolsMenuScreen.swift; sourceTree = "<group>"; };
+		5AGOV0002F9A0000000000S1 /* GovernanceMenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovernanceMenuScreen.swift; sourceTree = "<group>"; };
+		5AGOV0002F9A0000000000V1 /* GovernanceMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GovernanceMenuViewModel.swift; sourceTree = "<group>"; };
 		7566F4892BB6CAF2005238D2 /* MenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
 		7569D6822DE6DA6800768BFF /* ExploreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewController.swift; sourceTree = "<group>"; };
 		7569D6852DE6DB1B00768BFF /* ExploreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreHeaderView.swift; sourceTree = "<group>"; };
@@ -4722,6 +4728,7 @@
 				2A7A7BD32348CB4F00451078 /* Settings */,
 				51AA00102F970010005A0010 /* SyncInfo */,
 				2A7A7BDA2348DBE700451078 /* Tools */,
+				5AGOV0002F9A0000000000G0 /* Governance */,
 				755049AB2C846576008FA7EB /* MenuItemModel.swift */,
 			);
 			path = Menu;
@@ -4758,6 +4765,15 @@
 				750CED5F2C94BFD7000FB837 /* SettingsMenuViewModel.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		5AGOV0002F9A0000000000G0 /* Governance */ = {
+			isa = PBXGroup;
+			children = (
+				5AGOV0002F9A0000000000S1 /* GovernanceMenuScreen.swift */,
+				5AGOV0002F9A0000000000V1 /* GovernanceMenuViewModel.swift */,
+			);
+			path = Governance;
 			sourceTree = "<group>";
 		};
 		2A7A7BDA2348DBE700451078 /* Tools */ = {
@@ -10039,6 +10055,8 @@
 				47CF46A1296540EF0067B6EE /* AccountService.swift in Sources */,
 				47C6E6E7291A90B3003FEDF2 /* ListHandlerView.swift in Sources */,
 				7566F4832BB6949E005238D2 /* ToolsMenuScreen.swift in Sources */,
+				5AGOV0002F9A0000000000S2 /* GovernanceMenuScreen.swift in Sources */,
+				5AGOV0002F9A0000000000V2 /* GovernanceMenuViewModel.swift in Sources */,
 				RC00C0012FA0000000000001 /* CSVExportSheet.swift in Sources */,
 				754D020E2D1558EB005CA466 /* GroupedTransactions.swift in Sources */,
 				11BD738128E7356100A34022 /* CrowdNode.swift in Sources */,
@@ -10664,6 +10682,8 @@
 				C9D2C7AB2A320AA000D15901 /* DWBaseFormTableViewCell.m in Sources */,
 				C9D2C7AC2A320AA000D15901 /* AccountCell.swift in Sources */,
 				7566F4842BB6949E005238D2 /* ToolsMenuScreen.swift in Sources */,
+				5AGOV0002F9A0000000000S3 /* GovernanceMenuScreen.swift in Sources */,
+				5AGOV0002F9A0000000000V3 /* GovernanceMenuViewModel.swift in Sources */,
 				RC00C0022FA0000000000001 /* CSVExportSheet.swift in Sources */,
 				C943B33A2A408CED00AF23C5 /* DWUploadAvatarModel.m in Sources */,
 				C943B3392A408CED00AF23C5 /* DWUploadAvatarViewController.m in Sources */,

--- a/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuScreen.swift
@@ -1,0 +1,128 @@
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DashUIKit
+import SwiftUI
+import UIKit
+
+/// Governance submenu: the wallet's masternode-facing surfaces, reached from
+/// the main menu's "Governance" row. Groups Masternodes (moved here from
+/// Tools) with username Voting (moved here from the main menu).
+struct GovernanceMenuScreen: View {
+    private let vc: UINavigationController
+
+    @StateObject private var viewModel = GovernanceMenuViewModel()
+
+    init(vc: UINavigationController) {
+        self.vc = vc
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            NavBarBack {
+                vc.popViewController(animated: true)
+            }
+
+            TopIntro(title: NSLocalizedString("Governance", comment: "Governance"))
+                .padding(.leading, 20)
+                .padding(.trailing, 60)
+                .padding(.top, 10)
+                .padding(.bottom, 20)
+
+            VStack(spacing: 2) {
+                ForEach(viewModel.items) { item in
+                    MenuItem(
+                        title: item.title,
+                        subtitle: item.subtitle,
+                        details: item.details,
+                        icon: item.icon,
+                        showInfo: item.showInfo,
+                        showChevron: false,
+                        isToggled: item.isToggled,
+                        action: item.action
+                    )
+                    .frame(minHeight: 56)
+                }
+            }
+            .padding(6)
+            .background(Color.dash.secondaryBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .shadow(color: Color.dash.shadow, radius: 20, x: 0, y: 5)
+            .padding(.horizontal, 20)
+
+            Spacer()
+        }
+        .background(Color.dash.primaryBackground)
+        .navigationBarHidden(true)
+        .onReceive(viewModel.$navigationDestination) { destination in
+            handleNavigation(destination)
+        }
+    }
+
+    private func handleNavigation(_ destination: GovernanceMenuNavigationDestination?) {
+        switch destination {
+        case .masternodes:
+            showMasternodes()
+        #if DASHPAY
+        case .voting:
+            showVoting()
+        #endif
+        case .none:
+            break
+        }
+
+        if destination != nil {
+            viewModel.resetNavigation()
+        }
+    }
+
+    /// Same hosting wrapper Tools used when this screen lived there: the
+    /// SwiftUI list needs its own `NavigationStack` for row drill-downs, so
+    /// the back button is wired explicitly to pop the UIKit stack.
+    private func showMasternodes() {
+        let navController = vc
+        let popRoot: () -> Void = { [weak navController] in
+            _ = navController?.popViewController(animated: true)
+        }
+
+        let hosting = UIHostingController(
+            rootView: AnyView(
+                NavigationStack {
+                    MasternodesScreen()
+                        .navigationTitle(NSLocalizedString("Masternodes", comment: "Masternodes"))
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button(action: popRoot) {
+                                    Image(systemName: "chevron.left")
+                                }
+                            }
+                        }
+                }
+            )
+        )
+        hosting.hidesBottomBarWhenPushed = true
+        vc.pushViewController(hosting, animated: true)
+    }
+
+    #if DASHPAY
+    private func showVoting() {
+        let controller = UsernameVotingViewController.controller()
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
+    }
+    #endif
+}

--- a/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuViewModel.swift
@@ -1,0 +1,73 @@
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+enum GovernanceMenuNavigationDestination {
+    case masternodes
+    #if DASHPAY
+    case voting
+    #endif
+}
+
+@MainActor
+final class GovernanceMenuViewModel: ObservableObject {
+    @Published var items: [MenuItemModel] = []
+    @Published var navigationDestination: GovernanceMenuNavigationDestination?
+
+    init() {
+        setupMenuItems()
+    }
+
+    private func setupMenuItems() {
+        var allItems: [MenuItemModel] = []
+
+        // Masternodes — not DashPay-gated: masternode ownership is a Core
+        // concern and this screen is reachable in every build configuration
+        // (it previously lived under Tools with no gate).
+        allItems.append(MenuItemModel(
+            title: NSLocalizedString("Masternodes", comment: "Masternodes"),
+            subtitle: NSLocalizedString(
+                "Masternodes and evonodes using this wallet's keys", comment: "Masternodes"),
+            icon: .system("server.rack"),
+            action: { [weak self] in
+                self?.navigationDestination = .masternodes
+            }
+        ))
+
+        #if DASHPAY
+        // Username voting, behind the same preference that gated it on the
+        // main menu (Settings → "Username voting").
+        if VotingPrefs.shared.votingEnabled {
+            allItems.append(MenuItemModel(
+                title: NSLocalizedString("Voting", comment: ""),
+                subtitle: NSLocalizedString(
+                    "Vote on contested usernames", comment: "Voting"),
+                icon: .custom("menu_voting", maxHeight: 30),
+                action: { [weak self] in
+                    self?.navigationDestination = .voting
+                }
+            ))
+        }
+        #endif
+
+        items = allItems
+    }
+
+    func resetNavigation() {
+        navigationDestination = nil
+    }
+}

--- a/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuViewModel.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+import Combine
 import Foundation
 
 enum GovernanceMenuNavigationDestination {

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -152,6 +152,7 @@ struct MainMenuScreen: View {
     @ObservedObject private var viewModel: MainMenuViewModel
     @State private var openSettings: Bool = false
     @State private var showTools: Bool = false
+    @State private var showGovernance: Bool = false
     @State private var showSyncInfo: Bool = false
     @State private var showWallets: Bool = false
     @State private var showIdentities: Bool = false
@@ -337,6 +338,13 @@ struct MainMenuScreen: View {
             ) {
                 EmptyView()
             }
+
+            NavigationLink(
+                destination: GovernanceMenuScreen(vc: vc),
+                isActive: $showGovernance
+            ) {
+                EmptyView()
+            }
             
             NavigationLink(
                 destination: SyncInfoMenuScreen(vc: vc),
@@ -451,10 +459,8 @@ struct MainMenuScreen: View {
             showTools = true
         case .support:
             onContactSupport()
-        #if DASHPAY
-        case .voting:
-            showVoting()
-        #endif
+        case .governance:
+            showGovernance = true
         case .none:
             return
         }

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -28,9 +28,7 @@ enum MainMenuNavigationDestination {
     case settings
     case tools
     case support
-    #if DASHPAY
-    case voting
-    #endif
+    case governance
 }
 
 protocol MainMenuViewModelDelegate: AnyObject {
@@ -166,18 +164,16 @@ class MainMenuViewModel: ObservableObject {
             }
         ))
         
-        #if DASHPAY
-        // Voting
-        if VotingPrefs.shared.votingEnabled {
-            allItems.append(MenuItemModel(
-                title: NSLocalizedString("Voting", comment: ""),
-                icon: .custom("menu_voting", maxHeight: 30),
-                action: { [weak self] in
-                    self?.navigationDestination = .voting
-                }
-            ))
-        }
-        #endif
+        // Governance — Masternodes plus (on DashPay builds, when enabled)
+        // username Voting. Not DashPay-gated: Masternodes is a Core-side
+        // surface that every build configuration can reach.
+        allItems.append(MenuItemModel(
+            title: NSLocalizedString("Governance", comment: "Governance"),
+            icon: .custom("menu_voting", maxHeight: 30),
+            action: { [weak self] in
+                self?.navigationDestination = .governance
+            }
+        ))
         
         self.items = allItems
     }

--- a/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift
@@ -33,6 +33,21 @@ final class MasternodesViewModel: ObservableObject {
     @Published private(set) var masternodes: [PlatformMasternode] = []
     @Published private(set) var loaded = false
 
+    /// Registrations still on the network — active, PoSe-banned, or (before
+    /// the list arrives) indeterminate. These stay expanded at the top: an
+    /// inactive node is a problem the user probably wants to see, not
+    /// history.
+    var currentMasternodes: [PlatformMasternode] {
+        masternodes.filter { MasternodeStatus(rawValue: $0.status) != .retired }
+    }
+
+    /// Registrations no longer in the masternode list — collateral spent,
+    /// revoked, or expired. History: shown in a collapsed section at the
+    /// bottom.
+    var retiredMasternodes: [PlatformMasternode] {
+        masternodes.filter { MasternodeStatus(rawValue: $0.status) == .retired }
+    }
+
     /// In-wallet key index by base58 address for the two address-carrying
     /// families. Operator/platform ownership comes pre-resolved on the
     /// aggregation row; owner/voting is joined here against the derived
@@ -166,6 +181,9 @@ private extension PlatformMasternode {
 struct MasternodesScreen: View {
     @StateObject private var viewModel = MasternodesViewModel()
 
+    /// Retired registrations are history — collapsed until asked for.
+    @State private var isRetiredExpanded = false
+
     var body: some View {
         List {
             if viewModel.loaded && viewModel.masternodes.isEmpty {
@@ -187,15 +205,32 @@ struct MasternodesScreen: View {
                     .padding(.vertical, 20)
                 }
             } else {
-                Section {
-                    ForEach(viewModel.masternodes, id: \.proTxHash) { masternode in
-                        NavigationLink {
-                            MasternodeDetailScreen(
-                                masternode: masternode,
-                                ownerOwnership: viewModel.ownerOwnership(for: masternode),
-                                votingOwnership: viewModel.votingOwnership(for: masternode))
+                if !viewModel.currentMasternodes.isEmpty {
+                    Section {
+                        ForEach(viewModel.currentMasternodes, id: \.proTxHash) { masternode in
+                            row(for: masternode)
+                        }
+                    }
+                }
+
+                if !viewModel.retiredMasternodes.isEmpty {
+                    Section {
+                        DisclosureGroup(isExpanded: $isRetiredExpanded) {
+                            ForEach(viewModel.retiredMasternodes, id: \.proTxHash) { masternode in
+                                row(for: masternode)
+                            }
                         } label: {
-                            MasternodeListRow(masternode: masternode)
+                            HStack {
+                                Text(NSLocalizedString("Retired", comment: "Masternodes"))
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+
+                                Spacer()
+
+                                Text("\(viewModel.retiredMasternodes.count)")
+                                    .font(.caption)
+                                    .foregroundColor(Color.dash.secondaryText)
+                            }
                         }
                     }
                 }
@@ -203,6 +238,17 @@ struct MasternodesScreen: View {
         }
         .onAppear {
             viewModel.load()
+        }
+    }
+
+    private func row(for masternode: PlatformMasternode) -> some View {
+        NavigationLink {
+            MasternodeDetailScreen(
+                masternode: masternode,
+                ownerOwnership: viewModel.ownerOwnership(for: masternode),
+                votingOwnership: viewModel.votingOwnership(for: masternode))
+        } label: {
+            MasternodeListRow(masternode: masternode)
         }
     }
 }

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
@@ -197,8 +197,6 @@ struct ToolsMenuScreen: View {
             showExtendedPublicKeys()
         case .masternodeKeys:
             showMasternodeKeys()
-        case .masternodes:
-            showMasternodes()
         case .csvExport:
             showCSVExportSheet = true
         case .zenLedger:
@@ -271,32 +269,6 @@ struct ToolsMenuScreen: View {
         vc.pushViewController(controller, animated: true)
     }
 
-    private func showMasternodes() {
-        let navController = vc
-        let popRoot: () -> Void = { [weak navController] in
-            _ = navController?.popViewController(animated: true)
-        }
-
-        let hosting = UIHostingController(
-            rootView: AnyView(
-                NavigationStack {
-                    MasternodesScreen()
-                        .navigationTitle(NSLocalizedString("Masternodes", comment: ""))
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button(action: popRoot) {
-                                    Image(systemName: "chevron.left")
-                                }
-                            }
-                        }
-                }
-            )
-        )
-        hosting.hidesBottomBarWhenPushed = true
-        vc.pushViewController(hosting, animated: true)
-    }
-    
     private func handleCSVExport() {
         Task {
             do {

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuViewModel.swift
@@ -22,7 +22,6 @@ import SwiftDashSDK
 enum ToolsMenuNavigationDestination {
     case extendedPublicKeys
     case masternodeKeys
-    case masternodes
     case csvExport
     case zenLedger
     case storageExplorer
@@ -99,14 +98,6 @@ class ToolsMenuViewModel: ObservableObject {
                 icon: .custom("image.masternode.keys", maxHeight: 30),
                 action: { [weak self] in
                     self?.navigationDestination = .masternodeKeys
-                }
-            ),
-            MenuItemModel(
-                title: NSLocalizedString("Masternodes", comment: ""),
-                subtitle: NSLocalizedString("Masternodes and evonodes using this wallet's keys", comment: "Masternodes"),
-                icon: .system("server.rack"),
-                action: { [weak self] in
-                    self?.navigationDestination = .masternodes
                 }
             ),
             MenuItemModel(

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1447,6 +1447,9 @@
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
 
+/* Governance */
+"Governance" = "Governance";
+
 /* No comment provided by engineer. */
 "Get Started" = "Get Started";
 
@@ -3929,6 +3932,9 @@
 
 /* Balance info sheet */
 "Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uses one of the most audited and tested zero-knowledge libraries (Orchard)";
+
+/* Voting */
+"Vote on contested usernames" = "Vote on contested usernames";
 
 /* Raw transaction inspector */
 "Version" = "Version";


### PR DESCRIPTION
## What

Two menu changes, one commit each.

**1. Governance submenu.** The main menu's "Voting" row becomes **Governance**, a new submenu holding **Masternodes** (moved out of Tools) and **Voting**.

**2. Retired masternodes collapse.** The Masternodes list splits into two sections: registrations still on the network stay expanded at the top, retired ones move to a `DisclosureGroup` at the bottom, collapsed by default with a count on its label.

## Decisions worth reviewing

**Governance is not DashPay-gated, unlike the row it replaces.** The old Voting row required `#if DASHPAY` *and* `VotingPrefs.votingEnabled`. Masternodes was never gated at all, so gating the parent would have made it unreachable in the `dashwallet` scheme — a regression. Governance is therefore always present and its contents adapt: Masternodes always, Voting only under DASHPAY when the preference is on. With voting disabled, Governance holds Masternodes alone.

**Masternodes moves rather than being duplicated**, keeping one path to the screen. "Masternode Keychain" stays in Tools — that is key material, not governance. Say the word if you want a Tools shortcut kept as well.

**Only `retired` collapses.** `MasternodeStatus` has four cases; `inactive` (PoSe-banned) and `unknown` (masternode list not yet synced) stay in the top section alongside `active`. A banned node is a problem worth surfacing and `unknown` is a transient sync state, so burying either would hide something actionable. Trivial to change if you want the top section to be strictly `active`.

## Notes

- The Masternodes hosting wrapper (`UIHostingController` + `NavigationStack`, needed for row drill-downs) and the UIKit push for `UsernameVotingViewController` move verbatim — behaviour unchanged.
- New screen follows the SwiftUI-first rule: `GovernanceMenuScreen` + `@MainActor GovernanceMenuViewModel`, matching the `ToolsMenuScreen` idiom.
- Both list sections render only when non-empty, so a wallet with no retired nodes sees no stray disclosure row; the existing empty state is untouched.
- One new English string (`Governance`); `Retired` already existed.

## Not included

A PoSe **score** next to the status ("Active — With Score 5") was requested and is **not implementable from our data**, so nothing was built. The score (`nPoSePenalty`) is not in the DML wire format that an SPV client receives — `MasternodeListEntry` carries only `is_valid`, and that boolean is already what drives the existing "Inactive" label. `pose_penalty` exists in rust-dashcore solely under `rpc-json`, i.e. the full-node `protx` RPC surface. Surfacing a real score would mean querying a Core node, which is a separate architectural decision for a screen that is currently a pure local snapshot.

## Verification

`dashpay` scheme builds clean (arm64 simulator) from `develop` with no dependency on #922, and was installed to the simulator. Not visually confirmed on-device: the simulator is PIN-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Governance section to the main menu.
  * Added access to Masternodes and, when enabled, Username Voting.
  * Separated active and retired masternode registrations, with retired nodes shown in a collapsible section.

* **Improvements**
  * Moved Masternodes from the Tools menu into Governance.
  * Added English labels for Governance and username voting features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->