### PR TITLE
fix(ui): restore Governance → Voting (build break + missing back navigation)

### DIFF
--- a/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Governance/GovernanceMenuScreen.swift
@@ -120,7 +120,7 @@ struct GovernanceMenuScreen: View {
 
     #if DASHPAY
     private func showVoting() {
-        let controller = UsernameVotingViewController.controller()
+        let controller = UIHostingController(rootView: UsernameVotingScreen())
         controller.hidesBottomBarWhenPushed = true
         vc.pushViewController(controller, animated: true)
     }

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -508,12 +508,6 @@ struct MainMenuScreen: View {
 
 
     #if DASHPAY
-    private func showVoting() {
-        let controller = UIHostingController(rootView: UsernameVotingScreen())
-        controller.hidesBottomBarWhenPushed = true
-        vc.pushViewController(controller, animated: true)
-    }
-    
     private func editProfile() {
         // Gate on the strict SDK-side identity check so the editor
         // never opens against a missing identity — Save would fail


### PR DESCRIPTION
Two fixes to the same entry point, one commit each.

## 1. `develop` is currently red

`develop` does not compile. #923 and #924 collided after both merged green independently:

- **#923** replaced `UsernameVotingViewController` with the SwiftUI `UsernameVotingScreen`, updating the `showVoting()` that lived in `MainMenuViewController` **at the time that PR was written**.
- **#924** had since moved the Voting entry point into `GovernanceMenuScreen`, which #923 never saw.

On the merged tip the two halves are crossed:

- `GovernanceMenuScreen.swift:123` — the **live** entry point — still called the deleted `UsernameVotingViewController`: `error: cannot find 'UsernameVotingViewController' in scope`.
- `MainMenuViewController.showVoting()` — the **updated** copy — was orphaned: defined, never called, because #924 removed its caller.

So the reachable path was broken and the fixed path was unreachable. Points Governance at `UsernameVotingScreen` (exactly what #923 wrote, in the location that is actually reachable) and deletes the dead copy.

## 2. No way back out of a contested name

With the build restored, opening a name stranded the user: the contest detail had no back button and no navigation bar at all.

`showVoting()` pushed a bare `UIHostingController(rootView: UsernameVotingScreen())`. Both voting screens set `.navigationTitle`, and the list drills into `ContestDetailScreen` via `NavigationLink` — but with no `NavigationStack` there was no bar to host that title, and no automatic back button for the push.

Wrapped in a `NavigationStack` with a leading chevron that pops the UIKit stack — the same wrapper `showMasternodes()` in this file already uses, for the same reason. Contest detail now gets its standard back button, and the root gets a way back to Governance.

## Verification

`dashpay` scheme builds clean (arm64 simulator) — it does not on `develop` without commit 1. Installed and launched on the simulator; back navigation itself is unverified on-device (PIN-gated), so the thing to click is Governance → Voting → a contested name → back.