### PR TITLE
feat(dashpay): identity banner, network contact search, and shielded-first identity top-up

### DIFF
--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -64,11 +64,19 @@ struct PlatformAddressActivityUnitPolicy {
         Int64(clamping: credits / creditsPerDuff)
     }
 
-    static func unshieldMatches(
+    /// True when an observed balance increase is explainable by an own
+    /// unshield of `creditedAmountCredits`: the delta equals the credited
+    /// principal, or is SMALLER — an own follow-on spend (e.g. the
+    /// shielded identity top-up claims most of the landed credits before
+    /// the next sync observes the address) shrinks the net delta below
+    /// the principal, but the remainder is still the own operation's
+    /// residue, not an external payment.
+    static func unshieldCoversDelta(
         creditedAmountCredits: UInt64,
         observedDeltaDuffs: Int64
     ) -> Bool {
-        duffs(fromCredits: creditedAmountCredits) == observedDeltaDuffs
+        observedDeltaDuffs > 0
+            && observedDeltaDuffs <= duffs(fromCredits: creditedAmountCredits)
     }
 
     static func isOwnUnshieldCandidate(
@@ -79,14 +87,20 @@ struct PlatformAddressActivityUnitPolicy {
             && kindTag == ShieldedActivityItem.Kind.unshield.rawValue
     }
 
-    static func exactUnshieldMatches(
+    /// Same destination address AND the delta is covered by the credited
+    /// principal (see `unshieldCoversDelta`). Known blind spot, accepted:
+    /// an external payment landing on the SAME fresh address inside the
+    /// own-operation window with a delta ≤ the principal would be
+    /// suppressed too — the previous exact-match rule had the equivalent
+    /// blind spot for payments that exactly equalled the principal.
+    static func unshieldResidueMatches(
         destinationAddress: String,
         observedAddress: String,
         creditedAmountCredits: UInt64,
         observedDeltaDuffs: Int64
     ) -> Bool {
         destinationAddress == observedAddress
-            && unshieldMatches(
+            && unshieldCoversDelta(
                 creditedAmountCredits: creditedAmountCredits,
                 observedDeltaDuffs: observedDeltaDuffs)
     }
@@ -336,10 +350,13 @@ enum PlatformAddressActivityRecorder {
         }
     }
 
-    /// Exact match against an own internal unshield: same destination
-    /// address and credited principal. The unshield builder reserves the fee
-    /// in addition to `amount`; the Platform address receives `amount`
-    /// exactly, while the shielded pool is debited by amount + fee.
+    /// Match against an own internal unshield: same destination address,
+    /// with the observed delta covered by the credited principal (equal, or
+    /// smaller when an own follow-on spend — e.g. a shielded identity
+    /// top-up — consumed part of it before this sync). The unshield builder
+    /// reserves the fee in addition to `amount`; the Platform address
+    /// receives `amount` exactly, while the shielded pool is debited by
+    /// amount + fee.
     private static func matchesOwnUnshield(
         address: String,
         deltaDuffs: Int64,
@@ -363,7 +380,7 @@ enum PlatformAddressActivityRecorder {
                 row.counterparty,
                 asBech32m: true,
                 isTestnet: network != .mainnet)
-            if PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+            if PlatformAddressActivityUnitPolicy.unshieldResidueMatches(
                 destinationAddress: destination,
                 observedAddress: address,
                 creditedAmountCredits: row.amount,

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -19,7 +19,14 @@ import DashUIKit
 struct AddContactScreen: View {
     @Environment(\.dismiss) private var dismiss
 
-    @State private var query = ""
+    @State private var query: String
+
+    /// `initialQuery` prefills the search (the Contacts tab's network
+    /// teaser hands its text over); the search fires on appear so the
+    /// results are already loading when the sheet lands.
+    init(initialQuery: String = "") {
+        _query = State(initialValue: initialQuery)
+    }
     @State private var results: [DpnsSearchResult] = []
     @State private var isSearching = false
     @State private var searchTask: Task<Void, Never>? = nil
@@ -66,6 +73,11 @@ struct AddContactScreen: View {
             }
             .onChange(of: query) { _, _ in
                 scheduleSearch()
+            }
+            .onAppear {
+                if !trimmedQuery.isEmpty {
+                    scheduleSearch()
+                }
             }
             .alert(
                 NSLocalizedString("Error", comment: ""),

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -50,9 +50,11 @@ final class ContactsViewModel: ObservableObject {
 
     /// Banner headline: display name → username → honest placeholder.
     var ownDisplayTitle: String {
-        ownDisplayName?.isEmpty == false
-            ? ownDisplayName!
-            : (ownUsername ?? NSLocalizedString("My identity", comment: "DashPay: banner fallback when the identity has no name yet"))
+        if let displayName = ownDisplayName, !displayName.isEmpty {
+            return displayName
+        }
+        return ownUsername
+            ?? NSLocalizedString("My identity", comment: "DashPay: banner fallback when the identity has no name yet")
     }
 
     /// Network (DPNS) matches for the tab's search text — the discovery
@@ -73,6 +75,9 @@ final class ContactsViewModel: ObservableObject {
             isSearchingNetwork = false
             return
         }
+        // Clear immediately so a previous query's matches can't sit under
+        // the new text through the debounce + request.
+        networkSearchResults = []
         isSearchingNetwork = true
         networkSearchTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 350_000_000)

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -39,6 +39,21 @@ final class ContactsViewModel: ObservableObject {
     /// `needsDashPayEnable`); sizes the fee estimate.
     private var missingDashPayKeyCount = 0
 
+    /// Own-identity snapshot for the banner (display name, @username,
+    /// avatar, and the id that seeds the initials placeholder), refreshed
+    /// with the rest of the tab from `DWCurrentUserIdentityInfo`.
+    @Published var ownDisplayName: String?
+    @Published var ownUsername: String?
+    @Published var ownAvatarURL: String?
+    @Published var ownIdentitySeed = Data()
+
+    /// Banner headline: display name → username → honest placeholder.
+    var ownDisplayTitle: String {
+        ownDisplayName?.isEmpty == false
+            ? ownDisplayName!
+            : (ownUsername ?? NSLocalizedString("My identity", comment: "DashPay: banner fallback when the identity has no name yet"))
+    }
+
     private let service = SwiftDashSDKContactsService.shared
 
     init() {
@@ -57,6 +72,11 @@ final class ContactsViewModel: ObservableObject {
         service.refresh()
         missingDashPayKeyCount = service.missingDashPayKeyCount()
         needsDashPayEnable = missingDashPayKeyCount > 0
+        let info = DWCurrentUserIdentityInfo.shared
+        ownDisplayName = info.displayName
+        ownUsername = info.username?.withoutDashSuffix
+        ownAvatarURL = info.avatarURL
+        ownIdentitySeed = info.identityId ?? Data()
     }
 
     /// Estimated IdentityUpdate fee for the confirm sheet, sized to the
@@ -177,6 +197,8 @@ struct ContactsScreen: View {
     /// the add-contact sheet.
     @State private var pendingFirstContactRequest = false
     @State private var selectedContact: ContactItem? = nil
+    /// Banner identity row → read-only profile sheet.
+    @State private var showingOwnProfile = false
 
     var body: some View {
         NavigationStack {
@@ -184,27 +206,20 @@ struct ContactsScreen: View {
                 Color.dash.primaryBackground.ignoresSafeArea()
                 content
             }
-            .navigationTitle(viewModel.needsDashPayEnable
-                ? NSLocalizedString("DashPay", comment: "DashPay")
-                : NSLocalizedString("Contacts", comment: "DashPay Contacts"))
-            .toolbar {
-                // Adding a contact needs the DIP-15 key pair on our own
-                // side too (the outgoing request's ECDH) — hide the
-                // affordance until the identity is DashPay-enabled.
-                if !viewModel.needsDashPayEnable {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            showingAddContact = true
-                        } label: {
-                            Image(systemName: "person.badge.plus")
-                                .foregroundColor(.dash.blue)
-                        }
-                        .accessibilityLabel(NSLocalizedString("Add a New Contact", comment: "DashPay Contacts"))
-                    }
-                }
-            }
+            .navigationTitle(NSLocalizedString("DashPay", comment: "DashPay"))
+            // The enabled state draws its own Dash-blue identity banner
+            // (title, add-contact, and profile entry live inside it);
+            // the system bar only fronts the pre-enable intro.
+            .toolbar(viewModel.needsDashPayEnable ? .visible : .hidden, for: .navigationBar)
             .sheet(isPresented: $showingAddContact) {
                 AddContactScreen()
+            }
+            .sheet(isPresented: $showingOwnProfile) {
+                // Read-only profile view. Editing stays on the Home
+                // avatar's flow (it owns the RootEditProfileViewController
+                // delegate wiring); TODO(dashpay-banner-edit): present the
+                // editor from here once that wiring has a shared owner.
+                SDKIdentityProfileSheet()
             }
             .sheet(
                 isPresented: $viewModel.showEnableSuccess,
@@ -259,11 +274,92 @@ struct ContactsScreen: View {
                         // sheet content scrolls and .large stays reachable.
                         .presentationDetents([.medium, .large])
                 }
-        } else if viewModel.isEmpty {
-            emptyState
         } else {
-            list
+            VStack(spacing: 0) {
+                dashPayBanner
+                if viewModel.isEmpty {
+                    emptyState
+                } else {
+                    list
+                }
+            }
         }
+    }
+
+    /// Dash-blue identity banner (design option C): the tab opens with
+    /// WHO you are on DashPay — ringed avatar, display name, @username —
+    /// before who you know. The whole identity row opens the profile
+    /// sheet; add-contact lives on the title line. The gradient runs
+    /// under the status bar, and the search field below overlaps the
+    /// seam via the banner's negative bottom padding.
+    private var dashPayBanner: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(NSLocalizedString("Contacts", comment: "DashPay Contacts"))
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(.white)
+                Spacer()
+                Button {
+                    showingAddContact = true
+                } label: {
+                    Image(systemName: "person.badge.plus")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 34, height: 34)
+                        .background(Circle().fill(Color.white.opacity(0.18)))
+                }
+                .accessibilityLabel(NSLocalizedString("Add a New Contact", comment: "DashPay Contacts"))
+            }
+            .padding(.bottom, 8)
+
+            Button {
+                showingOwnProfile = true
+            } label: {
+                HStack(spacing: 12) {
+                    ContactAvatarView(
+                        title: viewModel.ownDisplayTitle,
+                        avatarURL: viewModel.ownAvatarURL,
+                        identitySeed: viewModel.ownIdentitySeed,
+                        size: 52)
+                        .overlay(Circle().stroke(Color.white.opacity(0.85), lineWidth: 2.5))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(viewModel.ownDisplayTitle)
+                            .font(.system(size: 17, weight: .bold))
+                            .foregroundColor(.white)
+                            .lineLimit(1)
+                        if let username = viewModel.ownUsername {
+                            Text("@\(username) · " + NSLocalizedString("View profile", comment: "DashPay: banner identity row subtitle"))
+                                .font(.system(size: 12.5))
+                                .foregroundColor(.white.opacity(0.82))
+                                .lineLimit(1)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.7))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 6)
+        .padding(.bottom, 40)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LinearGradient(
+                colors: [
+                    Color(red: 0 / 255, green: 155 / 255, blue: 241 / 255),
+                    Color(red: 0 / 255, green: 116 / 255, blue: 207 / 255),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing)
+                .ignoresSafeArea(edges: .top))
+        // Pull the content below up over the banner's seam so the search
+        // field (or empty state) overlaps it, mockup-style — later
+        // siblings draw on top of the banner's bottom edge.
+        .padding(.bottom, -28)
     }
 
     private var list: some View {

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -13,6 +13,7 @@
 //  outgoing rows.
 //
 
+import SwiftDashSDK
 import SwiftUI
 import DashUIKit
 
@@ -52,6 +53,39 @@ final class ContactsViewModel: ObservableObject {
         ownDisplayName?.isEmpty == false
             ? ownDisplayName!
             : (ownUsername ?? NSLocalizedString("My identity", comment: "DashPay: banner fallback when the identity has no name yet"))
+    }
+
+    /// Network (DPNS) matches for the tab's search text — the discovery
+    /// teaser under the local sections. Excludes the user's own identity
+    /// and everyone already in the local snapshots (they're in the
+    /// filtered sections above).
+    @Published var networkSearchResults: [DpnsSearchResult] = []
+    @Published var isSearchingNetwork = false
+    private var networkSearchTask: Task<Void, Never>?
+
+    /// Debounced DPNS prefix search driving `networkSearchResults`.
+    /// Mirrors AddContactScreen's 2-character minimum and debounce.
+    func updateNetworkSearch(query: String) {
+        networkSearchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= 2 else {
+            networkSearchResults = []
+            isSearchingNetwork = false
+            return
+        }
+        isSearchingNetwork = true
+        networkSearchTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            guard let self, !Task.isCancelled else { return }
+            let results = (try? await service.searchUsernames(prefix: trimmed, limit: 12)) ?? []
+            guard !Task.isCancelled else { return }
+            let known = Set((contacts + incomingRequests + outgoingRequests).map(\.contactIdentityId))
+            let ownId = DWCurrentUserIdentityInfo.shared.identityId
+            networkSearchResults = results.filter {
+                !known.contains($0.identityId) && $0.identityId != ownId
+            }
+            isSearchingNetwork = false
+        }
     }
 
     private let service = SwiftDashSDKContactsService.shared
@@ -199,6 +233,9 @@ struct ContactsScreen: View {
     @State private var selectedContact: ContactItem? = nil
     /// Banner identity row → read-only profile sheet.
     @State private var showingOwnProfile = false
+    /// Prefill for AddContactScreen when opened from a network search
+    /// row / "Show more" (empty for the plain add button).
+    @State private var addContactInitialQuery = ""
 
     var body: some View {
         NavigationStack {
@@ -212,7 +249,7 @@ struct ContactsScreen: View {
             // the system bar only fronts the pre-enable intro.
             .toolbar(viewModel.needsDashPayEnable ? .visible : .hidden, for: .navigationBar)
             .sheet(isPresented: $showingAddContact) {
-                AddContactScreen()
+                AddContactScreen(initialQuery: addContactInitialQuery)
             }
             .sheet(isPresented: $showingOwnProfile) {
                 // Read-only profile view. Editing stays on the Home
@@ -300,7 +337,7 @@ struct ContactsScreen: View {
                     .foregroundColor(.white)
                 Spacer()
                 Button {
-                    showingAddContact = true
+                    openAddContact(query: "")
                 } label: {
                     Image(systemName: "person.badge.plus")
                         .font(.system(size: 16, weight: .semibold))
@@ -426,10 +463,76 @@ struct ContactsScreen: View {
                     }
                 }
 
+                networkResultsSection
+
                 Spacer(minLength: 24)
             }
         }
         .refreshable { await viewModel.syncNow() }
+        .onChange(of: filterText) { _, newValue in
+            viewModel.updateNetworkSearch(query: newValue)
+        }
+    }
+
+    /// Discovery teaser under the local sections while the user types:
+    /// up to three DPNS matches from the network (people NOT yet in the
+    /// lists above), with the full add-contact search one tap away. Rows
+    /// and "Show more" both open AddContactScreen prefilled — the send /
+    /// accept / eligibility machinery lives there, unduplicated.
+    @ViewBuilder
+    private var networkResultsSection: some View {
+        if trimmedFilter.count >= 2 {
+            sectionHeader(NSLocalizedString("On the Dash network", comment: "DashPay Contacts: search results from DPNS, not the local contact list"), size: 15)
+            if viewModel.isSearchingNetwork && viewModel.networkSearchResults.isEmpty {
+                SwiftUI.ProgressView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            } else if viewModel.networkSearchResults.isEmpty {
+                Text(NSLocalizedString("No usernames found", comment: "DashPay Contacts"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.dash.secondaryText)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            } else {
+                ForEach(viewModel.networkSearchResults.prefix(3)) { result in
+                    cardRow {
+                        HStack(spacing: 10) {
+                            ContactAvatarView(
+                                title: result.fullName.withoutDashSuffix,
+                                avatarURL: nil,
+                                identitySeed: result.identityId)
+                                .padding(.leading, 17)
+                            Text(result.fullName.withoutDashSuffix)
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundColor(.dash.primaryText)
+                                .lineLimit(1)
+                            Spacer()
+                            Image(systemName: "person.badge.plus")
+                                .foregroundColor(.dash.blue)
+                                .padding(.trailing, 14)
+                        }
+                        .frame(height: 58)
+                    }
+                    .onTapGesture { openAddContact(query: result.fullName.withoutDashSuffix) }
+                }
+                if viewModel.networkSearchResults.count > 3 {
+                    Button {
+                        openAddContact(query: trimmedFilter)
+                    } label: {
+                        Text(NSLocalizedString("Show more results", comment: "DashPay Contacts: expands the network search into the full add-contact flow"))
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(.dash.blue)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                    }
+                }
+            }
+        }
+    }
+
+    private func openAddContact(query: String) {
+        addContactInitialQuery = query
+        showingAddContact = true
     }
 
     private func sectionHeader(_ text: String, size: CGFloat) -> some View {
@@ -495,8 +598,10 @@ struct ContactsScreen: View {
 
     // MARK: Filtering (local, over the already-materialized snapshots)
 
+    private var trimmedFilter: String { filterText.trimmingCharacters(in: .whitespaces) }
+
     private func matches(_ item: ContactItem) -> Bool {
-        let trimmed = filterText.trimmingCharacters(in: .whitespaces)
+        let trimmed = trimmedFilter
         guard !trimmed.isEmpty else { return true }
         return item.displayTitle.localizedCaseInsensitiveContains(trimmed)
             || (item.username?.localizedCaseInsensitiveContains(trimmed) ?? false)

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -361,15 +361,45 @@ struct SDKIdentityProfileSheet: View {
 
 // MARK: - IdentityTopUpViewModel
 
-/// Business side of the profile sheet's Top Up: PIN/biometric gate, then
-/// one Core asset lock + IdentityTopUp transition via the SDK
-/// (`topUpIdentityWithFunding` — funded from the wallet's Transparent
-/// balance, account 0). Returns the identity's post-transition credit
-/// balance for the sheet to display.
+/// Business side of the profile sheet's Top Up: one PIN/biometric gate,
+/// then the funding route the user picked.
+///
+/// - `.shielded` (default — keeps the identity unlinked from transparent
+///   coins): two steps. Step 1 unshields the amount from the Orchard pool
+///   to the wallet's own next Platform receive address
+///   (`shieldedUnshield`, proven execution). Step 2 claims the landed
+///   credits minus the policy fee headroom from that address into an
+///   IdentityTopUp (`topUpFromAddresses` — its fee comes out of the
+///   supplied credits, so the identity receives "most" of the amount and
+///   the unclaimed headroom stays in the Platform balance).
+/// - `.platform`: one `topUpFromAddresses` over inputs selected by
+///   `PlatformPaymentIdentityFundingPolicy` (same policy the registration
+///   coordinator uses).
+/// - `.transparent`: one Core asset lock + IdentityTopUp
+///   (`topUpIdentityWithFunding`, account 0).
+///
+/// Returns the identity's post-transition credit balance.
 @MainActor
 final class IdentityTopUpViewModel: ObservableObject {
+
+    enum FundingSource: CaseIterable {
+        case shielded
+        case platform
+        case transparent
+
+        var title: String {
+            switch self {
+            case .shielded: return NSLocalizedString("Shielded", comment: "Shielded activity: funds moved into the private shielded balance")
+            case .platform: return NSLocalizedString("Platform", comment: "Identity top-up sheet — the DIP-17 Platform address balance")
+            case .transparent: return NSLocalizedString("Transparent", comment: "Identity top-up sheet — the Core wallet balance")
+            }
+        }
+    }
+
     @Published var isProcessing = false
     @Published var errorMessage: String?
+    /// User-visible progress for the shielded route's two steps.
+    @Published var stepLabel: String?
 
     private let authorizer = DWIdentityAuthorizer()
 
@@ -379,14 +409,18 @@ final class IdentityTopUpViewModel: ObservableObject {
     static let presetsDuffs: [UInt64] = [1_000_000, 5_000_000, 10_000_000]
 
     /// nil = cancelled or failed (errorMessage carries the failure).
-    func topUp(identityId: Data, amountDuffs: UInt64) async -> UInt64? {
+    func topUp(identityId: Data, amountDuffs: UInt64, source: FundingSource) async -> UInt64? {
         guard !isProcessing else { return nil }
-        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let modelContainer = SwiftDashSDKHost.shared.modelContainer else {
             errorMessage = NSLocalizedString("Wallet is not ready", comment: "DashPay")
             return nil
         }
         isProcessing = true
-        defer { isProcessing = false }
+        defer {
+            isProcessing = false
+            stepLabel = nil
+        }
         do {
             try await authorizer.authorize()
         } catch {
@@ -394,14 +428,105 @@ final class IdentityTopUpViewModel: ObservableObject {
             return nil
         }
         do {
-            return try await wallet.topUpIdentityWithFunding(
-                identityId: identityId,
-                amountDuffs: amountDuffs,
-                accountIndex: 0)
+            switch source {
+            case .transparent:
+                return try await wallet.topUpIdentityWithFunding(
+                    identityId: identityId,
+                    amountDuffs: amountDuffs,
+                    accountIndex: 0)
+
+            case .platform:
+                let credits = amountDuffs * PlatformPaymentIdentityFundingPolicy.creditsPerDuff
+                let candidates = try PlatformPaymentIdentityFundingPolicy.candidates(
+                    walletId: wallet.walletId,
+                    modelContainer: modelContainer)
+                let inputs = try PlatformPaymentIdentityFundingPolicy.makeInputs(
+                    candidates: candidates,
+                    targetCredits: credits)
+                let signer = KeychainSigner(modelContainer: modelContainer)
+                return try await wallet.topUpFromAddresses(
+                    identityId: identityId,
+                    inputs: inputs,
+                    addressSigner: signer)
+
+            case .shielded:
+                return try await topUpFromShielded(
+                    identityId: identityId,
+                    amountDuffs: amountDuffs,
+                    wallet: wallet,
+                    modelContainer: modelContainer)
+            }
+        } catch let error as PlatformPaymentIdentityFundingPolicy.PlanningError {
+            if case .insufficient(let required, let available) = error {
+                errorMessage = String.localizedStringWithFormat(
+                    NSLocalizedString("Not enough funds in this balance: %@ DASH needed, %@ DASH available.", comment: "Identity top-up sheet — insufficient funding source"),
+                    (required / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol,
+                    (available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
+            } else {
+                errorMessage = error.localizedDescription
+            }
+            return nil
         } catch {
             errorMessage = error.localizedDescription
             return nil
         }
+    }
+
+    /// The privacy-default two-step: Shielded → own Platform address →
+    /// identity credits.
+    private func topUpFromShielded(
+        identityId: Data,
+        amountDuffs: UInt64,
+        wallet: ManagedPlatformWallet,
+        modelContainer: ModelContainer
+    ) async throws -> UInt64 {
+        guard let manager = SwiftDashSDKHost.shared.manager else {
+            throw SwiftDashSDKContactsService.ServiceError.noWallet
+        }
+        guard let destination = PlatformAddressSyncCoordinator.shared
+            .derivedAddresses.nextReceiveAddress?.address,
+            !destination.isEmpty,
+            let storageBytes = AddressTransformer.parseBech32mAddress(destination),
+            storageBytes.count == 21 else {
+            errorMessage = NSLocalizedString("No Platform receive address is available yet — wait for the Platform sync to finish and try again.", comment: "Identity top-up sheet — missing unshield destination")
+            throw SwiftDashSDKContactsService.ServiceError.noWallet
+        }
+        let credits = amountDuffs * PlatformPaymentIdentityFundingPolicy.creditsPerDuff
+
+        // Step 1: Orchard notes → own Platform address. `shieldedUnshield`
+        // waits for proven execution, so the credits are on-chain at the
+        // destination when it returns; the unshield's own fee comes from
+        // the shielded side on top of `credits`.
+        stepLabel = NSLocalizedString("Step 1 of 2 — moving Dash out of your Shielded balance…", comment: "Identity top-up sheet — shielded route progress")
+        try await manager.shieldedUnshield(
+            walletId: wallet.walletId,
+            resolver: MnemonicResolver(),
+            account: 0,
+            toPlatformAddress: destination,
+            amount: credits)
+        // Same post-spend refreshes the transfer coordinator schedules —
+        // BLAST stays the source of truth for the persisted balances.
+        PlatformAddressSyncCoordinator.shared.refreshShieldedBalanceAfterSpend(using: manager)
+
+        // Step 2: claim the landed credits minus the policy's fee headroom
+        // into the identity. The transition's fee is deducted from the
+        // supplied credits; the unclaimed headroom stays at the address
+        // (it is the wallet's own Platform balance, not lost).
+        stepLabel = NSLocalizedString("Step 2 of 2 — topping up your identity…", comment: "Identity top-up sheet — shielded route progress")
+        let claim = credits > PlatformPaymentIdentityFundingPolicy.feeHeadroomCredits
+            ? credits - PlatformPaymentIdentityFundingPolicy.feeHeadroomCredits
+            : credits
+        let input = ManagedPlatformWallet.IdentityAddressInput(
+            addressType: storageBytes[storageBytes.startIndex],
+            hash: Data(storageBytes.dropFirst()),
+            credits: claim)
+        let signer = KeychainSigner(modelContainer: modelContainer)
+        let newBalance = try await wallet.topUpFromAddresses(
+            identityId: identityId,
+            inputs: [input],
+            addressSigner: signer)
+        Task { await PlatformAddressSyncCoordinator.shared.syncNow() }
+        return newBalance
     }
 }
 
@@ -418,6 +543,9 @@ struct IdentityTopUpSheet: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = IdentityTopUpViewModel()
     @State private var selectedDuffs: UInt64 = IdentityTopUpViewModel.presetsDuffs[0]
+    /// Shielded is the privacy default; the transparent-side sources are
+    /// an explicit opt-in behind the linkability warning.
+    @State private var source: IdentityTopUpViewModel.FundingSource = .shielded
 
     var body: some View {
         // Scrollable so every action stays reachable at large Dynamic
@@ -437,7 +565,7 @@ struct IdentityTopUpSheet: View {
                     .padding(.top, 16)
 
                 Text(NSLocalizedString(
-                    "Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates.",
+                    "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates.",
                     comment: "Identity top-up sheet — body"))
                     .font(.system(size: 14))
                     .foregroundColor(.dash.secondaryText)
@@ -445,6 +573,40 @@ struct IdentityTopUpSheet: View {
                     .fixedSize(horizontal: false, vertical: true)
                     .padding(.horizontal, 28)
                     .padding(.top, 8)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(NSLocalizedString("Pay from", comment: "Identity top-up sheet — funding source picker label"))
+                        .font(.caption)
+                        .foregroundColor(.dash.secondaryText)
+                    Picker(NSLocalizedString("Pay from", comment: "Identity top-up sheet — funding source picker label"), selection: $source) {
+                        ForEach(IdentityTopUpViewModel.FundingSource.allCases, id: \.self) { candidate in
+                            Text(candidate.title).tag(candidate)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    if source == .shielded {
+                        Text(NSLocalizedString(
+                            "Recommended: a two-step transfer through your own Platform address keeps your identity unlinked from your transparent coins.",
+                            comment: "Identity top-up sheet — shielded source note"))
+                            .font(.system(size: 12))
+                            .foregroundColor(.dash.secondaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Label {
+                            Text(NSLocalizedString(
+                                "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.",
+                                comment: "Identity top-up sheet — linkability warning for transparent-side sources"))
+                                .font(.system(size: 12))
+                                .fixedSize(horizontal: false, vertical: true)
+                        } icon: {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 12))
+                        }
+                        .foregroundColor(.orange)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
 
                 HStack(spacing: 10) {
                     ForEach(IdentityTopUpViewModel.presetsDuffs, id: \.self) { duffs in
@@ -476,18 +638,28 @@ struct IdentityTopUpSheet: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 18)
 
-                Text(NSLocalizedString("Paid from your Transparent balance, plus the network fee.", comment: "Identity top-up sheet — funding source note"))
+                Text(NSLocalizedString("Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.", comment: "Identity top-up sheet — fee note"))
                     .font(.system(size: 12))
                     .foregroundColor(.dash.tertiaryText)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 24)
                     .padding(.top, 8)
 
                 Button {
                     confirm()
                 } label: {
                     if viewModel.isProcessing {
-                        SwiftUI.ProgressView()
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
+                        VStack(spacing: 6) {
+                            SwiftUI.ProgressView()
+                            if let step = viewModel.stepLabel {
+                                Text(step)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.dash.secondaryText)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
                     } else {
                         Text(NSLocalizedString("Top Up", comment: "SDK identity profile sheet — add credits to the identity"))
                             .font(.system(size: 16, weight: .semibold))
@@ -534,7 +706,8 @@ struct IdentityTopUpSheet: View {
         Task {
             if let newBalance = await viewModel.topUp(
                 identityId: identityId,
-                amountDuffs: selectedDuffs) {
+                amountDuffs: selectedDuffs,
+                source: source) {
                 onToppedUp(newBalance)
                 dismiss()
             }

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -177,8 +177,8 @@ struct SDKIdentityProfileSheet: View {
     /// address balance — the row this replaces read
     /// `platformPaymentCreditsAsDuffs` under a "Platform Credits" label,
     /// which showed the DIP-17 wallet balance on an identity sheet).
-    /// The ⓘ explains the difference; Top Up funds it from the
-    /// Transparent balance via a Core asset lock.
+    /// The ⓘ explains the difference; Top Up funds it from a
+    /// user-selected balance, Shielded by default.
     private var identityBalanceRow: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 5) {
@@ -222,7 +222,7 @@ struct SDKIdentityProfileSheet: View {
             Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
         } message: {
             Text(NSLocalizedString(
-                "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits.",
+                "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.",
                 comment: "SDK identity profile sheet — explains the identity credit balance"))
         }
         .sheet(isPresented: $showingTopUp) {
@@ -406,6 +406,17 @@ final class IdentityTopUpViewModel: ObservableObject {
 
     private let authorizer = DWIdentityAuthorizer()
 
+    enum TopUpError: LocalizedError {
+        case noPlatformReceiveAddress
+
+        var errorDescription: String? {
+            switch self {
+            case .noPlatformReceiveAddress:
+                return NSLocalizedString("No Platform receive address is available yet — wait for the Platform sync to finish and try again.", comment: "Identity top-up sheet — missing unshield destination")
+            }
+        }
+    }
+
     /// Preset top-up amounts (duffs): 0.05 / 0.1 DASH. Small amounts are
     /// deliberately not offered — the fixed fees (especially the shielded
     /// route's unshield step) would be a large share of them. A custom
@@ -518,8 +529,9 @@ final class IdentityTopUpViewModel: ObservableObject {
             !destination.isEmpty,
             let storageBytes = AddressTransformer.parseBech32mAddress(destination),
             storageBytes.count == 21 else {
-            errorMessage = NSLocalizedString("No Platform receive address is available yet — wait for the Platform sync to finish and try again.", comment: "Identity top-up sheet — missing unshield destination")
-            throw SwiftDashSDKContactsService.ServiceError.noWallet
+            // Typed so the generic catch surfaces THIS message instead of
+            // overwriting it with an unrelated one.
+            throw TopUpError.noPlatformReceiveAddress
         }
         let credits = amountDuffs * PlatformPaymentIdentityFundingPolicy.creditsPerDuff
 
@@ -562,9 +574,9 @@ final class IdentityTopUpViewModel: ObservableObject {
 
 // MARK: - IdentityTopUpSheet
 
-/// Amount picker + confirm for topping up the identity's credit balance
-/// from the Transparent balance. Nothing is signed or broadcast until
-/// Confirm passes the PIN gate.
+/// Amount + funding-source picker and confirm for topping up the
+/// identity's credit balance (Shielded by default). Nothing is signed or
+/// broadcast until Confirm passes the PIN gate.
 struct IdentityTopUpSheet: View {
     let identityId: Data
     let currentBalanceCredits: UInt64

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -233,7 +233,10 @@ struct SDKIdentityProfileSheet: View {
                     onToppedUp: { newBalanceCredits in
                         identityBalanceCredits = newBalanceCredits
                     })
-                    .presentationDetents([.medium, .large])
+                    // Full-height: the source picker + amount chips +
+                    // custom field don't fit a half sheet without
+                    // clipping the confirm button.
+                    .presentationDetents([.large])
             }
         }
     }
@@ -403,10 +406,37 @@ final class IdentityTopUpViewModel: ObservableObject {
 
     private let authorizer = DWIdentityAuthorizer()
 
-    /// Preset top-up amounts (duffs): 0.01 / 0.05 / 0.1 DASH, all well
-    /// above the Rust-side minimum top-up asset lock of 50,500 duffs
-    /// (mirrored from `DWIdentityRegistrationCoordinator.minimumCoreTopUpDuffs`).
-    static let presetsDuffs: [UInt64] = [1_000_000, 5_000_000, 10_000_000]
+    /// Preset top-up amounts (duffs): 0.05 / 0.1 DASH. Small amounts are
+    /// deliberately not offered — the fixed fees (especially the shielded
+    /// route's unshield step) would be a large share of them. A custom
+    /// amount is accepted down to `customMinimumDuffs`.
+    static let presetsDuffs: [UInt64] = [5_000_000, 10_000_000]
+
+    /// Floor for the custom amount: 0.01 DASH — well above the Rust-side
+    /// minimum top-up asset lock of 50,500 duffs (mirrored from
+    /// `DWIdentityRegistrationCoordinator.minimumCoreTopUpDuffs`) and large
+    /// enough that the fees below can't consume it.
+    static let customMinimumDuffs: UInt64 = 1_000_000
+
+    /// Observed IdentityTopUp/from-addresses transition fee — ~0.0004 DASH
+    /// ("required 41500000" credits, the measurement
+    /// `PlatformPaymentIdentityFundingPolicy`'s headroom doc cites). The
+    /// actual fee is metered at execution; this is the display estimate.
+    static let observedTopUpTransitionFeeCredits: UInt64 = 41_500_000
+
+    /// Display fee estimate (credits) for a route: the consensus-pinned
+    /// unshield minimum (shielded route only, via the pure
+    /// `estimateShieldedFee` FFI) plus the observed top-up transition fee.
+    /// The transparent route also pays a small Core miner fee on top.
+    static func estimatedFeeCredits(source: FundingSource) -> UInt64 {
+        let unshieldFee: UInt64
+        if source == .shielded {
+            unshieldFee = (try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)) ?? 0
+        } else {
+            unshieldFee = 0
+        }
+        return unshieldFee + observedTopUpTransitionFeeCredits
+    }
 
     /// nil = cancelled or failed (errorMessage carries the failure).
     func topUp(identityId: Data, amountDuffs: UInt64, source: FundingSource) async -> UInt64? {
@@ -542,7 +572,10 @@ struct IdentityTopUpSheet: View {
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var viewModel = IdentityTopUpViewModel()
-    @State private var selectedDuffs: UInt64 = IdentityTopUpViewModel.presetsDuffs[0]
+    /// nil = the Custom chip is selected and `customText` carries the amount.
+    @State private var selectedPresetDuffs: UInt64? = IdentityTopUpViewModel.presetsDuffs[0]
+    @State private var customText = ""
+    @FocusState private var customFieldFocused: Bool
     /// Shielded is the privacy default; the transparent-side sources are
     /// an explicit opt-in behind the linkability warning.
     @State private var source: IdentityTopUpViewModel.FundingSource = .shielded
@@ -610,9 +643,10 @@ struct IdentityTopUpSheet: View {
 
                 HStack(spacing: 10) {
                     ForEach(IdentityTopUpViewModel.presetsDuffs, id: \.self) { duffs in
-                        Button {
-                            selectedDuffs = duffs
-                        } label: {
+                        amountChip(isSelected: selectedPresetDuffs == duffs) {
+                            selectedPresetDuffs = duffs
+                            customFieldFocused = false
+                        } content: {
                             VStack(spacing: 2) {
                                 Text("\(duffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)")
                                     .font(.system(size: 15, weight: .semibold))
@@ -620,25 +654,65 @@ struct IdentityTopUpSheet: View {
                                     .font(.system(size: 11))
                                     .opacity(0.75)
                             }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(
-                                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                    .fill(selectedDuffs == duffs
-                                        ? Color.dash.blue.opacity(0.12)
-                                        : Color.dash.secondaryBackground))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                    .stroke(selectedDuffs == duffs ? Color.dash.blue : .clear, lineWidth: 1.5))
-                            .foregroundColor(selectedDuffs == duffs ? .dash.blue : .dash.primaryText)
                         }
-                        .buttonStyle(.plain)
+                    }
+                    amountChip(isSelected: selectedPresetDuffs == nil) {
+                        selectedPresetDuffs = nil
+                        customFieldFocused = true
+                    } content: {
+                        VStack(spacing: 2) {
+                            Text(NSLocalizedString("Custom", comment: "Identity top-up sheet — free amount chip"))
+                                .font(.system(size: 15, weight: .semibold))
+                            Text(verbatim: "···")
+                                .font(.system(size: 11))
+                                .opacity(0.75)
+                        }
                     }
                 }
                 .padding(.horizontal, 20)
                 .padding(.top, 18)
 
-                Text(NSLocalizedString("Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.", comment: "Identity top-up sheet — fee note"))
+                if selectedPresetDuffs == nil {
+                    VStack(alignment: .leading, spacing: 4) {
+                        TextField(
+                            NSLocalizedString("Amount in DASH", comment: "Identity top-up sheet — custom amount placeholder"),
+                            text: $customText)
+                            .keyboardType(.decimalPad)
+                            .focused($customFieldFocused)
+                            .font(.system(size: 16, weight: .semibold))
+                            .padding(12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .fill(Color.dash.secondaryBackground))
+                        if let duffs = customDuffs {
+                            Text(CurrencyExchanger.shared.fiatAmountString(for: duffs.dashAmount))
+                                .font(.system(size: 12))
+                                .foregroundColor(.dash.secondaryText)
+                        } else if !customText.isEmpty {
+                            Text(String.localizedStringWithFormat(
+                                NSLocalizedString("Enter at least %@ DASH", comment: "Identity top-up sheet — custom amount below the floor"),
+                                IdentityTopUpViewModel.customMinimumDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol))
+                                .font(.system(size: 12))
+                                .foregroundColor(.orange)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 10)
+                }
+
+                HStack {
+                    Text(NSLocalizedString("Estimated fees", comment: "Identity top-up sheet — fee estimate line"))
+                        .font(.system(size: 13))
+                        .foregroundColor(.dash.secondaryText)
+                    Spacer()
+                    Text(estimatedFeeText)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 14)
+
+                Text(NSLocalizedString("Fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.", comment: "Identity top-up sheet — fee note"))
                     .font(.system(size: 12))
                     .foregroundColor(.dash.tertiaryText)
                     .multilineTextAlignment(.center)
@@ -670,7 +744,8 @@ struct IdentityTopUpSheet: View {
                             .cornerRadius(12)
                     }
                 }
-                .disabled(viewModel.isProcessing)
+                .disabled(viewModel.isProcessing || effectiveDuffs == nil)
+                .opacity(effectiveDuffs == nil ? 0.55 : 1)
                 .padding(.horizontal, 20)
                 .padding(.top, 20)
 
@@ -702,11 +777,59 @@ struct IdentityTopUpSheet: View {
         }
     }
 
+    /// Shared chip chrome for the preset and Custom amount buttons.
+    private func amountChip<Content: View>(
+        isSelected: Bool,
+        action: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        Button(action: action) {
+            content()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(isSelected ? Color.dash.blue.opacity(0.12) : Color.dash.secondaryBackground))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(isSelected ? Color.dash.blue : .clear, lineWidth: 1.5))
+                .foregroundColor(isSelected ? .dash.blue : .dash.primaryText)
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Parsed custom amount in duffs; nil when absent or below the floor.
+    private var customDuffs: UInt64? {
+        let normalized = customText
+            .trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: ",", with: ".")
+        guard let dash = Decimal(string: normalized), dash > 0, dash <= 1000 else { return nil }
+        let duffsDecimal = dash * Decimal(kOneDash)
+        guard let duffs = UInt64(exactly: NSDecimalNumber(decimal: duffsDecimal).int64Value),
+              duffs >= IdentityTopUpViewModel.customMinimumDuffs else { return nil }
+        return duffs
+    }
+
+    /// The amount the Top Up button will submit — preset or valid custom.
+    private var effectiveDuffs: UInt64? {
+        selectedPresetDuffs ?? customDuffs
+    }
+
+    private var estimatedFeeText: String {
+        let credits = IdentityTopUpViewModel.estimatedFeeCredits(source: source)
+        let duffs = credits / 1000
+        return String.localizedStringWithFormat(
+            NSLocalizedString("~%@ DASH (≈ %@)", comment: "DashPay: estimated network fee — DASH amount, then its local-currency equivalent"),
+            duffs.dashAmount.formattedDashAmountWithoutCurrencySymbol,
+            CurrencyExchanger.shared.fiatAmountString(for: duffs.dashAmount))
+    }
+
     private func confirm() {
+        guard let amountDuffs = effectiveDuffs else { return }
         Task {
             if let newBalance = await viewModel.topUp(
                 identityId: identityId,
-                amountDuffs: selectedDuffs,
+                amountDuffs: amountDuffs,
                 source: source) {
                 onToppedUp(newBalance)
                 dismiss()

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -14,7 +14,6 @@ import DashUIKit
 
 struct SDKIdentityProfileSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var walletState = SwiftDashSDKWalletState.shared
     @State private var identityIdHex: String? = nil
     /// Owner's profile picture, read from the same identity snapshot the rest
     /// of the app renders from. nil → the deterministic initials placeholder.
@@ -30,6 +29,14 @@ struct SDKIdentityProfileSheet: View {
     /// `ContestVoteState.endTime` once the contest is indexed.
     @State private var pendingVotingEndTime: Date? = nil
     @State private var copyToast: String? = nil
+    /// The identity's credit balance (credits, 1000 credits = 1 duff),
+    /// from the persisted identity row; refreshed by a top-up's returned
+    /// post-transition balance. nil until the identity row loads.
+    @State private var identityBalanceCredits: UInt64?
+    /// 32-byte identity id the top-up transition targets.
+    @State private var identityIdData: Data?
+    @State private var showingBalanceInfo = false
+    @State private var showingTopUp = false
 
     /// Callback invoked when the user taps Edit. Owner (HomeViewController)
     /// dismisses the sheet and pushes `RootEditProfileViewController`.
@@ -83,7 +90,6 @@ struct SDKIdentityProfileSheet: View {
                 }
             }
             .onAppear {
-                walletState.refreshPlatformPaymentCredits()
                 loadIdentityId()
                 dpnsNames = DWCurrentUserIdentityInfo.shared.usernames
                 hasIdentity = DWCurrentUserIdentityInfo.shared.hasIdentity
@@ -163,12 +169,72 @@ struct SDKIdentityProfileSheet: View {
                 monospaced: true,
                 copyable: identityIdHex != nil
             )
-            infoRow(
-                title: NSLocalizedString("Platform Credits", comment: "SDK identity profile sheet"),
-                value: platformCreditsFormatted,
-                monospaced: false,
-                copyable: false
-            )
+            identityBalanceRow
+        }
+    }
+
+    /// The identity's own credit balance (NOT the wallet's Platform
+    /// address balance — the row this replaces read
+    /// `platformPaymentCreditsAsDuffs` under a "Platform Credits" label,
+    /// which showed the DIP-17 wallet balance on an identity sheet).
+    /// The ⓘ explains the difference; Top Up funds it from the
+    /// Transparent balance via a Core asset lock.
+    private var identityBalanceRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 5) {
+                Text(NSLocalizedString("Identity Account Balance", comment: "SDK identity profile sheet — the identity's credit balance"))
+                    .font(.caption)
+                    .foregroundColor(.dash.secondaryText)
+                Button {
+                    showingBalanceInfo = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.caption)
+                        .foregroundColor(.dash.blue)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(NSLocalizedString("About the identity account balance", comment: "SDK identity profile sheet — info button"))
+            }
+            HStack(alignment: .center, spacing: 8) {
+                Text(identityBalanceFormatted)
+                    .font(.body)
+                    .foregroundColor(.dash.primaryText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if identityIdData != nil {
+                    Button {
+                        showingTopUp = true
+                    } label: {
+                        Text(NSLocalizedString("Top Up", comment: "SDK identity profile sheet — add credits to the identity"))
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.dash.blue)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Capsule().fill(Color.dash.blue.opacity(0.1)))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .alert(
+            NSLocalizedString("Identity Account Balance", comment: "SDK identity profile sheet — the identity's credit balance"),
+            isPresented: $showingBalanceInfo
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString(
+                "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits.",
+                comment: "SDK identity profile sheet — explains the identity credit balance"))
+        }
+        .sheet(isPresented: $showingTopUp) {
+            if let identityIdData {
+                IdentityTopUpSheet(
+                    identityId: identityIdData,
+                    currentBalanceCredits: identityBalanceCredits ?? 0,
+                    onToppedUp: { newBalanceCredits in
+                        identityBalanceCredits = newBalanceCredits
+                    })
+                    .presentationDetents([.medium, .large])
+            }
         }
     }
 
@@ -244,8 +310,11 @@ struct SDKIdentityProfileSheet: View {
             ?? "—"
     }
 
-    private var platformCreditsFormatted: String {
-        let duffs = walletState.platformPaymentCreditsAsDuffs
+    private var identityBalanceFormatted: String {
+        guard let credits = identityBalanceCredits else {
+            return NSLocalizedString("Loading…", comment: "")
+        }
+        let duffs = credits / 1000
         if duffs == 0 {
             return NSLocalizedString("0 DASH", comment: "SDK identity profile sheet — zero Platform credits")
         }
@@ -282,6 +351,193 @@ struct SDKIdentityProfileSheet: View {
         if let identity = try? context.fetch(descriptor).first {
             identityIdHex = identity.identityId.map { String(format: "%02x", $0) }.joined()
             identitySeed = identity.identityId
+            identityIdData = identity.identityId
+            // Stored as the Int64 bit-pattern of the UInt64 credits (see
+            // IdentitiesViewModel's identical read).
+            identityBalanceCredits = UInt64(bitPattern: identity.balance)
+        }
+    }
+}
+
+// MARK: - IdentityTopUpViewModel
+
+/// Business side of the profile sheet's Top Up: PIN/biometric gate, then
+/// one Core asset lock + IdentityTopUp transition via the SDK
+/// (`topUpIdentityWithFunding` — funded from the wallet's Transparent
+/// balance, account 0). Returns the identity's post-transition credit
+/// balance for the sheet to display.
+@MainActor
+final class IdentityTopUpViewModel: ObservableObject {
+    @Published var isProcessing = false
+    @Published var errorMessage: String?
+
+    private let authorizer = DWIdentityAuthorizer()
+
+    /// Preset top-up amounts (duffs): 0.01 / 0.05 / 0.1 DASH, all well
+    /// above the Rust-side minimum top-up asset lock of 50,500 duffs
+    /// (mirrored from `DWIdentityRegistrationCoordinator.minimumCoreTopUpDuffs`).
+    static let presetsDuffs: [UInt64] = [1_000_000, 5_000_000, 10_000_000]
+
+    /// nil = cancelled or failed (errorMessage carries the failure).
+    func topUp(identityId: Data, amountDuffs: UInt64) async -> UInt64? {
+        guard !isProcessing else { return nil }
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            errorMessage = NSLocalizedString("Wallet is not ready", comment: "DashPay")
+            return nil
+        }
+        isProcessing = true
+        defer { isProcessing = false }
+        do {
+            try await authorizer.authorize()
+        } catch {
+            // Backing out of the PIN prompt is not an error state.
+            return nil
+        }
+        do {
+            return try await wallet.topUpIdentityWithFunding(
+                identityId: identityId,
+                amountDuffs: amountDuffs,
+                accountIndex: 0)
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+}
+
+// MARK: - IdentityTopUpSheet
+
+/// Amount picker + confirm for topping up the identity's credit balance
+/// from the Transparent balance. Nothing is signed or broadcast until
+/// Confirm passes the PIN gate.
+struct IdentityTopUpSheet: View {
+    let identityId: Data
+    let currentBalanceCredits: UInt64
+    let onToppedUp: (UInt64) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = IdentityTopUpViewModel()
+    @State private var selectedDuffs: UInt64 = IdentityTopUpViewModel.presetsDuffs[0]
+
+    var body: some View {
+        // Scrollable so every action stays reachable at large Dynamic
+        // Type sizes.
+        ScrollView {
+            VStack(spacing: 0) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 34))
+                    .foregroundColor(.dash.blue)
+                    .frame(width: 72, height: 72)
+                    .background(Circle().fill(Color.dash.blue.opacity(0.08)))
+                    .padding(.top, 28)
+
+                Text(NSLocalizedString("Top Up Identity Balance", comment: "Identity top-up sheet — title"))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                    .padding(.top, 16)
+
+                Text(NSLocalizedString(
+                    "Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates.",
+                    comment: "Identity top-up sheet — body"))
+                    .font(.system(size: 14))
+                    .foregroundColor(.dash.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 8)
+
+                HStack(spacing: 10) {
+                    ForEach(IdentityTopUpViewModel.presetsDuffs, id: \.self) { duffs in
+                        Button {
+                            selectedDuffs = duffs
+                        } label: {
+                            VStack(spacing: 2) {
+                                Text("\(duffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)")
+                                    .font(.system(size: 15, weight: .semibold))
+                                Text(CurrencyExchanger.shared.fiatAmountString(for: duffs.dashAmount))
+                                    .font(.system(size: 11))
+                                    .opacity(0.75)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .fill(selectedDuffs == duffs
+                                        ? Color.dash.blue.opacity(0.12)
+                                        : Color.dash.secondaryBackground))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .stroke(selectedDuffs == duffs ? Color.dash.blue : .clear, lineWidth: 1.5))
+                            .foregroundColor(selectedDuffs == duffs ? .dash.blue : .dash.primaryText)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
+
+                Text(NSLocalizedString("Paid from your Transparent balance, plus the network fee.", comment: "Identity top-up sheet — funding source note"))
+                    .font(.system(size: 12))
+                    .foregroundColor(.dash.tertiaryText)
+                    .padding(.top, 8)
+
+                Button {
+                    confirm()
+                } label: {
+                    if viewModel.isProcessing {
+                        SwiftUI.ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                    } else {
+                        Text(NSLocalizedString("Top Up", comment: "SDK identity profile sheet — add credits to the identity"))
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color.dash.whiteText)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.dash.blue)
+                            .cornerRadius(12)
+                    }
+                }
+                .disabled(viewModel.isProcessing)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text(NSLocalizedString("Cancel", comment: ""))
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.dash.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .disabled(viewModel.isProcessing)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 10)
+            }
+        }
+        .background(Color.dash.primaryBackground)
+        .interactiveDismissDisabled(viewModel.isProcessing)
+        .alert(
+            NSLocalizedString("Error", comment: ""),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } })
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    private func confirm() {
+        Task {
+            if let newBalance = await viewModel.topUp(
+                identityId: identityId,
+                amountDuffs: selectedDuffs) {
+                onToppedUp(newBalance)
+                dismiss()
+            }
         }
     }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2357,7 +2357,7 @@
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";
 
 /* SDK identity profile sheet — explains the identity credit balance */
-"This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits.";
+"This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.";
 
 /* SDK identity profile sheet — add credits to the identity */
 "Top Up" = "Top Up";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -185,6 +185,9 @@
 /* No comment provided by engineer. */
 "About me" = "About me";
 
+/* SDK identity profile sheet — info button */
+"About the identity account balance" = "About the identity account balance";
+
 /* No comment provided by engineer. */
 "Accept" = "Accept";
 
@@ -653,6 +656,9 @@
 /* DashPay Contacts: success card after sending a request */
 "Contact request sent to %@" = "Contact request sent to %@";
 
+/* Identity top-up sheet — body */
+"Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates." = "Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates.";
+
 /* DashPay: title of the enable success sheet */
 "DashPay enabled" = "DashPay enabled";
 
@@ -661,6 +667,9 @@
 
 /* DashPay FAQ */
 "How does this compare to Ethereum Accounts in terms of privacy?" = "How does this compare to Ethereum Accounts in terms of privacy?";
+
+/* SDK identity profile sheet — the identity's credit balance */
+"Identity Account Balance" = "Identity Account Balance";
 
 /* DashPay: banner fallback when the identity has no name yet */
 "My identity" = "My identity";
@@ -673,6 +682,9 @@
 
 /* DashPay Contacts: search results from DPNS, not the local contact list */
 "On the Dash network" = "On the Dash network";
+
+/* Identity top-up sheet — funding source note */
+"Paid from your Transparent balance, plus the network fee." = "Paid from your Transparent balance, plus the network fee.";
 
 /* DashPay FAQ */
 "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.";
@@ -2310,6 +2322,15 @@
 
 /* DashPay: body of the Enable DashPay confirmation */
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";
+
+/* SDK identity profile sheet — explains the identity credit balance */
+"This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from your Transparent balance into identity credits.";
+
+/* SDK identity profile sheet — add credits to the identity */
+"Top Up" = "Top Up";
+
+/* Identity top-up sheet — title */
+"Top Up Identity Balance" = "Top Up Identity Balance";
 
 /* DashPay intro: feature title */
 "Usernames, not addresses" = "Usernames, not addresses";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -662,6 +662,9 @@
 /* DashPay FAQ */
 "How does this compare to Ethereum Accounts in terms of privacy?" = "How does this compare to Ethereum Accounts in terms of privacy?";
 
+/* DashPay: banner fallback when the identity has no name yet */
+"My identity" = "My identity";
+
 /* DashPay FAQ */
 "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers.";
 
@@ -2304,6 +2307,9 @@
 
 /* DashPay intro: feature title */
 "Usernames, not addresses" = "Usernames, not addresses";
+
+/* DashPay: banner identity row subtitle */
+"View profile" = "View profile";
 
 /* DashPay FAQ */
 "What about Unstoppable Domains and similar name services?" = "What about Unstoppable Domains and similar name services?";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -312,6 +312,9 @@
 /* Coinbase/Buy Dash */
 "Amount in Dash" = "Amount in Dash";
 
+/* Identity top-up sheet — custom amount placeholder */
+"Amount in DASH" = "Amount in DASH";
+
 /* No comment provided by engineer. */
 "Amount received" = "Amount received";
 
@@ -659,8 +662,20 @@
 /* Identity top-up sheet — body */
 "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates." = "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates.";
 
+/* Identity top-up sheet — free amount chip */
+"Custom" = "Custom";
+
 /* DashPay: title of the enable success sheet */
 "DashPay enabled" = "DashPay enabled";
+
+/* Identity top-up sheet — custom amount below the floor */
+"Enter at least %@ DASH" = "Enter at least %@ DASH";
+
+/* Identity top-up sheet — fee estimate line */
+"Estimated fees" = "Estimated fees";
+
+/* Identity top-up sheet — fee note */
+"Fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance." = "Fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.";
 
 /* Identity top-up sheet — linkability warning for transparent-side sources */
 "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance." = "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.";
@@ -679,9 +694,6 @@
 
 /* DashPay FAQ */
 "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers.";
-
-/* Identity top-up sheet — fee note */
-"Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance." = "Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.";
 
 /* Identity top-up sheet — missing unshield destination */
 "No Platform receive address is available yet — wait for the Platform sync to finish and try again." = "No Platform receive address is available yet — wait for the Platform sync to finish and try again.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -671,6 +671,9 @@
 /* DashPay FAQ */
 "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves.";
 
+/* DashPay Contacts: search results from DPNS, not the local contact list */
+"On the Dash network" = "On the Dash network";
+
 /* DashPay FAQ */
 "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.";
 
@@ -2301,6 +2304,9 @@
 
 /* DashPay: CTA of the enable success sheet */
 "Send your first contact request" = "Send your first contact request";
+
+/* DashPay Contacts: expands the network search into the full add-contact flow */
+"Show more results" = "Show more results";
 
 /* DashPay: body of the Enable DashPay confirmation */
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -657,10 +657,13 @@
 "Contact request sent to %@" = "Contact request sent to %@";
 
 /* Identity top-up sheet — body */
-"Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates." = "Convert Dash from your Transparent balance into identity credits to pay for Platform actions like contact requests and profile updates.";
+"Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates." = "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates.";
 
 /* DashPay: title of the enable success sheet */
 "DashPay enabled" = "DashPay enabled";
+
+/* Identity top-up sheet — linkability warning for transparent-side sources */
+"Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance." = "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.";
 
 /* DashPay FAQ */
 "How does this compare to Bitcoin in terms of privacy?" = "How does this compare to Bitcoin in terms of privacy?";
@@ -677,14 +680,23 @@
 /* DashPay FAQ */
 "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers.";
 
+/* Identity top-up sheet — fee note */
+"Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance." = "Network fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.";
+
+/* Identity top-up sheet — missing unshield destination */
+"No Platform receive address is available yet — wait for the Platform sync to finish and try again." = "No Platform receive address is available yet — wait for the Platform sync to finish and try again.";
+
+/* Identity top-up sheet — insufficient funding source */
+"Not enough funds in this balance: %@ DASH needed, %@ DASH available." = "Not enough funds in this balance: %@ DASH needed, %@ DASH available.";
+
 /* DashPay FAQ */
 "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves.";
 
 /* DashPay Contacts: search results from DPNS, not the local contact list */
 "On the Dash network" = "On the Dash network";
 
-/* Identity top-up sheet — funding source note */
-"Paid from your Transparent balance, plus the network fee." = "Paid from your Transparent balance, plus the network fee.";
+/* Identity top-up sheet — funding source picker label */
+"Pay from" = "Pay from";
 
 /* DashPay FAQ */
 "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.";
@@ -2302,6 +2314,9 @@
 /* Identities: key visible to the wallet but not usable for signing */
 "Read-only" = "Read-only";
 
+/* Identity top-up sheet — shielded source note */
+"Recommended: a two-step transfer through your own Platform address keeps your identity unlinked from your transparent coins." = "Recommended: a two-step transfer through your own Platform address keeps your identity unlinked from your transparent coins.";
+
 /* Identities: DPP security level of a public key */
 "Security level" = "Security level";
 
@@ -2319,6 +2334,12 @@
 
 /* DashPay Contacts: expands the network search into the full add-contact flow */
 "Show more results" = "Show more results";
+
+/* Identity top-up sheet — shielded route progress */
+"Step 1 of 2 — moving Dash out of your Shielded balance…" = "Step 1 of 2 — moving Dash out of your Shielded balance…";
+
+/* Identity top-up sheet — shielded route progress */
+"Step 2 of 2 — topping up your identity…" = "Step 2 of 2 — topping up your identity…";
 
 /* DashPay: body of the Enable DashPay confirmation */
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -249,6 +249,13 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
             creditedAmountCredits: creditedAmount,
             observedDeltaDuffs: 10_000_000))
+        // Non-positive deltas are never own-operation residue.
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: 0))
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
+            creditedAmountCredits: creditedAmount,
+            observedDeltaDuffs: -1))
         // A credits-vs-duffs unit mixup must never pass as a match.
         XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
             creditedAmountCredits: creditedAmount,

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -246,10 +246,11 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(
             PlatformAddressActivityUnitPolicy.duffs(fromCredits: creditedAmount),
             10_000_000)
-        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldMatches(
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
             creditedAmountCredits: creditedAmount,
             observedDeltaDuffs: 10_000_000))
-        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldMatches(
+        // A credits-vs-duffs unit mixup must never pass as a match.
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldCoversDelta(
             creditedAmountCredits: creditedAmount,
             observedDeltaDuffs: Int64(creditedAmount)))
     }
@@ -270,16 +271,36 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
     }
 
     func testOwnUnshieldSuppressionDoesNotMatchAnExternalReceive() {
-        XCTAssertFalse(PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+        // Different address: never suppressed, whatever the amount.
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldResidueMatches(
             destinationAddress: "tdash1own",
             observedAddress: "tdash1external",
             creditedAmountCredits: 10_000_000_000,
             observedDeltaDuffs: 10_000_000))
-        XCTAssertFalse(PlatformAddressActivityUnitPolicy.exactUnshieldMatches(
+        // Same address, delta LARGER than the credited principal: more
+        // money arrived than the own unshield explains — not residue.
+        XCTAssertFalse(PlatformAddressActivityUnitPolicy.unshieldResidueMatches(
             destinationAddress: "tdash1own",
             observedAddress: "tdash1own",
             creditedAmountCredits: 10_000_000_000,
-            observedDeltaDuffs: 9_999_999))
+            observedDeltaDuffs: 10_000_001))
+    }
+
+    func testOwnUnshieldSuppressionCoversTopUpResidue() {
+        // Shielded identity top-up: unshield lands 0.05, the top-up claims
+        // most of it before the next sync, so the observed delta is the
+        // small remainder — still the own operation's residue.
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldResidueMatches(
+            destinationAddress: "tdash1own",
+            observedAddress: "tdash1own",
+            creditedAmountCredits: 5_000_000_000,
+            observedDeltaDuffs: 198_000))
+        // The full principal (no follow-on spend) still matches.
+        XCTAssertTrue(PlatformAddressActivityUnitPolicy.unshieldResidueMatches(
+            destinationAddress: "tdash1own",
+            observedAddress: "tdash1own",
+            creditedAmountCredits: 5_000_000_000,
+            observedDeltaDuffs: 5_000_000))
     }
 
     func testPlatformActivityUnitMigrationKeepsPrereleaseVersion() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Post-enable, the Contacts tab treated the user's DashPay identity as an afterthought: no visible "who am I", search only filtered the local lists, the profile sheet's "Platform Credits" row silently displayed the **wallet's DIP-17 Platform address balance** rather than the identity's, and there was no way to top up the identity's credit balance from the app at all.

## What was done?

**Dash-blue identity banner (Contacts tab)** — once DashPay is enabled, the tab opens with who you are: a gradient header with the ringed avatar, display name, and `@username · View profile` (opens the read-only profile sheet), plus the add-contact button on the title line. The system nav bar now fronts only the pre-enable intro; the search field overlaps the banner seam. Identity fields come from `DWCurrentUserIdentityInfo` via the view model. (Editing stays on the Home avatar flow, which owns the editor's delegate wiring — `TODO(dashpay-banner-edit)`.)

**Network results in Contacts search** — typing ≥2 characters still filters the local sections, and now also runs a debounced DPNS prefix search: an "On the Dash network" section shows up to three usernames not already in your lists (own identity excluded). Tapping a result or "Show more results" opens `AddContactScreen` prefilled with the query (new `initialQuery:` — search auto-fires on appear), so the send/accept/eligibility machinery stays in one place, unduplicated.

**Identity Account Balance (profile sheet)** — the "Platform Credits" row was miswired: it rendered `platformPaymentCreditsAsDuffs` (the wallet's Platform address balance) on an identity sheet. It is now "Identity Account Balance", reading the identity's own credit balance from the persisted row, with an ⓘ alert explaining how it differs from the wallet balances (pays Platform fees; not spendable as regular Dash).

**Shielded-first identity top-up** — a Top Up flow on that row, defaulting to the Shielded balance for privacy:

- **Shielded (default)**: a two-step route — unshield the amount to the wallet's own next Platform receive address (`shieldedUnshield`, proven execution, fee paid on the shielded side), then claim the landed credits minus `PlatformPaymentIdentityFundingPolicy.feeHeadroomCredits` into one `topUpFromAddresses` IdentityTopUp. The transition's fee comes out of the supplied credits, so the identity receives most of the amount and the unclaimed headroom stays in the Platform balance (stated in the sheet). The confirm button narrates both steps.
- **Platform / Transparent**: explicit alternatives behind a linkability warning ("funding from a transparent balance publicly links those coins to your identity"). Platform reuses `PlatformPaymentIdentityFundingPolicy` input selection; Transparent uses the Core asset-lock route (`topUpIdentityWithFunding`).
- Amounts: **0.05 / 0.1 / Custom** (decimal field, 0.01 DASH floor, fiat preview) — no small presets, since fixed fees would be a large share of them. An "Estimated fees" line shows the per-source estimate in DASH and local currency: the consensus-pinned unshield minimum (pure `estimateShieldedFee` FFI) plus the observed ~0.0004 DASH top-up transition fee.
- One PIN gate covers the chosen route; nothing signs or broadcasts before it passes. Full-height sheet so nothing clips.

**Observed-payments residue fix** — the shielded top-up's step 2 spends most of the landed credits before the next sync, so the address's observed net delta (the small remainder) no longer matched the ledger's *exact-amount* own-unshield suppression and rendered as a bogus "Received" row. The suppression is now coverage-based: a positive delta on the unshield's own destination address that is at most the credited principal is the own operation's residue. Deltas larger than the principal still record. The symmetric blind spot is documented in the policy; compile-ready tests updated with a top-up-residue case.

## How Has This Been Tested?

Manual, on mainnet with a real identity:

- Banner renders with avatar/name/@username; identity row opens the profile sheet; add-contact opens prefilled from network-search rows.
- A real 0.05 shielded top-up ran end-to-end: Shielded −0.0516 (amount + unshield fee), identity +0.048, Platform balance kept the ~0.002 headroom remainder, history shows the "Unshielded 0.05 / Shielded → Platform" internal row. The pre-fix run also reproduced the bogus "Received +0.00198" row that the residue fix now suppresses.
- Linkability warning appears on Platform/Transparent; Custom amounts validate against the 0.01 floor; fee estimate changes with the source.

Clean `dashpay` builds throughout, including against the rebuilt SwiftDashSDK xcframework carrying platform PR #4342. (Unit-test target pre-existing broken; the policy tests are compile-ready.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DashPay contact search across local contacts and the Dash network.
  * Added identity banners, profile access, and streamlined add-contact flows.
  * Added identity balance viewing and top-up options with shielded, Platform, and transparent funding sources.
  * Added fee estimates, validation, privacy warnings, progress updates, and balance refresh after top-ups.

* **Bug Fixes**
  * Improved unshield activity recognition when credited amounts are partially covered by a valid balance increase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->