### PR TITLE
fix(wallet): restored internal transfers show their route and amount

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -1603,25 +1603,26 @@ final class ShieldedTxLookup {
     /// execution and do NOT survive a wipe & recover, so a restored wallet's
     /// asset-lock funding txs otherwise render "Internal Transfer — 0 DASH".
     /// For every persisted AssetLock transaction with no store row, parse the
-    /// credit outputs from the raw bytes (consensus truth) and add:
-    /// - funding type 4 when every credit output pays one of the wallet's own
-    ///   persisted Platform addresses — the full Core → Platform treatment;
-    /// - a `reconstructedUnknownFundingType` entry otherwise — real amount,
-    ///   no destination claim (one-time identity/shield keys are not
-    ///   distinguishable from the L1 tx alone).
-    /// Store-backed entries always win (`map` is checked first).
+    /// credit outputs from the raw bytes (consensus truth) and classify the
+    /// destination through the wallet's persisted funding-account address
+    /// pools: each credit output pays a one-time address the wallet derived
+    /// from a purpose-specific account (identity registration/top-up/
+    /// invitation, Platform address top-up, shielded top-up — accountType
+    /// 2…7), and those pools DO survive a restore as `PersistentCoreAddress`
+    /// rows. A match yields the exact funding type and the full existing
+    /// route treatment; no match yields a `reconstructedUnknownFundingType`
+    /// entry — real amount, no destination claim. Store-backed entries
+    /// always win (`map` is checked first).
     @MainActor
     private func addReconstructedLocks(to map: inout [String: ShieldedLockInfo], context: ModelContext) {
         let assetLockKind = TransactionTypeKind.assetLock.rawValue
         let descriptor = FetchDescriptor<PersistentTransaction>(
             predicate: #Predicate { $0.transactionTypeKind == assetLockKind })
         guard let rows = try? context.fetch(descriptor), !rows.isEmpty else { return }
+        guard let walletId = SwiftDashSDKHost.shared.wallet?.walletId else { return }
 
-        // Own DIP-17 Platform address key hashes, for the provable-route case.
-        let ownPlatformHashes: Set<Data> = {
-            let addresses = (try? context.fetch(FetchDescriptor<PersistentPlatformAddress>())) ?? []
-            return Set(addresses.map { $0.addressHash })
-        }()
+        let fundingTypeByAddress = Self.fundingAccountTypeByAddress(walletId: walletId, in: context)
+        let network: PaymentNetwork = WalletEnvironment.isTestnet ? .testnet : .mainnet
 
         var reconstructed = 0
         for row in rows {
@@ -1644,22 +1645,59 @@ final class ShieldedTxLookup {
                 .map { $0.offset }
             guard opReturnIndexes.count == 1, let voutIndex = opReturnIndexes.first else { continue }
 
-            let keyHashes = creditOutputs.compactMap { RawTransactionInspector.p2pkhKeyHash(script: $0.script) }
-            let paysOnlyOwnPlatformAddresses = keyHashes.count == creditOutputs.count
-                && keyHashes.allSatisfy { ownPlatformHashes.contains($0) }
+            // Funding type: every credit output must resolve to the SAME
+            // funding account — mixed or unmatched destinations stay unknown.
+            let matchedTypes = Set(creditOutputs.map { output -> Int in
+                guard let address = ScriptAddressCodec.address(forScript: output.script, network: network),
+                      let fundingType = fundingTypeByAddress[address] else {
+                    return Self.reconstructedUnknownFundingType
+                }
+                return fundingType
+            })
+            let fundingType = matchedTypes.count == 1
+                ? matchedTypes.first ?? Self.reconstructedUnknownFundingType
+                : Self.reconstructedUnknownFundingType
 
             map[txid] = ShieldedLockInfo(
                 amountDuffs: amount,
                 statusRaw: Self.reconstructedStatus,
                 vout: UInt32(voutIndex),
-                fundingTypeRaw: paysOnlyOwnPlatformAddresses
-                    ? Self.platformFundingType
-                    : Self.reconstructedUnknownFundingType)
+                fundingTypeRaw: fundingType)
             reconstructed += 1
         }
         if reconstructed > 0 {
             Self.logger.info("🛡️ SHIELD-TX :: reconstructed \(reconstructed, privacy: .public) asset lock(s) from raw tx bytes (no store row)")
         }
+    }
+
+    /// Credit-output address → `ManagedAssetLockManager.FundingType` raw
+    /// value, from the active wallet's persisted funding-account pools.
+    /// Account type tags (see `accountTypeName`): 2 Identity Registration,
+    /// 3 Identity Top-Up, 4 Identity Top-Up (Unbound), 5 Identity
+    /// Invitation, 6 Asset Lock Address Top-Up, 7 Asset Lock Shielded
+    /// Address Top-Up — mapped to funding types 0…5 in the same order.
+    @MainActor
+    private static func fundingAccountTypeByAddress(walletId: Data, in context: ModelContext) -> [String: Int] {
+        // Accounts are a tiny table; fetch all and filter in Swift rather
+        // than fighting `#Predicate` relationship-traversal rules.
+        let accounts = (try? context.fetch(FetchDescriptor<PersistentAccount>())) ?? []
+        var byAddress: [String: Int] = [:]
+        for account in accounts where account.wallet.walletId == walletId {
+            let fundingType: Int
+            switch account.accountType {
+            case 2: fundingType = 0 // IdentityRegistration
+            case 3: fundingType = 1 // IdentityTopUp
+            case 4: fundingType = 2 // IdentityTopUpNotBound
+            case 5: fundingType = 3 // IdentityInvitation
+            case 6: fundingType = 4 // AssetLockAddressTopUp
+            case 7: fundingType = 5 // AssetLockShieldedAddressTopUp
+            default: continue
+            }
+            for address in account.coreAddresses {
+                byAddress[address.address] = fundingType
+            }
+        }
+        return byAddress
     }
 
     private func store(_ map: [String: ShieldedLockInfo]) {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -1461,6 +1461,19 @@ final class ShieldedTxLookup {
     /// 2 = IdentityTopUpNotBound, 3 = IdentityInvitation.
     private static let identityFundingTypes = 0...3
 
+    /// App-side sentinel (never emitted by the SDK's funding-type enum) for a
+    /// lock reconstructed from raw transaction bytes whose destination can't
+    /// be proven: the amount is consensus-parsed truth, but whether it funded
+    /// an identity, a Platform address, or the shielded pool is unknown.
+    static let reconstructedUnknownFundingType = -1
+
+    /// App-side sentinel for `statusRaw` on reconstructed entries: the lock is
+    /// confirmed on-chain but its consumption state is unknown (the SDK's
+    /// `PersistentAssetLock` row didn't survive the wallet restore). Outside
+    /// both the pending window (1…3) and consumed (4), so reconstructed rows
+    /// never render "Pending" and never claim success.
+    static let reconstructedStatus = -1
+
     private static let logger = Logger(
         subsystem: "org.dashfoundation.dash",
         category: "swift-sdk-migration.shielded-tx-lookup")
@@ -1506,6 +1519,14 @@ final class ShieldedTxLookup {
     /// shielded ones. Thread-safe; touches no SwiftData.
     func platformFundingInfo(forTxidHex txidHex: String) -> ShieldedLockInfo? {
         entry(forTxidHex: txidHex, fundingType: Self.platformFundingType)
+    }
+
+    /// Snapshot entry for an asset lock reconstructed from raw tx bytes after
+    /// a restore — real locked amount, unknown destination and consumption
+    /// (see `reconstructedUnknownFundingType`). Thread-safe; touches no
+    /// SwiftData.
+    func reconstructedLockInfo(forTxidHex txidHex: String) -> ShieldedLockInfo? {
+        entry(forTxidHex: txidHex, fundingType: Self.reconstructedUnknownFundingType)
     }
 
     /// Snapshot entry for an identity funding lock (types 0…3 — registration,
@@ -1563,6 +1584,7 @@ final class ShieldedTxLookup {
                 if let existing = map[txid], existing.statusRaw >= info.statusRaw { continue }
                 map[txid] = info
             }
+            addReconstructedLocks(to: &map, context: container.mainContext)
             store(map)
             Self.logger.info("🛡️ SHIELD-TX :: snapshot \(map.count, privacy: .public) funding tx(s) (shielded + platform)")
             // Diagnostic: if asset locks exist but none matched the shielded
@@ -1574,6 +1596,69 @@ final class ShieldedTxLookup {
             }
         } catch {
             Self.logger.error("🛡️ SHIELD-TX :: refresh failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Restore-time fallback: `PersistentAssetLock` rows are SDK-recorded at
+    /// execution and do NOT survive a wipe & recover, so a restored wallet's
+    /// asset-lock funding txs otherwise render "Internal Transfer — 0 DASH".
+    /// For every persisted AssetLock transaction with no store row, parse the
+    /// credit outputs from the raw bytes (consensus truth) and add:
+    /// - funding type 4 when every credit output pays one of the wallet's own
+    ///   persisted Platform addresses — the full Core → Platform treatment;
+    /// - a `reconstructedUnknownFundingType` entry otherwise — real amount,
+    ///   no destination claim (one-time identity/shield keys are not
+    ///   distinguishable from the L1 tx alone).
+    /// Store-backed entries always win (`map` is checked first).
+    @MainActor
+    private func addReconstructedLocks(to map: inout [String: ShieldedLockInfo], context: ModelContext) {
+        let assetLockKind = TransactionTypeKind.assetLock.rawValue
+        let descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { $0.transactionTypeKind == assetLockKind })
+        guard let rows = try? context.fetch(descriptor), !rows.isEmpty else { return }
+
+        // Own DIP-17 Platform address key hashes, for the provable-route case.
+        let ownPlatformHashes: Set<Data> = {
+            let addresses = (try? context.fetch(FetchDescriptor<PersistentPlatformAddress>())) ?? []
+            return Set(addresses.map { $0.addressHash })
+        }()
+
+        var reconstructed = 0
+        for row in rows {
+            let txid = Transaction.displayHex(row.txid).lowercased()
+            if map[txid] != nil { continue }
+            guard !row.transactionData.isEmpty,
+                  let parsed = try? ParsedRawTransaction(data: row.transactionData),
+                  let payload = parsed.extraPayload,
+                  let creditOutputs = RawTransactionInspector.assetLockCreditOutputs(payload: payload) else {
+                continue
+            }
+            let amount = creditOutputs.reduce(UInt64(0)) { $0 + $1.valueDuffs }
+            guard amount > 0 else { continue }
+            // The lock outpoint's vout is the index of the OP_RETURN output
+            // that carries the locked value on L1. Skip on ambiguity — a
+            // reconstructed entry never feeds a recovery resume, but a wrong
+            // vout shouldn't exist even unused.
+            let opReturnIndexes = parsed.outputs.enumerated()
+                .filter { $0.element.scriptPubKey.first == 0x6a }
+                .map { $0.offset }
+            guard opReturnIndexes.count == 1, let voutIndex = opReturnIndexes.first else { continue }
+
+            let keyHashes = creditOutputs.compactMap { RawTransactionInspector.p2pkhKeyHash(script: $0.script) }
+            let paysOnlyOwnPlatformAddresses = keyHashes.count == creditOutputs.count
+                && keyHashes.allSatisfy { ownPlatformHashes.contains($0) }
+
+            map[txid] = ShieldedLockInfo(
+                amountDuffs: amount,
+                statusRaw: Self.reconstructedStatus,
+                vout: UInt32(voutIndex),
+                fundingTypeRaw: paysOnlyOwnPlatformAddresses
+                    ? Self.platformFundingType
+                    : Self.reconstructedUnknownFundingType)
+            reconstructed += 1
+        }
+        if reconstructed > 0 {
+            Self.logger.info("🛡️ SHIELD-TX :: reconstructed \(reconstructed, privacy: .public) asset lock(s) from raw tx bytes (no store row)")
         }
     }
 

--- a/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
@@ -215,6 +215,42 @@ enum RawTransactionInspector {
 
     // MARK: - Special transaction payloads
 
+    /// One credit output of an asset-lock payload: the locked value and the
+    /// destination scriptPubKey it credits on Platform.
+    struct AssetLockCreditOutput {
+        let valueDuffs: UInt64
+        let script: Data
+    }
+
+    /// Consensus-decode the credit outputs of a DIP-2 asset-lock payload
+    /// (u8 version, varint count, TxOuts). Nil when the bytes don't parse as
+    /// that shape — callers must treat the lock as undecodable rather than
+    /// substitute a guess. Shared by the inspector's field list and
+    /// `ShieldedTxLookup`'s restore-time reconstruction.
+    static func assetLockCreditOutputs(payload: Data) -> [AssetLockCreditOutput]? {
+        var reader = ByteReader(payload)
+        guard (try? reader.readUInt8()) != nil,
+              let count = try? reader.readVarInt(),
+              count > 0, count <= 32 else { return nil }
+        var outputs: [AssetLockCreditOutput] = []
+        for _ in 0 ..< count {
+            guard let value = try? reader.readUInt64(),
+                  let scriptLength = try? reader.readVarInt(),
+                  let script = try? reader.readBytes(Int(scriptLength)) else { return nil }
+            outputs.append(AssetLockCreditOutput(valueDuffs: value, script: script))
+        }
+        return outputs
+    }
+
+    /// The 20-byte pubkey hash of a P2PKH script, or nil for any other shape.
+    static func p2pkhKeyHash(script: Data) -> Data? {
+        let b = [UInt8](script)
+        guard b.count == 25, b[0] == 0x76, b[1] == 0xa9, b[2] == 0x14, b[23] == 0x88, b[24] == 0xac else {
+            return nil
+        }
+        return Data(b[3 ..< 23])
+    }
+
     /// DIP-2 special transaction names, keyed by the tx `type` field.
     static func specialTypeName(_ type: UInt16) -> String? {
         switch type {
@@ -253,20 +289,15 @@ enum RawTransactionInspector {
                 }
             }
         case 8: // Asset lock: u8 version, varint count, credit outputs (TxOuts).
-            var reader = ByteReader(payload)
-            if let version = try? reader.readUInt8(),
-               let count = try? reader.readVarInt() {
-                fields.append(.init(label: "Payload version", value: "\(version)"))
-                fields.append(.init(label: "Credit outputs", value: "\(count)"))
-                for i in 0 ..< min(count, 16) {
-                    guard let value = try? reader.readUInt64(),
-                          let scriptLength = try? reader.readVarInt(),
-                          let script = try? reader.readBytes(Int(scriptLength)) else { break }
-                    let destination = ScriptAddressCodec.address(forScript: script, network: network)
-                        ?? script.map { String(format: "%02x", $0) }.joined()
+            if let creditOutputs = assetLockCreditOutputs(payload: payload) {
+                fields.append(.init(label: "Payload version", value: "\(payload[payload.startIndex])"))
+                fields.append(.init(label: "Credit outputs", value: "\(creditOutputs.count)"))
+                for (i, output) in creditOutputs.enumerated() {
+                    let destination = ScriptAddressCodec.address(forScript: output.script, network: network)
+                        ?? output.script.map { String(format: "%02x", $0) }.joined()
                     fields.append(.init(
                         label: String(format: "Credit output %d", i),
-                        value: "\(value.formattedDashAmountWithoutCurrencySymbol) → \(destination)"))
+                        value: "\(output.valueDuffs.formattedDashAmountWithoutCurrencySymbol) → \(destination)"))
                 }
             }
         default:

--- a/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
@@ -236,7 +236,7 @@ enum RawTransactionInspector {
         for _ in 0 ..< count {
             guard let value = try? reader.readUInt64(),
                   let scriptLength = try? reader.readVarInt(),
-                  let script = try? reader.readBytes(Int(scriptLength)) else { return nil }
+                  let script = try? reader.readBytes(length: scriptLength) else { return nil }
             outputs.append(AssetLockCreditOutput(valueDuffs: value, script: script))
         }
         return outputs
@@ -347,7 +347,7 @@ struct ParsedRawTransaction {
             let prevTxid = try reader.readBytes(32)
             let prevVout = try reader.readUInt32()
             let scriptLength = try reader.readVarInt()
-            let scriptSig = try reader.readBytes(Int(scriptLength))
+            let scriptSig = try reader.readBytes(length: scriptLength)
             let sequence = try reader.readUInt32()
             return Input(prevTxid: prevTxid, prevVout: prevVout, scriptSig: scriptSig, sequence: sequence)
         }
@@ -357,7 +357,7 @@ struct ParsedRawTransaction {
         outputs = try (0 ..< outputCount).map { _ in
             let value = try reader.readUInt64()
             let scriptLength = try reader.readVarInt()
-            let script = try reader.readBytes(Int(scriptLength))
+            let script = try reader.readBytes(length: scriptLength)
             return Output(valueDuffs: value, scriptPubKey: script)
         }
 
@@ -365,7 +365,7 @@ struct ParsedRawTransaction {
 
         if type > 0, reader.remaining > 0 {
             let payloadLength = try reader.readVarInt()
-            extraPayload = try reader.readBytes(Int(payloadLength))
+            extraPayload = try reader.readBytes(length: payloadLength)
         } else {
             extraPayload = nil
         }
@@ -438,5 +438,13 @@ private struct ByteReader {
         guard count >= 0, offset + count <= bytes.count else { throw ReadError.outOfBounds }
         defer { offset += count }
         return Data(bytes[offset ..< offset + count])
+    }
+
+    /// Consensus lengths arrive as CompactSize `UInt64`s; a plain `Int(_:)`
+    /// conversion traps on values above `Int.max`, which malformed bytes can
+    /// encode. Reject those as out-of-bounds instead of crashing.
+    mutating func readBytes(length: UInt64) throws -> Data {
+        guard let count = Int(exactly: length) else { throw ReadError.outOfBounds }
+        return try readBytes(count)
     }
 }

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -307,6 +307,15 @@ class Transaction: TransactionDataItem, Identifiable {
 
     private var identityFundingAmountDuffs: UInt64? { identityFundingLockInfo?.amountDuffs }
 
+    /// Locked amount for an asset lock reconstructed from raw tx bytes after
+    /// a restore (`ShieldedTxLookup.reconstructedLockInfo`): the destination
+    /// is unprovable, so the row keeps its generic "Internal Transfer"
+    /// presentation, but the amount is consensus-parsed truth instead of the
+    /// 0 the net-change view derives for a self-directed lock.
+    private var reconstructedLockAmountDuffs: UInt64? {
+        ShieldedTxLookup.shared.reconstructedLockInfo(forTxidHex: shieldedDisplayTxid)?.amountDuffs
+    }
+
     /// True when this is the funding tx of an identity registration/top-up/
     /// invitation.
     var isIdentityFundingTransfer: Bool { identityFundingLockInfo != nil }
@@ -389,7 +398,7 @@ class Transaction: TransactionDataItem, Identifiable {
         // asset lock; surface the real locked amount the SDK recorded
         // instead of the 0 the generic logic below derives for a
         // self-directed move.
-        if let locked = shieldedTransferAmountDuffs ?? platformFundingAmountDuffs ?? identityFundingAmountDuffs { return locked }
+        if let locked = shieldedTransferAmountDuffs ?? platformFundingAmountDuffs ?? identityFundingAmountDuffs ?? reconstructedLockAmountDuffs { return locked }
         let fee = Int64(snapshot.fee ?? 0)
         switch direction {
         case .received:
@@ -419,6 +428,7 @@ class Transaction: TransactionDataItem, Identifiable {
             ?? shieldedTransferAmountDuffs
             ?? platformFundingAmountDuffs
             ?? identityFundingAmountDuffs
+            ?? reconstructedLockAmountDuffs
             ?? _dashAmount
     }
     var signedDashAmount: Int64 {
@@ -454,7 +464,7 @@ class Transaction: TransactionDataItem, Identifiable {
         // The shielded / DashPay-payment amount is read live (see
         // `dashAmount`), so compute its fiat live too; other rows keep the
         // lazily-cached value.
-        if dashPayPayment != nil || shieldedTransferAmountDuffs != nil || platformFundingAmountDuffs != nil || identityFundingAmountDuffs != nil {
+        if dashPayPayment != nil || shieldedTransferAmountDuffs != nil || platformFundingAmountDuffs != nil || identityFundingAmountDuffs != nil || reconstructedLockAmountDuffs != nil {
             return userInfo?.fiatAmountString(from: dashAmount) ?? NSLocalizedString("Not available", comment: "")
         }
         return storedFiatAmount

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1560,6 +1560,19 @@ class SwiftDashSDKWalletSource: TransactionSource {
                 items.append(ShieldedActivityItem(
                     row: row,
                     amountCreditsOverride: reconstructedAmountCredits))
+            case ShieldedActivityItem.Kind.sent.rawValue:
+                // A shielded → shielded send's counterparty is the recipient's
+                // 43-byte raw Orchard address (live-recorded, or OVK-recovered
+                // by the restore scan). Surface it so the row and detail sheet
+                // name where the money went instead of a bare "Sent /
+                // Shielded". Sent entries are outgoing to a non-own address by
+                // the recorder's classification, hence external.
+                let address = shieldedDestinationAddress(counterparty: row.counterparty)
+                items.append(ShieldedActivityItem(
+                    row: row,
+                    amountCreditsOverride: reconstructedAmountCredits,
+                    destinationAddress: address,
+                    isExternalDestination: address != nil))
             default:
                 items.append(ShieldedActivityItem(
                     row: row,
@@ -1724,6 +1737,18 @@ class SwiftDashSDKWalletSource: TransactionSource {
             counterparty,
             asBech32m: true,
             isTestnet: WalletEnvironment.isTestnet)
+    }
+
+    /// Decode a shielded send's counterparty (43-byte raw Orchard address) to
+    /// its DIP-0018 display form: HRP `dash`/`tdash`, payload = 0x10 type
+    /// byte + the raw address bytes (same encoding as
+    /// `PaymentsLandingViewModel.reloadShieldedAddress`). Nil for empty /
+    /// non-43-byte counterparties.
+    private static func shieldedDestinationAddress(counterparty: Data) -> String? {
+        guard counterparty.count == 43 else { return nil }
+        return Bech32m.encode(
+            hrp: Bech32m.platformHrp(mainnet: !WalletEnvironment.isTestnet),
+            data: Data([0x10]) + counterparty)
     }
 
     /// True when `address` is one of the ACTIVE wallet's own DIP-17

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1436,13 +1436,14 @@ class SwiftDashSDKWalletSource: TransactionSource {
         let outgoingNoteValueByCmx = outgoingShieldedNoteValueByCmx(in: context, walletId: walletId)
 
         // The wallet's own default Orchard address (raw 43 bytes), for the
-        // Sent-destination ownership check. Nil until the shielded
-        // sub-wallet is bound — then the Received-row evidence still covers
-        // live intra-wallet transfers.
+        // Sent-destination ownership check. Keyed by the SAME walletId the
+        // rows were fetched with (not a re-read of the host's active wallet,
+        // which could have switched between the two main hops). Nil until
+        // the shielded sub-wallet is bound — then the Received-row evidence
+        // still covers live intra-wallet transfers.
         let ownShieldedRaw43: Data? = onMain {
-            guard let manager = SwiftDashSDKHost.shared.manager,
-                  let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
-            return ((try? manager.shieldedDefaultAddress(walletId: wallet.walletId)) ?? nil)
+            guard let manager = SwiftDashSDKHost.shared.manager else { return nil }
+            return ((try? manager.shieldedDefaultAddress(walletId: walletId)) ?? nil)
         }
 
         var items: [ShieldedActivityItem] = []

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1414,7 +1414,15 @@ class SwiftDashSDKWalletSource: TransactionSource {
         guard let rows = try? context.fetch(descriptor) else { return [] }
 
         var byEntry: [Data: PersistentShieldedActivity] = [:]
+        // Entry ids that also produced a Received projection: an
+        // intra-wallet transfer writes Sent + Received rows for the same
+        // operation (see the dedupe doc above), so a surviving Sent row
+        // whose entry id is in here paid one of the wallet's own accounts.
+        var receivedEntryIds: Set<Data> = []
         for row in rows where row.kindTag != ShieldedActivityItem.Kind.shieldFromAssetLock.rawValue {
+            if row.kindTag == ShieldedActivityItem.Kind.received.rawValue {
+                receivedEntryIds.insert(row.entryId)
+            }
             if let existing = byEntry[row.entryId] {
                 if shouldPreferShieldedProjection(row, over: existing) {
                     byEntry[row.entryId] = row
@@ -1426,6 +1434,16 @@ class SwiftDashSDKWalletSource: TransactionSource {
 
         let noteValueByCmx = shieldedNoteValueByCmx(in: context, walletId: walletId)
         let outgoingNoteValueByCmx = outgoingShieldedNoteValueByCmx(in: context, walletId: walletId)
+
+        // The wallet's own default Orchard address (raw 43 bytes), for the
+        // Sent-destination ownership check. Nil until the shielded
+        // sub-wallet is bound — then the Received-row evidence still covers
+        // live intra-wallet transfers.
+        let ownShieldedRaw43: Data? = onMain {
+            guard let manager = SwiftDashSDKHost.shared.manager,
+                  let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
+            return ((try? manager.shieldedDefaultAddress(walletId: wallet.walletId)) ?? nil)
+        }
 
         var items: [ShieldedActivityItem] = []
         for row in byEntry.values {
@@ -1565,14 +1583,18 @@ class SwiftDashSDKWalletSource: TransactionSource {
                 // 43-byte raw Orchard address (live-recorded, or OVK-recovered
                 // by the restore scan). Surface it so the row and detail sheet
                 // name where the money went instead of a bare "Sent /
-                // Shielded". Sent entries are outgoing to a non-own address by
-                // the recorder's classification, hence external.
+                // Shielded". External only when the destination is provably
+                // not the wallet's own: an intra-wallet transfer leaves a
+                // Received row under the same entry id, and a send to the
+                // wallet's default Orchard address is its own funds either way.
                 let address = shieldedDestinationAddress(counterparty: row.counterparty)
+                let isOwnDestination = receivedEntryIds.contains(row.entryId)
+                    || (ownShieldedRaw43 != nil && row.counterparty == ownShieldedRaw43)
                 items.append(ShieldedActivityItem(
                     row: row,
                     amountCreditsOverride: reconstructedAmountCredits,
                     destinationAddress: address,
-                    isExternalDestination: address != nil))
+                    isExternalDestination: address != nil && !isOwnDestination))
             default:
                 items.append(ShieldedActivityItem(
                     row: row,

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -162,7 +162,7 @@ struct ShieldedActivityItem: Identifiable {
         switch kind {
         case .shield, .shieldFromAssetLock:
             return NSLocalizedString("Platform → Shielded", comment: "Transfer of own funds from the Platform balance into the private shielded balance")
-        case .unshield, .withdrawal:
+        case .unshield, .withdrawal, .sent:
             if isExternalDestination {
                 // External destination: show where the money went,
                 // shortened to row-pill size (the detail sheet carries
@@ -172,10 +172,16 @@ struct ShieldedActivityItem: Identifiable {
                 }
                 return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
             }
-            return kind == .unshield
-                ? NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
-                : NSLocalizedString("Shielded → Transparent", comment: "Transfer of own funds from the private shielded balance back to the transparent wallet")
-        case .received, .sent, .identityCreate, .shieldedSpend:
+            switch kind {
+            case .unshield:
+                return NSLocalizedString("Shielded → Platform", comment: "Transfer of own funds from the private shielded balance to the Platform balance")
+            case .withdrawal:
+                return NSLocalizedString("Shielded → Transparent", comment: "Transfer of own funds from the private shielded balance back to the transparent wallet")
+            default:
+                // A Sent row whose recipient couldn't be decoded.
+                return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
+            }
+        case .received, .identityCreate, .shieldedSpend:
             return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
         }
     }
@@ -221,7 +227,7 @@ struct ShieldedActivityItem: Identifiable {
 
     /// From/To wording for the detail sheet. Internal moves name the
     /// user's own balances on both sides (a guarantee — see the fetch
-    /// doc); an external unshield/withdrawal names the destination
+    /// doc); an external unshield/withdrawal/send names the destination
     /// address (or an honest "External address" when the counterparty
     /// script couldn't be decoded).
     var internalMoveRoute: (source: String, destination: String)? {
@@ -237,7 +243,13 @@ struct ShieldedActivityItem: Identifiable {
                 return (shielded, destinationAddress ?? fallback)
             }
             return kind == .unshield ? (shielded, platform) : (shielded, transparent)
-        case .received, .sent, .identityCreate, .shieldedSpend: return nil
+        case .sent:
+            // Only when the recipient address decoded — a bare Sent row
+            // (no counterparty recovered) keeps the sheet route-less
+            // rather than claiming a destination we don't know.
+            guard let destinationAddress else { return nil }
+            return (shielded, destinationAddress)
+        case .received, .identityCreate, .shieldedSpend: return nil
         }
     }
 

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -227,9 +227,10 @@ struct ShieldedActivityItem: Identifiable {
 
     /// From/To wording for the detail sheet. Internal moves name the
     /// user's own balances on both sides (a guarantee — see the fetch
-    /// doc); an external unshield/withdrawal/send names the destination
+    /// doc); an external unshield/withdrawal names the destination
     /// address (or an honest "External address" when the counterparty
-    /// script couldn't be decoded).
+    /// script couldn't be decoded); a Sent entry names its decoded
+    /// recipient and stays route-less when the counterparty didn't decode.
     var internalMoveRoute: (source: String, destination: String)? {
         let platform = NSLocalizedString("Your Platform balance", comment: "Shielded activity: source/destination of an internal move")
         let shielded = NSLocalizedString("Your Shielded balance", comment: "Shielded activity: source/destination of an internal move")


### PR DESCRIPTION
## Issue being fixed or feature implemented

On a restored (wipe & recover / second same-seed device) wallet, internal transfers lose their identity in the history:

- **Asset-lock funding txs render "Internal Transfer — 0 DASH / Not available".** The route/amount labelling added in #826/#827 reads `ShieldedTxLookup`, which mirrors the SDK's `PersistentAssetLock` store — and those rows are live-recorded at execution and do **not** survive a restore. On a freshly restored mainnet wallet, two July asset locks (0.4 and 0.302 DASH) both showed as zero-amount "Internal Transfer".
- **Shielded `Sent` rows hide their destination.** A shielded → shielded send's row pill and detail sheet said only "Sent / Type: Shielded" — the recipient address (which the SDK records as the 43-byte raw Orchard counterparty, live or OVK-recovered by the restore scan) was displayed nowhere, making an old send indistinguishable from an internal transfer.

Both were found on a restored wallet whose only shielded history row was a scan-derived `Sent −0.01` with no visible destination.

## What was done?

**Asset-lock reconstruction (`ShieldedTxLookup.refresh()`):** after building the snapshot from `PersistentAssetLock` rows, every persisted `AssetLock` transaction with no store row gets a reconstructed entry parsed from its raw bytes (consensus truth — parser shared with the raw-tx inspector, whose credit-output parsing was promoted into reusable `RawTransactionInspector.assetLockCreditOutputs` / `p2pkhKeyHash` helpers).

The destination is recovered exactly: every credit output pays a one-time address derived from a purpose-specific **funding account** (identity registration / top-up / invitation, Platform address top-up, shielded top-up — account types 2…7), and those pools survive a restore as `PersistentCoreAddress` rows. Matching the credit outputs against the active wallet's persisted funding-account addresses yields the exact `FundingType` (0…5), so a restored Transparent → Shielded funding renders the full existing Core → Shielded treatment ("Internal Transfer" with the shield route icon, `From: Transparent balance` / `To: Shielded balance` on the detail sheet), Platform top-ups render the Core → Platform treatment, and identity fundings render their named titles. Credit outputs that match no pool (or mix pools) fall back to a `reconstructedUnknownFundingType` sentinel: the row keeps its generic "Internal Transfer" title but still shows the **real locked amount** instead of 0.

Reconstructed entries carry `statusRaw = -1` (outside both the pending window 1…3 and consumed 4), so they never render "Pending", never claim a completion status (`lockStatusText` maps -1 to no Status row), and never feed a recovery resume. Store-backed rows always win over reconstruction.

**Shielded Sent destination (`fetchShieldedActivity` + `ShieldedActivityItem`):** `Sent` entries decode their 43-byte counterparty to the DIP-0018 bech32m display form (`0x10` type byte + raw address, same encoding as the Receive screen). The row pill shows the shortened address (matching the external unshield/withdrawal treatment) and the detail sheet gains `From: Your Shielded balance` / `To: <copyable address>` rows. A Sent row whose counterparty didn't decode keeps the current route-less presentation rather than claiming a destination.

## What was deliberately NOT done (SDK follow-ups)

The restore scan currently collapses shielded history poorly: on the test wallet it reconstructed the entire multi-transaction history into a single `Sent` entry whose cmx list aggregates all nine actions across several transactions, attached one nullifier from a different transaction, recorded no fee, and stamped every note and the activity row with the scan-tip block height (411495 on one device, 412108 on the other, for the same on-chain history). Own-shield (`Shield`/`ShieldFromAssetLock`) entries were not reconstructed at all, so a restored wallet shows no "Transparent → Shielded" rows for past shields. That is rs-platform-wallet / swift-sdk scan-reconstruction territory and needs a cross-repo fix; this PR fixes what is honestly derivable app-side.

## How Has This Been Tested?

Manual, on a restored mainnet wallet (fresh iPhone 16 Pro simulator, wallet recovered from seed — the exact state that exhibits both bugs):

- The two July asset-lock rows show their real amounts (0.4 / 0.302 DASH) instead of "0"; the 0.302 lock's credit output matched the wallet's shielded top-up funding account (`m/9'/5'/5'/5'/0`) and renders the Core → Shielded route, the 0.4 lock matched the Platform address top-up account (`m/9'/5'/5'/4'/0`) and renders Core → Platform; no "Pending" pill on either.
- The shielded `Sent −0.01` row pill shows the shortened `dash1…` recipient; its detail sheet shows From/To with the full copyable address.
- Regression: masternode registration, classic sends/receives, and the live-recorded transfer rows are unchanged.

Clean `dashpay` build verified. (The unit-test target is pre-existing broken; not run.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restores missing asset-lock transaction details and displays their parsed amounts.
  * Shows decoded shielded recipients for sent activity when available.
  * Adds clearer routes and destination details for shielded sends, withdrawals, and unshield operations.

* **Bug Fixes**
  * Improves asset-lock parsing and safely handles malformed or ambiguous transaction data.
  * Displays decoded asset-lock outputs with address details or a script fallback.
  * Prevents errors when processing unusually large serialized transaction data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->