### PR TITLE
perf(home): stop reloading the feed on unrelated SwiftData saves

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -124,6 +124,18 @@ public final class CrowdNode {
     private(set) var isOnlineStateRestored = false
     var showNotificationOnResult = false
 
+    /// Persisted transaction count as of the last `restoreState()` that found
+    /// no CrowdNode account at all.
+    ///
+    /// The restore's own guard is `signUpState > .notStarted`, which a wallet
+    /// that never signed up never reaches — so every caller (launch sync-done,
+    /// each entry into the CrowdNode portal) re-ran the full history scan and
+    /// blocked the main thread for seconds apiece. A signup can still turn up
+    /// later when a restored seed syncs its history in, so this memo is keyed
+    /// to the store's row count rather than latching permanently: new rows
+    /// persisted means the scan gets to run again.
+    private var fruitlessRestoreTxCount: Int? = nil
+
     var masternodeAPY: Double
     var crowdnodeAPY: Double
 
@@ -195,6 +207,13 @@ extension CrowdNode {
             return
         }
 
+        // A previous pass already scanned this exact history and found no
+        // account; without new rows it would reach the same conclusion.
+        if let scanned = fruitlessRestoreTxCount,
+           TransactionObserver.persistedTransactionCount() == scanned {
+            return
+        }
+
         DWLogger.log("restoring CrowdNode state")
         signUpState = SignUpState.notStarted
         validatePrefs()
@@ -232,6 +251,10 @@ extension CrowdNode {
             }
         } else {
             DWLogger.log("CrowdNode: account not found")
+            // Nothing found by either the signup scan or the online-account
+            // lookup, so this whole pass was a no-op — memoize it against the
+            // history it saw.
+            fruitlessRestoreTxCount = TransactionObserver.persistedTransactionCount()
         }
     }
 
@@ -331,6 +354,7 @@ extension CrowdNode {
         primaryAddress = nil
         apiError = nil
         balance = 0
+        fruitlessRestoreTxCount = nil
         prefs.resetUserDefaults()
     }
 
@@ -364,6 +388,9 @@ extension CrowdNode {
         apiError = nil
         balance = 0
         isOnlineStateRestored = false
+        // The memo describes the PREVIOUS wallet's scan; the new wallet must
+        // get a real one even though the store's row count is unchanged.
+        fruitlessRestoreTxCount = nil
         restoreState()
     }
     
@@ -1016,7 +1043,13 @@ extension CrowdNode {
     private func getApiAddressConfirmationTx() -> ObservedTransaction? {
         let filter = CoinsToAddressTxFilter(coins: CrowdNode.apiConfirmationDashAmount, address: nil) // account address is unknown at this point
         let forwardedConfirmationFilter = CrowdNodeAPIConfirmationTxForwarded()
-        let observed = TransactionObserver.fetchObserved()
+        // Same floor the signup scan uses: an API-address confirmation is
+        // CrowdNode protocol traffic, so it cannot predate CrowdNode. Without
+        // it this walked and decoded the wallet's entire history on the main
+        // thread during restore — the more expensive of the restore's two
+        // scans, on a wallet that has no CrowdNode account at all.
+        let observed = TransactionObserver.fetchObserved(
+            firstSeenAtOrAfter: FullCrowdNodeSignUpTxSet.januaryFirst2022Epoch)
 
         // There might be several matching transactions. The real one is the
         // one whose destination CrowdNode forwarded from.

--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -134,7 +134,7 @@ public final class CrowdNode {
     /// later when a restored seed syncs its history in, so this memo is keyed
     /// to the store's row count rather than latching permanently: new rows
     /// persisted means the scan gets to run again.
-    private var fruitlessRestoreTxCount: Int? = nil
+    private var fruitlessRestoreTxCount: Int?
 
     var masternodeAPY: Double
     var crowdnodeAPY: Double
@@ -207,10 +207,15 @@ extension CrowdNode {
             return
         }
 
+        // Read the count ONCE, before the scans, and memoize that same value
+        // below. Reading it again afterwards would record rows the scans never
+        // inspected — a save landing mid-restore would make the next call skip
+        // a scan that still owes work on those rows.
+        let txCountBeforeScans = TransactionObserver.persistedTransactionCount()
+
         // A previous pass already scanned this exact history and found no
         // account; without new rows it would reach the same conclusion.
-        if let scanned = fruitlessRestoreTxCount,
-           TransactionObserver.persistedTransactionCount() == scanned {
+        if let scanned = fruitlessRestoreTxCount, txCountBeforeScans == scanned {
             return
         }
 
@@ -253,8 +258,8 @@ extension CrowdNode {
             DWLogger.log("CrowdNode: account not found")
             // Nothing found by either the signup scan or the online-account
             // lookup, so this whole pass was a no-op — memoize it against the
-            // history it saw.
-            fruitlessRestoreTxCount = TransactionObserver.persistedTransactionCount()
+            // history the scans actually saw, not the store's count now.
+            fruitlessRestoreTxCount = txCountBeforeScans
         }
     }
 

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -93,6 +93,13 @@ public final class TransactionObserver {
     /// Scans slower than this get a log line; see `scan`.
     private static let slowScanLogThresholdMs = 150
 
+    /// The main-actor-owned SDK handles a scan needs, resolved once per call.
+    private struct HostHandles {
+        let container: ModelContainer
+        let walletId: Data
+        let network: Network
+    }
+
     // MARK: Shared row scanner
 
     /// Persisted rows decoded to `ObservedTransaction`, newest-first
@@ -111,7 +118,7 @@ public final class TransactionObserver {
         fetchLimit: Int? = nil,
         firstSeenAtOrAfter: UInt64? = nil
     ) -> [ObservedTransaction] {
-        let handles = { @MainActor () -> (container: ModelContainer, walletId: Data, network: Network)? in
+        let handles = { @MainActor () -> HostHandles? in
             guard let container = SwiftDashSDKHost.shared.modelContainer,
                   let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
                 logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
@@ -121,10 +128,10 @@ public final class TransactionObserver {
                 logger.error("🅾 OBSERVER :: unsupported network — empty scan")
                 return nil
             }
-            return (container, walletId, network)
+            return HostHandles(container: container, walletId: walletId, network: network)
         }
 
-        let resolved: (container: ModelContainer, walletId: Data, network: Network)?
+        let resolved: HostHandles?
         if Thread.isMainThread {
             resolved = MainActor.assumeIsolated { handles() }
         } else {

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -25,9 +25,15 @@ import SwiftDashSDK
 
 extension ObservedTransaction {
     /// Build from a persisted SwiftDashSDK row + a consensus decode of its raw
-    /// bytes. nil (logged) when the bytes fail to decode. Main-actor: the row's
-    /// model context and the `Transaction` wrapper are main-bound.
-    @MainActor
+    /// bytes. nil (logged) when the bytes fail to decode.
+    ///
+    /// Runs on whatever thread owns `row`'s context — it only reads the row's
+    /// own properties and its TXO relationship, decodes bytes, and wraps the
+    /// row (`HomeViewModel`'s reload already builds `Transaction` off the main
+    /// thread the same way). It was `@MainActor` while the only caller read
+    /// through `mainContext`; the scanner now owns its context, and forcing
+    /// the decode back onto the main actor is what made a CrowdNode restore
+    /// stall the main thread for ~2s.
     init?(row: PersistentTransaction, network: Network) {
         let decoded: DecodedTransaction
         do {
@@ -84,71 +90,122 @@ public final class TransactionObserver {
     /// Rows admitted per rescan; the floor predicate already bounds the
     /// window, this guards a resync burst mid-wait.
     private static let rescanFetchLimit = 200
+    /// Scans slower than this get a log line; see `scan`.
+    private static let slowScanLogThresholdMs = 150
 
     // MARK: Shared row scanner
 
     /// Persisted rows decoded to `ObservedTransaction`, newest-first
     /// (`firstSeen` desc). Empty (logged) when the SDK host has no container
-    /// yet or the network is unsupported. Safe from any thread — trampolines
-    /// to main because this scanner reads through `mainContext`.
+    /// yet or the network is unsupported. Safe from any thread.
+    ///
+    /// The scan itself runs on the CALLER's thread against its own
+    /// `ModelContext`, never `mainContext` — callers that hold the main
+    /// thread (`CrowdNode.restoreState`) therefore pay the scan inline, so
+    /// keep it cheap. Only the two host reads need the main actor; they are
+    /// cheap property reads.
+    ///
+    /// `ObservedTransaction` is a struct decoded from each row, so the results
+    /// carry nothing back to the context they were read through.
     static func fetchObserved(
         fetchLimit: Int? = nil,
         firstSeenAtOrAfter: UInt64? = nil
     ) -> [ObservedTransaction] {
+        let handles = { @MainActor () -> (container: ModelContainer, walletId: Data, network: Network)? in
+            guard let container = SwiftDashSDKHost.shared.modelContainer,
+                  let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
+                logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
+                return nil
+            }
+            guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
+                logger.error("🅾 OBSERVER :: unsupported network — empty scan")
+                return nil
+            }
+            return (container, walletId, network)
+        }
+
+        let resolved: (container: ModelContainer, walletId: Data, network: Network)?
         if Thread.isMainThread {
-            return MainActor.assumeIsolated {
-                fetchObservedOnMain(fetchLimit: fetchLimit, firstSeenAtOrAfter: firstSeenAtOrAfter)
-            }
+            resolved = MainActor.assumeIsolated { handles() }
+        } else {
+            resolved = DispatchQueue.main.sync { MainActor.assumeIsolated { handles() } }
         }
-        var result: [ObservedTransaction] = []
-        DispatchQueue.main.sync {
-            result = MainActor.assumeIsolated {
-                fetchObservedOnMain(fetchLimit: fetchLimit, firstSeenAtOrAfter: firstSeenAtOrAfter)
-            }
-        }
-        return result
+        guard let resolved else { return [] }
+        return scan(
+            container: resolved.container,
+            walletId: resolved.walletId,
+            network: resolved.network,
+            fetchLimit: fetchLimit,
+            firstSeenAtOrAfter: firstSeenAtOrAfter)
     }
 
-    @MainActor
-    private static func fetchObservedOnMain(
+    /// Total persisted transaction count, or nil when the SDK host has no
+    /// container yet. A `SELECT COUNT(*)` with no join, predicate or decode —
+    /// cheap enough for callers to use as a "has anything new been persisted"
+    /// check before deciding whether a full rescan is worth its cost.
+    static func persistedTransactionCount() -> Int? {
+        let container = { @MainActor () -> ModelContainer? in
+            SwiftDashSDKHost.shared.modelContainer
+        }
+        let resolved: ModelContainer?
+        if Thread.isMainThread {
+            resolved = MainActor.assumeIsolated { container() }
+        } else {
+            resolved = DispatchQueue.main.sync { MainActor.assumeIsolated { container() } }
+        }
+        guard let resolved else { return nil }
+        return try? ModelContext(resolved).fetchCount(FetchDescriptor<PersistentTransaction>())
+    }
+
+    private static func scan(
+        container: ModelContainer,
+        walletId: Data,
+        network: Network,
         fetchLimit: Int?,
         firstSeenAtOrAfter: UInt64?
     ) -> [ObservedTransaction] {
-        guard let container = SwiftDashSDKHost.shared.modelContainer,
-              let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
-            logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
-            return []
-        }
-        guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
-            logger.error("🅾 OBSERVER :: unsupported network — empty scan")
-            return []
-        }
-        // Scope to the active wallet via the TXO join: gather the wallet's
-        // txids from its walletId-scoped TXO rows (CrowdNode responses land
-        // in the active wallet's own addresses), then match transactions in
-        // that set. `PersistentTransaction` carries no walletId of its own.
-        let txoDescriptor = FetchDescriptor<PersistentTxo>(
-            predicate: #Predicate { $0.walletId == walletId })
-        let txos = (try? container.mainContext.fetch(txoDescriptor)) ?? []
-        var txids = Set<Data>()
-        for txo in txos {
-            if let producing = txo.transaction { txids.insert(producing.txid) }
-            if let spending = txo.spendingTransaction { txids.insert(spending.txid) }
-        }
-        guard !txids.isEmpty else { return [] }
+        // Own context, so the scan never contends with the main actor.
+        let context = ModelContext(container)
+        // Scope to the active wallet through the TXO relationship, evaluated
+        // by the store: a transaction is this wallet's when it produced or
+        // spent one of the wallet's TXOs, and `PersistentTxo.walletId` is
+        // indexed. Doing the same join in Swift — fetch every walletId TXO,
+        // fault `.transaction` and `.spendingTransaction` on each, then feed
+        // the resulting txid set back through a `contains` predicate — costs
+        // two relationship faults per TXO plus an IN-list the width of the
+        // wallet's history, which is where this scan's seconds went.
         var descriptor = FetchDescriptor<PersistentTransaction>(
             sortBy: [SortDescriptor(\.firstSeen, order: .reverse)])
         if let floor = firstSeenAtOrAfter {
-            descriptor.predicate = #Predicate { txids.contains($0.txid) && $0.firstSeen >= floor }
+            descriptor.predicate = #Predicate {
+                $0.firstSeen >= floor &&
+                    ($0.outputs.contains { $0.walletId == walletId } ||
+                        $0.inputs.contains { $0.walletId == walletId })
+            }
         } else {
-            descriptor.predicate = #Predicate { txids.contains($0.txid) }
+            descriptor.predicate = #Predicate {
+                $0.outputs.contains { $0.walletId == walletId } ||
+                    $0.inputs.contains { $0.walletId == walletId }
+            }
         }
         if let fetchLimit {
             descriptor.fetchLimit = fetchLimit
         }
         do {
-            let rows = try container.mainContext.fetch(descriptor)
-            return rows.compactMap { ObservedTransaction(row: $0, network: network) }
+            let fetchStart = Date()
+            let rows = try context.fetch(descriptor)
+            let fetchMs = Int(Date().timeIntervalSince(fetchStart) * 1000)
+            let decodeStart = Date()
+            let observed = rows.compactMap { ObservedTransaction(row: $0, network: network) }
+            let decodeMs = Int(Date().timeIntervalSince(decodeStart) * 1000)
+            // Only when it actually costs something: `observe()` rescans on
+            // every SwiftData save, so an unconditional line here is sync-time
+            // log spam. A slow scan is worth seeing because callers on the
+            // main thread pay it inline.
+            if fetchMs + decodeMs > Self.slowScanLogThresholdMs {
+                DWLogger.log("CrowdNode scan: fetch \(rows.count) rows in \(fetchMs)ms, decode in \(decodeMs)ms")
+            }
+            return observed
         } catch {
             logger.error("🅾 OBSERVER :: PersistentTransaction fetch failed: \(String(describing: error), privacy: .public)")
             return []

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -376,152 +376,170 @@ class HomeViewModel: ObservableObject {
     
     // This is expensive and should not be called often
     private func reloadTxDataSource() {
-        self.queue.async { [weak self] in
-            guard let self = self else { return }
+        // Read main-actor state BEFORE handing off, never from inside the
+        // worker pass. A `DispatchQueue.main.sync` from the queue is a barrier
+        // whose cost is main-thread *availability*, not work: at launch the
+        // main thread is busy with tab-bar layout, avatar state and CrowdNode
+        // restore, so a reload that hops mid-pass inherits all of it. Hopping
+        // once up front, asynchronously, keeps the pass free-running.
+        let dispatch = { @MainActor [weak self] in
+            guard let self else { return }
+            // Pair each request with the filter selection that was live when
+            // it was made. Reading it inside the pass instead would let a pass
+            // triggered by one change render a selection the user made after
+            // it started.
+            let selectedFilters = self.selectedFilters
+            let startedAt = Date()
+            self.queue.async { [weak self] in
+                self?.performReload(selectedFilters: selectedFilters, startedAt: startedAt)
+            }
+        }
+        if Thread.isMainThread {
+            MainActor.assumeIsolated { dispatch() }
+        } else {
+            DispatchQueue.main.async { MainActor.assumeIsolated { dispatch() } }
+        }
+    }
 
-            // Fix #3: Set reload flag to prevent race conditions with incremental updates
-            self.isReloading = true
-            DWLogger.log("HomeViewModel: Starting full transaction reload")
+    private func performReload(selectedFilters: Set<TransactionFilterCategory>, startedAt: Date) {
+        // Fix #3: Set reload flag to prevent race conditions with incremental updates
+        self.isReloading = true
+        DWLogger.log("HomeViewModel: Starting full transaction reload")
 
-            // SwiftUI mutates the filter on the main thread. Snapshot it once
-            // before doing the worker-queue computation instead of reading the
-            // published property concurrently during the reload.
-            let selectedFilters = DispatchQueue.main.sync { self.selectedFilters }
+        let transactions = transactionSource.allTransactions
+        // Reconcile restored Shielded → Core destinations before Core rows
+        // are filtered/classified. The activity projection can recover a
+        // destination tag that was absent from the local withdrawal store.
+        let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity(
+            coreTransactions: transactions)
+        self.crowdNodeTxSet = FullCrowdNodeSignUpTxSet()
+        self.coinJoinTxSets = [:]
+        self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
 
-            let transactions = transactionSource.allTransactions
-            // Reconcile restored Shielded → Core destinations before Core rows
-            // are filtered/classified. The activity projection can recover a
-            // destination tag that was absent from the local withdrawal store.
-            let shieldedItems = SwiftDashSDKWalletSource.fetchShieldedActivity(
-                coreTransactions: transactions)
-            self.crowdNodeTxSet = FullCrowdNodeSignUpTxSet()
-            self.coinJoinTxSets = [:]
-            self.coinJoinWithdrawalSet = CoinJoinWithdrawalTxSet()
+        // Gate the "Rewards" / "Masternode" filter rows; computed from the
+        // unfiltered history so they don't flap with the current selection.
+        let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
+        let hasMasternodes = transactions.contains { $0.isMasternodeTransaction }
 
-            // Gate the "Rewards" / "Masternode" filter rows; computed from the
-            // unfiltered history so they don't flap with the current selection.
-            let hasRewards = transactions.contains { $0.isCoinbaseTransaction }
-            let hasMasternodes = transactions.contains { $0.isMasternodeTransaction }
+        // Snapshot each provider's metadata once per reload —
+        // `availableMetadata` copies the whole dictionary through the
+        // provider's serial queue, so reading it per-transaction costs
+        // O(n) queue hops + dictionary copies per reload.
+        let metadataSnapshots = self.metadataProviders.map { $0.availableMetadata }
+        let giftCardTxIds = Set(GiftCardMetadataProvider.shared.availableMetadata.keys)
 
-            // Snapshot each provider's metadata once per reload —
-            // `availableMetadata` copies the whole dictionary through the
-            // provider's serial queue, so reading it per-transaction costs
-            // O(n) queue hops + dictionary copies per reload.
-            let metadataSnapshots = self.metadataProviders.map { $0.availableMetadata }
-            let giftCardTxIds = Set(GiftCardMetadataProvider.shared.availableMetadata.keys)
+        var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
+            Tx.shared.updateRateIfNeeded(for: wrappedTx)
 
-            var items: [TransactionListDataItem] = transactions.compactMap { wrappedTx -> TransactionListDataItem? in
-                Tx.shared.updateRateIfNeeded(for: wrappedTx)
+            if !self.passesFilter(transaction: wrappedTx, selected: selectedFilters, hasRewards: hasRewards, hasMasternodes: hasMasternodes, giftCardTxIds: giftCardTxIds) {
+                return nil
+            }
 
-                if !self.passesFilter(transaction: wrappedTx, selected: selectedFilters, hasRewards: hasRewards, hasMasternodes: hasMasternodes, giftCardTxIds: giftCardTxIds) {
+            // TODO(crowdnode-home-grouping): the "CrowdNode · Account" group
+            // needs decode-based ObservedTransaction matching (the SDK
+            // snapshot here doesn't carry transactionData); ports separately.
+            // Until then CrowdNode txs render as individual rows — the
+            // current behavior (the old DS-backed grouping branch was dead
+            // long before the .ds source case was deleted).
+            if wrappedTx.isCoinJoinMixing {
+                // CoinJoin mixing tx — group it into the per-day
+                // "Mixing Transactions" set.
+                let date = DWDateFormatter.sharedInstance.dateOnly(from: wrappedTx.date)
+                let coinJoinTxSet = self.coinJoinTxSets[date] ?? CoinJoinMixingTxSet()
+                self.coinJoinTxSets[date] = coinJoinTxSet
+
+                if coinJoinTxSet.tryInclude(wrappedTx) {
                     return nil
                 }
-
-                // TODO(crowdnode-home-grouping): the "CrowdNode · Account" group
-                // needs decode-based ObservedTransaction matching (the SDK
-                // snapshot here doesn't carry transactionData); ports separately.
-                // Until then CrowdNode txs render as individual rows — the
-                // current behavior (the old DS-backed grouping branch was dead
-                // long before the .ds source case was deleted).
-                if wrappedTx.isCoinJoinMixing {
-                    // CoinJoin mixing tx — group it into the per-day
-                    // "Mixing Transactions" set.
-                    let date = DWDateFormatter.sharedInstance.dateOnly(from: wrappedTx.date)
-                    let coinJoinTxSet = self.coinJoinTxSets[date] ?? CoinJoinMixingTxSet()
-                    self.coinJoinTxSets[date] = coinJoinTxSet
-
-                    if coinJoinTxSet.tryInclude(wrappedTx) {
-                        return nil
-                    }
-                } else if wrappedTx.isCoinJoinWithdrawal {
-                    // App-tagged CoinJoin offload (sweep) tx → the single
-                    // combined "CoinJoin Withdrawals" group.
-                    if self.coinJoinWithdrawalSet.tryInclude(wrappedTx) {
-                        return nil
-                    }
+            } else if wrappedTx.isCoinJoinWithdrawal {
+                // App-tagged CoinJoin offload (sweep) tx → the single
+                // combined "CoinJoin Withdrawals" group.
+                if self.coinJoinWithdrawalSet.tryInclude(wrappedTx) {
+                    return nil
                 }
-
-                return .tx(wrappedTx, self.resolveMetadata(for: wrappedTx.txHashData, in: metadataSnapshots))
             }
 
-            // Interleave the shielded operations (private receives/sends,
-            // Platform↔Shielded moves, shielded identity fundings) — the
-            // Core rows above only cover operations with an L1 leg. The
-            // day-grouping sort below merges the two timelines.
-            for shielded in shieldedItems {
-                guard self.passesShieldedFilter(
-                    item: shielded,
-                    selected: selectedFilters,
-                    hasRewards: hasRewards,
-                    hasMasternodes: hasMasternodes)
-                else { continue }
-                items.append(.shieldedActivity(shielded))
-            }
+            return .tx(wrappedTx, self.resolveMetadata(for: wrappedTx.txHashData, in: metadataSnapshots))
+        }
 
-            // Observed incoming Platform-address payments (app-recorded —
-            // the SDK persists no per-payment platform history; see
-            // PlatformAddressActivityStore.swift). Received-only by
-            // construction, so they ride the .received filter category.
-            let platformItems = SwiftDashSDKWalletSource.fetchPlatformActivity()
-            for platform in platformItems {
-                guard self.passesCategoryFilter(
-                    categories: [.received],
-                    selected: selectedFilters,
-                    hasRewards: hasRewards,
-                    hasMasternodes: hasMasternodes)
-                else { continue }
-                items.append(.platformActivity(platform))
-            }
+        // Interleave the shielded operations (private receives/sends,
+        // Platform↔Shielded moves, shielded identity fundings) — the
+        // Core rows above only cover operations with an L1 leg. The
+        // day-grouping sort below merges the two timelines.
+        for shielded in shieldedItems {
+            guard self.passesShieldedFilter(
+                item: shielded,
+                selected: selectedFilters,
+                hasRewards: hasRewards,
+                hasMasternodes: hasMasternodes)
+            else { continue }
+            items.append(.shieldedActivity(shielded))
+        }
 
-            self.txByHash.removeAll()
-            items.forEach { item in
-                self.txByHash[item.id] = item
-            }
+        // Observed incoming Platform-address payments (app-recorded —
+        // the SDK persists no per-payment platform history; see
+        // PlatformAddressActivityStore.swift). Received-only by
+        // construction, so they ride the .received filter category.
+        let platformItems = SwiftDashSDKWalletSource.fetchPlatformActivity()
+        for platform in platformItems {
+            guard self.passesCategoryFilter(
+                categories: [.received],
+                selected: selectedFilters,
+                hasRewards: hasRewards,
+                hasMasternodes: hasMasternodes)
+            else { continue }
+            items.append(.platformActivity(platform))
+        }
 
-            if !crowdNodeTxSet.transactionMap.isEmpty {
-                let item: TransactionListDataItem = .crowdnode(crowdNodeTxSet)
+        self.txByHash.removeAll()
+        items.forEach { item in
+            self.txByHash[item.id] = item
+        }
+
+        if !crowdNodeTxSet.transactionMap.isEmpty {
+            let item: TransactionListDataItem = .crowdnode(crowdNodeTxSet)
+            items.append(item)
+            self.txByHash[FullCrowdNodeSignUpTxSet.id] = item
+        }
+
+        for (_, coinJoinTxSet) in self.coinJoinTxSets {
+            if !coinJoinTxSet.transactionMap.isEmpty {
+                let item: TransactionListDataItem = .coinjoin(coinJoinTxSet)
                 items.append(item)
-                self.txByHash[FullCrowdNodeSignUpTxSet.id] = item
+                self.txByHash[coinJoinTxSet.id] = item
             }
+        }
 
-            for (_, coinJoinTxSet) in self.coinJoinTxSets {
-                if !coinJoinTxSet.transactionMap.isEmpty {
-                    let item: TransactionListDataItem = .coinjoin(coinJoinTxSet)
-                    items.append(item)
-                    self.txByHash[coinJoinTxSet.id] = item
-                }
+        if !self.coinJoinWithdrawalSet.transactionMap.isEmpty {
+            let item: TransactionListDataItem = .coinjoinWithdrawal(self.coinJoinWithdrawalSet)
+            items.append(item)
+            self.txByHash[self.coinJoinWithdrawalSet.id] = item
+        }
+
+        let groupedItems = Dictionary(
+            grouping: items.sorted(by: { $0.date > $1.date }),
+            by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
+        )
+
+        let array = groupedItems.map { key, items in
+            TransactionGroup(id: key, date: items.first!.date, items: items)
+        }.sorted { $0.date > $1.date }
+
+        // Fix #2 & #3: Mark initial load complete and clear reload flag
+        self.hasCompletedInitialLoad = true
+        self.isReloading = false
+
+        let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        DWLogger.log("HomeViewModel: Full reload complete in \(elapsedMs)ms, \(array.count) groups, \(self.txByHash.count) transactions cached")
+
+        DispatchQueue.main.async {
+            self.txItems = array
+            self.hasLoadedInitialTxItems = true
+            if self.hasRewardsHistory != hasRewards {
+                self.hasRewardsHistory = hasRewards
             }
-
-            if !self.coinJoinWithdrawalSet.transactionMap.isEmpty {
-                let item: TransactionListDataItem = .coinjoinWithdrawal(self.coinJoinWithdrawalSet)
-                items.append(item)
-                self.txByHash[self.coinJoinWithdrawalSet.id] = item
-            }
-
-            let groupedItems = Dictionary(
-                grouping: items.sorted(by: { $0.date > $1.date }),
-                by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
-            )
-
-            let array = groupedItems.map { key, items in
-                TransactionGroup(id: key, date: items.first!.date, items: items)
-            }.sorted { $0.date > $1.date }
-
-            // Fix #2 & #3: Mark initial load complete and clear reload flag
-            self.hasCompletedInitialLoad = true
-            self.isReloading = false
-
-            DWLogger.log("HomeViewModel: Full reload complete, \(array.count) groups, \(self.txByHash.count) transactions cached")
-
-            DispatchQueue.main.async {
-                self.txItems = array
-                self.hasLoadedInitialTxItems = true
-                if self.hasRewardsHistory != hasRewards {
-                    self.hasRewardsHistory = hasRewards
-                }
-                if self.hasMasternodeHistory != hasMasternodes {
-                    self.hasMasternodeHistory = hasMasternodes
-                }
+            if self.hasMasternodeHistory != hasMasternodes {
+                self.hasMasternodeHistory = hasMasternodes
             }
         }
     }
@@ -730,8 +748,12 @@ extension HomeViewModel {
 
         let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
-            DWLogger.log("HomeViewModel: Sync state changed (debounced), reloading")
-            self.reloadTxsAndShortcuts()
+            DWLogger.log("HomeViewModel: Sync state changed (debounced), requesting reload")
+            // Through the shared funnel, not straight to the reload: this
+            // debounce only coalesces sync-state changes among themselves, so
+            // calling directly raced the throttled save/balance triggers and
+            // each fired its own full pass.
+            self.txReloadRequests.send()
             #if DASHPAY
             self.checkJoinDashPay()
             #endif

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -521,8 +521,9 @@ class HomeViewModel: ObservableObject {
             by: { DWDateFormatter.sharedInstance.dateOnly(from: $0.date) }
         )
 
-        let array = groupedItems.map { key, items in
-            TransactionGroup(id: key, date: items.first!.date, items: items)
+        let array = groupedItems.compactMap { key, items -> TransactionGroup? in
+            guard let first = items.first else { return nil }
+            return TransactionGroup(id: key, date: first.date, items: items)
         }.sorted { $0.date > $1.date }
 
         // Fix #2 & #3: Mark initial load complete and clear reload flag

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Combine
+import CoreData
 import SwiftData
 import SwiftDashSDK
 
@@ -320,6 +321,7 @@ class HomeViewModel: ObservableObject {
         // directly from SwiftData via SwiftDashSDKWalletSource and use this
         // notification as the reload trigger.
         NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
+            .filter { Self.saveTouchesFeedRows($0) }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.txReloadRequests.send()
@@ -364,9 +366,14 @@ class HomeViewModel: ObservableObject {
                 guard let self = self else { return }
                 if state == .syncing {
                     // Reload once per transition into .syncing — replaces the
-                    // legacy sync-will-start notification observer.
+                    // legacy sync-will-start notification observer. Goes
+                    // through the throttled funnel rather than calling
+                    // `reloadTxsAndShortcuts()` directly: this sink also
+                    // schedules the debounced sync-state reload, so a direct
+                    // call raced it into two full passes per transition. The
+                    // funnel's sink reloads shortcuts too, so nothing is lost.
                     DWLogger.log("HomeViewModel: Sync started, reloading transactions")
-                    self.reloadTxsAndShortcuts()
+                    self.txReloadRequests.send()
                 }
                 self.onSyncStateChanged()
                 self.maybeShowCoinJoinSweepDialog()
@@ -374,6 +381,38 @@ class HomeViewModel: ObservableObject {
             .store(in: &cancellableBag)
     }
     
+    /// Entities whose rows the home feed actually renders.
+    private static let feedRowEntityNames: Set<String> = [
+        "PersistentTransaction",
+        "PersistentTxo",
+    ]
+
+    /// Whether a SwiftData save touched anything the feed renders.
+    ///
+    /// The model container is shared with bookkeeping that saves on its own
+    /// cadence — sync state, masternode lists, platform-address sync — and an
+    /// unfiltered save trigger turned every one of those into a full re-read
+    /// of the whole history plus a wholesale `txItems` republish. On a
+    /// 1756-transaction wallet that fired roughly every 15s indefinitely, and
+    /// the republish re-diffs the list under the user's finger mid-scroll.
+    ///
+    /// Fails OPEN: a save whose payload we can't inspect is treated as
+    /// relevant, so an unexpected notification shape costs a redundant reload
+    /// rather than a feed that stops updating.
+    private static func saveTouchesFeedRows(_ notification: Notification) -> Bool {
+        guard let userInfo = notification.userInfo else { return true }
+        var sawInspectableChange = false
+        for key in [NSInsertedObjectsKey, NSUpdatedObjectsKey, NSDeletedObjectsKey, NSRefreshedObjectsKey] {
+            guard let objects = userInfo[key] as? Set<NSManagedObject> else { continue }
+            guard !objects.isEmpty else { continue }
+            sawInspectableChange = true
+            if objects.contains(where: { feedRowEntityNames.contains($0.entity.name ?? "") }) {
+                return true
+            }
+        }
+        return !sawInspectableChange
+    }
+
     // This is expensive and should not be called often
     private func reloadTxDataSource() {
         // Read main-actor state BEFORE handing off, never from inside the


### PR DESCRIPTION
## Problem

Scrolling the transaction list stalls periodically — it reads as "it stops, then loads more", but **there is no pagination**; the list is a `LazyVStack` over all 998 groups.

The real cause: the feed reloads on **any** `NSManagedObjectContextDidSave` in the model container. That container is shared with bookkeeping that saves on its own cadence — sync state, masternode lists, platform-address sync — none of which change a row the feed renders. Every one cost a full re-read of 1756 transactions plus a wholesale `txItems` republish, and the republish re-diffs the whole list under the user's finger.

Measured on a 1756-transaction mainnet wallet — a full reload every ~15s, indefinitely, ~1.3s apiece:

```
18:53:59 → 18:54:03 → 18:54:19 → 18:54:35 → 18:54:53
18:55:08 → 18:55:21 → 18:55:39 → 18:55:55   (never stops)
```

## Fix

Filter the save trigger to `PersistentTransaction` / `PersistentTxo`. Same wallet, same build otherwise:

```
19:12:05, 19:12:07     ← 2 reloads
   ... 3m 50s quiet ...
19:15:58, 19:16:00, 19:16:01
```

The 15s tick is gone; reloads now cluster around actual activity.

### Two deliberate choices

**Fixed at the trigger, not the republish.** Skipping republishes when computed output is unchanged sounds cleaner, but a transaction's confirmation state can change under an unchanged row `id` — that version would render stale rows.

**Fails open.** A save whose payload can't be inspected is treated as relevant. If SwiftData's notification shape differs from what this expects, the cost is a redundant reload, never a feed that silently stops updating. (This mattered: whether the filter matched at all was the one thing I couldn't determine by reading, which is why the before/after cadence above is the acceptance test.)

## Also

Routes the `.syncing` transition through the throttled funnel instead of calling `reloadTxsAndShortcuts()` directly — flagged in review on #931. The same `syncModel.$state` sink already schedules the debounced sync-state reload, so the direct call raced it into two full passes per transition. The funnel's sink reloads shortcuts too, so nothing is lost.

## Testing

- `dashpay` scheme builds clean
- Before/after reload cadence captured from device logs on iPhone 16 Plus, 1756-tx mainnet wallet, with no concurrent build running
- Not verified: that the reload clusters at 19:12 and 19:16 correspond to genuine transaction-row saves rather than something else relevant slipping through. The cadence change is the evidence; the residual clusters aren't attributed.

## Related

Stacks conceptually on #931 (CrowdNode restore blocking main at launch) but touches disjoint code and can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)