### PR TITLE
perf(crowdnode): stop rescanning full tx history on every restore

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -124,6 +124,18 @@ public final class CrowdNode {
     private(set) var isOnlineStateRestored = false
     var showNotificationOnResult = false
 
+    /// Persisted transaction count as of the last `restoreState()` that found
+    /// no CrowdNode account at all.
+    ///
+    /// The restore's own guard is `signUpState > .notStarted`, which a wallet
+    /// that never signed up never reaches — so every caller (launch sync-done,
+    /// each entry into the CrowdNode portal) re-ran the full history scan and
+    /// blocked the main thread for seconds apiece. A signup can still turn up
+    /// later when a restored seed syncs its history in, so this memo is keyed
+    /// to the store's row count rather than latching permanently: new rows
+    /// persisted means the scan gets to run again.
+    private var fruitlessRestoreTxCount: Int? = nil
+
     var masternodeAPY: Double
     var crowdnodeAPY: Double
 
@@ -195,6 +207,13 @@ extension CrowdNode {
             return
         }
 
+        // A previous pass already scanned this exact history and found no
+        // account; without new rows it would reach the same conclusion.
+        if let scanned = fruitlessRestoreTxCount,
+           TransactionObserver.persistedTransactionCount() == scanned {
+            return
+        }
+
         DWLogger.log("restoring CrowdNode state")
         signUpState = SignUpState.notStarted
         validatePrefs()
@@ -232,6 +251,10 @@ extension CrowdNode {
             }
         } else {
             DWLogger.log("CrowdNode: account not found")
+            // Nothing found by either the signup scan or the online-account
+            // lookup, so this whole pass was a no-op — memoize it against the
+            // history it saw.
+            fruitlessRestoreTxCount = TransactionObserver.persistedTransactionCount()
         }
     }
 
@@ -331,6 +354,7 @@ extension CrowdNode {
         primaryAddress = nil
         apiError = nil
         balance = 0
+        fruitlessRestoreTxCount = nil
         prefs.resetUserDefaults()
     }
 
@@ -364,6 +388,9 @@ extension CrowdNode {
         apiError = nil
         balance = 0
         isOnlineStateRestored = false
+        // The memo describes the PREVIOUS wallet's scan; the new wallet must
+        // get a real one even though the store's row count is unchanged.
+        fruitlessRestoreTxCount = nil
         restoreState()
     }
     
@@ -1016,7 +1043,13 @@ extension CrowdNode {
     private func getApiAddressConfirmationTx() -> ObservedTransaction? {
         let filter = CoinsToAddressTxFilter(coins: CrowdNode.apiConfirmationDashAmount, address: nil) // account address is unknown at this point
         let forwardedConfirmationFilter = CrowdNodeAPIConfirmationTxForwarded()
-        let observed = TransactionObserver.fetchObserved()
+        // Same floor the signup scan uses: an API-address confirmation is
+        // CrowdNode protocol traffic, so it cannot predate CrowdNode. Without
+        // it this walked and decoded the wallet's entire history on the main
+        // thread during restore — the more expensive of the restore's two
+        // scans, on a wallet that has no CrowdNode account at all.
+        let observed = TransactionObserver.fetchObserved(
+            firstSeenAtOrAfter: FullCrowdNodeSignUpTxSet.januaryFirst2022Epoch)
 
         // There might be several matching transactions. The real one is the
         // one whose destination CrowdNode forwarded from.

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -134,7 +134,7 @@ public final class CrowdNode {
     /// later when a restored seed syncs its history in, so this memo is keyed
     /// to the store's row count rather than latching permanently: new rows
     /// persisted means the scan gets to run again.
-    private var fruitlessRestoreTxCount: Int? = nil
+    private var fruitlessRestoreTxCount: Int?
 
     var masternodeAPY: Double
     var crowdnodeAPY: Double
@@ -207,10 +207,15 @@ extension CrowdNode {
             return
         }
 
+        // Read the count ONCE, before the scans, and memoize that same value
+        // below. Reading it again afterwards would record rows the scans never
+        // inspected — a save landing mid-restore would make the next call skip
+        // a scan that still owes work on those rows.
+        let txCountBeforeScans = TransactionObserver.persistedTransactionCount()
+
         // A previous pass already scanned this exact history and found no
         // account; without new rows it would reach the same conclusion.
-        if let scanned = fruitlessRestoreTxCount,
-           TransactionObserver.persistedTransactionCount() == scanned {
+        if let scanned = fruitlessRestoreTxCount, txCountBeforeScans == scanned {
             return
         }
 
@@ -253,8 +258,8 @@ extension CrowdNode {
             DWLogger.log("CrowdNode: account not found")
             // Nothing found by either the signup scan or the online-account
             // lookup, so this whole pass was a no-op — memoize it against the
-            // history it saw.
-            fruitlessRestoreTxCount = TransactionObserver.persistedTransactionCount()
+            // history the scans actually saw, not the store's count now.
+            fruitlessRestoreTxCount = txCountBeforeScans
         }
     }
 

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -93,6 +93,13 @@ public final class TransactionObserver {
     /// Scans slower than this get a log line; see `scan`.
     private static let slowScanLogThresholdMs = 150
 
+    /// The main-actor-owned SDK handles a scan needs, resolved once per call.
+    private struct HostHandles {
+        let container: ModelContainer
+        let walletId: Data
+        let network: Network
+    }
+
     // MARK: Shared row scanner
 
     /// Persisted rows decoded to `ObservedTransaction`, newest-first
@@ -111,7 +118,7 @@ public final class TransactionObserver {
         fetchLimit: Int? = nil,
         firstSeenAtOrAfter: UInt64? = nil
     ) -> [ObservedTransaction] {
-        let handles = { @MainActor () -> (container: ModelContainer, walletId: Data, network: Network)? in
+        let handles = { @MainActor () -> HostHandles? in
             guard let container = SwiftDashSDKHost.shared.modelContainer,
                   let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
                 logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
@@ -121,10 +128,10 @@ public final class TransactionObserver {
                 logger.error("🅾 OBSERVER :: unsupported network — empty scan")
                 return nil
             }
-            return (container, walletId, network)
+            return HostHandles(container: container, walletId: walletId, network: network)
         }
 
-        let resolved: (container: ModelContainer, walletId: Data, network: Network)?
+        let resolved: HostHandles?
         if Thread.isMainThread {
             resolved = MainActor.assumeIsolated { handles() }
         } else {

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -25,9 +25,15 @@ import SwiftDashSDK
 
 extension ObservedTransaction {
     /// Build from a persisted SwiftDashSDK row + a consensus decode of its raw
-    /// bytes. nil (logged) when the bytes fail to decode. Main-actor: the row's
-    /// model context and the `Transaction` wrapper are main-bound.
-    @MainActor
+    /// bytes. nil (logged) when the bytes fail to decode.
+    ///
+    /// Runs on whatever thread owns `row`'s context — it only reads the row's
+    /// own properties and its TXO relationship, decodes bytes, and wraps the
+    /// row (`HomeViewModel`'s reload already builds `Transaction` off the main
+    /// thread the same way). It was `@MainActor` while the only caller read
+    /// through `mainContext`; the scanner now owns its context, and forcing
+    /// the decode back onto the main actor is what made a CrowdNode restore
+    /// stall the main thread for ~2s.
     init?(row: PersistentTransaction, network: Network) {
         let decoded: DecodedTransaction
         do {
@@ -84,71 +90,122 @@ public final class TransactionObserver {
     /// Rows admitted per rescan; the floor predicate already bounds the
     /// window, this guards a resync burst mid-wait.
     private static let rescanFetchLimit = 200
+    /// Scans slower than this get a log line; see `scan`.
+    private static let slowScanLogThresholdMs = 150
 
     // MARK: Shared row scanner
 
     /// Persisted rows decoded to `ObservedTransaction`, newest-first
     /// (`firstSeen` desc). Empty (logged) when the SDK host has no container
-    /// yet or the network is unsupported. Safe from any thread — trampolines
-    /// to main because this scanner reads through `mainContext`.
+    /// yet or the network is unsupported. Safe from any thread.
+    ///
+    /// The scan itself runs on the CALLER's thread against its own
+    /// `ModelContext`, never `mainContext` — callers that hold the main
+    /// thread (`CrowdNode.restoreState`) therefore pay the scan inline, so
+    /// keep it cheap. Only the two host reads need the main actor; they are
+    /// cheap property reads.
+    ///
+    /// `ObservedTransaction` is a struct decoded from each row, so the results
+    /// carry nothing back to the context they were read through.
     static func fetchObserved(
         fetchLimit: Int? = nil,
         firstSeenAtOrAfter: UInt64? = nil
     ) -> [ObservedTransaction] {
+        let handles = { @MainActor () -> (container: ModelContainer, walletId: Data, network: Network)? in
+            guard let container = SwiftDashSDKHost.shared.modelContainer,
+                  let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
+                logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
+                return nil
+            }
+            guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
+                logger.error("🅾 OBSERVER :: unsupported network — empty scan")
+                return nil
+            }
+            return (container, walletId, network)
+        }
+
+        let resolved: (container: ModelContainer, walletId: Data, network: Network)?
         if Thread.isMainThread {
-            return MainActor.assumeIsolated {
-                fetchObservedOnMain(fetchLimit: fetchLimit, firstSeenAtOrAfter: firstSeenAtOrAfter)
-            }
+            resolved = MainActor.assumeIsolated { handles() }
+        } else {
+            resolved = DispatchQueue.main.sync { MainActor.assumeIsolated { handles() } }
         }
-        var result: [ObservedTransaction] = []
-        DispatchQueue.main.sync {
-            result = MainActor.assumeIsolated {
-                fetchObservedOnMain(fetchLimit: fetchLimit, firstSeenAtOrAfter: firstSeenAtOrAfter)
-            }
-        }
-        return result
+        guard let resolved else { return [] }
+        return scan(
+            container: resolved.container,
+            walletId: resolved.walletId,
+            network: resolved.network,
+            fetchLimit: fetchLimit,
+            firstSeenAtOrAfter: firstSeenAtOrAfter)
     }
 
-    @MainActor
-    private static func fetchObservedOnMain(
+    /// Total persisted transaction count, or nil when the SDK host has no
+    /// container yet. A `SELECT COUNT(*)` with no join, predicate or decode —
+    /// cheap enough for callers to use as a "has anything new been persisted"
+    /// check before deciding whether a full rescan is worth its cost.
+    static func persistedTransactionCount() -> Int? {
+        let container = { @MainActor () -> ModelContainer? in
+            SwiftDashSDKHost.shared.modelContainer
+        }
+        let resolved: ModelContainer?
+        if Thread.isMainThread {
+            resolved = MainActor.assumeIsolated { container() }
+        } else {
+            resolved = DispatchQueue.main.sync { MainActor.assumeIsolated { container() } }
+        }
+        guard let resolved else { return nil }
+        return try? ModelContext(resolved).fetchCount(FetchDescriptor<PersistentTransaction>())
+    }
+
+    private static func scan(
+        container: ModelContainer,
+        walletId: Data,
+        network: Network,
         fetchLimit: Int?,
         firstSeenAtOrAfter: UInt64?
     ) -> [ObservedTransaction] {
-        guard let container = SwiftDashSDKHost.shared.modelContainer,
-              let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
-            logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
-            return []
-        }
-        guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
-            logger.error("🅾 OBSERVER :: unsupported network — empty scan")
-            return []
-        }
-        // Scope to the active wallet via the TXO join: gather the wallet's
-        // txids from its walletId-scoped TXO rows (CrowdNode responses land
-        // in the active wallet's own addresses), then match transactions in
-        // that set. `PersistentTransaction` carries no walletId of its own.
-        let txoDescriptor = FetchDescriptor<PersistentTxo>(
-            predicate: #Predicate { $0.walletId == walletId })
-        let txos = (try? container.mainContext.fetch(txoDescriptor)) ?? []
-        var txids = Set<Data>()
-        for txo in txos {
-            if let producing = txo.transaction { txids.insert(producing.txid) }
-            if let spending = txo.spendingTransaction { txids.insert(spending.txid) }
-        }
-        guard !txids.isEmpty else { return [] }
+        // Own context, so the scan never contends with the main actor.
+        let context = ModelContext(container)
+        // Scope to the active wallet through the TXO relationship, evaluated
+        // by the store: a transaction is this wallet's when it produced or
+        // spent one of the wallet's TXOs, and `PersistentTxo.walletId` is
+        // indexed. Doing the same join in Swift — fetch every walletId TXO,
+        // fault `.transaction` and `.spendingTransaction` on each, then feed
+        // the resulting txid set back through a `contains` predicate — costs
+        // two relationship faults per TXO plus an IN-list the width of the
+        // wallet's history, which is where this scan's seconds went.
         var descriptor = FetchDescriptor<PersistentTransaction>(
             sortBy: [SortDescriptor(\.firstSeen, order: .reverse)])
         if let floor = firstSeenAtOrAfter {
-            descriptor.predicate = #Predicate { txids.contains($0.txid) && $0.firstSeen >= floor }
+            descriptor.predicate = #Predicate {
+                $0.firstSeen >= floor &&
+                    ($0.outputs.contains { $0.walletId == walletId } ||
+                        $0.inputs.contains { $0.walletId == walletId })
+            }
         } else {
-            descriptor.predicate = #Predicate { txids.contains($0.txid) }
+            descriptor.predicate = #Predicate {
+                $0.outputs.contains { $0.walletId == walletId } ||
+                    $0.inputs.contains { $0.walletId == walletId }
+            }
         }
         if let fetchLimit {
             descriptor.fetchLimit = fetchLimit
         }
         do {
-            let rows = try container.mainContext.fetch(descriptor)
-            return rows.compactMap { ObservedTransaction(row: $0, network: network) }
+            let fetchStart = Date()
+            let rows = try context.fetch(descriptor)
+            let fetchMs = Int(Date().timeIntervalSince(fetchStart) * 1000)
+            let decodeStart = Date()
+            let observed = rows.compactMap { ObservedTransaction(row: $0, network: network) }
+            let decodeMs = Int(Date().timeIntervalSince(decodeStart) * 1000)
+            // Only when it actually costs something: `observe()` rescans on
+            // every SwiftData save, so an unconditional line here is sync-time
+            // log spam. A slow scan is worth seeing because callers on the
+            // main thread pay it inline.
+            if fetchMs + decodeMs > Self.slowScanLogThresholdMs {
+                DWLogger.log("CrowdNode scan: fetch \(rows.count) rows in \(fetchMs)ms, decode in \(decodeMs)ms")
+            }
+            return observed
         } catch {
             logger.error("🅾 OBSERVER :: PersistentTransaction fetch failed: \(String(describing: error), privacy: .public)")
             return []

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -376,152 +376,170 @@ class HomeViewModel: ObservableObject {
     
     // This is expensive and should not be called often
     private func reloadTxDataSource() {
-        self.queue.async { [weak self] in
-            guard let self = self else { return }
+        // Read main-actor state BEFORE handing off, never from inside the
+        // worker pass. A `DispatchQueue.main.sync` from the queue is a barrier
+        // whose cost is main-thread *availability*, not work: at launch the
+        // main thread is busy with tab-bar layout, avatar state and CrowdNode
+        // restore, so a reload that hops mid-pass inherits all of it. Hopping
+        // once up front, asynchronously, keeps the pass free-running.
+        let dispatch = { @MainActor [weak self] in
+            guard let self else { return }
+            // Pair each request with the filter selection that was live when
+            // it was made. Reading it inside the pass instead would let a pass
+            // triggered by one change render a selection the user made after
+            // it started.
+            let selectedFilters = self.selectedFilters
+            let startedAt = Date()
+            self.queue.async { [weak self] in
+                self?.performReload(selectedFilters: selectedFilters, startedAt: startedAt)
+            }
+        }
+        if Thread.isMainThread {
+            MainActor.assumeIsolated { dispatch() }
+        } else {
+            DispatchQueue.main.async { MainActor.assumeIsolated { dispatch() } }
+        }
+    }
 
-            // Fix #3: Set reload flag to prevent race conditions with incremental updates
-            self.isReloading = true
-            DWLogger.log("HomeViewModel: Starting full transaction reload")
+    private func performReload(selectedFilters: Set<TransactionFilterCategory>, startedAt: Date) {
+        // Fix #3: Set reload flag to prevent race conditions with incremental updates
+        self.isReloading = true
+        DWLogger.log("HomeViewModel: Starting full transaction reload")
 
-            // SwiftUI mutates the filter on the main thread. Snapshot it once
-            // before doing the worker-queue computation instead of reading the
-            // published property concurrently during the reload.
-            let selectedFilters = DispatchQueue.main.sync { self.selectedFilters }
+        let transactions = transactionSource.allTransactions
+        // Reconcile restored Shielded → Core destinations before Core rows
+        // are filtered/classified. The activity projection can recover a
+        // destination tag that was absent from the local withdrawal store.
+        let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity(
+            coreTransactions: transactions)
+        self.crowdNodeTxSet = FullCrowdNodeSignUpTxSet()
+        self.coinJoinTxSets = [:]
+        self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
 
-            let transactions = transactionSource.allTransactions
-            // Reconcile restored Shielded → Core destinations before Core rows
-            // are filtered/classified. The activity projection can recover a
-            // destination tag that was absent from the local withdrawal store.
-            let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity(
-                coreTransactions: transactions)
-            self.crowdNodeTxSet = FullCrowdNodeSignUpTxSet()
-            self.coinJoinTxSets = [:]
-            self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
+        // Gate the "Rewards" / "Masternode" filter rows; computed from the
+        // unfiltered history so they don't flap with the current selection.
+        let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
+        let hasMasternodes = transactions.contains { $0.isMasternodeTransaction }
 
-            // Gate the "Rewards" / "Masternode" filter rows; computed from the
-            // unfiltered history so they don't flap with the current selection.
-            let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
-            let hasMasternodes = transactions.contains { $0.isMasternodeTransaction }
+        // Snapshot each provider's metadata once per reload —
+        // `availableMetadata` copies the whole dictionary through the
+        // provider's serial queue, so reading it per-transaction costs
+        // O(n) queue hops + dictionary copies per reload.
+        let metadataSnapshots = self.metadataProviders.map { $0.availableMetadata }
+        let giftCardTxIds = Set(GiftCardMetadataProvider.shared.availableMetadata.keys)
 
-            // Snapshot each provider's metadata once per reload —
-            // `availableMetadata` copies the whole dictionary through the
-            // provider's serial queue, so reading it per-transaction costs
-            // O(n) queue hops + dictionary copies per reload.
-            let metadataSnapshots = self.metadataProviders.map { $0.availableMetadata }
-            let giftCardTxIds = Set(GiftCardMetadataProvider.shared.availableMetadata.keys)
+        var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
+            Tx.shared.updateRateIfNeeded(for: wrappedTx)
 
-            var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
-                Tx.shared.updateRateIfNeeded(for: wrappedTx)
+            if !self.passesFilter(transaction: wrappedTx, selected: selectedFilters, hasRewards: hasRewards, hasMasternodes: hasMasternodes, giftCardTxIds: giftCardTxIds) {
+                return nil
+            }
 
-                if !self.passesFilter(transaction: wrappedTx, selected: selectedFilters, hasRewards: hasRewards, hasMasternodes: hasMasternodes, giftCardTxIds: giftCardTxIds) {
+            // TODO(crowdnode-home-grouping): the "CrowdNode · Account" group
+            // needs decode-based ObservedTransaction matching (the SDK
+            // snapshot here doesn't carry transactionData); ports separately.
+            // Until then CrowdNode txs render as individual rows — the
+            // current behavior (the old DS-backed grouping branch was dead
+            // long before the .ds source case was deleted).
+            if wrappedTx.isCoinJoinMixing {
+                // CoinJoin mixing tx — group it into the per-day
+                // "Mixing Transactions" set.
+                let date = DWDateFormatter.sharedInstance.dateOnly(from: wrappedTx.date)
+                let coinJoinTxSet = self.coinJoinTxSets[date] ?? CoinJoinMixingTxSet()
+                self.coinJoinTxSets[date] = coinJoinTxSet
+
+                if coinJoinTxSet.tryInclude(wrappedTx) {
                     return nil
                 }
-
-                // TODO(crowdnode-home-grouping): the "CrowdNode · Account" group
-                // needs decode-based ObservedTransaction matching (the SDK
-                // snapshot here doesn't carry transactionData); ports separately.
-                // Until then CrowdNode txs render as individual rows — the
-                // current behavior (the old DS-backed grouping branch was dead
-                // long before the .ds source case was deleted).
-                if wrappedTx.isCoinJoinMixing {
-                    // CoinJoin mixing tx — group it into the per-day
-                    // "Mixing Transactions" set.
-                    let date = DWDateFormatter.sharedInstance.dateOnly(from: wrappedTx.date)
-                    let coinJoinTxSet = self.coinJoinTxSets[date] ?? CoinJoinMixingTxSet()
-                    self.coinJoinTxSets[date] = coinJoinTxSet
-
-                    if coinJoinTxSet.tryInclude(wrappedTx) {
-                        return nil
-                    }
-                } else if wrappedTx.isCoinJoinWithdrawal {
-                    // App-tagged CoinJoin offload (sweep) tx → the single
-                    // combined "CoinJoin Withdrawals" group.
-                    if self.coinJoinWithdrawalSet.tryInclude(wrappedTx) {
-                        return nil
-                    }
+            } else if wrappedTx.isCoinJoinWithdrawal {
+                // App-tagged CoinJoin offload (sweep) tx → the single
+                // combined "CoinJoin Withdrawals" group.
+                if self.coinJoinWithdrawalSet.tryInclude(wrappedTx) {
+                    return nil
                 }
-
-                return .tx(wrappedTx, self.resolveMetadata(for: wrappedTx.txHashData, in: metadataSnapshots))
             }
 
-            // Interleave the shielded operations (private receives/sends,
-            // Platform↔Shielded moves, shielded identity fundings) — the
-            // Core rows above only cover operations with an L1 leg. The
-            // day-grouping sort below merges the two timelines.
-            for shielded in shieldedItems {
-                guard self.passesShieldedFilter(
-                    item: shielded,
-                    selected: selectedFilters,
-                    hasRewards: hasRewards,
-                    hasMasternodes: hasMasternodes)
-                else { continue }
-                items.append(.shieldedActivity(shielded))
-            }
+            return .tx(wrappedTx, self.resolveMetadata(for: wrappedTx.txHashData, in: metadataSnapshots))
+        }
 
-            // Observed incoming Platform-address payments (app-recorded —
-            // the SDK persists no per-payment platform history; see
-            // PlatformAddressActivityStore.swift). Received-only by
-            // construction, so they ride the .received filter category.
-            let platformItems = SwiftDashSDKWalletSource.fetchPlatformActivity()
-            for platform in platformItems {
-                guard self.passesCategoryFilter(
-                    categories: [.received],
-                    selected: selectedFilters,
-                    hasRewards: hasRewards,
-                    hasMasternodes: hasMasternodes)
-                else { continue }
-                items.append(.platformActivity(platform))
-            }
+        // Interleave the shielded operations (private receives/sends,
+        // Platform↔Shielded moves, shielded identity fundings) — the
+        // Core rows above only cover operations with an L1 leg. The
+        // day-grouping sort below merges the two timelines.
+        for shielded in shieldedItems {
+            guard self.passesShieldedFilter(
+                item: shielded,
+                selected: selectedFilters,
+                hasRewards: hasRewards,
+                hasMasternodes: hasMasternodes)
+            else { continue }
+            items.append(.shieldedActivity(shielded))
+        }
 
-            self.txByHash.removeAll()
-            items.forEach { item in
-                self.txByHash[item.id] = item
-            }
+        // Observed incoming Platform-address payments (app-recorded —
+        // the SDK persists no per-payment platform history; see
+        // PlatformAddressActivityStore.swift). Received-only by
+        // construction, so they ride the .received filter category.
+        let platformItems = SwiftDashSDKWalletSource.fetchPlatformActivity()
+        for platform in platformItems {
+            guard self.passesCategoryFilter(
+                categories: [.received],
+                selected: selectedFilters,
+                hasRewards: hasRewards,
+                hasMasternodes: hasMasternodes)
+            else { continue }
+            items.append(.platformActivity(platform))
+        }
 
-            if !crowdNodeTxSet.transactionMap.isEmpty {
-                let item: TransactionListDataItem = .crowdnode(crowdNodeTxSet)
+        self.txByHash.removeAll()
+        items.forEach { item in
+            self.txByHash[item.id] = item
+        }
+
+        if !crowdNodeTxSet.transactionMap.isEmpty {
+            let item: TransactionListDataItem = .crowdnode(crowdNodeTxSet)
+            items.append(item)
+            self.txByHash[FullCrowdNodeSignUpTxSet.id] = item
+        }
+
+        for (_, coinJoinTxSet) in self.coinJoinTxSets {
+            if !coinJoinTxSet.transactionMap.isEmpty {
+                let item: TransactionListDataItem = .coinjoin(coinJoinTxSet)
                 items.append(item)
-                self.txByHash[FullCrowdNodeSignUpTxSet.id] = item
+                self.txByHash[coinJoinTxSet.id] = item
             }
+        }
 
-            for (_, coinJoinTxSet) in self.coinJoinTxSets {
-                if !coinJoinTxSet.transactionMap.isEmpty {
-                    let item: TransactionListDataItem = .coinjoin(coinJoinTxSet)
-                    items.append(item)
-                    self.txByHash[coinJoinTxSet.id] = item
-                }
+        if !self.coinJoinWithdrawalSet.transactionMap.isEmpty {
+            let item: TransactionListDataItem = .coinjoinWithdrawal(self.coinJoinWithdrawalSet)
+            items.append(item)
+            self.txByHash[self.coinJoinWithdrawalSet.id] = item
+        }
+
+        let groupedItems = Dictionary(
+            grouping: items.sorted(by: { $0.date > $1.date }),
+            by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
+        )
+
+        let array = groupedItems.map { key, items in
+            TransactionGroup(id: key, date: items.first!.date, items: items)
+        }.sorted { $0.date > $1.date }
+
+        // Fix #2 & #3: Mark initial load complete and clear reload flag
+        self.hasCompletedInitialLoad = true
+        self.isReloading = false
+
+        let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        DWLogger.log("HomeViewModel: Full reload complete in \(elapsedMs)ms, \(array.count) groups, \(self.txByHash.count) transactions cached")
+
+        DispatchQueue.main.async {
+            self.txItems = array
+            self.hasLoadedInitialTxItems = true
+            if self.hasRewardsHistory != hasRewards {
+                self.hasRewardsHistory = hasRewards
             }
-
-            if !self.coinJoinWithdrawalSet.transactionMap.isEmpty {
-                let item: TransactionListDataItem = .coinjoinWithdrawal(self.coinJoinWithdrawalSet)
-                items.append(item)
-                self.txByHash[self.coinJoinWithdrawalSet.id] = item
-            }
-
-            let groupedItems = Dictionary(
-                grouping: items.sorted(by: { $0.date > $1.date }),
-                by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
-            )
-
-            let array = groupedItems.map { key, items in
-                TransactionGroup(id: key, date: items.first!.date, items: items)
-            }.sorted { $0.date > $1.date }
-
-            // Fix #2 & #3: Mark initial load complete and clear reload flag
-            self.hasCompletedInitialLoad = true
-            self.isReloading = false
-
-            DWLogger.log("HomeViewModel: Full reload complete, \(array.count) groups, \(self.txByHash.count) transactions cached")
-
-            DispatchQueue.main.async {
-                self.txItems = array
-                self.hasLoadedInitialTxItems = true
-                if self.hasRewardsHistory != hasRewards {
-                    self.hasRewardsHistory = hasRewards
-                }
-                if self.hasMasternodeHistory != hasMasternodes {
-                    self.hasMasternodeHistory = hasMasternodes
-                }
+            if self.hasMasternodeHistory != hasMasternodes {
+                self.hasMasternodeHistory = hasMasternodes
             }
         }
     }
@@ -730,8 +748,12 @@ extension HomeViewModel {
 
         let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
-            DWLogger.log("HomeViewModel: Sync state changed (debounced), reloading")
-            self.reloadTxsAndShortcuts()
+            DWLogger.log("HomeViewModel: Sync state changed (debounced), requesting reload")
+            // Through the shared funnel, not straight to the reload: this
+            // debounce only coalesces sync-state changes among themselves, so
+            // calling directly raced the throttled save/balance triggers and
+            // each fired its own full pass.
+            self.txReloadRequests.send()
             #if DASHPAY
             self.checkJoinDashPay()
             #endif

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -521,8 +521,9 @@ class HomeViewModel: ObservableObject {
             by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
         )
 
-        let array = groupedItems.map { key, items in
-            TransactionGroup(id: key, date: items.first!.date, items: items)
+        let array = groupedItems.compactMap { key, items -> TransactionGroup? in
+            guard let first = items.first else { return nil }
+            return TransactionGroup(id: key, date: first.date, items: items)
         }.sorted { $0.date > $1.date }
 
         // Fix #2 & #3: Mark initial load complete and clear reload flag


### PR DESCRIPTION
## Problem

The home feed's first transaction load was starved behind CrowdNode's restore.

`CrowdNode.restoreState()` guards only on `signUpState > .notStarted` — a state a wallet that never signed up **never reaches**. So every caller re-ran the full history scan: twice during launch, and again on each entry into the CrowdNode portal. Every `restoreState()` caller is on the main thread ([CrowdNodeModel.swift:28](https://github.com/dashpay/dashwallet-ios/blob/develop/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift#L28), [:142](https://github.com/dashpay/dashwallet-ios/blob/develop/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift#L142), [CrowdNodeWithdrawalRouter.swift:31](https://github.com/dashpay/dashwallet-ios/blob/develop/DashWallet/Sources/UI/CrowdNode/BalanceReminder/CrowdNodeWithdrawalRouter.swift#L31)), so each pass blocked main outright.

From a launch trace: the first reload took 3344 ms against a 1180 ms steady state — the ~2.1 s delta lines up exactly with the CrowdNode window.

## Fixes

Measured on a 1756-transaction mainnet wallet (1720 TXO rows):

1. **Memoize a fruitless restore.** Keyed to the persisted transaction count, not latched permanently — a restored seed syncing its history in still gets a real scan. Cleared on reset, wipe and wallet switch. Launch restores **2 → 1**.
2. **Floor the confirmation scan.** `getApiAddressConfirmationTx()` scanned unbounded while `tryRestoreSignUp()` already floored at `januaryFirst2022Epoch`. An API-address confirmation is CrowdNode protocol traffic and cannot predate CrowdNode. This was the restore's expensive half: **1728 rows → 692**.
3. **Do the wallet join in the store.** It fetched every `walletId` TXO, faulted `.transaction` and `.spendingTransaction` on each (~3440 faults), then fed the resulting txid set back through a `contains` predicate as wide as the wallet's history. `PersistentTxo.walletId` is indexed and `PersistentTransaction` carries both inverses.

### Result

| | before | after |
|---|---|---|
| restores per launch | 2 | 1 |
| scan rows | 692 + 1728 | 692 + 692 |
| main-thread block | ~4 s (2 restores) | **0.64–1.95 s (1 restore)** |

```
restoring CrowdNode state
CrowdNode scan: fetch 692 rows in 153ms, decode in 207ms
CrowdNode scan: fetch 692 rows in 172ms, decode in 221ms
CrowdNode: account not found
```

Scan cost varies with launch contention — the same code measured 641 ms on a
warm store and 1954 ms on a cold launch competing with initial sync. The
durable wins are structural rather than a single figure: **one restore instead
of two**, and **692 rows instead of 1728** on the second scan.

## Also

Drops the `DispatchQueue.main.sync` read of `selectedFilters` from inside the home reload pass (`performReload` extraction accounts for most of the line count — it's re-indentation). Pairing each request with the selection live when it was made is tighter than reading it at pass start, which could render a selection made *after* the pass began.

## What I did not keep

I also tried coalescing redundant reloads. **It never fired in measurement** — the reloads are sequential triggers spread over time, not concurrent enqueues — and it introduced a real bug: `selectedFilters`' `didSet` calls `reloadTxDataSource()` directly, so a filter tap arriving while a pass was queued would be dropped and silently do nothing. Removed rather than shipped.

## Testing

- `dashpay` scheme builds clean
- Launch traces captured on iPhone 16 Plus simulator against a 1756-tx mainnet wallet, before/after, with no concurrent build running (an earlier round's numbers were contaminated by `xcodebuild` saturating the CPU)
- Not verified: filter-tap smoke test on device — the simulator was PIN-locked. The change is argued above rather than measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved transaction scanning and reload performance, especially for larger wallets.
  * Repeated scans with no new transactions are now skipped.
  * Wallet activity filtering and transaction processing are more efficient.
* **Bug Fixes**
  * Reduced main-screen delays during transaction reloads.
  * Improved synchronization between wallet updates and displayed activity.
  * API transaction lookups now focus on relevant, recently observed transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
