### PR TITLE
feat(ui): show a loading state while transaction history loads

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -356,10 +356,27 @@ struct HomeViewContent<Content: View>: View {
                     })
                     
                     if viewModel.txItems.isEmpty {
-                        Text(NSLocalizedString("There are no transactions to display", comment: ""))
-                            .font(.caption)
-                            .foregroundColor(Color.primary.opacity(0.5))
+                        // An empty feed means "nothing yet" only once the first
+                        // load has finished; before that it just means the
+                        // reload is still running, so show progress rather than
+                        // telling the user they have no transactions.
+                        if viewModel.hasLoadedInitialTxItems {
+                            Text(NSLocalizedString("There are no transactions to display", comment: ""))
+                                .font(.caption)
+                                .foregroundColor(Color.primary.opacity(0.5))
+                                .padding(.top, 20)
+                        } else {
+                            HStack(spacing: 10) {
+                                SwiftUI.ProgressView()
+                                    .progressViewStyle(CircularProgressViewStyle())
+
+                                Text(NSLocalizedString("Loading transactions", comment: "Home"))
+                                    .font(.caption)
+                                    .foregroundColor(Color.primary.opacity(0.5))
+                            }
+                            .frame(maxWidth: .infinity)
                             .padding(.top, 20)
+                        }
                     } else {
                         ForEach(viewModel.txItems) { group in
                             Section(header: SectionHeader(key: group.id, date: group.date)

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -92,6 +92,17 @@ class HomeViewModel: ObservableObject {
     }
     
     @Published private(set) var txItems: [TransactionGroup] = []
+
+    /// Whether the first full transaction load has finished, published on the
+    /// main thread for the home feed.
+    ///
+    /// Distinct from the worker-queue `hasCompletedInitialLoad`, which guards
+    /// reload/incremental-update sequencing off the main thread. This one
+    /// exists so the view can tell "still loading" from "genuinely empty" —
+    /// `txItems` is empty in both cases, and rendering the empty-state copy
+    /// during the initial load tells the user they have no transactions
+    /// before that is known.
+    @Published private(set) var hasLoadedInitialTxItems: Bool = false
     @Published var shortcutItems: [ShortcutAction] = []
     @Published var showTimeSkewAlertDialog: Bool = false
     @Published var showCoinJoinSweepDialog: Bool = false
@@ -243,9 +254,12 @@ class HomeViewModel: ObservableObject {
             self.hasCompletedInitialLoad = false
             self.isReloading = false
 
-            // Update UI-bound property on main thread
+            // Update UI-bound properties on main thread. The new network's
+            // history is loading from scratch, so the feed goes back to its
+            // loading state rather than claiming the wallet is empty.
             DispatchQueue.main.async {
                 self.txItems = []
+                self.hasLoadedInitialTxItems = false
             }
 
             // Reload fresh data from the new network's wallet
@@ -501,6 +515,7 @@ class HomeViewModel: ObservableObject {
 
             DispatchQueue.main.async {
                 self.txItems = array
+                self.hasLoadedInitialTxItems = true
                 if self.hasRewardsHistory != hasRewards {
                     self.hasRewardsHistory = hasRewards
                 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1959,6 +1959,9 @@
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
+/* Home */
+"Loading transactions" = "Loading transactions";
+
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 


### PR DESCRIPTION
## Problem

On launch the home feed rendered **"There are no transactions to display"** until the first reload finished.

`HomeView` keyed that copy on `viewModel.txItems.isEmpty` alone — but `txItems` is empty in two very different situations: while the initial load is still running on the worker queue, and when the wallet genuinely has no history. Treating them the same meant every cold launch briefly asserted the wallet was empty before that was known, which reads as data loss on a wallet that actually has transactions.

## Fix

`HomeViewModel` gains `hasLoadedInitialTxItems`, published on the main thread and set when the first full reload publishes its results. The feed shows a spinner + "Loading transactions" until then, and falls back to the empty-state copy only once an empty result is actually established.

Deliberately kept separate from the existing private `hasCompletedInitialLoad`: that one guards reload/incremental-update sequencing on the worker queue, is not published, and is not main-thread-confined, so it can't drive a view. Its behaviour is untouched.

## Behaviour details

- **Network switch** resets the flag. That path clears the feed and reloads the new network's history from scratch — the same "loading, not empty" situation as a cold launch, so it gets the same treatment rather than briefly claiming the new network has no transactions.
- **Ordinary refreshes never clear it**, so the spinner does not flash on incremental updates once the first load has landed.
- A wallet with genuinely no transactions still ends at the same empty-state copy, just one load later than before.

## Verification

`dashpay` scheme builds clean (arm64 simulator).

Note this branch is cut from `develop`, which is currently red — see #925, which fixes an unrelated #923/#924 merge collision. Building this branch locally needs that fix (or merge #925 first); the change here is independent of it.

Not visually confirmed on-device: the simulator is PIN-gated, and the state is transient by nature — it appears between launch and the first reload completing.