### PR TITLE
feat(dashpay): show the username people typed, not the normalized form

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Voting/ContestedNamesService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Voting/ContestedNamesService.swift
@@ -155,13 +155,47 @@ final class ContestedNamesService {
 extension DPNSContender {
     /// Truncated base58 identity, e.g. `5rTJhbA…9Xk2Qd`.
     ///
-    /// Contenders are identified by identity id because Platform returns each
-    /// requester's own spelling of the label only inside a serialized document
-    /// the app cannot decode — showing a name here would mean inventing one.
-    /// Shared by the contest detail rows and the request-status rows so the two
-    /// never drift apart.
+    /// The identifying fallback for a contender whose `domain` document could
+    /// not be decoded, so their own spelling of the label is unknown. Shared by
+    /// the contest detail rows and the request-status rows so the two never
+    /// drift apart.
     var shortIdentityId: String {
         guard identityId.count > 16 else { return identityId }
         return String(identityId.prefix(8)) + "…" + String(identityId.suffix(6))
+    }
+}
+
+// MARK: - Contest display
+
+extension DPNSContest {
+    /// What to put in front of the user as the contest's name.
+    ///
+    /// Platform keys contests by the homograph-normalized label (`p1zza`),
+    /// which reads as a typo to the people who typed `pizza`. Contenders carry
+    /// their own spelling, so show that instead — and when they disagree, show
+    /// each one, since the disagreement is the whole point of the contest.
+    ///
+    /// Falls back to the normalized label when no contender document could be
+    /// decoded. Never reverse-engineered from the normalized form: `0`→`o` and
+    /// `1`→`i`/`l` are ambiguous, so guessing would invent a name nobody asked
+    /// for.
+    var displayTitle: String {
+        let labels = requestedLabels
+        guard !labels.isEmpty else { return normalizedLabel }
+        return labels.joined(separator: NSLocalizedString(" or ", comment: "Voting"))
+    }
+
+    /// `true` when ``displayTitle`` differs from ``normalizedLabel``, so the
+    /// UI knows whether the normalized form still needs showing alongside.
+    var displayTitleDiffersFromNormalized: Bool {
+        displayTitle != normalizedLabel
+    }
+}
+
+extension DPNSContender {
+    /// The contender's own spelling, or their truncated identity when the
+    /// document could not be decoded.
+    var displayNameOrIdentity: String {
+        displayLabel ?? shortIdentityId
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Usernames/UsernameRequestStatusScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Usernames/UsernameRequestStatusScreen.swift
@@ -106,6 +106,9 @@ struct UsernameRequestStatusScreen: View {
         List {
             Section {
                 VStack(alignment: .leading, spacing: 6) {
+                    // `label` here is the submission as the user typed it,
+                    // straight from our own bookmark — already the display
+                    // form, so no decode is involved.
                     Text(viewModel.label)
                         .font(.title2)
                         .fontWeight(.semibold)
@@ -229,10 +232,10 @@ private struct ContestantStatusRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(isMe
                      ? NSLocalizedString("You", comment: "Usernames")
-                     : contender.shortIdentityId)
+                     : contender.displayNameOrIdentity)
                     .font(.subheadline)
                     .fontWeight(isMe ? .semibold : .regular)
-                    .monospaced(!isMe)
+                    .monospaced(!isMe && contender.displayLabel == nil)
                 Text(String(format: NSLocalizedString("%u votes", comment: "Voting"),
                             contender.voteTally))
                     .font(.caption)

--- a/DashWallet/Sources/UI/DashPay/Voting/ContestDetailScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Voting/ContestDetailScreen.swift
@@ -58,14 +58,23 @@ struct ContestDetailScreen: View {
 
             Section {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(current.normalizedLabel)
+                    Text(current.displayTitle)
                         .font(.title2)
                         .fontWeight(.semibold)
-                    Text(NSLocalizedString(
-                        "Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed.",
-                        comment: "Voting"))
+                    if current.displayTitleDiffersFromNormalized {
+                        LabeledContent(
+                            NSLocalizedString("Stored as", comment: "Voting")
+                        ) {
+                            Text(current.normalizedLabel).monospaced()
+                        }
                         .font(.caption)
                         .foregroundColor(Color.dash.secondaryText)
+                        Text(NSLocalizedString(
+                            "Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed.",
+                            comment: "Voting"))
+                            .font(.caption)
+                            .foregroundColor(Color.dash.secondaryText)
+                    }
                     HStack {
                         Text(NSLocalizedString("Voting ends", comment: "Voting"))
                             .font(.caption)
@@ -115,7 +124,7 @@ struct ContestDetailScreen: View {
                 }
             }
         }
-        .navigationTitle(current.normalizedLabel)
+        .navigationTitle(current.displayTitle)
         .navigationBarTitleDisplayMode(.inline)
         .refreshable { await viewModel.refreshContest(normalizedLabel: contest.normalizedLabel) }
         .sheet(item: $pendingChoice) { choice in
@@ -138,9 +147,9 @@ private struct ContenderRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text(contender.shortIdentityId)
+                Text(contender.displayNameOrIdentity)
                     .font(.subheadline)
-                    .monospaced()
+                    .monospaced(contender.displayLabel == nil)
                 Text(String(format: NSLocalizedString("%u votes", comment: "Voting"),
                             contender.voteTally))
                     .font(.caption)

--- a/DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift
@@ -112,7 +112,7 @@ struct UsernameVotingScreen: View {
                         "No usernames are being contested right now. Contests open when two or more people request the same name.",
                         comment: "Voting")
                     : NSLocalizedString(
-                        "No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”.",
+                        "No open contest matches that search.",
                         comment: "Voting"))
             Spacer()
         } else {
@@ -214,9 +214,20 @@ struct ContestRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text(contest.normalizedLabel)
-                    .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(contest.displayTitle)
+                        .font(.headline)
+                    // Platform keys the contest by the homograph-normalized
+                    // form; keep it visible so the name being voted on is
+                    // never ambiguous, but behind the spelling people typed.
+                    if contest.displayTitleDiffersFromNormalized {
+                        Text(contest.normalizedLabel)
+                            .font(.caption2)
+                            .monospaced()
+                            .foregroundColor(Color.dash.tertiaryText)
+                    }
+                }
                 Spacer()
                 ContestDeadlineLabel(endTime: contest.endTime)
             }

--- a/DashWallet/Sources/UI/DashPay/Voting/VotingViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Voting/VotingViewModel.swift
@@ -131,7 +131,14 @@ final class VotingViewModel: ObservableObject {
         guard let needle = contestsService.normalizedLabel(for: trimmed) else {
             return sorted(contests)
         }
-        return sorted(contests.filter { $0.normalizedLabel.contains(needle) })
+        // Match the normalized form *and* the spellings people actually typed,
+        // so searching "pizza" finds the contest whether the row is showing
+        // "pizza" or the normalized "p1zza".
+        let raw = trimmed.lowercased()
+        return sorted(contests.filter { contest in
+            contest.normalizedLabel.contains(needle)
+                || contest.requestedLabels.contains { $0.lowercased().contains(raw) }
+        })
     }
 
     private func sorted(_ input: [DPNSContest]) -> [DPNSContest] {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -4794,3 +4794,9 @@
 "Voting ended with no winner" = "Voting ended with no winner";
 "You" = "You";
 "Leading" = "Leading";
+"Stored as" = "Stored as";
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed.";
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen.";
+"No open contest matches that search." = "No open contest matches that search.";
+"“%@” could not be read as a Dash username." = "“%@” could not be read as a Dash username.";
+" or " = " or ";


### PR DESCRIPTION
## Why

The voting screens render Platform's **homograph-normalized** label, so a contest for `pizza` shows as `p1zza`. That reads as a typo to the very people whose username is being voted on.

This was written as part of #923 but landed **after** that PR was squash-merged, so it never reached `develop` — hence this follow-up PR.

## Why it needed an SDK change first

Normalization maps `o`→`0` and `i`/`l`→`1`. It is lossy and ambiguous — `p1zza` could be *pizza*, *plzza* or *p1zza* — so no client can recover the spelling by guessing.

dashpay/platform#4331 (**merged**, `8f98180c55`) decodes the spelling from each contender's `domain` document, where it was already on the wire, and derives the ordered, de-duplicated label list in Rust.

## What changes

- **List row** leads with the typed spelling; the stored form sits beneath it in small monospace **only when the two differ**.
- **Detail screen** titles on the typed spelling and adds a "Stored as" row plus a one-line explanation of why they differ.
- **Contender rows** show each requester's own spelling, falling back to the truncated identity id when their document could not be decoded.
- **Search matches both forms**, so typing `pizza` finds the contest whether the row reads `pizza` or `p1zza`.

### Contenders who typed different spellings

That is the situation a contest exists to resolve, so all distinct spellings are shown joined by "or" (`pizza or p1zza`) rather than arbitrarily picking one. The ordering and de-duplication happen in Rust (`DashSDKContestInfo.requested_labels`); Swift copies the result verbatim, per `packages/swift-sdk/CLAUDE.md`'s thin-bridge rule.

### Nothing is guessed

A contest with no decodable contender document keeps showing the normalized form. The normalized label is never reverse-engineered, and never hidden — it stays visible as supporting information wherever it differs.

## Testing

Clean `dashpay` build against merged `v4.2-dev` (`8f98180c55`) with the xcframework rebuilt for both slices.

⚠️ **`develop` does not currently build against merged `v4.2-dev`, independent of this PR.** `a9ff688a8` calls `ManagedPlatformWallet.invitationProspectiveIdentityId`, which does not exist in any merged platform branch — so that cross-repo change is still in flight. Verified plain `origin/develop` fails identically, then temporarily stubbed that one call locally (not committed) to confirm this branch's own code compiles clean. Worth resolving before merging anything that needs a green app build.

Runtime behaviour is still unverified — whether real contests carry decodable labels needs a testnet check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contest and username voting screens now show more recognizable contender names, with identity details as a fallback.
  * Contest titles display both the user-entered name and normalized name when they differ.
  * Contest search matches both entered and normalized spellings.
* **Bug Fixes**
  * Improved handling of unreadable contender information and incomplete search results.
* **Documentation**
  * Added clearer explanations for normalized names, invalid input, and related voting states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->