### PR TITLE
feat(ui): use the shared amount entry for contact payments

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -538,7 +538,7 @@ struct PayContactSheet: View {
     /// `amountText` back made any gap between the two — a locale separator, a
     /// stray character, precision the parser drops — render as a truthful-looking
     /// "sent" line for an amount that never left the wallet.
-    @State private var sentAmountDuffs: UInt64? = nil
+    @State private var sentAmountDuffs: UInt64?
     @State private var errorMessage: String? = nil
 
     var body: some View {

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -532,8 +532,14 @@ struct PayContactSheet: View {
     @State private var sentTxid: Data? = nil
     /// Exact network fee (duffs) of the broadcast transaction.
     @State private var sentFeeDuffs: UInt64? = nil
+    /// Duffs actually broadcast, captured at send time.
+    ///
+    /// The confirmation must state what was paid, not what was typed. Echoing
+    /// `amountText` back made any gap between the two — a locale separator, a
+    /// stray character, precision the parser drops — render as a truthful-looking
+    /// "sent" line for an amount that never left the wallet.
+    @State private var sentAmountDuffs: UInt64? = nil
     @State private var errorMessage: String? = nil
-    @FocusState private var amountFocused: Bool
 
     var body: some View {
         NavigationStack {
@@ -568,22 +574,27 @@ struct PayContactSheet: View {
                 Text(errorMessage ?? "")
             }
         }
-        .presentationDetents([.medium])
+        // The sheet carries its own keypad now, so it needs the room the
+        // system keyboard used to occupy.
+        .presentationDetents([.large])
     }
 
     @ViewBuilder
     private var form: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            TextField("0", text: $amountText)
-                .keyboardType(.decimalPad)
-                .font(.system(size: 40, weight: .semibold))
-                .multilineTextAlignment(.trailing)
-                .focused($amountFocused)
-                .onAppear { amountFocused = true }
-            Text("DASH")
-                .font(.system(size: 17, weight: .bold))
-                .foregroundColor(.dash.secondaryText)
-        }
+        // The shared amount surface every other send screen uses, over the
+        // app's own keypad. A raw `TextField` + `.decimalPad` accepted whatever
+        // the system keyboard allowed — a bare separator, a locale comma, more
+        // precision than DASH has — and left validation to the parser, so the
+        // typed text and the amount actually sent could disagree.
+        EnterAmountView(
+            primaryAmount: amountText.isEmpty ? "0" : amountText,
+            secondaryAmount: fiatAmountText,
+            primaryCurrency: .dash,
+            secondaryCurrency: .fiat(App.fiatCurrency),
+            isPrimarySelected: true,
+            isCurrencySelectorHidden: true,
+            onMax: { amountText = Self.dashString(duffs: maxSendable) }
+        )
         .padding(.top, 12)
 
         Text(String(
@@ -596,25 +607,23 @@ struct PayContactSheet: View {
             .font(.system(size: 12))
             .foregroundColor(.dash.tertiaryText)
 
-        if isSending {
-            SwiftUI.ProgressView()
-                .padding(.top, 8)
-        } else {
-            Button {
-                pay()
-            } label: {
-                Text(NSLocalizedString("Pay", comment: "DashPay Contacts"))
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(Color.dash.whiteText)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 46)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(parsedDuffs == nil ? Color.dash.gray300 : Color.dash.blue))
-            }
-            .buttonStyle(.plain)
-            .disabled(parsedDuffs == nil)
-        }
+        NumericKeyboardView(
+            value: $amountText,
+            showDecimalSeparator: true,
+            actionButtonText: NSLocalizedString("Pay", comment: "DashPay Contacts"),
+            actionEnabled: parsedDuffs != nil,
+            inProgress: isSending,
+            actionHandler: { pay() }
+        )
+        .padding(.top, 8)
+    }
+
+    /// Fiat equivalent of what is typed, for the secondary line. Empty while
+    /// the amount is unparseable or rates have not arrived.
+    private var fiatAmountText: String {
+        guard let duffs = parsedDuffs else { return "" }
+        let dash = Decimal(duffs) / Decimal(100_000_000)
+        return CurrencyExchanger.shared.fiatAmountString(for: dash)
     }
 
     private func success(txid: Data) -> some View {
@@ -627,7 +636,8 @@ struct PayContactSheet: View {
                 .foregroundColor(.dash.primaryText)
             Text(String(
                 format: NSLocalizedString("%@ DASH sent to %@", comment: "DashPay Contacts"),
-                amountText, contact.displayTitle))
+                sentAmountDuffs.map { Self.dashString(duffs: $0) } ?? amountText,
+                contact.displayTitle))
                 .font(.system(size: 14))
                 .foregroundColor(.dash.secondaryText)
             if let fee = sentFeeDuffs {
@@ -683,6 +693,7 @@ struct PayContactSheet: View {
                     amount: duffs)
                 sentTxid = txid
                 sentFeeDuffs = feeDuffs
+                sentAmountDuffs = duffs
                 // Project the freshly recorded Sent entry to SwiftData
                 // right away — the entry lives only in Rust memory
                 // until a projection runs, and an app kill before one


### PR DESCRIPTION
## Issue being fixed or feature implemented

The contact Pay sheet took its amount through a bare `TextField` + `.decimalPad`, while every other send surface in the app uses `DashUIKit.EnterAmountView`. The system keyboard let through input the parser then had to rescue — a locale comma, a bare separator, more precision than DASH carries — so **what was typed and what was sent could disagree**. There was also no fiat line, no Max, and none of the shared validation.

The confirmation compounded it: it echoed `amountText` back rather than reporting what was broadcast, so any gap between the two rendered as a truthful-looking "sent" line for an amount that never left the wallet.

## What was done?

- **`EnterAmountView` + `NumericKeyboardView` replace the raw `TextField` and the system keypad**, matching `SendAmountScreen` and `InternalTransferScreen`. That brings the fiat line, a Max button, and the shared parsing/validation the rest of the app already relies on.
- **The confirmation now states the broadcast amount.** A new `sentAmountDuffs` is captured at send time and rendered instead of the typed text.
- **Sheet detent goes `.medium` → `.large`**, since the sheet now carries its own keypad and needs the room the system keyboard used to occupy.

One file, +44/−33.

Note the Max button leans on `maxSendable`, which #928 corrected to the wallet-wide spendable balance — so Max here is accurate on top of current `develop` in a way it would not have been before that landed.

## How Has This Been Tested?

Testnet, on device. Paid an established DashPay contact from the profile sheet: the keypad rejects a second separator and over-precision instead of silently reshaping the value, the fiat line tracks the entry, Max fills the spendable balance, and the confirmation reports the amount that was actually broadcast.

This commit was written alongside #918 and tested in the same sessions; it is split out here because it is a Pay-sheet UI change rather than part of the payment-history restore, and it did not make it into that PR before it merged.

## Breaking Changes

None. UI-only, single screen.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned payment amount entry experience with a numeric keypad.
  * Added fiat currency conversion and support for entering the maximum available amount.
  * Improved payment confirmation by displaying the exact amount broadcast.

* **Bug Fixes**
  * Added validation for parsed payment amounts.
  * Expanded the payment sheet for easier amount entry and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->