### PR TITLE
refactor(home): drop the isReloading guard that could never fire

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -62,10 +62,6 @@ class HomeViewModel: ObservableObject {
     var isPreviewMode: Bool = false
     #endif
 
-    /// Tracks whether a full reload is currently in progress to prevent race conditions
-    /// with incremental updates (Fix #3)
-    private var isReloading: Bool = false
-
     /// Tracks whether initial data load has completed (Fix #2)
     private var hasCompletedInitialLoad: Bool = false
 
@@ -251,9 +247,8 @@ class HomeViewModel: ObservableObject {
             self.crowdNodeTxSet = FullCrowdNodeSignUpTxSet()
             self.coinJoinTxSets.removeAll()
 
-            // Reset load tracking flags so the new network's data loads correctly
+            // Reset load tracking so the new network's data loads correctly
             self.hasCompletedInitialLoad = false
-            self.isReloading = false
 
             // Update UI-bound properties on main thread. The new network's
             // history is loading from scratch, so the feed goes back to its
@@ -441,8 +436,6 @@ class HomeViewModel: ObservableObject {
     }
 
     private func performReload(selectedFilters: Set<TransactionFilterCategory>, startedAt: Date) {
-        // Fix #3: Set reload flag to prevent race conditions with incremental updates
-        self.isReloading = true
         DWLogger.log("HomeViewModel: Starting full transaction reload")
 
         let transactions = transactionSource.allTransactions
@@ -565,9 +558,8 @@ class HomeViewModel: ObservableObject {
             return TransactionGroup(id: key, date: first.date, items: items)
         }.sorted { $0.date > $1.date }
 
-        // Fix #2 & #3: Mark initial load complete and clear reload flag
+        // Fix #2: Mark initial load complete
         self.hasCompletedInitialLoad = true
-        self.isReloading = false
 
         let elapsedMs = Int(Date().timeIntervalSince(startedAt) * 1000)
         DWLogger.log("HomeViewModel: Full reload complete in \(elapsedMs)ms, \(array.count) groups, \(self.txByHash.count) transactions cached")
@@ -587,13 +579,6 @@ class HomeViewModel: ObservableObject {
     private func onTransactionStatusChanged(tx: Transaction) {
         self.queue.async { [weak self] in
             guard let self = self else { return }
-
-            // Fix #3: Skip incremental updates while a full reload is in progress
-            // to prevent race conditions that could cause missing transactions
-            if self.isReloading {
-                DWLogger.log("HomeViewModel: Skipping incremental update during full reload for tx: \(tx.txHashHexString)")
-                return
-            }
 
             // Fix #2: If initial load hasn't completed yet, the cache is empty and
             // incremental updates won't work correctly. Trigger a full reload instead.


### PR DESCRIPTION
Raised by CodeRabbit on #931, and deliberately left out of that PR to keep a CrowdNode-focused change from expanding into pre-existing develop code.

## The problem

`HomeViewModel.isReloading` is dead. `performReload` sets it `true` on entry and back to `false` before returning; `onTransactionStatusChanged` then checks it from inside `queue.async`. Both run on the same **serial** `queue`, so the reload has always completed — and reset the flag — before the guard can run. It never observes `true`.

The comment on that guard claimed it would

> Skip incremental updates while a full reload is in progress to prevent race conditions that could cause missing transactions

which describes protection that does not exist. That is the failure mode [CLAUDE.md guardrail #2](../blob/develop/CLAUDE.md) exists to prevent: anyone auditing the feed for dropped transactions would have credited a guard that does nothing.

## Verification of the serial-queue premise

Checked before deleting, since a concurrent queue would have made the guard live:

- `queue` is `DispatchQueue(label: "HomeViewModel", qos: .userInitiated)` — no `attributes: .concurrent`, so serial.
- `performReload` has exactly one caller, itself inside `queue.async`.
- No top-level early `return`, `await`, or re-dispatch between the `true` and `false` assignments — the body is synchronous, so the flag cannot leak past the call.
- `isReloading` is referenced nowhere outside `HomeViewModel.swift`.

## Changes

Removes the property, all three assignments (`performReload` entry/exit and the network-change handler), and the guard with its comment. Two neighbouring comments are trimmed so they stop describing a flag that no longer exists:

- `Reset load tracking flags` → `Reset load tracking`
- `Fix #2 & #3: Mark initial load complete and clear reload flag` → `Fix #2: Mark initial load complete`

No behavior change — the guard's body was unreachable.

## Testing

Clean `dashpay` build, `** BUILD SUCCEEDED **`:

```
xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator \
  -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build
```

The unit-test target is still broken on develop (pre-existing), so the build is the verification standard here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction updates by allowing incremental changes to appear while a full refresh is in progress.
  * Streamlined refresh behavior to provide more consistent loading and synchronization results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->