### PR TITLE
feat(wallet): fund sends from every spendable account

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -60,6 +60,13 @@ final class SwiftDashSDKTransactionSender: NSObject {
     private static let bip44TypeTag: UInt8 = 0
     /// `AccountBalance.standardTag` discriminant for BIP44 within Standard.
     private static let bip44StandardTag: UInt8 = 0
+    /// `StandardAccountTypeTagFFI.Bip32` — the other half of the Standard
+    /// family that `.allSpendable` pools.
+    private static let bip32StandardTag: UInt8 = 1
+    /// `AccountTypeTagFFI.DashpayReceivingFunds`. Its sibling tag 13
+    /// (`DashpayExternalAccount`) is a contact's watch-only coins and is NOT
+    /// pooled — the local seed cannot sign them.
+    private static let dashpayReceivingTypeTag: UInt8 = 12
     /// Signal sends spend from the primary BIP44 account.
     private static let bip44AccountIndex: UInt32 = 0
     /// How long to wait for a just-broadcast funding output to appear in the
@@ -452,7 +459,7 @@ final class SwiftDashSDKTransactionSender: NSObject {
     }
 
     /// Fee reserve for a "Max" / all-funds core send, sized from the BIP44
-    /// account's actual spendable-UTXO count instead of a flat constant.
+    /// pooled accounts' actual spendable-UTXO count instead of a flat constant.
     ///
     /// The flat `WalletBalance.sendFeeReserveDuffs` (100_000 duffs) is a large
     /// worst-case over-estimate — a typical send costs ~1–2k duffs, so Max used
@@ -461,23 +468,39 @@ final class SwiftDashSDKTransactionSender: NSObject {
     /// inputs) plus a **+50 % safety margin** so it can never *under*-reserve —
     /// an under-estimate would make the Max send fail to build.
     ///
-    /// Fail-safe: any inability to enumerate the account (no wallet/manager, no
-    /// UTXOs) falls back to the flat reserve, i.e. the previous behaviour — the
-    /// change never makes Max worse than before, only tighter when it can.
+    /// The enumerated set must stay in step with the `.allSpendable` funding
+    /// `finalizeAtomic` uses: BIP44 + BIP32 at the funding index plus every
+    /// DashPay receiving account, and never CoinJoin or a contact's watch-only
+    /// external coins.
+    ///
+    /// Fail-safe: any inability to enumerate the accounts (no wallet/manager,
+    /// no UTXOs) falls back to the flat reserve, i.e. the previous behaviour —
+    /// the change never makes Max worse than before, only tighter when it can.
     static func maxSendFeeReserveDuffs() -> UInt64 {
         let read = { @MainActor () -> UInt64? in
             let host = SwiftDashSDKHost.shared
             guard let manager = host.manager, let wallet = host.wallet else { return nil }
             let walletId = wallet.walletId
-            // `typeTag == 0` is the whole Standard family; account 0 can exist as
-            // both BIP44 (`standardTag == 0`) and BIP32 (`standardTag == 1`), so
-            // require the standard tag too — mirrors `addressUtxos(script:)`.
-            guard let bip44 = manager.accountBalances(for: walletId).first(where: {
-                $0.typeTag == Self.bip44TypeTag
-                    && $0.standardTag == Self.bip44StandardTag
-                    && $0.index == Self.bip44AccountIndex
-            }) else { return nil }
-            let count = manager.accountUtxos(for: walletId, balance: bip44).count
+            // Enumerate exactly what `.allSpendable` spends — BIP44 + BIP32 at
+            // the funding index, plus every DashPay receiving account. Sizing
+            // the reserve off BIP44 alone would under-reserve whenever the
+            // other sources contribute inputs, and Max would then price itself
+            // above what the builder can actually fund.
+            let pooled = manager.accountBalances(for: walletId).filter { balance in
+                if balance.typeTag == Self.bip44TypeTag {
+                    // Standard family: BIP44 and BIP32 both resolve to the
+                    // single account at the funding index.
+                    let isStandardPooled = balance.standardTag == Self.bip44StandardTag
+                        || balance.standardTag == Self.bip32StandardTag
+                    return isStandardPooled && balance.index == Self.bip44AccountIndex
+                }
+                // Every DashPay receiving account, whatever its index.
+                return balance.typeTag == Self.dashpayReceivingTypeTag
+            }
+            guard !pooled.isEmpty else { return nil }
+            let count = pooled.reduce(0) { total, balance in
+                total + manager.accountUtxos(for: walletId, balance: balance).count
+            }
             guard count > 0 else { return nil }
             let base = estimatedSignalFee(inputCount: count)
             return base + base / 2 // +50 % margin — must never under-reserve

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -98,7 +98,7 @@ final class SwiftDashSDKTransactionSender: NSObject {
                   let network = SwiftDashSDKHost.shared.runningNetwork else {
                 throw SendError.walletNotReady("PlatformWalletManager wallet is not available")
             }
-            // Build + sign a standard BIP44 payment via the core
+            // Build + sign a standard payment via the core
             // TransactionBuilder. `finalizeAtomic` selects + reserves the
             // inputs and routes change to the account's next internal address
             // in one native operation (single tx — normal sends don't need
@@ -107,7 +107,14 @@ final class SwiftDashSDKTransactionSender: NSObject {
             for recipient in recipients {
                 try builder.addOutput(address: recipient.address, amountDuffs: recipient.amountDuffs)
             }
-            return try builder.finalizeAtomic(wallet: wallet, accountType: .bip44, accountIndex: 0)
+            // `.allSpendable` pools BIP44 + BIP32 + every DashPay
+            // contact-receiving account — the same set the home balance
+            // already totals, so a send can spend everything the user is
+            // shown. CoinJoin is excluded by construction (spending mixed
+            // outputs beside transparent ones would undo the mixing), as are
+            // a contact's watch-only external coins. Change returns to BIP44,
+            // the first pooled source.
+            return try builder.finalizeAtomic(wallet: wallet, accountType: .allSpendable)
         }
 
         let tx: FinalizedCoreTransaction
@@ -153,7 +160,12 @@ final class SwiftDashSDKTransactionSender: NSObject {
             try builder.addOpReturn(memoData)
             try builder.preserveOutputOrder()
             try builder.changeToFirstInput()
-            let tx = try builder.finalizeAtomic(wallet: wallet, accountType: .bip44, accountIndex: 0)
+            // Same pooled funding as a plain send — see `buildAndSign`.
+            // `changeToFirstInput` stays correct under pooling: it routes to
+            // whichever input BIP-69 puts at VIN0, whatever account it came
+            // from, and the builder sizes the change output for the largest
+            // eligible routing script.
+            let tx = try builder.finalizeAtomic(wallet: wallet, accountType: .allSpendable)
             return (tx, network)
         }
 
@@ -618,10 +630,13 @@ final class SwiftDashSDKTransactionSender: NSObject {
         }
 
         if decoded.outputs.count == 3 {
-            // `DecodedTransaction.Input.address` is recovered from a P2PKH-shaped scriptSig and
-            // is nil for anything else. Every BIP44 account UTXO this builder can spend is
-            // P2PKH, so nil here means the transaction is not the shape we asked for — refuse
-            // rather than skip the check.
+            // `DecodedTransaction.Input.address` is recovered from a P2PKH-shaped scriptSig
+            // and is nil for anything else. Every UTXO the pooled funding set can spend —
+            // BIP44, BIP32, and DashPay contact-receiving — is P2PKH, so nil here means the
+            // transaction is not the shape we asked for: refuse rather than skip the check.
+            // Note VIN0 decides where MAYA sends a refund, so under pooling that can be a
+            // DashPay receiving address rather than a BIP44 one. Still this wallet's own
+            // seed-signable address, and still counted in its balance.
             guard let inputAddress = decoded.inputs.first?.address else {
                 throw SendError.invalidInput("swap deposit VIN0 address could not be recovered")
             }


### PR DESCRIPTION
Adopts `.allSpendable` from dashpay/platform#4329 on both send paths, replacing the explicit `.bip44` pin.

## Why this is a bug fix, not just an opt-in

The home balance has **always** been wallet-wide: `refreshBalanceBridge` publishes `coreWallet().balance()` and the initial seed uses `getWalletBalance(walletId:)` — neither is per-account. But sends could only spend BIP44.

So a user holding funds on BIP32 or a DashPay contact-receiving account saw those funds in their total and got **"insufficient funds"** trying to spend them. `maxSendable` derives from the same wallet-wide balance, so it was over-optimistic for exactly the same reason; it becomes correct here.

## CoinJoin is not pooled

`.allSpendable` resolves to `SEND_FUNDING_SOURCES` = BIP44 + BIP32 + `AllDashpayReceivingFunds`. CoinJoin is excluded **by construction** in the Rust const, not merely by convention — spending mixed outputs beside transparent ones links them and undoes the mixing. A contact's watch-only `DashpayExternalAccount` coins are excluded too: the selector takes only the receiving side the local seed can sign. Change returns to BIP44, the first pooled source.

The mixed balance stays reachable only through the paths that name it explicitly — the CoinJoin sweep and the CoinJoin-drain asset lock — which are the two deliberate "move the mixed coins" flows.

## MAYA swap path — checked

The swap deposit takes the same pooled funding. Verified rather than assumed:

- **`changeToFirstInput` is unaffected.** It routes change to `selected_inputs.first()` **post-BIP-69-sort**, whatever account that input came from, and the builder already reserves *"the largest eligible routing script so every possible winner is covered"* when sizing the change output. Account-agnostic by construction.
- **`assertSwapDepositShape` still holds**, because every pooled source is P2PKH. Its comment claimed BIP44 was the only possible source; corrected.
- **One behavioural nuance, now recorded in that comment:** VIN0 decides where MAYA sends a refund, so under pooling a refund can land on a DashPay receiving address rather than a BIP44 one. Still this wallet's own seed-signable address, still counted in its balance — but worth knowing.

If a non-P2PKH input ever reached VIN0 the assertion refuses the build: fail-closed, before broadcast.

## Left pinned deliberately

| Call site | Kept as | Why |
|---|---|---|
| CoinJoin sweep | `.coinJoin` | must drain exactly that account |
| CrowdNode selected-input send | `.bip44` + `addInputs` | CrowdNode identifies the user by the originating address, so inputs *and* change must stay on it |

## Requires an SDK rebuild

Needs `DashSDKFFI.xcframework` rebuilt from platform `v4.2-dev` at or past #4329 (adds `CORE_ACCOUNT_TYPE_FFI_ALL_SPENDABLE`): `cd ../platform/packages/swift-sdk && ./build_ios.sh --target ios --target sim`.

## Max-send reserve

`maxSendFeeReserveDuffs()` enumerated BIP44 account 0 only — exactly right for the old BIP44-pinned send, but an under-reserve once funding pools BIP32 and DashPay receiving inputs. Since `feeAwareMaxSendable()` subtracts that reserve from a wallet-wide balance, Max could have priced itself above what the builder can fund. Fixed in f8c03da: the reserve now enumerates the same set `.allSpendable` spends, still excluding CoinJoin and watch-only external coins.

## Verification

`dashpay` scheme builds clean (arm64 simulator) against a freshly rebuilt xcframework, on a branch merged up to current `develop` (#925 and #926 are in).

Not exercised on-device: spending pooled funds needs a wallet holding balance on BIP32 or a DashPay receiving account, and the simulator is PIN-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standard payments and swap deposits can now use all eligible spendable funds, rather than being limited to a single account.
  - Max-send fee estimates now account for the full set of eligible wallet funds, with a safe fallback when balances cannot be fully enumerated.
  - Swap validation supports a broader range of wallet inputs and change addresses, improving compatibility with pooled wallet funds and seed-signable addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
