### PR TITLE
feat(menu): move Buy & Sell Dash to the Explore tab

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -86,6 +86,14 @@ struct ExploreMenuScreen: View {
                 }
 
                 MenuItem(
+                    title: NSLocalizedString("Buy & Sell Dash", comment: ""),
+                    subtitle: NSLocalizedString("Select a service to buy, sell, convert and transfer Dash", comment: "Buy Sell Dash"),
+                    icon: .custom("image.buy.and.sell", maxHeight: 30),
+                    action: { showBuySellPortal() }
+                )
+                .frame(minHeight: 56)
+
+                MenuItem(
                     title: NSLocalizedString("Where to Spend?", comment: ""),
                     subtitle: NSLocalizedString("Find merchants that accept Dash payments", comment: ""),
                     icon: .custom("image-menu-merchant", maxHeight: 30),
@@ -193,6 +201,22 @@ struct ExploreMenuScreen: View {
             onShowGiftCard(txId)
         }
         vc.pushViewController(merchantVC, animated: true)
+    }
+
+    /// Same auth gate the row carried in the More menu — the portal
+    /// exposes account-linked balances (Coinbase/Uphold), so it stays
+    /// behind PIN/biometrics wherever it is reached from.
+    private func showBuySellPortal() {
+        AuthenticationService.shared.authenticate(
+            withPrompt: nil,
+            usingBiometricAuthentication: DWGlobalOptions.sharedInstance().biometricAuthEnabled,
+            alertIfLockout: true
+        ) { authenticated, _, _ in
+            guard authenticated else { return }
+            let controller = BuySellPortalViewController.controller()
+            controller.hidesBottomBarWhenPushed = true
+            vc.pushViewController(controller, animated: true)
+        }
     }
 
     private func showAtms() {

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -454,8 +454,6 @@ struct MainMenuScreen: View {
     
     private func handleNavigation(_ destination: MainMenuNavigationDestination?) {
         switch destination {
-        case .buySellPortal:
-            showBuySellPortal()
         case .explore:
             showExplore()
         case .syncInfo:
@@ -486,12 +484,6 @@ struct MainMenuScreen: View {
     
     // MARK: - Navigation Methods
     
-    private func showBuySellPortal() {
-        let controller = BuySellPortalViewController.controller()
-        controller.hidesBottomBarWhenPushed = true
-        vc.pushViewController(controller, animated: true)
-    }
-
     private func showExplore() {
         let screen = ExploreMenuScreen(
             vc: vc,

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -19,7 +19,6 @@ import SwiftUI
 import Combine
 
 enum MainMenuNavigationDestination {
-    case buySellPortal
     case explore
     case syncInfo
     case wallets
@@ -82,15 +81,6 @@ class MainMenuViewModel: ObservableObject {
     
     func buildMenuSections() {
         var allItems: [MenuItemModel] = []
-        
-        // Buy & Sell Dash
-        allItems.append(MenuItemModel(
-            title: NSLocalizedString("Buy & Sell Dash", comment: ""),
-            icon: .custom("image.buy.and.sell", maxHeight: 30),
-            action: { [weak self] in
-                self?.handleBuySellDash()
-            }
-        ))
         
         // Explore
         allItems.append(MenuItemModel(
@@ -180,18 +170,6 @@ class MainMenuViewModel: ObservableObject {
     
     // MARK: - Actions
 
-    private func handleBuySellDash() {
-        AuthenticationService.shared.authenticate(
-            withPrompt: nil,
-            usingBiometricAuthentication: DWGlobalOptions.sharedInstance().biometricAuthEnabled,
-            alertIfLockout: true
-        ) { [weak self] authenticated, usedBiometrics, cancelled in
-            if authenticated {
-                self?.navigationDestination = .buySellPortal
-            }
-        }
-    }
-    
     func resetNavigation() {
         navigationDestination = nil
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Buy & Sell Dash was a row in the More menu (last tab) — several taps away for one of the wallet's primary actions. It belongs on the Explore tab, whose intro already promises "where to buy it".

## What was done?

- `ExploreMenuScreen` gains a "Buy & Sell Dash" row (existing icon and portal subtitle copy, placed above "Where to Spend?"). The row keeps the exact PIN/biometric gate it had in More (`AuthenticationService.authenticate` before pushing `BuySellPortalViewController`) — the portal exposes account-linked balances (Coinbase/Uphold), so it stays authenticated wherever it is reached from.
- The More menu's row, its `handleBuySellDash` handler, the `buySellPortal` navigation-destination case, and the controller's now-unused `showBuySellPortal` are removed.
- No new strings — both the title and subtitle reuse existing localized entries.

## How Has This Been Tested?

Clean `dashpay` build; installed on the mainnet QA simulator — visual pass of the Explore row and its auth gate is pending device unlock and will be confirmed in a comment. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Buy & Sell Dash” option to the Explore menu.
  * Requires PIN or biometric authentication before opening the buy/sell portal.
  * Opens the portal with the bottom navigation bar hidden.

* **Updates**
  * Moved buy/sell access from the main menu to the Explore menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->