### PR TITLE
chore(ui): fill 411 missing strings + 15 plural entries across all 42 languages

### DIFF
--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " أو ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "تعذّر العثور على %@ على شبكة داش لإرسال طلب جهة اتصال إليه.";
+
+/* Usernames */
+"%@ Dash available" = "%@ داش متاح";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "قبل %@ طلب جهة الاتصال الخاص بك";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d بايت";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld من %ld إيداعات";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "رصيد أرصدة على Dash Platform يُستخدم للمدفوعات الفورية بين عناوين Platform ولميزات مثل أسماء المستخدمين.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "يجيب إضافة رقم مرور الجهاز لحماية محفظتك. انتقل إلى الإعدادات وشغِّل رقم المرور للمتابعة";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "عن";
 
+/* DashPay FAQ title */
+"About DashPay" = "حول DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "الامتناع";
+
+"Abstain on “%@”" = "امتنع بشأن ”%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "استرجاع الحساب";
 
+/* Masternode status */
+"Active" = "نشط";
+
+/* No comment provided by engineer. */
+"Activity" = "النشاط";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "النشاط علني لكن تتبّعه ليس سهلاً";
+
 /* No comment provided by engineer. */
 "Add" = "إضافة";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "إضافة %@ كجهة اتصال";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "أضف %@ كجهة اتصال لتدفع مباشرةً إلى اسم المستخدم وتحتفظ بسجل المعاملات المشترك";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "أضف %@ داش إلى رصيدك المحمي واتركه يستقر بضع ساعات لتسجّل دون ربط اسم المستخدم بأموالك الأخرى.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "أضف %@ داش على الأقل إلى رصيدك المحمي";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "أضف أموالاً إلى رصيدك المحمي الآن وسجّل اسم المستخدم بخصوصية بعد بضع ساعات";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "الكل";
 
+"All nodes at once" = "كل العقد دفعة واحدة";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "صوّتت جميع عقد الماسترنود لديك على اسم المستخدم هذا. لتغيير صوت، صوّت مجددًا من المتنافس الذي تفضّله الآن.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "مزامنة الأرصدة شبه فورية";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "المبالغ والعناوين علنية على البلوكشين";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "حساب إيثريوم هو عنوان واحد يُعاد استخدامه: رصيدك بالكامل وسجل مدفوعاتك يقعان علنًا تحته، والاسم (مثل نطاق ENS) يشير عادةً مباشرةً إلى ذلك العنوان ليتمكن أي شخص من تحليله. DashPay على النقيض تمامًا — الاسم يُحلّ إلى هوية لا إلى عنوان دفع، وتبقى عناوين الدفع الفعلية داخل تبادلات جهات اتصال مشفّرة، جديدة مع كل جهة اتصال.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "تجربة بديهية ومألوفة عبر جميع أجهزتك";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "أي شخص يعرف عنوانًا يمكنه الاطلاع على سجله";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "تطبيق";
 
+"Approve" = "الموافقة";
+
+"Approving a specific request can only be done one username at a time." = "لا يمكن الموافقة على طلب محدد إلا لاسم مستخدم واحد في كل مرة.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "كنص";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "أُلغي التحقق. لم يُدلَ بصوتك.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "فشل التحقق. لم يُدلَ بصوتك.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "امنح ”%@“ لهذا المتنافس";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "رصيد";
 
 /* CrowdNode */
+"Balance after" = "الرصيد بعد ذلك";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "الأرصدة والتحويلات ليست مرئية للعامة";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "تم حفظ ارتفاع البداية — يسري حد الفحص الأدنى المرفوع بدءًا من التشغيل التالي.";
+
 /* Voting */
 "Block" = "بلوك";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "مرتبط بعقد";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "مرتبط بعقد، نوع المستند ”%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "تصفّح فقط";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "يجمع سجلات التشخيص الأخيرة في ملف مضغوط لإرسالها عبر AirDrop أو البريد أو حفظها في الملفات";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "أدلِ بصوتك";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "تغيير الأقران";
 
 /* No comment provided by engineer. */
 "Change PIN" = "قم بتغيير الرقم السري";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "جارٍ التحقق…";
+
+"Choice" = "الخيار";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "استلم دعوتك";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "رصيد قابل للمطالبة";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "مسح وإعادة المزامنة";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "مسح بيانات السلسلة وإعادة المزامنة؟";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "قيد الإغلاق";
+
 /* Dash Portal */
 "Coinbase" = "كوين بيس";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (عملات جديدة)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "كود كوين بيس 2FA";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "لم يعد CoinJoin مدعومًا — اختر إلى أين تنقل عملاتك المخلوطة.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "الضمان";
+
+/* DashPay intro: feature title */
+"Coming soon" = "قريبًا";
+
+/* Shielded transfer status */
+"Completed" = "اكتمل";
 
 /* No comment provided by engineer. */
 "Confirm" = "تأكد";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "مؤكدة";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "يؤدي التأكيد إلى حفظ ارتفاع البداية %u ومسح بيانات السلسلة لهذه الشبكة عند التشغيل التالي للتطبيق، ثم إعادة تنزيلها وإعادة فحص المرشّحات من ذلك الارتفاع. تحتفظ الجلسة الحالية بحدّ الفحص القديم — أغلق التطبيق وافتحه من جديد لتبدأ.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "عنوان داش متصل";
 
+/* SPV sync */
+"Connected peers" = "الأقران المتصلون";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "السلبيات";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "فشل طلب جهة الاتصال";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "تم إرسال طلب جهة اتصال إلى %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "طلبات جهات الاتصال";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "المتنافس %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "استمر";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "تابع لاختيار اسم المستخدم. الدعوة تدفع رسوم التسجيل.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "نسخ المعاملة الخام";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "تعذّر إنشاء أرشيف السجلات: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "تعذر العثور على سعر الصرف.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "تعذّر تحديث %d هويات";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "تعذّر جلب الرصيد (خطأ في الشبكة). جرّب التحديث.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "أنشئ اسم المستخدم الخاص بك، واعثر على الأصدقاء والعائلة بأسماء مستخدميهم وأضفهم إلى جهات اتصالك";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "بطاقة إئتمان";
+
+/* Masternodes */
+"Credits" = "الأرصدة";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "لم تفهرس Dash Platform هذه المنافسة بعد. ستظهر أعداد الأصوات هنا بمجرد أن تفعل ذلك.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "لم يتم الاتصال بـ Dash Platform بعد. انتظر انتهاء المزامنة وحاول مجددًا.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "لا يمكن استرداد داش المرسلة إلى عنوان خاطئ. تأكد من أن العنوان هو بالضبط العنوان الذي تنوي الدفع إليه.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "تخزّن داش أسماء المستخدمين بصيغة آمنة ضد التشابه البصري، لذا قد يختلف الاسم المخزّن عمّا كتبه كل شخص.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "محفظة داش";
+
+/* CoinJoin */
+"Dash Wallet balance" = "رصيد محفظة داش";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "محفظة داش على هذا الجهاز";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "تم تفعيل DashPay";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay هي تجربة المدفوعات الاجتماعية من داش، مبنية على Dash Platform. تسجّل اسم مستخدم، وتضيف مستخدمين آخرين كجهات اتصال، وتدفع لهم بالاسم — لا حاجة لنسخ العناوين بعد الآن.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "يستبدل DashPay العناوين الطويلة الغامضة بأسماء المستخدمين. أضف الأصدقاء كجهات اتصال، وأرسل المال إلى اسم، واحتفظ بكل دفعة منظمة حسب الشخص.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "الموعد النهائي غير معروف";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "تم إرسال الإيداع";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "مسار الاشتقاق";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "معطّل";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "افصل حساب كوين بيس";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "تم";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "تم — استقرّ رصيدك مدة كافية";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "تحقق من العنوان مرتين";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "لكل عقدة ماسترنود صوت واحد فعّال في كل منافسة. يمكنك تغييره لاحقًا، لكن Dash Platform لا تسمح إلا بـ5 أصوات إجمالاً لكل عقدة ماسترنود في كل منافسة.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "كل نقرة تضيف عقدة أخرى إلى التصويت، فتختار كم عقدة تربطها معًا.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "قم بستاك داش بسهولة واكسب دخلًا سلبيًا ببضع نقرات بسيطة.";
+
+/* SPV diagnostics */
+"Edit birth height" = "تعديل ارتفاع البداية";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "البريد الإلكتروني";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "تفعيل";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "تفعيل DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "يكلّف تفعيل DashPay رسوم شبكة صغيرة لمرة واحدة، تُدفع من رصيد أرصدة هويتك. يُعرض التقدير الدقيق قبل التأكيد. أما إرسال طلبات جهات الاتصال والمدفوعات فيكلّف رسوم الشبكة المعتادة.";
+
+"Ending soonest" = "ينتهي أولاً";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "رسوم الشبكة التقديرية";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "تصوّت كل العقد معًا. أسرع، لكنه يربط عقد الماسترنود لديك ببعضها علنًا.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "مفاتيح مشغّل Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "تصدير السجلات";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "عنوان خارجي";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "محدد وجه التعريف";
+
+/* No comment provided by engineer. */
+"Failed" = "فشل";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "جارٍ الجلب…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "منقي";
+
+/* SPV sync phase */
+"Filter headers" = "ترويسات المرشّحات";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "ابحث عن مستخدم على شبكة داش";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "البحث عن الهويات";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "نسيت الرقم السري ؟";
 
+/* Identities */
+"Found %d new identities" = "تم العثور على %d هويات جديدة";
+
+/* Identities */
+"Found 1 new identity" = "تم العثور على هوية جديدة واحدة";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "موّل اسم المستخدم من رصيدك المحمي. أضف الأموال قبل بضع ساعات — فترة الاستقرار القصيرة تجعل اسم المستخدم غير قابل للربط ببقية داش لديك.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "مُموَّل من رصيدك المحمي — لا يمكن ربط اسم المستخدم ببقية داش لديك.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "الأموال مقفلة — جارٍ إنهاء التحويل";
+
+/* CoinJoin */
+"Funds moved" = "تم نقل الأموال";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "احصل على مكافآت من الودائع في Dash Masternodes بأقل من 0.5 داش.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "احصل على السعر";
+
+/* Usernames */
+"Get ready to join DashPay" = "استعد للانضمام إلى DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "احصل على المكافآت على الفور";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "فهمت";
+
+/* Governance */
+"Governance" = "الحوكمة";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "امنح أذونات GPS حتى نتمكن من إظهار المواقع القريبة منك.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "طلب أن يكون صديقك";
+
+/* DashPay Invitations */
+"Have an invitation?" = "هل لديك دعوة؟";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "تمتع بالتحكم الكامل وتخصيص محفظتك بناءً على احتياجاتك";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "الترويسات";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "الارتفاع %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "رسوم أعلى تقارب 7 سنتات (وما زالت أقل من بلوكشينات أخرى تقدّم خصوصية مماثلة)";
+
 /* No comment provided by engineer. */
 "History" = "التاريخ";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "كيف يقارَن هذا ببيتكوين من حيث الخصوصية؟";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "كيف يقارَن هذا بحسابات إيثريوم من حيث الخصوصية؟";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "ما مدى خصوصية DashPay؟";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "كيفية تأكيد عنوان API Dash الخاص بك";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "كتبتها";
 
+/* Identities */
+"Identities" = "الهويات";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "أرصدة الهوية";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "فهرس الهوية";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "تسجيل الهوية";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "شحن الهوية";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "غير نشط";
+
+/* No comment provided by engineer. */
 "Income" = "دخل";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "المدخل %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "المدخل %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "المدخلات (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "رصيد غير كاف";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "دعوة من %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "ادعُ شخصًا للانضمام إلى شبكة داش";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "ادعُ أصدقاءك وعائلتك إلى شبكة داش";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "الانضمام إلى المجموعة";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "أبقِ هذه العملات خاصة. تُطبَّق رسوم الشبكة ورسوم الخصوصية.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "المفتاح رقم %d";
+
+/* Identities: the public key bytes */
+"Key data" = "بيانات المفتاح";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "ملكية المفتاح";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "المفاتيح";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "متقدم";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "اعرف المزيد";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "جارٍ تحميل المعاملات";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "العملة المحلية";
 
+/* Identities */
+"Local Only" = "محلي فقط";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "الموقع";
 
+"Lock" = "قفل";
+
+"Lock the name" = "قفل الاسم";
+
+"Lock “%@” so nobody gets it" = "اقفل ”%@“ حتى لا يحصل عليه أحد";
+
 /* No comment provided by engineer. */
 "Locked" = "مقفول";
 
+"Locked — nobody receives this username" = "مقفل — لن يحصل أحد على اسم المستخدم هذا";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "منخفض";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "رسوم منخفضة للإنفاق اليومي";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "رئيسية";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "سلسلة مفاتيح الماسترنود";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "مفاتيح ماسترنود";
+
+/* SPV sync phase */
+"Masternode list" = "قائمة الماسترنود";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "ماسترنود";
 
+"Masternode votes" = "أصوات الماسترنود";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "الماسترنود";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "ستظهر هنا عقد الماسترنود وعقد Evonode المسجّلة بمفاتيح هذه المحفظة بعد مزامنة المحفظة.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "عقد الماسترنود وعقد Evonode التي تستخدم مفاتيح هذه المحفظة";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "تصوّت عقد الماسترنود على الأسماء التي طلبها أكثر من شخص. سيتم إشعارك عند انتهاء التصويت.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "الحد الأقصى";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "تم بلوغ الحد الأدنى";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "المزيد من التحكم";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "المزيد من الاقتراحات";
+
+"Most lock votes" = "الأكثر أصوات قفل";
+
+"Most votes" = "الأكثر أصواتًا";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "انقلها إلى رصيدك العادي القابل للإنفاق.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "جارٍ نقل الأموال";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "اسم";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "خدمات الأسماء مثل Unstoppable Domains تربط اسمًا مقروءًا بعنوان علني ثابت على السلسلة. يستطيع أي شخص تحليل الاسم ورؤية كل دفعة أُرسلت إليه على الإطلاق. أما اسم مستخدم DashPay فلا يُحلّ علنًا إلى عنوان دفع أبدًا — تُكشف العناوين فقط داخل التبادل المشفّر مع كل جهة اتصال، فيبقى اسمك وأموالك غير مرتبطين بالنسبة للمراقبين من الخارج.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "يحتاج إلى انتباه";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "لم يُعثر على سجلات تشخيص على هذا الجهاز. تُكتب السجلات بدءًا من التشغيل التالي.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "لا توجد هويات";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "لا توجد عقد ماسترنود بعد";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "لا توجد منافسات مطابقة";
+
+/* Identities */
+"No new identities were found for this wallet" = "لم يُعثر على هويات جديدة لهذه المحفظة";
+
+"No open contest matches that search." = "لا توجد منافسة مفتوحة تطابق هذا البحث.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "لا توجد منافسة مفتوحة تطابق هذا البحث. تُخزَّن الأسماء بصيغة موحّدة، لذا تُدرَج ”alice“ باسم ”a11ce“.";
+
+"No open contests" = "لا توجد منافسات مفتوحة";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "لم يُعثر على سجل محفظة محفوظ للمحفظة المرتبطة.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "لا يتوفر بعد عنوان Platform للتسجيل المحمي البديل. حاول مجددًا بعد انتهاء مزامنة المحفظة.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "لم يتم العثور على نتائج";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "لا يوجد حاليًا اسم مستخدم متنازع عليه. تُفتح المنافسة عندما يطلب شخصان أو أكثر الاسم نفسه.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "لم يُدلَ بأي أصوات";
+
+"Nobody gets it" = "لا يحصل عليه أحد";
+
+/* SPV sync peer type */
+"Node" = "عقدة";
+
+/* Raw transaction inspector */
+"Non-standard" = "غير قياسي";
 
 /* adjective, security level */
 "None" = "لا يوجد";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "غير متاح";
 
+"Not available yet" = "غير متاح بعد";
+
+"Not cast" = "لم يُدلَ به";
+
+/* Masternodes */
+"Not checked yet" = "لم يُفحص بعد";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "الرصيد المحمي غير كافٍ لتسجيل هوية";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "غير موجود في سجل المحفظة";
+
+"Not now" = "ليس الآن";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "غير مقبول على نطاق واسع لدى التجار";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "غير مقبول بعد على نطاق واسع لدى التجار";
+
+/* Masternode keys */
+"Not yet used" = "لم يُستخدم بعد";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "لا توجد في بيتكوين طبقة أسماء، لذا يشارك الناس العناوين ويعيدون استخدامها علانيةً — وبمجرد أن يُعرف عنوان، يصبح كل ما استلمه قابلاً للربط بمالكه. مع DashPay يكون اسم المستخدم علنيًا لكنه لا يشير أبدًا إلى عنوان دفع: تُتبادل العناوين بشكل خاص مع كل جهة اتصال وتتناوب، فالدفع بالاسم لا يكشف إلى أين تذهب أموالك. كلتاهما سلسلتان شفافتان، لذا يظل تحليل السلسلة ساريًا على العملات نفسها.";
+
+/* Identities */
+"On Network" = "على الشبكة";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "بمجرد أن يقبل %@ طلبك ستتمكن من الدفع مباشرةً إلى اسم المستخدم";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "عقدة واحدة في كل مرة";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "لا يمكن التصويت على أسماء المستخدمين إلا لعقد الماسترنود وعقد Evonode. لا تحتوي هذه المحفظة على مفاتيح تصويت ماسترنود نشطة.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "المشغّل";
+
+/* Masternode keys */
+"Operator keys" = "مفاتيح المشغّل";
+
+/* Masternodes */
+"Operator public key (BLS)" = "المفتاح العام للمشغّل (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "أو";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "معاينة الطلب";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "نتائج أخرى";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "المخرج %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "المخرجات (%d)";
+
+/* Masternodes */
+"Owner" = "المالك";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "عنوان المالك";
+
+/* Masternodes */
+"Owner key hash" = "بصمة مفتاح المالك";
 
 /* No comment provided by engineer. */
 "Owner keys" = "مفاتيح المالك";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "مدفوعة من رصيد أرصدة هويتك.";
 
 /* DashSpend */
 "Password" = "كلمة المرور";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "الصق رابط الدعوة الذي استلمته، أو امسح رمز QR الخاص به. إنه يموّل تسجيل اسم المستخدم الخاص بك.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "ادفع واحصل على المال على الفور مع تدفقات دفع سهلة الاستخدام";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "الدفع مباشرةً إلى اسم المستخدم";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "ادفع للأشخاص لا للعناوين";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "الحمولة (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "طريقة الدفع ";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "المدفوعات خاصة: العناوين التي تتبادلها مع جهة اتصال تنتقل داخل حمولة مشفّرة لا يستطيع قراءتها سواكما، ولا تُنشر أبدًا — لذا لا يمكن ربط مدفوعاتك باسم المستخدم بسهولة. غير أنها تبقى مدفوعات عادية على سلسلة شفافة: قد يكشف تحليل سلسلة متقدم بعض المعلومات. وسيسدّ Shielded DashPay (قريبًا) هذه الفجوة. أما طلبات جهات الاتصال نفسها فليست خاصة حاليًا: يستطيع أي شخص أن يرى أن هويتين مرتبطتان. وطلبات جهات الاتصال الخاصة ميزة قادمة قريبًا. كما أن اسم المستخدم وملفك الشخصي علنيان أيضًا على Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "تُؤكَّد المدفوعات خلال ثوانٍ مع InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "لن يُحتفظ في النشاط بالمدفوعات التي تُجرى مباشرةً إلى العناوين.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "تُجمَّع المدفوعات مع كل جهة اتصال في مكان واحد، بالأسماء والملفات الشخصية بدلاً من المعاملات الخام.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "عنوان الصرف";
 
 /* CrowdNode */
 "Payout Options" = "خيارات الدفع";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "عنوان Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "رصيد Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "عقدة Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "معرّف عقدة Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "لا تحدّد مدفوعات Platform هوية المرسل. سُجّلت هذه الدفعة عندما لاحظت المحفظة تغيّر الرصيد — وقد تكون وصلت قبل ذلك.";
+
+"Platform SDK not ready" = "‏SDK الخاص بـ Platform غير جاهز";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "مزامنة Platform لا تعمل. افتح معلومات المزامنة ← حالة مزامنة Platform لبدئها.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform ← محمي";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "استُخدم سابقًا في: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "خاص بحكم التصميم";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "طلبات جهات الاتصال الخاصة (لتبقى هوية من تتواصل معهم خاصة)، وShielded DashPay — مدفوعات جهات الاتصال من رصيدك المحمي الخاص — والدفع لمستخدمين ليسوا بعد ضمن جهات اتصالك، كلها قادمة قريبًا.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "طلبات جهات الاتصال الخاصة قيد التطوير ومتوقعة نحو سبتمبر–أكتوبر 2026. اليوم يكون الطلب نفسه علنيًا — يستطيع أي شخص أن يرى أن هويتين مرتبطتان، حتى وإن كانت تفاصيل الدفع بداخله مشفّرة. وعند إطلاق طلبات جهات الاتصال الخاصة، سيكون بإمكانك اختيار جعل صداقتك علنية أو خاصة.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "طلبات جهات اتصال خاصة، وShielded DashPay، والدفع لأشخاص ليسوا بعد ضمن جهات اتصالك.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "تُتبادل عناوين الدفع الخاصة بينك وبين جهات اتصالك. أنت وجهة اتصالك وحدكما تعرفان مستلم ومرسل المدفوعات فيما بينكما.";
+
+/* DashPay intro: feature title */
+"Private payments" = "مدفوعات خاصة";
+
+/* Usernames */
+"Private registration" = "تسجيل خاص";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "مدة المعالجة";
+
+/* Balance info sheet section */
+"Pros" = "الإيجابيات";
 
 /* CrowdNode Portal */
 "Protect your savings" = "حماية مدخراتك";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "معاملات المزوّد";
+
+/* Masternode keys */
+"Public key" = "المفتاح العام";
+
+/* Masternode keys */
+"Public key (legacy)" = "المفتاح العام (قديم)";
+
+/* Identities */
+"Public keys" = "المفاتيح العامة";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "الشراء لم ينجح";
+
+/* Identities: what a public key is used for */
+"Purpose" = "الغرض";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "المعاملة الخام";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "المعاملة الخام غير متاحة";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "يعيد فحص مرشّحات الكتل المدمجة بدءًا من الارتفاع المختار بحثًا عن معاملات هذه المحفظة، بإعادة تنزيلها ومطابقتها من جديد. يقتصر حد إعادة الفحص الأدنى على ارتفاع إنشاء المحفظة وعلى بيانات السلسلة المخزّنة محليًا — ولاسترجاع السجل الأقدم من ذلك، اخفض ارتفاع بداية المحفظة بدلاً من ذلك.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "قراءة سياسة السحب";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "للقراءة فقط";
+
+/* Usernames */
+"Ready around %@" = "جاهز نحو %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "السبب";
 
 /* No comment provided by engineer. */
 "Receive" = "إستقبال";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "مستلمة من %@";
+
 /* CrowdNode */
 "Receiving rewards" = "استلام المكافآت";
+
+"Records your masternodes as having voted, without taking a side." = "يسجّل عقد الماسترنود لديك على أنها صوّتت، دون الانحياز لأي طرف.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "تحديث";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "مسجّل في";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "يتطلب التسجيل الخاص %@ داش على الأقل في رصيدك المحمي إضافةً إلى بضع ساعات من الاستقرار — والشاشات التالية سترشدك خلال ذلك.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "التسجيل";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "يطلب هذا الاسم";
+
 /* An action */
 "Rescan" = "إعادة تفحص";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "لا تستطيع المحافظ المستعادة دائمًا استرجاع نوع العملية. أُعيد بناء هذا السجل من بيانات الملاحظة على السلسلة.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "تم تجهيز إعادة المزامنة من الارتفاع %u — أغلق التطبيق وافتحه من جديد لتبدأ.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "الاحتفاظ بسجل المعاملات المشترك";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "متقاعد";
 
 /* No comment provided by engineer. */
 "Retry" = "إعادة المحاولة";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "الإبطال";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "تكون لقطات الشاشة مرئية للتطبيقات والأجهزة الأخرى. إنشاء كلمة الإستراد جديدة والحفاظ على سريتها.";
 
+/* Raw transaction inspector */
+"Script" = "السكربت";
+
+/* Raw transaction inspector */
+"Script signature" = "توقيع السكربت";
+
+/* Raw transaction inspector */
+"Script type" = "نوع السكربت";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "ابحث عن جهة اتصال";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "ابحث عن طلب جهة اتصال";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "ابحث عن مستخدم على شبكة داش";
+
+/* No comment provided by engineer. */
+"Search for a username" = "ابحث عن اسم مستخدم";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "نتائج البحث عن \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "ابحث في أسماء المستخدمين";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "جارٍ البحث عن اسم المستخدم %@ على شبكة داش";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "مستوى الأمان";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "مستوى الأمان";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "تحديد الكل";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "اختر عقدة ماسترنود واحدة على الأقل للتصويت بها.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "اختر عملة ";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "اختيار عدد أقل من العقد يكشف أقل عن عقد الماسترنود التي تشغّلها.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "إرسال الى";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "الإرسال إلى جهة اتصال";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "أرسل إلى اسم مستخدم يمكنك فعلاً تذكّره والتحقق منه.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "أرسل أول طلب جهة اتصال لك";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "جاري الإرسال";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "جارٍ إرسال طلب جهة الاتصال";
+
+/* No comment provided by engineer. */
+"Sending to" = "الإرسال إلى";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "الإرسال إلى حساب CrowdNode";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "أرسلت الى";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "أُرسلت إلى %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "الخدمة";
+
+/* Identities */
+"Set as Main" = "تعيين كرئيسية";
+
+/* Identities */
+"Set as Main Identity" = "تعيين كهوية رئيسية";
 
 /* No comment provided by engineer. */
 "Set PIN" = "قم بتعيين الرقم السري";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "بلغ تجمّع الخصوصية المشترك حده الأدنى";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "عنوان محمي";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "إنفاق محمي";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "جارٍ تشغيل المحفظة المحمية…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "محمي ← Platform";
+
+"Shielded → Transparent" = "محمي ← شفاف";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "الحجم";
+
 /* No comment provided by engineer. */
 "Skip" = "تخطي";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "قد تكون بعض عقد الماسترنود لديك مفقودة من هذه القائمة — إذ تعذّر على المحفظة قراءة مجموعة مفاتيح التصويت كاملة. أكمل المزامنة ثم افتح هذه الشاشة من جديد.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "ترتيب حسب";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "فرز جهات الاتصال";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "حمولة خاصة";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "حدد المبلغ";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "ستاكنج";
 
+/* Usernames */
+"Starts after you add funds" = "يبدأ بعد إضافة الأموال";
+
+/* Transaction details */
+"Status" = "الحالة";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "مخزّن باسم";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "المزامنة جارية... قد لا تكون النتائج كاملة.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "معلومات المزامنة";
+
+/* SPV sync */
+"Sync too slow?" = "المزامنة بطيئة جدًا؟";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "عدم الانحياز لأي طرف";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "اضغط على العنوان من لوحة الملاحظات للصقه";
+
+/* Raw transaction inspector */
+"Tap to copy" = "انقر للنسخ";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "اضغط لاخفاء الرصيد";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "مفتاح عقدة Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "الرمز غير صحيح. يرجى مراجعة وحاول مرة أخرى!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "تصل داش إلى عنوان المستلم بعد أن تعالج الشبكة السحب — وقد يستغرق ذلك حتى 10 دقائق.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "تصل داش إلى عنوان المستلم بمجرد أن تعالج الشبكة السحب.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "تصل داش إلى رصيدك الشفاف بمجرد أن تعالج الشبكة السحب.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "لا يمكن اختيار الهوية الرئيسية إلا من المحفظة النشطة";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "أكثر الأماكن خصوصية للاحتفاظ بداش الخاصة بك";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "سجل المحفظة المحفوظ ليس له شبكة — تعذّر تجهيز إعادة المزامنة.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "أُرسل التسجيل لكن تعذّر تأكيد نتيجته. انتظر دقيقة حتى تتزامن المحفظة ثم حاول مجددًا — ولا تعِد الإرسال فورًا.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "لا يزال تجمّع الخصوصية المشترك ينمو (%1$ld من %2$ld إيداعات). يُفتح التسجيل الخاص بمجرد بلوغه الحد الأدنى.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "لا يزال تجمّع الخصوصية المشترك ينمو (%1$ld من %2$ld إيداعات). حاول مجددًا بمجرد بلوغه الحد الأدنى.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "ارتفاع إنشاء المحفظة — الحد الأدنى لفحوصات المرشّحات ولعمليات إعادة الفحص ”من إنشاء المحفظة“. اضبطه عند أول تمويل للمحفظة أو أقل منه؛ وتستخدم عمليات الاستيراد افتراضيًا 200000 على mainnet و0 على testnet. حفظ ارتفاع مساوٍ للحالي أو أقل منه يمسح بيانات السلسلة لهذه الشبكة عند التشغيل التالي ويعيد الفحص منه.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "له (جارٍ جلب المعلومات)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "لا توجد إشعارات جديدة";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "لا توجد معاملات لعرضها";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "لا يوجد مستخدمون يطابقون الاسم %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "لا يوجد في جهات اتصالك مستخدمون يطابقون الاسم %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "تنتقل هذه الأموال إلى رصيد Platform وتصبح جاهزة للإنفاق بمجرد اكتمال التحويل.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "لا يمكن الدفع إلى هذا العنوان من رصيد %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "يضيف هذا مفتاحين إلى هويتك ليتمكن مستخدمون آخرون من إرسال طلبات جهات اتصال إليك، ولتتمكن أنت من قبول طلباتهم. يحدث هذا مرة واحدة فقط.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "يطبّق هذا خيارًا واحدًا على جميع أسماء المستخدمين المحددة البالغ عددها %d.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "توضح هذه الخطوة الإضافية أنك تحاول حقًا إجراء معاملة.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "رابط الدعوة هذا غير صالح.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "هذا ليس عنوان داش صالحًا لهذه الشبكة";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "هذا ليس رابط دعوة صالحًا";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "هذه هي هويتك الرئيسية";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "لا تملك عقدة الماسترنود هذه هوية Platform بعد.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "يمثل هذا النسبة المئوية السنوية الحالية لعائد ماسترنود كامل مطروحًا منه رسوم CrowdNode البالغة 15٪. إنه ليس معدل عائد مضمون وقد يرتفع أو ينخفض بناءً على حجم مجمعات CrowdNode وسعر داش.";
 
+"This still counts as your masternodes having voted in this contest." = "يُحتسب هذا مع ذلك على أن عقد الماسترنود لديك قد صوّتت في هذه المنافسة.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "البايتات الخام لهذه المعاملة غير مخزّنة على هذا الجهاز.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "ذهب اسم المستخدم هذا إلى شخص آخر";
+
+"This wallet could not derive the voting key for this node." = "تعذّر على هذه المحفظة اشتقاق مفتاح التصويت لهذه العقدة.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "لا تحتوي هذه المحفظة على مفاتيح تصويت ماسترنود نشطة، لذا لا يمكنها التصويت. تظهر العقد المسجّلة ضمن الأدوات ← الماسترنود.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "يسحب هذا كامل رصيد Platform في تحويل واحد. تصل داش إلى عنوان المستلم بمجرد أن تعالج الشبكة السحب.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "يسحب هذا كامل رصيد Platform في تحويل واحد. تصل داش إلى رصيدك الشفاف بمجرد أن تعالج الشبكة السحب.";
 
 /* Send Screen: to address */
 "to" = "إلى";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "تاريخ المعاملات";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "سجل المعاملات غير متاح";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "معرّف المعاملة";
 
 /* A verb, button title. */
 "Transfer" = "نقل";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "تحويل وارد";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "تحويل صادر";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "تستغرق التحويلات وقتًا أطول — إذ يحتاج بناء براهين الخصوصية إلى وقت";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "التحويلات إلى عناوين Platform الأخرى وإلى العناوين المحمية فورية ونهائية";
+
+/* Balance breakdown */
+"Transparent" = "شفاف";
+
+/* Send screen destination type */
+"Transparent address" = "عنوان شفاف";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "رصيد شفاف";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "التمويل الشفاف يربط اسم المستخدم بهذه الأموال علنًا.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "شفاف ← Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "شفاف ← محمي";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "تعذّر تقديم اقتراحات";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "نوع خاص غير معروف %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "غير محمي";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "الترقية إلى Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "دعم";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "استخدم الرصيد الشفاف بدلاً من ذلك";
+
+/* Masternode keys */
+"Used" = "مستخدم";
+
+/* Masternode keys */
+"Used at: " = "استُخدم في: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "المستخدم (جارٍ جلب المعلومات)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "أسماء المستخدمين";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "تُخزَّن أسماء المستخدمين بصيغة موحّدة لمنع الأسماء المتشابهة، لذا قد يختلف هذا عمّا كتبه كل شخص.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "أسماء مستخدمين لا عناوين";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "المستخدمون الذين يطابقون %@ وليسوا حاليًا ضمن جهات اتصالك";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "يستخدم إحدى أكثر مكتبات المعرفة الصفرية تدقيقًا واختبارًا (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "دعوة صالحة";
+
 /* CrowdNode Portal */
 "Validating address…" = "التحقق من صحة العنوان ...";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "التحقق مطلوب";
 
+/* Usernames */
+"Verified during registration" = "تم التحقق أثناء التسجيل";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "تم التحقق بنجاح";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "الإصدار";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "كفاءة عالية جدًا مع رسوم منخفضة";
+
 /* adjective, security level */
 "Very High" = "مرتفع جداً";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "سيتم إرسال كميات صغيرة جدًا من داش من وإلى CrowdNode للتحقق من أنك مالك عنوان المحفظة هذا.";
+
+/* No comment provided by engineer. */
+"View All" = "عرض الكل";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "عرض عبارة الاسترداد";
 
+/* Raw transaction inspector */
+"View Transaction" = "عرض المعاملة";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "تصويت";
+
+"Vote cast" = "تم الإدلاء بالصوت";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "صوّت على أسماء المستخدمين المتنازع عليها";
+
+"Vote on several" = "التصويت على عدة أسماء";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "صوّت باستخدام";
+
+"Votes that nobody should receive these usernames." = "يصوّت بألا يحصل أحد على أسماء المستخدمين هذه.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "عنوان التصويت";
+
+"Voting ended with no winner" = "انتهى التصويت دون فائز";
+
+"Voting ends" = "ينتهي التصويت";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "التصويت جارٍ";
+
+"Voting in progress — lock votes are ahead" = "التصويت جارٍ — أصوات القفل متقدمة";
+
+"Voting in progress — you are ahead" = "التصويت جارٍ — أنت متقدم";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "بصمة مفتاح التصويت";
+
 /* No comment provided by engineer. */
 "Voting keys" = "مفاتيح التصويت";
+
+"Voting on this username has closed. The counts below are the last ones read." = "أُغلق التصويت على اسم المستخدم هذا. الأعداد أدناه هي آخر ما تمت قراءته.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "أُغلق التصويت على ”%@“ بالفعل. حدّث لعرض النتيجة.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "في انتظار Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "عنوان المحفظة ";
+
+/* SPV diagnostics */
+"Wallet birth height" = "ارتفاع بداية المحفظة";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "المحفظة معطلة";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "ماذا عن Unstoppable Domains وخدمات الأسماء المشابهة؟";
+
+/* DashPay FAQ */
+"What does it cost?" = "كم تبلغ التكلفة؟";
+
+/* DashPay FAQ */
+"What is DashPay?" = "ما هو DashPay؟";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "ما القادم؟";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "متى ستصبح طلبات جهات الاتصال خاصة؟";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "أين تنفق؟";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "أين تنفق؟";
+
+"Who is requesting this name" = "من يطلب هذا الاسم";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "لماذا أحتاج إلى تفعيله؟";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "لماذا أرى كل هذه المعاملات؟";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "طلب سحب";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "يسحب الرصيد بالكامل";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "يعمل مع كل محفظة داش ومنصة تداول وتاجر";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "في الامس";
+
+"You" = "أنت";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "قبلت طلب جهة الاتصال من %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "ليس لديك أي جهات اتصال في الوقت الحالي";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "ليس لديك رصيد كافي لإتمام هذه المعاملة";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "لقد تجاوزت حد التفويض على كوين بيس.";
+
+/* Usernames */
+"You have %@ Dash so far" = "لديك %@ داش حتى الآن";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "أرسلت طلب جهة الاتصال إلى %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "يجب أن يكون لديك رصيد إيجابي في محفظة داش";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "لقد فزت باسم المستخدم هذا";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "كل شيء جاهز. يمكن للمستخدمين الآخرين الآن إرسال طلبات جهات اتصال إليك — ويمكنك إرسال طلباتك.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "تظهر هوية Dash Platform الخاصة بك هنا بمجرد تسجيلك اسم مستخدم.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "سجلك، منظّمًا";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "تحتاج هويتك إلى مفتاحين إضافيين حتى يمكن تشفير طلبات جهات الاتصال بينك وبين المستخدمين الآخرين. يضيفهما التفعيل بمعاملة شبكة واحدة. يحدث هذا مرة واحدة فقط.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "دعوتك تدفع رسوم التسجيل لاسم المستخدم هذا.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "رصيد داش الرئيسي لديك على بلوكشين Core — ما ترسله وتستلمه مع المحافظ ومنصات التداول والتجار الآخرين.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "نُقلت عملاتك المخلوطة إلى رصيد محفظة داش.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "نُقلت عملاتك المخلوطة إلى رصيدك المحمي. لأفضل خصوصية، انتظر ساعتين على الأقل قبل استخدام هذه الأموال.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "رصيد Platform الخاص بك";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "عنوان داش الأساسي الذي تستخدمه حاليًا لحساب CrowdNode الخاص بك";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "رصيدك الخاص. المبالغ والعناوين مشفّرة على السلسلة، فتبقى ممتلكاتك وسجلك سريّين.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "رصيدك المحمي";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "رصيدك المحمي شبه جاهز — يمكنك التسجيل بخصوصية نحو %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "رصيدك المحمي جاهز — سجّل اسم المستخدم بخصوصية الآن";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "رصيدك المحمي يستقر — يمكنك التسجيل بخصوصية نحو %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "لا يزال رصيدك المحمي ينضج. سيكون جاهزًا نحو %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "رصيدك الشفاف";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "اسم المستخدم الخاص بك مرئي للجميع. تمويله من رصيدك المحمي — بعد ترك الأموال تستقر بضع ساعات — يعني أنه لا يمكن لأحد ربط اسم المستخدم ببقية داش لديك.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "اسم المستخدم وملفك الشخصي وجهات اتصالك تتبع هذه الهوية.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "سيتبع اسم المستخدم وملفك الشخصي وجهات اتصالك هذه الهوية.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "أصواتك";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "محفظتك مؤمنة الآن. يمكنك استخدام عبارة الاسترداد في أي وقت لاسترداد حسابك على جهاز آخر.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "لا تزال محفظتك تتزامن مع شبكة داش. سيتاح الإرسال بمجرد اكتمال المزامنة.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "لا تزال محفظتك تتزامن. سيتاح الإرسال من رصيدك الشفاف بمجرد اكتمال المزامنة.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "تعذّرت قراءة ”%@“ كاسم مستخدم داش.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "تم تسجيل ”%@“. هل تريد إرسال طلب جهة اتصال إلى الشخص الذي دعاك؟";

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "كل العقد دفعة واحدة";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "صوّتت جميع عقد الماسترنود لديك على اسم المستخدم هذا. لتغيير صوت، صوّت مجددًا من المتنافس الذي تفضّله الآن.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "صوّتت جميع عقد الماسترنود لديك على اسم المستخدم هذا. لتغيير صوت، صوّت مجددًا للمتنافس الذي تفضّله الآن.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ar.lproj/Localizable.stringsdict
+++ b/DashWallet/ar.lproj/Localizable.stringsdict
@@ -82,5 +82,365 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ محتسبة لـ «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>zero</key>
+			<string>%1$u صوت</string>
+			<key>one</key>
+			<string>%1$u صوت</string>
+			<key>two</key>
+			<string>%1$u صوتان</string>
+			<key>few</key>
+			<string>%1$u أصوات</string>
+			<key>many</key>
+			<string>%1$u صوتًا</string>
+			<key>other</key>
+			<string>%1$u صوت</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>تم التصويت على %1$d من %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%2$d اسم مستخدم</string>
+			<key>one</key>
+			<string>%2$d اسم مستخدم</string>
+			<key>two</key>
+			<string>%2$d اسمي مستخدم</string>
+			<key>few</key>
+			<string>%2$d أسماء مستخدمين</string>
+			<key>many</key>
+			<string>%2$d اسم مستخدم</string>
+			<key>other</key>
+			<string>%2$d اسم مستخدم</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>zero</key>
+			<string>أدلِ بـ %u صوت</string>
+			<key>one</key>
+			<string>أدلِ بـ %u صوت</string>
+			<key>two</key>
+			<string>أدلِ بـ %u صوتين</string>
+			<key>few</key>
+			<string>أدلِ بـ %u أصوات</string>
+			<key>many</key>
+			<string>أدلِ بـ %u صوتًا</string>
+			<key>other</key>
+			<string>أدلِ بـ %u صوت</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>صوّت %1$d من %#@nodes@</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%2$d ماسترنود</string>
+			<key>one</key>
+			<string>%2$d ماسترنود</string>
+			<key>two</key>
+			<string>%2$d ماسترنود</string>
+			<key>few</key>
+			<string>%2$d عقد ماسترنود</string>
+			<key>many</key>
+			<string>%2$d عقدة ماسترنود</string>
+			<key>other</key>
+			<string>%2$d ماسترنود</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>صوّت %1$d من %#@nodes@</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%2$d عقدة</string>
+			<key>one</key>
+			<string>%2$d عقدة</string>
+			<key>two</key>
+			<string>%2$d عقدتان</string>
+			<key>few</key>
+			<string>%2$d عقد</string>
+			<key>many</key>
+			<string>%2$d عقدة</string>
+			<key>other</key>
+			<string>%2$d عقدة</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d evonode</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>two</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>many</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>zero</key>
+			<string>%u صوت في المجموع</string>
+			<key>one</key>
+			<string>%u صوت في المجموع</string>
+			<key>two</key>
+			<string>%u صوتان في المجموع</string>
+			<key>few</key>
+			<string>%u أصوات في المجموع</string>
+			<key>many</key>
+			<string>%u صوتًا في المجموع</string>
+			<key>other</key>
+			<string>%u صوت في المجموع</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d ماسترنود</string>
+			<key>one</key>
+			<string>%d ماسترنود</string>
+			<key>two</key>
+			<string>%d ماسترنود</string>
+			<key>few</key>
+			<string>%d عقد ماسترنود</string>
+			<key>many</key>
+			<string>%d عقدة ماسترنود</string>
+			<key>other</key>
+			<string>%d ماسترنود</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d محدد</string>
+			<key>one</key>
+			<string>%d محدد</string>
+			<key>two</key>
+			<string>%d محددان</string>
+			<key>few</key>
+			<string>%d محددة</string>
+			<key>many</key>
+			<string>%d محددًا</string>
+			<key>other</key>
+			<string>%d محدد</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+			<key>one</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+			<key>two</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+			<key>few</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+			<key>many</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+			<key>other</key>
+			<string>%d من عقدك صوّتت هنا بالفعل ولا تظهر في القائمة.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>zero</key>
+			<string>%u صوت لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+			<key>one</key>
+			<string>%u صوت لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+			<key>two</key>
+			<string>%u صوتان لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+			<key>few</key>
+			<string>%u أصوات لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+			<key>many</key>
+			<string>%u صوتًا لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+			<key>other</key>
+			<string>%u صوت لكل منافسة — تُحتسب عقد evonode بـ4 وعقد الماسترنود بـ1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>التصويت على %d اسم مستخدم</string>
+			<key>one</key>
+			<string>التصويت على %d اسم مستخدم</string>
+			<key>two</key>
+			<string>التصويت على %d اسم مستخدم</string>
+			<key>few</key>
+			<string>التصويت على %d اسم مستخدم</string>
+			<key>many</key>
+			<string>التصويت على %d اسم مستخدم</string>
+			<key>other</key>
+			<string>التصويت على %d اسم مستخدم</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>zero</key>
+			<string>%u صوت</string>
+			<key>one</key>
+			<string>%u صوت</string>
+			<key>two</key>
+			<string>%u صوتان</string>
+			<key>few</key>
+			<string>%u أصوات</string>
+			<key>many</key>
+			<string>%u صوتًا</string>
+			<key>other</key>
+			<string>%u صوت</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>تصويت ×%d</string>
+			<key>one</key>
+			<string>تصويت ×%d</string>
+			<key>two</key>
+			<string>تصويت ×%d</string>
+			<key>few</key>
+			<string>تصويت ×%d</string>
+			<key>many</key>
+			<string>تصويت ×%d</string>
+			<key>other</key>
+			<string>تصويت ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%d طلب</string>
+			<key>one</key>
+			<string>%d طلب</string>
+			<key>two</key>
+			<string>%d طلبان</string>
+			<key>few</key>
+			<string>%d طلبات</string>
+			<key>many</key>
+			<string>%d طلبًا</string>
+			<key>other</key>
+			<string>%d طلب</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ar.lproj/Localizable.stringsdict
+++ b/DashWallet/ar.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ محتسبة لـ «%2$@»</string>
+		<string>%#@votes@ لـ «%2$@»</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,17 +93,17 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>zero</key>
-			<string>%1$u صوت</string>
+			<string>%1$u صوت محتسب</string>
 			<key>one</key>
-			<string>%1$u صوت</string>
+			<string>%1$u صوت محتسب</string>
 			<key>two</key>
-			<string>%1$u صوتان</string>
+			<string>%1$u صوتان محتسبان</string>
 			<key>few</key>
-			<string>%1$u أصوات</string>
+			<string>%1$u أصوات محتسبة</string>
 			<key>many</key>
-			<string>%1$u صوتًا</string>
+			<string>%1$u صوتًا محتسبًا</string>
 			<key>other</key>
-			<string>%1$u صوت</string>
+			<string>%1$u صوت محتسب</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -157,7 +157,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>صوّت %1$d من %#@nodes@</string>
+		<string>التصويت: %1$d من %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -181,7 +181,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>صوّت %1$d من %#@nodes@</string>
+		<string>التصويت: %1$d من %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " или ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ не беше намерен в мрежата Dash, за да му бъде изпратена заявка за контакт.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash налични";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ прие вашата заявка за контакт";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d байта";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld от %ld депозита";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Кредитен баланс в Dash Platform, който се използва за незабавни плащания между адреси в Platform и за функции като потребителските имена.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Необходима е парола на устройството за опазване на портфейла Ви. Отидете в настройки и включете използването на парола, за да продължите.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Относно";
 
+/* DashPay FAQ title */
+"About DashPay" = "Относно DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Въздържане";
+
+"Abstain on “%@”" = "Въздържане по „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Активен";
+
+/* No comment provided by engineer. */
+"Activity" = "Активност";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Активността е публична, но не се проследява лесно";
+
 /* No comment provided by engineer. */
 "Add" = "Добави";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Добавяне на %@ като контакт";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Добавете %@ като контакт, за да плащате директно на потребителско име и да запазвате общата история на транзакциите";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Добавете %@ Dash към защитения си баланс и го оставете да отлежи няколко часа, за да се регистрирате, без да свързвате потребителското си име с останалите си средства.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Добавете поне %@ Dash към защитения си баланс";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Захранете защитения си баланс сега и регистрирайте потребителското си име поверително след няколко часа";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Всички";
 
+"All nodes at once" = "Всички възли наведнъж";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Всички ваши мастерноди са гласували за това потребителско име. За да промените глас, гласувайте отново от кандидата, който предпочитате сега.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Почти мигновено синхронизиране на балансите";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Сумите и адресите са публични в блокчейна";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Един Ethereum акаунт е един-единствен адрес за многократна употреба: целият ви баланс и историята на плащанията стоят публично под него, а името (например ENS домейн) обикновено сочи право към този адрес и всеки може да го разреши. DashPay е точно обратното — името сочи към самоличност, а не към платежен адрес, а истинските платежни адреси остават вътре в криптирани обмени с контактите и са нови за всеки контакт.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Интуитивно и познато преживяване на всичките Ви устройства";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Всеки, който знае даден адрес, може да види историята му";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Одобряване";
+
+"Approving a specific request can only be done one username at a time." = "Одобряването на конкретна заявка може да се прави само за едно потребителско име наведнъж.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Като текст";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Удостоверяването е отменено. Гласът ви не беше подаден.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Удостоверяването е неуспешно. Гласът ви не беше подаден.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Удостоверяването не е налично";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Присъждане на „%@“ на този кандидат";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Баланс";
 
 /* CrowdNode */
+"Balance after" = "Баланс след това";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Балансите и преводите не са публично видими";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Началната височина е запазена — повишеният праг на сканиране важи от следващото стартиране.";
+
 /* Voting */
 "Block" = "Блок";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Обвързан с договор";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Обвързан с договор, тип документ „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Само разглеждане";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Събира последните диагностични журнали в zip файл, за да ги изпратите чрез AirDrop, по имейл или да ги запазите във Files";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Подаване на глас";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Смяна на пиърите";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Промяна на ПИН";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Проверка…";
+
+"Choice" = "Избор";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Вземете поканата си";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Баланс за получаване";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Изчистване и повторно синхронизиране";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Да се изчистят ли данните на веригата и да се синхронизира отново?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Затвори приложението";
 
+"Closing" = "Затваря се";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (нови монети)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin вече не се поддържа — изберете къде да преместите смесените си монети.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Обезпечение";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Очаквайте скоро";
+
+/* Shielded transfer status */
+"Completed" = "Завършен";
 
 /* No comment provided by engineer. */
 "Confirm" = "Потвърди";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Потвърдена";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Потвърждаването запазва началната височина %u и изчиства данните на веригата за тази мрежа при следващото стартиране на приложението, изтегля ги отново и сканира филтрите наново от тази височина. Текущата сесия запазва стария си праг на сканиране — затворете и отворете приложението отново, за да започне.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Свързани пиъри";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Недостатъци";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Заявката за контакт е неуспешна";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Заявката за контакт е изпратена до %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Заявки за контакт";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Кандидат %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Продължи";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Продължете, за да изберете потребителското си име. Поканата покрива таксата за регистрация.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Копиране на суровата транзакция";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Архивът с журналите не можа да бъде създаден: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Не може да намери обменните курсове.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Не можаха да бъдат опреснени %d самоличности";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Балансът не можа да бъде получен (мрежова грешка). Опитайте да опресните.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Плащането не може да се изпълни";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Създайте своето потребителско име, намерете приятели и роднини по техните потребителски имена и ги добавете към контактите си";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Кредити";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash плащанията не могат да бъдат по-малки от %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform все още не е индексирал този спор. Броят на гласовете ще се появи тук, когато го направи.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform все още не е свързан. Изчакайте синхронизирането да приключи и опитайте отново.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash, изпратен на грешен адрес, не може да бъде възстановен. Уверете се, че адресът е точно този, на който искате да платите.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash съхранява потребителските имена във вид, защитен от сходно изглеждащи изписвания, затова съхраненото име може да се различава от написаното от всеки човек.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Баланс на портфейла Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay е включен";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay е социалното платежно изживяване на Dash, изградено върху Dash Platform. Регистрирате потребителско име, добавяте други потребители като контакти и им плащате по име — край на копирането на адреси.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay заменя дългите неразбираеми адреси с потребителски имена. Добавяйте приятели като контакти, изпращайте пари на име и пазете всяко плащане подредено по човек.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Неизвестен краен срок";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Път на извеждане";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "СИГУРНОСТТА НА УСТРОЙСТВОТО Е КОМПРОМЕТИРАНА\nВсяко 'jailbreak' приложение може да достъпи всяко друго приложение с важна информация (и да открадне вашите Dash). Изтрийте този портфейл веднага и го възстановете на защитено устройство. ";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Деактивиран";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Завършено";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Готово — балансът ви отлежа достатъчно дълго";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Проверете адреса още веднъж";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Всеки мастернод има един действащ глас на спор. Можете да го промените по-късно, но Dash Platform допуска общо само 5 гласа на мастернод за един спор.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Всяко докосване добавя по още един възел към гласуването, така че вие избирате колко да свържете заедно.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Редактиране на началната височина";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Включване";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Включване на DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Включи Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Включи Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Включването на DashPay струва малка еднократна мрежова такса, платена от кредитния баланс на вашата самоличност. Точната оценка се показва преди да потвърдите. Изпращането на заявки за контакт и на плащания струва обичайните мрежови такси.";
+
+"Ending soonest" = "Приключва най-скоро";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Приблизителна мрежова такса";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Всички възли гласуват заедно. По-бързо е, но публично свързва вашите мастерноди помежду им.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Операторски ключове на Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Експортиране на журналите";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Външен адрес";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Лимит на лицева идентификация";
+
+/* No comment provided by engineer. */
+"Failed" = "Неуспешно";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Извличане…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Филтър";
+
+/* SPV sync phase */
+"Filter headers" = "Заглавки на филтрите";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Намерете потребител в мрежата Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Търсене на самоличности";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Забравен ПИН?";
 
+/* Identities */
+"Found %d new identities" = "Намерени са %d нови самоличности";
+
+/* Identities */
+"Found 1 new identity" = "Намерена е 1 нова самоличност";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Финансирайте потребителското си име от защитения си баланс. Добавете средствата няколко часа предварително — краткото отлежаване прави потребителското ви име несвързваемо с останалите ви Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Финансирано от защитения ви баланс — потребителското ви име не може да бъде свързано с останалите ви Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Средствата са заключени — преводът приключва";
+
+/* CoinJoin */
+"Funds moved" = "Средствата са преместени";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Пригответе се да се присъедините към DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Разбрах";
+
+/* Governance */
+"Governance" = "Управление";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "поиска да ви бъде приятел";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Имате ли покана?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Имате пълен контрол и персонализиране на портфейла според  нужди Ви";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Заглавки";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Височина %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "По-високи такси, около 7 цента (все пак по-ниски от други блокчейни с подобна поверителност)";
+
 /* No comment provided by engineer. */
 "History" = "История";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Как се сравнява това с Bitcoin по отношение на поверителността?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Как се сравнява това с Ethereum акаунтите по отношение на поверителността?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Колко поверителен е DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Написах го долу";
 
+/* Identities */
+"Identities" = "Самоличности";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Кредити на самоличността";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Индекс на самоличността";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Регистрация на самоличност";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Захранване на самоличността";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Неактивен";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Вход %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Вход %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Входове (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Недостатъчно средства";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Покана от %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Поканете някого да се присъедини към мрежата Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Поканете приятелите и семейството си в мрежата Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Запазете тези монети поверителни. Прилагат се мрежови такси и такси за поверителност.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ключ №%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Данни на ключа";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Собственост на ключа";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ключове";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Води";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Научете повече";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Зареждане на транзакциите";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Местна валута";
 
+/* Identities */
+"Local Only" = "Само локално";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Локална заявка за сума: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Заключване";
+
+"Lock the name" = "Заключване на името";
+
+"Lock “%@” so nobody gets it" = "Заключване на „%@“, за да не го получи никой";
+
 /* No comment provided by engineer. */
 "Locked" = "Заключена";
 
+"Locked — nobody receives this username" = "Заключено — никой не получава това потребителско име";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Ниско";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Ниски такси за ежедневни разходи";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Основна";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Основна мрежа";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Ключодържател на мастернода";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Списък с мастерноди";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode обновяване";
 
+"Masternode votes" = "Гласове на мастерноди";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Мастерноди";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Мастернодите и evonode, регистрирани с ключовете на този портфейл, ще се появят тук след като портфейлът се синхронизира.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Мастерноди и evonode, използващи ключовете на този портфейл";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Мастернодите гласуват за имена, поискани от повече от един човек. Ще получите известие, когато гласуването приключи.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Макс";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Минимумът е достигнат";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Повече контрол";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Още предложения";
+
+"Most lock votes" = "Най-много заключващи гласове";
+
+"Most votes" = "Най-много гласове";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Преместване към обичайния ви баланс за харчене.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Преместено в адрес";
+
+/* CoinJoin */
+"Moving funds" = "Преместване на средствата";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Услугите за имена като Unstoppable Domains свързват четимо име с фиксиран публичен адрес в блокчейна. Всеки може да разреши името и да види всяко плащане, правено някога към него. Потребителското име в DashPay никога не се разрешава публично до платежен адрес — адресите се разкриват само вътре в криптирания обмен с всеки контакт, така че името и парите ви остават несвързани за външните наблюдатели.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Изисква внимание";
 
 /* No comment provided by engineer. */
 "Network" = "Мрежа";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "На това устройство не бяха намерени диагностични журнали. Журналите се записват от следващото стартиране нататък.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Няма самоличности";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Все още няма мастерноди";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Няма съвпадащи спорове";
+
+/* Identities */
+"No new identities were found for this wallet" = "За този портфейл не бяха намерени нови самоличности";
+
+"No open contest matches that search." = "Няма открит спор, съвпадащ с това търсене.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Няма открит спор, съвпадащ с това търсене. Имената се съхраняват в нормализиран вид, затова „alice“ фигурира като „a11ce“.";
+
+"No open contests" = "Няма открити спорове";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Не е намерен запазен запис на портфейл за свързания портфейл.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Все още няма наличен адрес в Platform за резервната защитена регистрация. Опитайте отново, след като портфейлът приключи синхронизирането.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "В момента няма оспорвано потребителско име. Спор се открива, когато двама или повече души поискат едно и също име.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Не бяха подадени гласове";
+
+"Nobody gets it" = "Никой не го получава";
+
+/* SPV sync peer type */
+"Node" = "Възел";
+
+/* Raw transaction inspector */
+"Non-standard" = "Нестандартен";
 
 /* adjective, security level */
 "None" = "Никакъв";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Не е налично";
 
+"Not available yet" = "Все още не е налично";
+
+"Not cast" = "Не е подаден";
+
+/* Masternodes */
+"Not checked yet" = "Още не е проверено";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Недостатъчен защитен баланс за регистрация на самоличност";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Не е в историята на портфейла";
+
+"Not now" = "Не сега";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Не се приема широко от търговците";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Все още не се приема широко от търговците";
+
+/* Masternode keys */
+"Not yet used" = "Още не е използван";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "В Bitcoin няма слой с имена, затова хората споделят и използват адреси повторно на открито — щом даден адрес стане известен, всичко, което някога е получил, може да бъде свързано със собственика му. При DashPay потребителското ви име е публично, но никога не сочи към платежен адрес: адресите се обменят поверително с всеки контакт и се сменят, така че плащането по име не разгласява къде отиват парите ви. И двете са прозрачни вериги, така че анализът на веригата все още важи за самите монети.";
+
+/* Identities */
+"On Network" = "В мрежата";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Щом %@ приеме заявката ви, ще можете да плащате директно на потребителско име";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "По един възел";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Само мастерноди и evonode могат да гласуват за потребителски имена. Този портфейл не съдържа активни ключове за гласуване на мастерноди.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Оператор";
+
+/* Masternode keys */
+"Operator keys" = "Операторски ключове";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Публичен ключ на оператора (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "или";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Други изходи";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Изход %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Изходи (%d)";
+
+/* Masternodes */
+"Owner" = "Собственик";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Адрес на собственика";
+
+/* Masternodes */
+"Owner address" = "Адрес на собственика";
+
+/* Masternodes */
+"Owner key hash" = "Хеш на ключа на собственика";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Ключове на собственика";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Платено от кредитния баланс на вашата самоличност.";
 
 /* DashSpend */
 "Password" = "Парола";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Поставете получената покана-връзка или сканирайте нейния QR код. Тя покрива регистрацията на потребителското ви име.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Платете и вземете плащане незабавно с лесни за използване потоци на плащане";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "плащате директно на потребителско име";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Плащайте на хора, а не на адреси";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Полезен товар (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Плащанията са поверителни: адресите, които обменяте с даден контакт, пътуват вътре в криптиран пакет, който само вие двамата можете да прочетете, и никога не се публикуват — затова плащанията ви не се свързват лесно с потребителското ви име. Въпреки това те си остават обикновени плащания в прозрачна верига: изтънчен анализ на веригата може да разкрие информация. Shielded DashPay (очаквайте скоро) ще запълни тази празнина. Самите заявки за контакт в момента НЕ са поверителни: всеки може да види, че две самоличности са свързани. Поверителните заявки за контакт са функция, която предстои скоро. Потребителското ви име и профилът ви също са публични в Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Плащанията се потвърждават за секунди с InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Плащанията, направени директно към адреси, няма да се пазят в активността.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Плащанията с всеки контакт са събрани на едно място, с имена и профили вместо сурови транзакции.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Адрес за изплащане";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Адрес в Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Баланс в Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Възел в Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID на възела в Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Плащанията в Platform не идентифицират изпращача. Това плащане беше записано, когато портфейлът забеляза промяната в баланса — възможно е да е пристигнало по-рано.";
+
+"Platform SDK not ready" = "Platform SDK не е готов";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Синхронизирането на Platform не работи. Отворете Информация за синхронизирането → Състояние на синхронизирането на Platform, за да го стартирате.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Защитен";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Използван преди това на: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Поверителен по замисъл";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Поверителните заявки за контакт (за да остане поверително с кого се свързвате), Shielded DashPay — плащания към контакти от вашия поверителен защитен баланс — и плащанията към потребители, които още не са в контактите ви, предстоят скоро.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Поверителните заявки за контакт са в разработка и се очакват около септември–октомври 2026 г. Днес самата заявка е публична — всеки може да види, че две самоличности са свързани, макар данните за плащане в нея да са криптирани. След като поверителните заявки за контакт излязат, ще можете да избирате дали приятелството ви да е публично или поверително.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Поверителни заявки за контакт, Shielded DashPay и плащания към хора, които още не са контакти.";
+
 /* No comment provided by engineer. */
 "Private key" = "Частен ключ";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Поверителните платежни адреси се обменят между вас и вашите контакти. Само вие и вашият контакт знаете кой е получателят и кой изпращачът на плащанията помежду ви.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Поверителни плащания";
+
+/* Usernames */
+"Private registration" = "Поверителна регистрация";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Време за обработка";
+
+/* Balance info sheet section */
+"Pros" = "Предимства";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Адрес на досавчика";
 
+/* Masternodes */
+"Provider transactions" = "Транзакции на доставчика";
+
+/* Masternode keys */
+"Public key" = "Публичен ключ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Публичен ключ (стар)";
+
+/* Identities */
+"Public keys" = "Публични ключове";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Предназначение";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Цена: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Сурова транзакция";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Суровата транзакция не е налична";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Проверява отново компактните блокови филтри от избраната височина за транзакции на този портфейл, като ги изтегля и съпоставя наново. Повторните сканирания са ограничени отдолу от височината на създаване на портфейла и от локално съхранените данни на веригата — за да възстановите история под това ниво, вместо това понижете началната височина на портфейла.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Само за четене";
+
+/* Usernames */
+"Ready around %@" = "Готово около %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Причина";
 
 /* No comment provided by engineer. */
 "Receive" = "Получаване";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Получени от";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Получено от %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Записва вашите мастерноди като гласували, без да заемат страна.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Опресняване";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Регистриран на";
+
+/* No comment provided by engineer. */
 "Registered from" = "Регистриран от";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Регистриран Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Поверителната регистрация изисква поне %@ Dash в защитения ви баланс плюс няколко часа отлежаване — следващите екрани ще ви преведат през процеса.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Регистрация";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Иска това име";
+
 /* An action */
 "Rescan" = "Повторно сканиране";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Възстановените портфейли не винаги могат да установят типа на операцията. Този запис е реконструиран от данните на бележката във веригата.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Повторното синхронизиране е подготвено от височина %u — затворете и отворете приложението отново, за да започне.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "запазвате общата история на транзакциите";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Изведен от употреба";
 
 /* No comment provided by engineer. */
 "Retry" = "Отново";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Отмяна";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Снимките на екрана са видими от други приложения и устройства. Генерирайте нова фраза за възстановяване и го запазете в тайна.";
 
+/* Raw transaction inspector */
+"Script" = "Скрипт";
+
+/* Raw transaction inspector */
+"Script signature" = "Подпис на скрипта";
+
+/* Raw transaction inspector */
+"Script type" = "Тип на скрипта";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Търсене на контакт";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Търсене на заявка за контакт";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Търсене на потребител в мрежата Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Търсене на потребителско име";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Резултати от търсенето за \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Търсене на потребителски имена";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Търсене на потребителското име %@ в мрежата Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Ниво на сигурност";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Ниво на сигурност";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Избиране на всички";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Изберете поне един мастернод, с който да гласувате.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Избирането на по-малко възли разкрива по-малко за това кои мастерноди управлявате.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Изпрати на";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Изпращане до контакт";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Изпращайте на потребителско име, което наистина можете да запомните и проверите.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Изпратете първата си заявка за контакт";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Изпраща";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Изпращане на заявка за контакт";
+
+/* No comment provided by engineer. */
+"Sending to" = "Изпращане до";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Изпратени на";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Изпратено до %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Услуга";
+
+/* Identities */
+"Set as Main" = "Задаване като основна";
+
+/* Identities */
+"Set as Main Identity" = "Задаване като основна самоличност";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Постави ПИН";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Споделеният пул за поверителност е с минимален размер";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Защитен адрес";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Защитено харчене";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Стартиране на защитения портфейл…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Защитен → Platform";
+
+"Shielded → Transparent" = "Защитен → Прозрачен";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Размер";
+
 /* No comment provided by engineer. */
 "Skip" = "Пропусни";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Някои от вашите мастерноди може да липсват в този списък — портфейлът не успя да прочете целия ви набор от ключове за гласуване. Завършете синхронизирането и отворете този екран отново.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Подреждане на контактите";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Специален полезен товар";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Посочете сума";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Започва след като добавите средства";
+
+/* Transaction details */
+"Status" = "Състояние";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Съхранено като";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Информация за синхронизирането";
+
+/* SPV sync */
+"Sync too slow?" = "Синхронизирането е твърде бавно?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Без вземане на страна";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Докоснете, за да копирате";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Докоснете, за да скриете баланса";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ключ на възел Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Тестова мрежа";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash пристига на адреса на получателя, след като мрежата обработи тегленето — това може да отнеме до 10 минути.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash пристига на адреса на получателя веднага щом мрежата обработи тегленето.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash пристига в прозрачния ви баланс веднага щом мрежата обработи тегленето.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Основната самоличност може да бъде избрана само от активния портфейл";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Най-поверителното място за съхранение на вашите Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Запазеният запис на портфейла няма мрежа — не може да се подготви повторно синхронизиране.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Регистрацията беше подадена, но резултатът ѝ не можа да бъде потвърден. Изчакайте минута портфейлът да се синхронизира и опитайте отново — не подавайте повторно веднага.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Споделеният пул за поверителност все още расте (%1$ld от %2$ld депозита). Поверителната регистрация се отключва, щом достигне минимума.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Споделеният пул за поверителност все още расте (%1$ld от %2$ld депозита). Опитайте отново, щом достигне минимума.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Височината на създаване на портфейла — долната граница за сканиранията на филтри и за повторните сканирания „От създаването на портфейла“. Задайте я на нивото на първото захранване на портфейла или под него; при импортиране по подразбиране се използва 200000 в mainnet и 0 в testnet. Запазването на височина, равна или по-ниска от текущата, изчиства данните на веригата за тази мрежа при следващото стартиране и сканира наново оттам.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "него (Извличане на информация)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Няма нови известия";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Няма транзакции за показване";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Няма потребители, отговарящи на името %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "В контактите ви няма потребители, отговарящи на името %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Тези средства преминават към вашия баланс в Platform и са готови за харчене веднага щом преводът приключи.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Този адрес не може да бъде платен от вашия баланс %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Това добавя два ключа към вашата самоличност, за да могат други потребители да ви изпращат заявки за контакт и вие да приемате техните. Това се случва само веднъж.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Това прилага един избор върху всички %d избрани потребителски имена.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Тази покана-връзка не е валидна.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Това не е валиден Dash адрес за тази мрежа";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Това не е валидна покана-връзка";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Това е вашата основна самоличност";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Този мастернод все още няма самоличност в Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Това пак се брои за гласуване на вашите мастерноди в този спор.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Суровите байтове на тази транзакция не се съхраняват на това устройство.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Това потребителско име отиде при някой друг";
+
+"This wallet could not derive the voting key for this node." = "Този портфейл не успя да изведе ключа за гласуване за този възел.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Този портфейл не съдържа активни ключове за гласуване на мастерноди, затова не може да гласува. Регистрираните възли се показват в Инструменти → Мастерноди.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Това тегли целия ви баланс в Platform с един превод. Dash пристига на адреса на получателя веднага щом мрежата обработи тегленето.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Това тегли целия ви баланс в Platform с един превод. Dash пристига в прозрачния ви баланс веднага щом мрежата обработи тегленето.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Историята на транзакциите не е налична";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Транзакция id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID на транзакцията";
 
 /* A verb, button title. */
 "Transfer" = "Прехвърляне";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Входящ превод";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Изходящ превод";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Преводите отнемат повече време — изграждането на доказателствата за поверителност изисква време";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Преводите към други адреси в Platform и към защитени адреси са незабавни и окончателни";
+
+/* Balance breakdown */
+"Transparent" = "Прозрачен";
+
+/* Send screen destination type */
+"Transparent address" = "Прозрачен адрес";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Прозрачен баланс";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Прозрачното финансиране публично свързва потребителското ви име с тези средства.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Прозрачен → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Прозрачен → Защитен";
 
 /* An action */
 "Try again" = "Опитай отново";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Не могат да бъдат предоставени предложения";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Неизвестен специален тип %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Незащитен";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Неподдържан url";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Надграждане до Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Вместо това използвайте прозрачния баланс";
+
+/* Masternode keys */
+"Used" = "Използван";
+
+/* Masternode keys */
+"Used at: " = "Използван на: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Потребител (Извличане на информация)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Потребителски имена";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Потребителските имена се съхраняват в нормализиран вид, за да се избягват сходно изглеждащи имена, затова това може да се различава от написаното от всеки човек.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Потребителски имена, а не адреси";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Потребители, отговарящи на %@, които в момента не са в контактите ви";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Използва една от най-одитираните и тествани библиотеки с нулево знание (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Валидна покана";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Проверено по време на регистрацията";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Проверено успешно";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Версия";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Много ефективен, с ниски такси";
+
 /* adjective, security level */
 "Very High" = "Много високо";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Виж всички";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Преглед в Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Виж фразата за възстановяване";
 
+/* Raw transaction inspector */
+"View Transaction" = "Преглед на транзакцията";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Гласуване";
+
+"Vote cast" = "Гласът е подаден";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Гласувайте за оспорвани потребителски имена";
+
+"Vote on several" = "Гласуване за няколко";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Гласуване с";
+
+"Votes that nobody should receive these usernames." = "Гласува никой да не получи тези потребителски имена.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Адрес за гласуване";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Адрес за гласуване";
+
+"Voting ended with no winner" = "Гласуването приключи без победител";
+
+"Voting ends" = "Гласуването приключва";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Гласуването тече";
+
+"Voting in progress — lock votes are ahead" = "Гласуването тече — заключващите гласове водят";
+
+"Voting in progress — you are ahead" = "Гласуването тече — вие водите";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Хеш на ключа за гласуване";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Ключове за гласуване";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Гласуването за това потребителско име е затворено. Броят по-долу е последният отчетен.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Гласуването за „%@“ вече е затворено. Опреснете, за да видите резултата.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Изчакване на Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Начална височина на портфейла";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Портфейлът е изключен";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "А какво ще кажете за Unstoppable Domains и подобни услуги за имена?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Колко струва?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Какво е DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Какво следва?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Кога заявките за контакт ще станат поверителни?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Кой иска това име";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Защо трябва да го включвам?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Тегли целия баланс";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Работи с всеки Dash портфейл, борса и търговец";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Вие";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Приехте заявката за контакт от %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "В момента нямате контакти";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Нямате достатъчно средства за да извършите тази транзакция";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Досега имате %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Изпратихте заявката за контакт до %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Спечелихте това потребителско име";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Всичко е готово. Други потребители вече могат да ви изпращат заявки за контакт — а вие можете да изпращате своите.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Вашата самоличност в Dash Platform ще се появи тук, след като регистрирате потребителско име.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Вашата история, подредена";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Вашата самоличност се нуждае от два допълнителни ключа, за да могат заявките за контакт да се криптират между вас и другите потребители. Включването ги добавя с една-единствена мрежова транзакция. Това се случва само веднъж.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Вашата покана покрива таксата за регистрация на това потребителско име.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Основният ви баланс в Dash върху блокчейна Core — това, което изпращате и получавате с други портфейли, борси и търговци.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Смесените ви монети бяха преместени в баланса на портфейла Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Смесените ви монети бяха преместени в защитения ви баланс. За най-добра поверителност изчакайте поне 2 часа, преди да използвате тези средства.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Вашият баланс в Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Вашият поверителен баланс. Сумите и адресите са криптирани във веригата, така че притежанията и историята ви остават поверителни.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Вашият защитен баланс";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Защитеният ви баланс е почти готов — ще можете да се регистрирате поверително около %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Защитеният ви баланс е готов — регистрирайте потребителското си име поверително сега";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Защитеният ви баланс отлежава — ще можете да се регистрирате поверително около %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Защитеният ви баланс все още узрява. Ще бъде готов около %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Вашият прозрачен баланс";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Потребителското ви име е видимо за всички. Ако го финансирате от защитения си баланс — след като средствата отлежат няколко часа — никой няма да може да свърже потребителското ви име с останалите ви Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Потребителското ви име, профилът и контактите ви следват тази самоличност.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Потребителското ви име, профилът и контактите ви ще следват тази самоличност.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Вашите гласове";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Вашият портфейл сега е защитен. Можете да използвате вашата фраза за възстановяване по всяко време, за да възстановите акаунта си на друго устройство.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Портфейлът ви все още се синхронизира с мрежата Dash. Изпращането ще бъде достъпно, след като синхронизирането приключи.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Портфейлът ви все още се синхронизира. Изпращането от прозрачния ви баланс ще бъде достъпно, след като синхронизирането приключи.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ не можа да бъде прочетено като потребителско име в Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ беше регистрирано. Да се изпрати ли заявка за контакт до човека, който ви покани?";

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Всички възли наведнъж";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Всички ваши мастерноди са гласували за това потребителско име. За да промените глас, гласувайте отново от кандидата, който предпочитате сега.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Всички ваши мастерноди са гласували за това потребителско име. За да промените глас, гласувайте отново за кандидата, който предпочитате сега.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/bg.lproj/Localizable.stringsdict
+++ b/DashWallet/bg.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ преброени за „%2$@“</string>
+		<string>%#@votes@ за „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u глас</string>
+			<string>%1$u преброен глас</string>
 			<key>other</key>
-			<string>%1$u гласа</string>
+			<string>%1$u преброени гласа</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d от %#@nodes@ гласуваха</string>
+		<string>Гласували: %1$d от %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d от %#@nodes@ гласуваха</string>
+		<string>Гласували: %1$d от %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/bg.lproj/Localizable.stringsdict
+++ b/DashWallet/bg.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ преброени за „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u глас</string>
+			<key>other</key>
+			<string>%1$u гласа</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Гласувано за %1$d от %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d потребителско име</string>
+			<key>other</key>
+			<string>%2$d потребителски имена</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Подай %u глас</string>
+			<key>other</key>
+			<string>Подай %u гласа</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d от %#@nodes@ гласуваха</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d мастернод</string>
+			<key>other</key>
+			<string>%2$d мастернода</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d от %#@nodes@ гласуваха</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d възел</string>
+			<key>other</key>
+			<string>%2$d възела</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>общо %u глас</string>
+			<key>other</key>
+			<string>общо %u гласа</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d мастернод</string>
+			<key>other</key>
+			<string>%d мастернода</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d избран</string>
+			<key>other</key>
+			<string>%d избрани</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d от вашите възли вече е гласувал тук и не е в списъка.</string>
+			<key>other</key>
+			<string>%d от вашите възли вече са гласували тук и не са в списъка.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u глас на спор — evonode се броят за 4, мастернодите за 1</string>
+			<key>other</key>
+			<string>%u гласа на спор — evonode се броят за 4, мастернодите за 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Гласувайте за %d потребителско име</string>
+			<key>other</key>
+			<string>Гласувайте за %d потребителски имена</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u глас</string>
+			<key>other</key>
+			<string>%u гласа</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Глас ×%d</string>
+			<key>other</key>
+			<string>Глас ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d заявка</string>
+			<key>other</key>
+			<string>%d заявки</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -334,7 +334,7 @@
 "An error occurred" = "An error occurred";
 
 /* DashPay FAQ */
-"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un compte d'Ethereum és una única adreça reutilitzada: tot el teu saldo i el teu historial de pagaments queden públicament sota seu, i un nom (per exemple un domini ENS) sol apuntar directament a aquesta adreça, de manera que qualsevol la pot resoldre. DashPay té la forma contrària: el nom es resol a una identitat, no a una adreça de pagament, i les adreces de pagament reals queden dins d'intercanvis de contacte xifrats, noves per a cada contacte.";
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un compte d'Ethereum és una única adreça reutilitzada: tot el teu saldo i el teu historial de pagaments queden públicament sota seu, i un nom (per exemple un domini ENS) sol apuntar directament a aquesta adreça, de manera que qualsevol pot resoldre el nom. DashPay té la forma contrària: el nom es resol a una identitat, no a una adreça de pagament, i les adreces de pagament reals queden dins d'intercanvis de contacte xifrats, noves per a cada contacte.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -3167,7 +3167,7 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
-"Requesting this name" = "Demana aquest nom";
+"Requesting this name" = "Sol·liciten aquest nom";
 
 /* An action */
 "Rescan" = "Rescan";

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Tots els nodes alhora";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tots els teus masternodes han votat sobre aquest nom d'usuari. Per canviar un vot, torna a votar des de l'aspirant que ara prefereixes.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tots els teus masternodes han votat sobre aquest nom d'usuari. Per canviar un vot, torna a votar per l'aspirant que ara prefereixes.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " o ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "No s'ha pogut trobar %@ a la xarxa Dash per enviar-li una sol·licitud de contacte.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponibles";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ ha acceptat la teva sol·licitud de contacte";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld de %ld dipòsits";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Un saldo de crèdits a Dash Platform que s'utilitza per a pagaments instantanis entre adreces de Platform i per a funcions com els noms d'usuari.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Quant a";
 
+/* DashPay FAQ title */
+"About DashPay" = "Quant a DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Abstenir-se";
+
+"Abstain on “%@”" = "Abstenir-se a «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Actiu";
+
+/* No comment provided by engineer. */
+"Activity" = "Activitat";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "L'activitat és pública, però no és fàcil de rastrejar";
+
 /* No comment provided by engineer. */
 "Add" = "Afegeix";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Afegeix %@ com a contacte";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Afegeix %@ com a contacte per pagar directament al nom d'usuari i conservar l'historial de transaccions compartit";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Afegeix %@ Dash al teu saldo blindat i deixa'l reposar unes hores per registrar-te sense vincular el teu nom d'usuari amb la resta dels teus fons.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Afegeix com a mínim %@ Dash al teu saldo blindat";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Afegeix fons al teu saldo blindat ara i registra el teu nom d'usuari de manera privada unes hores després";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Tots els nodes alhora";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tots els teus masternodes han votat sobre aquest nom d'usuari. Per canviar un vot, torna a votar des de l'aspirant que ara prefereixes.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sincronització de saldos gairebé instantània";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Els imports i les adreces són públics a la cadena de blocs";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un compte d'Ethereum és una única adreça reutilitzada: tot el teu saldo i el teu historial de pagaments queden públicament sota seu, i un nom (per exemple un domini ENS) sol apuntar directament a aquesta adreça, de manera que qualsevol la pot resoldre. DashPay té la forma contrària: el nom es resol a una identitat, no a una adreça de pagament, i les adreces de pagament reals queden dins d'intercanvis de contacte xifrats, noves per a cada contacte.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Qualsevol que conegui una adreça en pot veure l'historial";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Aprova";
+
+"Approving a specific request can only be done one username at a time." = "Aprovar una sol·licitud concreta només es pot fer d'un nom d'usuari alhora.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Com a text";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autenticació cancel·lada. El teu vot no s'ha emès.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "L'autenticació ha fallat. El teu vot no s'ha emès.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Concedeix «%@» a aquest aspirant";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Saldo després";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Els saldos i les transferències no són visibles públicament";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Alçada d'inici desada — el límit inferior d'escaneig elevat s'aplica des del pròxim inici.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vinculada a un contracte";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vinculada a un contracte, tipus de document «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Només consulta";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Agrupa els registres de diagnòstic recents en un zip per enviar-los per AirDrop, per correu o desar-los a Fitxers";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Emet el vot";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Canvia de nodes";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "S'està comprovant…";
+
+"Choice" = "Opció";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Reclama la teva invitació";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo reclamable";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Neteja i torna a sincronitzar";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Vols netejar les dades de la cadena i tornar a sincronitzar?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "S'està tancant";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (monedes noves)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ja no és compatible: tria on vols moure les teves monedes barrejades.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Garantia";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Ben aviat";
+
+/* Shielded transfer status */
+"Completed" = "Completada";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confirmada";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "En confirmar es desa l'alçada d'inici %u i es netegen les dades de la cadena d'aquesta xarxa al pròxim inici de l'aplicació, es tornen a baixar i es tornen a escanejar els filtres des d'aquella alçada. La sessió en curs conserva el seu límit d'escaneig antic: tanca i torna a obrir l'aplicació per començar.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Nodes connectats";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Inconvenients";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "La sol·licitud de contacte ha fallat";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Sol·licitud de contacte enviada a %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Sol·licituds de contacte";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Aspirant %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continua per triar el teu nom d'usuari. La invitació paga la comissió de registre.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copia la transacció en cru";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "No s'ha pogut crear l'arxiu de registres: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "No es pot trobar el preu de canvi.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "No s'han pogut actualitzar %d identitats";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "No s'ha pogut obtenir el saldo (error de xarxa). Prova d'actualitzar.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Crea el teu nom d'usuari, troba amics i família pel seu nom d'usuari i afegeix-los als teus contactes";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Crèdits";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform encara no ha indexat aquesta disputa. Els recomptes de vots apareixeran aquí quan ho faci.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform encara no està connectat. Espera que acabi la sincronització i torna-ho a provar.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Els Dash enviats a una adreça equivocada no es poden recuperar. Assegura't que l'adreça sigui exactament aquella a la qual vols pagar.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash desa els noms d'usuari en una forma segura davant de noms semblants, de manera que el nom desat pot diferir del que ha escrit cada persona.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo de la cartera Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay activat";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay és l'experiència de pagaments socials de Dash, construïda sobre Dash Platform. Registres un nom d'usuari, afegeixes altres usuaris com a contactes i els pagues pel nom: s'ha acabat copiar adreces.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay substitueix les adreces llargues i críptiques per noms d'usuari. Afegeix amics com a contactes, envia diners a un nom i mantén cada pagament organitzat per persona.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Termini desconegut";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Camí de derivació";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Desactivada";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Fet: el teu saldo ha reposat prou temps";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Comprova l'adreça dues vegades";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Cada masternode té un vot vigent per disputa. El pots canviar més endavant, però Dash Platform només permet 5 vots en total per masternode i disputa.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Cada toc vota amb un node més, així que tries quants en vincules.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Edita l'alçada d'inici";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Activa";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Activa DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Activar DashPay costa una petita comissió de xarxa única, pagada des del saldo de crèdits de la teva identitat. L'estimació exacta es mostra abans que confirmis. Enviar sol·licituds de contacte i pagaments costa les comissions de xarxa habituals.";
+
+"Ending soonest" = "Acaba abans";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Comissió de xarxa estimada";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Tots els nodes voten junts. És més ràpid, però vincula públicament els teus masternodes entre si.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Claus d'operador d'Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Exporta els registres";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Adreça externa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Ha fallat";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "S'està obtenint…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Capçaleres de filtre";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Troba un usuari a la xarxa Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Cerca identitats";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "S'han trobat %d identitats noves";
+
+/* Identities */
+"Found 1 new identity" = "S'ha trobat 1 identitat nova";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finança el teu nom d'usuari des del teu saldo blindat. Afegeix els fons unes hores abans: el breu repòs fa que el teu nom d'usuari no es pugui vincular amb la resta dels teus Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finançat des del teu saldo blindat: el teu nom d'usuari no es pot vincular amb la resta dels teus Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fons bloquejats: s'està acabant la transferència";
+
+/* CoinJoin */
+"Funds moved" = "Fons moguts";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Prepara't per unir-te a DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Entesos";
+
+/* Governance */
+"Governance" = "Governança";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ha demanat ser el teu amic";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Tens una invitació?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Capçaleres";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Alçada %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Comissions més altes, al voltant de 7 cèntims (encara més baixes que altres cadenes de blocs amb una privadesa similar)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Com es compara això amb Bitcoin pel que fa a la privadesa?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Com es compara això amb els comptes d'Ethereum pel que fa a la privadesa?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Com de privat és DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identitats";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Crèdits d'identitat";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Índex d'identitat";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registre d'identitat";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Recàrrega d'identitat";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactiu";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Entrada %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Entrada %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Entrades (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitació de %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Convida algú a unir-se a la xarxa Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Convida els teus amics i la teva família a la xarxa Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Mantén aquestes monedes privades. S'apliquen comissions de xarxa i de privadesa.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Clau núm. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Dades de la clau";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Propietat de la clau";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Claus";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Al davant";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Més informació";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "S'estan carregant les transaccions";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Només local";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Bloqueja";
+
+"Lock the name" = "Bloqueja el nom";
+
+"Lock “%@” so nobody gets it" = "Bloqueja «%@» perquè no l'obtingui ningú";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Bloquejat: ningú no rep aquest nom d'usuari";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Comissions baixes per a la despesa diària";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principal";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Clauer de masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Llista de masternodes";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Vots de masternodes";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Els masternodes i evonodes registrats amb les claus d'aquesta cartera apareixeran aquí després que la cartera se sincronitzi.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes i evonodes que utilitzen les claus d'aquesta cartera";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Els masternodes voten sobre noms demanats per més d'una persona. Se't notificarà quan acabi la votació.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Mínim assolit";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Més suggeriments";
+
+"Most lock votes" = "Més vots de bloqueig";
+
+"Most votes" = "Més vots";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Mou-ho al teu saldo disponible habitual.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "S'estan movent els fons";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Els serveis de noms com Unstoppable Domains associen un nom llegible a una adreça pública fixa de la cadena. Qualsevol pot resoldre el nom i veure tots els pagaments que s'hi han fet mai. Un nom d'usuari de DashPay mai no es resol públicament a una adreça de pagament: les adreces només es revelen dins de l'intercanvi xifrat amb cada contacte, de manera que el teu nom i els teus diners queden desvinculats per als observadors externs.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Requereix atenció";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "No s'ha trobat cap registre de diagnòstic en aquest dispositiu. Els registres s'escriuen a partir del pròxim inici.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Cap identitat";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Encara no hi ha masternodes";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Cap disputa coincident";
+
+/* Identities */
+"No new identities were found for this wallet" = "No s'ha trobat cap identitat nova per a aquesta cartera";
+
+"No open contest matches that search." = "Cap disputa oberta coincideix amb aquesta cerca.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Cap disputa oberta coincideix amb aquesta cerca. Els noms es desen en una forma normalitzada, de manera que «alice» apareix com a «a11ce».";
+
+"No open contests" = "Cap disputa oberta";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "No s'ha trobat cap fila de cartera desada per a la cartera vinculada.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Encara no hi ha cap adreça de Platform disponible per al registre blindat alternatiu. Torna-ho a provar quan la cartera acabi de sincronitzar-se.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Ara mateix no hi ha cap nom d'usuari disputat. Les disputes s'obren quan dues o més persones demanen el mateix nom.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "No s'ha emès cap vot";
+
+"Nobody gets it" = "Ningú no l'obté";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "No estàndard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Encara no disponible";
+
+"Not cast" = "No emès";
+
+/* Masternodes */
+"Not checked yet" = "Encara no comprovat";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "No hi ha prou saldo blindat per registrar una identitat";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "No és a l'historial de la cartera";
+
+"Not now" = "Ara no";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "No és àmpliament acceptat pels comerços";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Encara no és àmpliament acceptat pels comerços";
+
+/* Masternode keys */
+"Not yet used" = "Encara no s'ha fet servir";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "A Bitcoin no hi ha una capa de noms, així que la gent comparteix i reutilitza adreces obertament: un cop es coneix una adreça, tot el que hagi rebut es pot vincular amb el seu propietari. Amb DashPay el teu nom d'usuari és públic, però mai no apunta a una adreça de pagament: les adreces s'intercanvien de manera privada amb cada contacte i van rotant, de manera que pagar per nom no fa públic on van els teus diners. Totes dues són cadenes transparents, així que l'anàlisi de cadena continua aplicant-se a les monedes mateixes.";
+
+/* Identities */
+"On Network" = "A la xarxa";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Quan %@ accepti la teva sol·licitud podràs pagar directament al nom d'usuari";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Un node cada vegada";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Només els masternodes i evonodes poden votar sobre els noms d'usuari. Aquesta cartera no té cap clau de vot de masternode activa.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operador";
+
+/* Masternode keys */
+"Operator keys" = "Claus d'operador";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Clau pública de l'operador (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "o";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Altres resultats";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Sortida %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Sortides (%d)";
+
+/* Masternodes */
+"Owner" = "Propietari";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adreça del propietari";
+
+/* Masternodes */
+"Owner key hash" = "Resum de la clau del propietari";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Pagat des del saldo de crèdits de la teva identitat.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Enganxa l'enllaç d'invitació que has rebut o escaneja'n el codi QR. Finança el registre del teu nom d'usuari.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "pagar directament al nom d'usuari";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Paga a persones, no a adreces";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Càrrega útil (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Els pagaments són privats: les adreces que intercanvies amb un contacte viatgen dins d'una càrrega xifrada que només podeu llegir vosaltres dos i no es publiquen mai, de manera que els teus pagaments no es poden vincular fàcilment amb el teu nom d'usuari. Tot i així, continuen sent pagaments normals en una cadena transparent: una anàlisi de cadena sofisticada podria filtrar informació. Shielded DashPay (ben aviat) tancarà aquesta escletxa. Les sol·licituds de contacte en si actualment NO són privades: qualsevol pot veure que dues identitats estan connectades. Les sol·licituds de contacte privades són una funció que arribarà ben aviat. El teu nom d'usuari i el teu perfil també són públics a Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Els pagaments es confirmen en segons amb InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Els pagaments fets directament a adreces no es conservaran a l'activitat.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Els pagaments amb cada contacte s'agrupen en un sol lloc, amb noms i perfils en comptes de transaccions en cru.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adreça de cobrament";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adreça de Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo de Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Node de Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID del node de Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Els pagaments de Platform no identifiquen el remitent. Aquest pagament es va registrar quan la cartera va detectar el canvi de saldo: pot haver arribat abans.";
+
+"Platform SDK not ready" = "L'SDK de Platform no està a punt";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "La sincronització de Platform no s'està executant. Obre Informació de sincronització → Estat de sincronització de Platform per iniciar-la.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Blindat";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Utilitzada anteriorment el: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat per disseny";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Les sol·licituds de contacte privades (perquè amb qui et connectes es mantingui privat), Shielded DashPay —pagaments a contactes des del teu saldo blindat privat— i els pagaments a usuaris que encara no són als teus contactes arribaran ben aviat.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Les sol·licituds de contacte privades estan en desenvolupament i s'esperen cap al setembre–octubre del 2026. Actualment la sol·licitud en si és pública: qualsevol pot veure que dues identitats estan connectades, encara que les dades de pagament que conté estiguin xifrades. Quan arribin les sol·licituds de contacte privades, podràs triar si la teva amistat és pública o privada.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Sol·licituds de contacte privades, Shielded DashPay i pagaments a persones que encara no són contactes.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Les adreces de pagament privades s'intercanvien entre tu i els teus contactes. Només tu i el teu contacte coneixeu el destinatari i el remitent dels pagaments entre vosaltres.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pagaments privats";
+
+/* Usernames */
+"Private registration" = "Registre privat";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Temps de processament";
+
+/* Balance info sheet section */
+"Pros" = "Avantatges";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transaccions de proveïdor";
+
+/* Masternode keys */
+"Public key" = "Clau pública";
+
+/* Masternode keys */
+"Public key (legacy)" = "Clau pública (antiga)";
+
+/* Identities */
+"Public keys" = "Claus públiques";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Finalitat";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transacció en cru";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "La transacció en cru no està disponible";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Torna a comprovar els filtres de blocs compactes des de l'alçada triada per buscar transaccions d'aquesta cartera, tornant-los a baixar i a comparar. Els reescanejos tenen com a límit inferior l'alçada de creació de la cartera i les dades de la cadena desades localment: per recuperar l'historial anterior, baixa l'alçada d'inici de la cartera.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Només de lectura";
+
+/* Usernames */
+"Ready around %@" = "A punt cap a les %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motiu";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Rebut de %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Registra els teus masternodes com a votants, sense prendre partit.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Actualitza";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrat el";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "El registre privat requereix com a mínim %@ Dash al teu saldo blindat més unes hores de repòs: les pantalles següents t'hi guiaran.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registre";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Demana aquest nom";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Les carteres restaurades no sempre poden recuperar el tipus d'operació. Aquesta entrada s'ha reconstruït a partir de les dades de nota de la cadena.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Resincronització preparada des de l'alçada %u: tanca i torna a obrir l'aplicació per començar.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "conservar l'historial de transaccions compartit";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retirat";
 
 /* No comment provided by engineer. */
 "Retry" = "Re-intenta";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Revocació";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Signatura de l'script";
+
+/* Raw transaction inspector */
+"Script type" = "Tipus d'script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Cerca un contacte";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Cerca una sol·licitud de contacte";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Cerca un usuari a la xarxa Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Cerca un nom d'usuari";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Resultats de la cerca per a \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Cerca noms d'usuari";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "S'està cercant el nom d'usuari %@ a la xarxa Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Nivell de seguretat";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Selecciona-ho tot";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Selecciona com a mínim un masternode amb què votar.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Seleccionar menys nodes revela menys sobre quins masternodes gestiones.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Envia a un contacte";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Envia a un nom d'usuari que realment puguis recordar i verificar.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Envia la teva primera sol·licitud de contacte";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "S'està enviant la sol·licitud de contacte";
+
+/* No comment provided by engineer. */
+"Sending to" = "S'està enviant a";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Enviat a %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Servei";
+
+/* Identities */
+"Set as Main" = "Estableix com a principal";
+
+/* Identities */
+"Set as Main Identity" = "Estableix com a identitat principal";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "El grup de privadesa compartit té la mida mínima";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Adreça blindada";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Despesa blindada";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "S'està iniciant la cartera blindada…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Blindat → Platform";
+
+"Shielded → Transparent" = "Blindat → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Mida";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "És possible que alguns dels teus masternodes faltin en aquesta llista: la cartera no ha pogut llegir tot el teu conjunt de claus de vot. Acaba la sincronització i torna a obrir aquesta pantalla.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ordena els contactes";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Càrrega útil especial";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Comença quan afegeixis fons";
+
+/* Transaction details */
+"Status" = "Estat";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Desat com a";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informació de sincronització";
+
+/* SPV sync */
+"Sync too slow?" = "La sincronització va massa lenta?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "No prendre partit";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Toca per copiar";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Clau de node Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Els Dash arriben a l'adreça del destinatari després que la xarxa processi la retirada: això pot trigar fins a 10 minuts.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Els Dash arriben a l'adreça del destinatari tan bon punt la xarxa processi la retirada.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Els Dash arriben al teu saldo transparent tan bon punt la xarxa processi la retirada.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "La identitat principal només es pot triar des de la cartera activa";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "El lloc més privat per guardar els teus Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "La fila de cartera desada no té xarxa: no es pot preparar una resincronització.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "El registre s'ha enviat, però no s'ha pogut confirmar el resultat. Espera un minut que la cartera se sincronitzi i torna-ho a provar: no el tornis a enviar immediatament.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "El grup de privadesa compartit encara està creixent (%1$ld de %2$ld dipòsits). El registre privat es desbloqueja quan arribi al mínim.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "El grup de privadesa compartit encara està creixent (%1$ld de %2$ld dipòsits). Torna-ho a provar quan arribi al mínim.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "L'alçada de creació de la cartera: el límit inferior per als escanejos de filtres i per als reescanejos «Des de la creació de la cartera». Estableix-la al nivell del primer finançament de la cartera o per sota; les importacions utilitzen 200000 per defecte a mainnet i 0 a testnet. Desar una alçada igual o inferior a l'actual neteja les dades de la cadena d'aquesta xarxa al pròxim inici i reescaneja a partir d'aquí.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "ell (s'està obtenint la informació)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "No hi ha cap notificació nova";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "No hi ha cap usuari que coincideixi amb el nom %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "No hi ha cap usuari als teus contactes que coincideixi amb el nom %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Aquests fons passen al teu saldo de Platform i estan a punt per gastar tan bon punt es completi la transferència.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Aquesta adreça no es pot pagar des del teu saldo %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Això afegeix dues claus a la teva identitat perquè altres usuaris et puguin enviar sol·licituds de contacte i perquè tu puguis acceptar les seves. Això passa una sola vegada.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Això aplica una sola opció a tots els %d noms d'usuari seleccionats.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Aquest enllaç d'invitació no és vàlid.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Aquesta no és una adreça Dash vàlida per a aquesta xarxa";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Aquest no és un enllaç d'invitació vàlid";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Aquesta és la teva identitat principal";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Aquest masternode encara no té identitat a Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Això continua comptant com que els teus masternodes han votat en aquesta disputa.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Els bytes en cru d'aquesta transacció no estan desats en aquest dispositiu.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Aquest nom d'usuari ha anat a una altra persona";
+
+"This wallet could not derive the voting key for this node." = "Aquesta cartera no ha pogut derivar la clau de vot d'aquest node.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Aquesta cartera no té cap clau de vot de masternode activa, de manera que no pot votar. Els nodes registrats apareixen a Eines → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Això retira tot el teu saldo de Platform en una sola transferència. Els Dash arriben a l'adreça del destinatari tan bon punt la xarxa processi la retirada.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Això retira tot el teu saldo de Platform en una sola transferència. Els Dash arriben al teu saldo transparent tan bon punt la xarxa processi la retirada.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "L'historial de transaccions no està disponible";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID de transacció";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Transferència entrant";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Transferència sortint";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Les transferències triguen més: construir les proves de privadesa requereix temps";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Les transferències a altres adreces de Platform i a adreces blindades són instantànies i definitives";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Adreça transparent";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo transparent";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "El finançament transparent vincula públicament el teu nom d'usuari amb aquests fons.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Blindat";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "No es poden oferir suggeriments";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tipus especial desconegut %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Sense blindar";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Actualitza a Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Fes servir el saldo transparent";
+
+/* Masternode keys */
+"Used" = "Utilitzada";
+
+/* Masternode keys */
+"Used at: " = "Utilitzada el: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Usuari (s'està obtenint la informació)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Noms d'usuari";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Els noms d'usuari es desen en una forma normalitzada per evitar noms semblants, de manera que això pot diferir del que ha escrit cada persona.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Noms d'usuari, no adreces";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Usuaris que coincideixen amb %@ i que actualment no són als teus contactes";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Fa servir una de les biblioteques de coneixement zero més auditades i provades (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Invitació vàlida";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Verificat durant el registre";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versió";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Molt eficient i amb comissions baixes";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Mostra-ho tot";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Mostra la transacció";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Vota";
+
+"Vote cast" = "Vot emès";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Vota sobre noms d'usuari disputats";
+
+"Vote on several" = "Vota sobre diversos";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Vota amb";
+
+"Votes that nobody should receive these usernames." = "Vota perquè ningú no rebi aquests noms d'usuari.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adreça de vot";
+
+"Voting ended with no winner" = "La votació ha acabat sense guanyador";
+
+"Voting ends" = "La votació acaba";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Votació en curs";
+
+"Voting in progress — lock votes are ahead" = "Votació en curs: els vots de bloqueig van al davant";
+
+"Voting in progress — you are ahead" = "Votació en curs: vas al davant";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Resum de la clau de vot";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "La votació sobre aquest nom d'usuari s'ha tancat. Els recomptes de sota són els últims llegits.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "La votació sobre «%@» ja s'ha tancat. Actualitza per veure el resultat.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "S'està esperant Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Alçada d'inici de la cartera";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "I què passa amb Unstoppable Domains i serveis de noms similars?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Quant costa?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Què és DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Què vindrà després?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Quan seran privades les sol·licituds de contacte?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Qui demana aquest nom";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Per què l'he d'activar?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Retira tot el saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funciona amb totes les carteres, cases de canvi i comerços de Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Tu";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Has acceptat la sol·licitud de contacte de %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "De moment no tens cap contacte";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Fins ara tens %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Has enviat la sol·licitud de contacte a %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Has guanyat aquest nom d'usuari";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Tot a punt. Ara altres usuaris et poden enviar sol·licituds de contacte, i tu pots enviar les teves.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "La teva identitat de Dash Platform apareixerà aquí quan registris un nom d'usuari.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "El teu historial, organitzat";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "La teva identitat necessita dues claus addicionals perquè les sol·licituds de contacte es puguin xifrar entre tu i els altres usuaris. En activar-ho s'afegeixen amb una única transacció de xarxa. Això passa una sola vegada.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "La teva invitació paga la comissió de registre d'aquest nom d'usuari.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "El teu saldo principal de Dash a la cadena de blocs Core: el que envies i reps amb altres carteres, cases de canvi i comerços.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Les teves monedes barrejades s'han mogut al saldo de la teva cartera Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Les teves monedes barrejades s'han mogut al teu saldo blindat. Per obtenir la millor privadesa, espera com a mínim 2 hores abans d'utilitzar aquests fons.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "El teu saldo de Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "El teu saldo privat. Els imports i les adreces estan xifrats a la cadena, de manera que les teves tinences i el teu historial es mantenen confidencials.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "El teu saldo blindat";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "El teu saldo blindat gairebé està a punt: et podràs registrar de manera privada cap a les %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "El teu saldo blindat està a punt: registra el teu nom d'usuari de manera privada ara";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "El teu saldo blindat està reposant: et podràs registrar de manera privada cap a les %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "El teu saldo blindat encara està madurant. Estarà a punt cap a les %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "El teu saldo transparent";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "El teu nom d'usuari és visible per a tothom. Finançar-lo des del teu saldo blindat —després de deixar reposar els fons unes hores— fa que ningú pugui vincular el teu nom d'usuari amb la resta dels teus Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "El teu nom d'usuari, el teu perfil i els teus contactes segueixen aquesta identitat.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "El teu nom d'usuari, el teu perfil i els teus contactes seguiran aquesta identitat.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Els teus vots";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "La teva cartera encara s'està sincronitzant amb la xarxa Dash. Podràs enviar quan acabi la sincronització.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "La teva cartera encara s'està sincronitzant. Podràs enviar des del teu saldo transparent quan acabi la sincronització.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "No s'ha pogut llegir «%@» com a nom d'usuari de Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» s'ha registrat. Vols enviar una sol·licitud de contacte a la persona que t'ha convidat?";

--- a/DashWallet/ca.lproj/Localizable.stringsdict
+++ b/DashWallet/ca.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ comptats per a «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u vot</string>
+			<key>other</key>
+			<string>%1$u vots</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>S'ha votat en %1$d de %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nom d'usuari</string>
+			<key>other</key>
+			<string>%2$d noms d'usuari</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Emet %u vot</string>
+			<key>other</key>
+			<string>Emet %u vots</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ han votat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ han votat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d node</string>
+			<key>other</key>
+			<string>%2$d nodes</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot en total</string>
+			<key>other</key>
+			<string>%u vots en total</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d seleccionat</string>
+			<key>other</key>
+			<string>%d seleccionats</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d dels teus nodes ja ha votat aquí i no apareix a la llista.</string>
+			<key>other</key>
+			<string>%d dels teus nodes ja han votat aquí i no apareixen a la llista.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot per disputa — els evonodes compten com a 4 i els masternodes com a 1</string>
+			<key>other</key>
+			<string>%u vots per disputa — els evonodes compten com a 4 i els masternodes com a 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Vota sobre %d nom d'usuari</string>
+			<key>other</key>
+			<string>Vota sobre %d noms d'usuari</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot</string>
+			<key>other</key>
+			<string>%u vots</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Vota ×%d</string>
+			<key>other</key>
+			<string>Vota ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d sol·licitud</string>
+			<key>other</key>
+			<string>%d sol·licituds</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ca.lproj/Localizable.stringsdict
+++ b/DashWallet/ca.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ comptats per a «%2$@»</string>
+		<string>%#@votes@ per a «%2$@»</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u vot</string>
+			<string>%1$u vot comptat</string>
 			<key>other</key>
-			<string>%1$u vots</string>
+			<string>%1$u vots comptats</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ han votat</string>
+		<string>Votat: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ han votat</string>
+		<string>Votat: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " nebo ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Uživatele %@ se v síti Dash nepodařilo najít, takže mu nelze poslat žádost o přidání mezi kontakty.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash k dispozici";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ přijal vaši žádost o přidání mezi kontakty";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtů";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffů";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld z %ld vkladů";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" není slovem fráze pro obnovení. Chcete se pokusit obnovit slovo, které by správně na tomto místě mělo být?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditní zůstatek na Dash Platform, který se používá pro okamžité platby mezi adresami Platform a pro funkce, jako jsou uživatelská jména.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Přístupový kód zařízení je třeba k zabezpečení vaší peněženky. Přejděte do nastavení a pokračujte zapnutím přístupového kódu.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "O aplikaci";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "O mně";
+
+"Abstain" = "Zdržet se";
+
+"Abstain on “%@”" = "Zdržet se u „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Přijmout";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktivní";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivita";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivita je veřejná, ale není snadné ji sledovat";
+
 /* No comment provided by engineer. */
 "Add" = "Přidat";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Přidat %@ jako kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Přidejte %@ mezi kontakty, abyste mohli platit přímo na uživatelské jméno a uchovávat společnou historii transakcí";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Přidejte %@ Dash do stíněného zůstatku a nechte je několik hodin odpočívat, aby registrace nespojila vaše uživatelské jméno s ostatními prostředky.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Přidat nový kontakt";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Přidejte do stíněného zůstatku alespoň %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Doplňte stíněný zůstatek nyní a uživatelské jméno si za pár hodin zaregistrujte soukromě";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Vše";
 
+"All nodes at once" = "Všechny uzly najednou";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všechny vaše masternody o tomto uživatelském jménu hlasovaly. Chcete‑li hlas změnit, hlasujte znovu od uchazeče, kterého nyní upřednostňujete.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Téměř okamžitá synchronizace zůstatků";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Částky a adresy jsou v blockchainu veřejné";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Účet Ethereum je jedna opakovaně používaná adresa: celý váš zůstatek i historie plateb jsou pod ní veřejně dostupné a jméno (například doména ENS) obvykle ukazuje přímo na tuto adresu, takže ji může přeložit kdokoli. DashPay má opačnou podobu — jméno se překládá na identitu, nikoli na platební adresu, a skutečné platební adresy zůstávají uvnitř šifrovaných výměn s kontakty, pro každý kontakt nové.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Intuitivní používání napříč všemi tvými zařízeními";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Kdokoli, kdo zná adresu, si může prohlédnout její historii";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Aplikovat";
 
+"Approve" = "Schválit";
+
+"Approving a specific request can only be done one username at a time." = "Schválit konkrétní žádost lze jen pro jedno uživatelské jméno najednou.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Jako text";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Ověření zrušeno. Váš hlas nebyl odevzdán.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Ověření selhalo. Váš hlas nebyl odevzdán.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Autentizace není dostupná";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Přidělit „%@“ tomuto uchazeči";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Bilance";
 
 /* CrowdNode */
+"Balance after" = "Zůstatek poté";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Zůstatky a převody nejsou veřejně viditelné";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Počáteční výška uložena — zvýšená spodní hranice skenování platí od příštího spuštění.";
+
 /* Voting */
 "Block" = "Blok";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vázán na kontrakt";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vázán na kontrakt, typ dokumentu „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Pouze prohlížení";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Sbalí poslední diagnostické záznamy do zipu, abyste je mohli poslat přes AirDrop, e‑mailem nebo uložit do Souborů";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Odevzdat hlas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Změnit protějšky";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Změnit PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontroluje se…";
+
+"Choice" = "Volba";
+
 /* Choose your Dash username */
 "Choose your" = "Vyberte váš";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Zvolte si uživatelské jméno";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Uplatněte svou pozvánku";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Nárokovatelný zůstatek";
+
 /* No comment provided by engineer. */
 "Claimed" = "Získáno";
+
+/* SPV diagnostics */
+"Clear & resync" = "Vymazat a znovu synchronizovat";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Vymazat data řetězce a znovu synchronizovat?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Zavřít aplikaci";
 
+"Closing" = "Uzavírá se";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nové mince)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin již není podporován — vyberte, kam přesunout vaše smíchané mince.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolaterál";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Již brzy";
+
+/* Shielded transfer status */
+"Completed" = "Dokončeno";
 
 /* No comment provided by engineer. */
 "Confirm" = "Potvrdit";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potvrzená";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potvrzením se uloží počáteční výška %u a při příštím spuštění aplikace se vymažou data řetězce této sítě, znovu se stáhnou a filtry se od této výšky znovu prohledají. Běžící relace si ponechá původní spodní hranici skenování — ukončete a znovu otevřete aplikaci, aby se spustilo.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Připojené protějšky";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nevýhody";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Žádost o přidání mezi kontakty selhala";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Žádost o přidání mezi kontakty odeslána uživateli %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Žádosti o přidání mezi kontakty";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kontakty";
 
+"Contender %@" = "Uchazeč %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Pokračovat";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Pokračujte a vyberte si uživatelské jméno. Pozvánka pokryje registrační poplatek.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Zkopírovat odkaz na pozvánku";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopírovat surovou transakci";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Nelze automaticky obnovit chybějící nebo nesprávná slova";
 
+/* Log export */
+"Could not create the log archive: %@" = "Nepodařilo se vytvořit archiv záznamů: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Nelze najít směnný kurz.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nepodařilo se obnovit %d identit";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Nepodařilo se načíst zůstatek (chyba sítě). Zkuste obnovit.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Platbu nelze provést";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Vytvořte si uživatelské jméno, najděte přátele a rodinu podle jejich uživatelských jmen a přidejte si je mezi kontakty";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Kreditní karta";
+
+/* Masternodes */
+"Credits" = "Kredity";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash platby nemohou být nižší než %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform tento spor ještě nezaindexovala. Počty hlasů se zde zobrazí, jakmile se tak stane.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ještě není připojena. Počkejte na dokončení synchronizace a zkuste to znovu.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash odeslaný na nesprávnou adresu nelze získat zpět. Ujistěte se, že adresa je přesně ta, které chcete zaplatit.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash ukládá uživatelská jména v podobě odolné vůči zaměnitelným zápisům, takže uložené jméno se může lišit od toho, co jednotliví lidé napsali.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash uživatelské jméno";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Zůstatek peněženky Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay povoleno";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay pozvánka";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je sociální platební zážitek Dash, postavený na Dash Platform. Zaregistrujete si uživatelské jméno, přidáte další uživatele jako kontakty a platíte jim na jméno — už žádné kopírování adres.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay nahrazuje dlouhé nesrozumitelné adresy uživatelskými jmény. Přidejte si přátele jako kontakty, posílejte peníze na jméno a mějte každou platbu uspořádanou podle osoby.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade poplatek";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Termín neznámý";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Odvozovací cesta";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "ZABEZPEČENÍ ZAŘÍZENÍ KOMPROMITOVÁNO\nJakákoliv ‚jailbreak‘ aplikace může přistupovat k datům jiné aplikace (a ukrást váš Dash). Vymažte tuto peněženku a prověďte obnovu na jiném zařízení.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Zakázán";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Hotovo";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Hotovo — váš zůstatek odpočíval dost dlouho";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Zkontrolujte adresu ještě jednou";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Každá pozvánka bude financována touto částkou, aby si příjemce mohl rychle vytvořit uživatelské jméno na Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Každý masternode má v jednom sporu jeden platný hlas. Můžete jej později změnit, ale Dash Platform povoluje celkem jen 5 hlasů na masternode v jednom sporu.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Každé klepnutí přidá do hlasování další uzel, takže si vyberete, kolik jich spojíte dohromady.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Dřívější";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Jednoduše Dash úročte a získejte pasivní příjem pomocí několika kliknutí.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Upravit počáteční výšku";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Upravit profil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Povolit";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Povolit DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Zapnout Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Zapnout Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Povolení DashPay stojí malý jednorázový síťový poplatek, který se hradí z kreditního zůstatku vaší identity. Přesný odhad se zobrazí před potvrzením. Za odesílání žádostí o kontakt a plateb se účtují běžné síťové poplatky.";
+
+"Ending soonest" = "Končí nejdříve";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Při aktualizaci profilu se stala chyba";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Odhadovaný poplatek síti";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Všechny uzly hlasují společně. Je to rychlejší, ale veřejně to vzájemně spojuje vaše masternody.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operátorské klíče Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Exportovat záznamy";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Externí adresa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Selhalo";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Načítá se…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtr";
+
+/* SPV sync phase */
+"Filter headers" = "Hlavičky filtrů";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Najděte uživatele v síti Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Najít identity";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Zapomenutý PIN?";
 
+/* Identities */
+"Found %d new identities" = "Nalezeno %d nových identit";
+
+/* Identities */
+"Found 1 new identity" = "Nalezena 1 nová identita";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Nalezené chybějící slovo:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financujte své uživatelské jméno ze stíněného zůstatku. Prostředky přidejte pár hodin dopředu — krátké odpočívání zabrání spojení vašeho uživatelského jména s ostatními Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financováno ze stíněného zůstatku — vaše uživatelské jméno nelze spojit s ostatními vašimi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Prostředky uzamčeny — převod se dokončuje";
+
+/* CoinJoin */
+"Funds moved" = "Prostředky přesunuty";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Připravte se vstoupit do DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Rozumím";
+
+/* Governance */
+"Governance" = "Správa sítě";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Udělte GPS oprávnění, abychom mohli zobrazovat místa ve vašem okolí.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "vás požádal o přátelství";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Máte pozvánku?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Spravuj a přizpůsob si svojí peněženku";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d z %2$d";
+
+/* SPV sync phase */
+"Headers" = "Hlavičky";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Výška %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Vyšší poplatky kolem 7 centů (stále nižší než u jiných blockchainů s podobným soukromím)";
+
 /* No comment provided by engineer. */
 "History" = "Historie";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Jak je to v porovnání s Bitcoinem z hlediska soukromí?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Jak je to v porovnání s účty Ethereum z hlediska soukromí?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Jak soukromé je DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Mám poznamenáno";
 
+/* Identities */
+"Identities" = "Identity";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kredity identity";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Index identity";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registrace identity";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Dobití identity";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktivní";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Vstup %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Vstup %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Vstupy (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Nedostatečný zůstatek";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Poplatek za pozvánku";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Pozvánka od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Pozvat";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Pozvěte někoho do sítě Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Pozvěte nejbližší, najděte své přátele vyhledáním jejich uživatelských jmen";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Pozvěte přátele a nejbližší, aby se připojili k Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Pozvěte přátele a rodinu do sítě Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Ponechat tyto mince soukromé. Účtují se síťové poplatky a poplatky za soukromí.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Klíč č. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Data klíče";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Vlastnictví klíče";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Klíče";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vede";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Zjistit více";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Načítají se transakce";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Místní Měna";
 
+/* Identities */
+"Local Only" = "Pouze lokálně";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Požadovaná částka: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Místo";
 
+"Lock" = "Uzamknout";
+
+"Lock the name" = "Uzamknout jméno";
+
+"Lock “%@” so nobody gets it" = "Uzamknout „%@“, aby jej nikdo nezískal";
+
 /* No comment provided by engineer. */
 "Locked" = "Blokováno";
 
+"Locked — nobody receives this username" = "Uzamčeno — toto uživatelské jméno nezíská nikdo";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Nízká";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Nízké poplatky pro každodenní útraty";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Hlavní";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Svazek klíčů masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Seznam masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "seznam masternodů #%1$d z %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Aktualizace masternode";
 
+"Masternode votes" = "Hlasy masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternody";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternody a evonody zaregistrované klíči této peněženky se zde zobrazí po synchronizaci peněženky.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternody a evonody používající klíče této peněženky";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternody hlasují o jménech, o která požádalo více než jedna osoba. Po skončení hlasování vám dáme vědět.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum splněno";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Lepší správa";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Další návrhy";
+
+"Most lock votes" = "Nejvíce uzamykacích hlasů";
+
+"Most votes" = "Nejvíce hlasů";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Posuňte a přibližte svou fotografii tak, aby vám dokonale seděla";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Přesunout do běžného použitelného zůstatku.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Přesunuto na adresu";
+
+/* CoinJoin */
+"Moving funds" = "Přesouvají se prostředky";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Jméno";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Jmenné služby jako Unstoppable Domains přiřazují čitelné jméno k pevné veřejné adrese v řetězci. Kdokoli může jméno přeložit a vidět každou platbu, která na něj kdy přišla. Uživatelské jméno DashPay se nikdy veřejně nepřekládá na platební adresu — adresy se odhalují jen uvnitř šifrované výměny s každým kontaktem, takže vaše jméno a vaše peníze zůstávají pro vnější pozorovatele nespojené.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Vyžaduje pozornost";
 
 /* No comment provided by engineer. */
 "Network" = "Síť";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "V tomto zařízení se nenašly žádné diagnostické záznamy. Záznamy se zapisují od příštího spuštění.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Žádné identity";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Zatím žádné masternody";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Žádné odpovídající spory";
+
+/* Identities */
+"No new identities were found for this wallet" = "Pro tuto peněženku se nenašly žádné nové identity";
+
+"No open contest matches that search." = "Tomuto vyhledávání neodpovídá žádný otevřený spor.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Tomuto vyhledávání neodpovídá žádný otevřený spor. Jména se ukládají v normalizované podobě, takže „alice“ je uvedena jako „a11ce“.";
+
+"No open contests" = "Žádné otevřené spory";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Pro připojenou peněženku se nenašel uložený záznam.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Pro záložní stíněnou registraci zatím není k dispozici žádná adresa Platform. Zkuste to znovu po dokončení synchronizace peněženky.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Žádné výsledky";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Momentálně není sporné žádné uživatelské jméno. Spor vznikne, když o stejné jméno požádají dva nebo více lidí.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nebyly odevzdány žádné hlasy";
+
+"Nobody gets it" = "Nezíská ho nikdo";
+
+/* SPV sync peer type */
+"Node" = "Uzel";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandardní";
 
 /* adjective, security level */
 "None" = "Žádná";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Není dostupný";
 
+"Not available yet" = "Zatím nedostupné";
+
+"Not cast" = "Neodevzdán";
+
+/* Masternodes */
+"Not checked yet" = "Zatím nezkontrolováno";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nedostatečný stíněný zůstatek pro registraci identity";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Není v historii peněženky";
+
+"Not now" = "Teď ne";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Obchodníci jej běžně nepřijímají";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Obchodníci jej zatím běžně nepřijímají";
+
+/* Masternode keys */
+"Not yet used" = "Zatím nepoužit";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "V Bitcoinu neexistuje vrstva jmen, takže lidé sdílejí a opakovaně používají adresy veřejně — jakmile je adresa známá, vše, co kdy přijala, lze spojit s jejím vlastníkem. V DashPay je vaše uživatelské jméno veřejné, ale nikdy neukazuje na platební adresu: adresy se vyměňují soukromě pro každý kontakt a střídají se, takže platba na jméno nezveřejňuje, kam vaše peníze míří. Oba jsou transparentní řetězce, takže analýza řetězce se na samotné mince stále vztahuje.";
+
+/* Identities */
+"On Network" = "V síti";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Jakmile %@ přijme vaši žádost, budete moci platit přímo na uživatelské jméno";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Po jednom uzlu";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "O uživatelských jménech mohou hlasovat pouze masternody a evonody. Tato peněženka neobsahuje aktivní hlasovací klíče masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operátor";
+
+/* Masternode keys */
+"Operator keys" = "Operátorské klíče";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Veřejný klíč operátora (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "nebo";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Jiné výsledky";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Výstup %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Výstupy (%d)";
+
+/* Masternodes */
+"Owner" = "Majitel";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Adresa majitele";
+
+/* Masternodes */
+"Owner address" = "Adresa majitele";
+
+/* Masternodes */
+"Owner key hash" = "Hash klíče majitele";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Klíče majitele";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Uhrazeno z kreditního zůstatku vaší identity.";
 
 /* DashSpend */
 "Password" = "Heslo";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Vložte pozvánkový odkaz, který jste dostali, nebo naskenujte jeho QR kód. Pokryje registraci vašeho uživatelského jména.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Vložte adresu URL obrázku";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Plať a přijímej platby zcela okamžitě";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "platit přímo na uživatelské jméno";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plaťte lidem, ne adresám";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Platby pomocí uživatelských jmén. Už žádné alfanumerické adresy";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Placení...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Platby jsou soukromé: adresy, které si vyměňujete s kontaktem, putují v šifrovaném obsahu, který dokážete přečíst jen vy dva, a nikdy se nezveřejňují — vaše platby tedy nelze snadno spojit s vaším uživatelským jménem. Stále však jde o běžné platby v transparentním řetězci: pokročilá analýza řetězce může odhalit informace. Shielded DashPay (již brzy) tuto mezeru uzavře. Samotné žádosti o přidání mezi kontakty momentálně NEJSOU soukromé: kdokoli vidí, že dvě identity jsou propojené. Soukromé žádosti o přidání mezi kontakty jsou funkce, která přijde brzy. Vaše uživatelské jméno i profil jsou na Dash Platform také veřejné.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Platby se díky InstantSend potvrdí během sekund";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Platby provedené přímo na adresy se v aktivitě neuchovají.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Platby s každým kontaktem jsou seskupeny na jednom místě, se jmény a profily místo surových transakcí.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Výplatní adresa";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adresa Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Zůstatek Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Uzel Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID uzlu Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platby Platform neidentifikují odesílatele. Tato platba byla zaznamenána, když peněženka zaznamenala změnu zůstatku — mohla dorazit dříve.";
+
+"Platform SDK not ready" = "SDK Platform není připraveno";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Synchronizace Platform neběží. Otevřete Informace o synchronizaci → Stav synchronizace Platform a spusťte ji.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Stíněný";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Náhled pozvánky";
 
+/* Masternode keys */
+"Previously used at: " = "Dříve použit dne: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Soukromý už z návrhu";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Soukromé žádosti o kontakt (aby zůstalo soukromé, s kým se spojujete), Shielded DashPay — platby kontaktům z vašeho soukromého stíněného zůstatku — a platby uživatelům, které ještě nemáte mezi kontakty, přijdou už brzy.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Soukromé žádosti o přidání mezi kontakty se vyvíjejí a očekávají se přibližně v září–říjnu 2026. Dnes je samotná žádost veřejná — kdokoli vidí, že dvě identity jsou propojené, i když jsou platební údaje v ní zašifrované. Až soukromé žádosti vyjdou, budete si moci vybrat, zda bude vaše přátelství veřejné nebo soukromé.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Soukromé žádosti o kontakt, Shielded DashPay a platby lidem, kteří ještě nejsou kontakty.";
+
 /* No comment provided by engineer. */
 "Private key" = "Privátní klíč";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Soukromé platební adresy si vyměňujete vy a vaše kontakty. Příjemce a odesílatele plateb mezi vámi znáte jen vy a váš kontakt.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Soukromé platby";
+
+/* Usernames */
+"Private registration" = "Soukromá registrace";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Doba zpracování";
+
+/* Balance info sheet section */
+"Pros" = "Výhody";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Adresa poskytovatele";
 
+/* Masternodes */
+"Provider transactions" = "Transakce poskytovatele";
+
+/* Masternode keys */
+"Public key" = "Veřejný klíč";
+
+/* Masternode keys */
+"Public key (legacy)" = "Veřejný klíč (starší verze)";
+
+/* Identities */
+"Public keys" = "Veřejné klíče";
+
 /* No comment provided by engineer. */
 "Public URL" = "Veřejná URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Účel";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Kurz: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Surová transakce";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Surová transakce není k dispozici";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Znovu zkontroluje kompaktní blokové filtry od zvolené výšky, zda neobsahují transakce této peněženky, přičemž je znovu stáhne a porovná. Opakované skenování je zdola ohraničeno výškou vytvoření peněženky a lokálně uloženými daty řetězce — chcete‑li obnovit starší historii, snižte raději počáteční výšku peněženky.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Pouze pro čtení";
+
+/* Usernames */
+"Ready around %@" = "Připraveno přibližně v %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Důvod";
 
 /* No comment provided by engineer. */
 "Receive" = "Přijmout";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Přijato od";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Přijato od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Zaznamená vaše masternody jako hlasující, aniž by se přiklonily k některé straně.";
 
 /* No comment provided by engineer. */
 "Recover" = "Obnovit";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Fráze pro obnovení musí mít 12, 15, 18, 21 nebo 24 slov";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Obnovit";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Registrovat?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Zaregistrován dne";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registrováno z";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registrovaný masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Soukromá registrace vyžaduje alespoň %@ Dash ve stíněném zůstatku a několik hodin odpočinku — další obrazovky vás postupem provedou.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrace";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Žádá o toto jméno";
+
 /* An action */
 "Rescan" = "Znovu skenovat";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovené peněženky nedokážou vždy zjistit typ operace. Tento záznam byl zrekonstruován z poznámkových dat v řetězci.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Opakovaná synchronizace připravena od výšky %u — ukončete a znovu otevřete aplikaci, aby se spustila.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "uchovávat společnou historii transakcí";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Vyřazen";
 
 /* No comment provided by engineer. */
 "Retry" = "Opakovat";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Odvolání";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Snímky obrazovky jsou dostupné pro ostatní aplikace a zařízení. Vygenerujte novou frázi pro obnovení a udržujte ji v tajnosti.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Podpis skriptu";
+
+/* Raw transaction inspector */
+"Script type" = "Typ skriptu";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Hledat kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Hledat žádost o kontakt";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Hledat uživatele v síti Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Hledat uživatelské jméno";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Výsledky hledání pro \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Hledat uživatelská jména";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Hledá se uživatelské jméno %@ v síti Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Zabezpečte svou peněženku";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Úroveň zabezpečení";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Úroveň zabezpečení";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Vybrat vše";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Vyberte alespoň jeden masternode, se kterým budete hlasovat.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Výběr menšího počtu uzlů prozradí méně o tom, které masternody provozujete.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Odeslat prostřednictvím";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Poslat kontaktu";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Posílejte na uživatelské jméno, které si opravdu zapamatujete a ověříte.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Odešlete svou první žádost o přidání mezi kontakty";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Odesílání";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Odesílá se žádost o kontakt";
+
+/* No comment provided by engineer. */
+"Sending to" = "Odesílá se na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Odeslat na";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Odesláno uživateli %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Služba";
+
+/* Identities */
+"Set as Main" = "Nastavit jako hlavní";
+
+/* Identities */
+"Set as Main Identity" = "Nastavit jako hlavní identitu";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Nastavit PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Sdílený fond soukromí má minimální velikost";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Stíněná adresa";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Stíněný výdaj";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Spouští se stíněná peněženka…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Stíněný → Platform";
+
+"Shielded → Transparent" = "Stíněný → Transparentní";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Velikost";
+
 /* No comment provided by engineer. */
 "Skip" = "Přeskočit";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Některé z vašich masternode v tomto seznamu možná chybí — peněženka nedokázala přečíst celou vaši sadu hlasovacích klíčů. Dokončete synchronizaci a otevřete tuto obrazovku znovu.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Řadit podle";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Seřadit kontakty";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Speciální payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Uvést částku";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Úročení";
 
+/* Usernames */
+"Starts after you add funds" = "Začne po přidání prostředků";
+
+/* Transaction details */
+"Status" = "Stav";
+
 /* Step 1 */
 "Step %ld" = "Krok %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Uloženo jako";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informace o synchronizaci";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronizace je příliš pomalá?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Vyfotit z fotoaparátu";
 
+"Take no side" = "Nepřiklánět se k žádné straně";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Klepnutím zkopírujete";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Klepněte pro skrytí zůstatku";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Klíč uzlu Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash dorazí na adresu příjemce poté, co síť zpracuje výběr — může to trvat až 10 minut.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash dorazí na adresu příjemce, jakmile síť zpracuje výběr.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash dorazí na váš transparentní zůstatek, jakmile síť zpracuje výběr.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Hlavní identitu lze vybrat pouze z aktivní peněženky";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Nejsoukromější místo pro uchovávání vašich Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Uložený záznam peněženky nemá síť — opakovanou synchronizaci nelze připravit.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registrace byla odeslána, ale její výsledek se nepodařilo potvrdit. Počkejte minutu, než se peněženka zsynchronizuje, a pak to zkuste znovu — neodesílejte ji hned znovu.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Sdílený fond soukromí stále roste (%1$ld z %2$ld vkladů). Soukromá registrace se odemkne, jakmile dosáhne minima.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Sdílený fond soukromí stále roste (%1$ld z %2$ld vkladů). Zkuste to znovu, jakmile dosáhne minima.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Výška vytvoření peněženky — spodní hranice pro skenování filtrů a opakované skenování „Od vytvoření peněženky“. Nastavte ji na úroveň prvního financování peněženky nebo níže; importy používají výchozí hodnotu 200000 na mainnetu a 0 na testnetu. Uložení výšky stejné nebo nižší než aktuální vymaže při příštím spuštění data řetězce této sítě a od této výšky znovu prohledá.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "jeho (načítají se informace)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nejsou žádná nová upozornění";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Žádné transakce k zobrazení";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nejsou žádní uživatelé odpovídající jménu %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Ve vašich kontaktech nejsou žádní uživatelé odpovídající jménu %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Tyto prostředky přejdou na váš zůstatek Platform a budou připraveny k použití, jakmile se převod dokončí.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Tuto adresu nelze zaplatit z vašeho zůstatku %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Toto přidá k vaší identitě dva klíče, aby vám ostatní uživatelé mohli posílat žádosti o kontakt a abyste mohli přijímat ty jejich. Děje se to pouze jednou.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Toto použije jednu volbu na všech %d vybraných uživatelských jmen.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Tento pozvánkový odkaz není platný.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Toto není platná adresa Dash pro tuto síť";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Toto není platný pozvánkový odkaz";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Toto je vaše hlavní identita";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Tento masternode zatím nemá identitu Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Stále se to počítá jako hlasování vašich masternode v tomto sporu.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Surové bajty této transakce nejsou v tomto zařízení uloženy.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Toto uživatelské jméno připadlo někomu jinému";
+
+"This wallet could not derive the voting key for this node." = "Tato peněženka nedokázala odvodit hlasovací klíč pro tento uzel.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Tato peněženka neobsahuje aktivní hlasovací klíče masternode, takže nemůže hlasovat. Zaregistrované uzly najdete v Nástroje → Masternody.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Toto vybere celý váš zůstatek Platform jedním převodem. Dash dorazí na adresu příjemce, jakmile síť zpracuje výběr.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Toto vybere celý váš zůstatek Platform jedním převodem. Dash dorazí na váš transparentní zůstatek, jakmile síť zpracuje výběr.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Historie transakcí není k dispozici";
+
 /* No comment provided by engineer. */
 "Transaction id" = "ID transakce";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakce";
 
 /* A verb, button title. */
 "Transfer" = "Transakce";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Převod dovnitř";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Převod ven";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Převody trvají déle — vytváření důkazů o soukromí zabere čas";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Převody na jiné adresy Platform a na stíněné adresy jsou okamžité a konečné";
+
+/* Balance breakdown */
+"Transparent" = "Transparentní";
+
+/* Send screen destination type */
+"Transparent address" = "Transparentní adresa";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentní zůstatek";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentní financování veřejně spojuje vaše uživatelské jméno s těmito prostředky.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentní → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentní → Stíněný";
 
 /* An action */
 "Try again" = "Zkusit to znovu";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nelze poskytnout návrhy";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Neznámý speciální typ %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nestíněné";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Nepodporovaná URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Přejít na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Použít raději transparentní zůstatek";
+
+/* Masternode keys */
+"Used" = "Použit";
+
+/* Masternode keys */
+"Used at: " = "Použit dne: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Uživatel (načítají se informace)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Uživatelská jména";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Uživatelská jména se ukládají v normalizované podobě, aby se předešlo zaměnitelným jménům, takže se to může lišit od toho, co jednotliví lidé napsali.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Uživatelská jména, ne adresy";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Uživatelé odpovídající %@, kteří momentálně nejsou ve vašich kontaktech";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Používá jednu z nejlépe auditovaných a otestovaných knihoven s nulovou znalostí (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Platná pozvánka";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Ověřeno během registrace";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Úspěšně verifikováno";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Verze";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Velmi efektivní při nízkých poplatcích";
+
 /* adjective, security level */
 "Very High" = "Vělmi vysoká";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Zobrazit vše";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Zobrazit ve vyhledávači";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Zobrazit frázi pro obnovení";
 
+/* Raw transaction inspector */
+"View Transaction" = "Zobrazit transakci";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Hlasovat";
+
+"Vote cast" = "Hlas odevzdán";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Hlasovat o sporných uživatelských jménech";
+
+"Vote on several" = "Hlasovat o více";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Hlasovat s";
+
+"Votes that nobody should receive these usernames." = "Hlasuje za to, aby tato uživatelská jména nezískal nikdo.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Adresa pro hlasování";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresa pro hlasování";
+
+"Voting ended with no winner" = "Hlasování skončilo bez vítěze";
+
+"Voting ends" = "Hlasování končí";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Hlasování probíhá";
+
+"Voting in progress — lock votes are ahead" = "Hlasování probíhá — uzamykací hlasy vedou";
+
+"Voting in progress — you are ahead" = "Hlasování probíhá — vedete";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash hlasovacího klíče";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Klíče pro hlasování";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Hlasování o tomto uživatelském jménu bylo uzavřeno. Počty níže jsou poslední načtené.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Hlasování o „%@“ již bylo uzavřeno. Obnovte, abyste viděli výsledek.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Čeká se na Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Počáteční výška peněženky";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Peněženka deaktivována";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "A co Unstoppable Domains a podobné jmenné služby?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Kolik to stojí?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Co je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Co přijde dál?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kdy budou žádosti o kontakt soukromé?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Kde nakupovat";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Kde nakupovat?";
+
+"Who is requesting this name" = "Kdo žádá o toto jméno";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Proč to musím povolit?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Vybere celý zůstatek";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funguje s každou peněženkou, burzou a obchodníkem Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vy";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Přijali jste žádost o kontakt od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Momentálně nemáte žádné kontakty";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Nemáte dostatečné prostředky pro uskutečnění této transakce";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Zatím máte %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Odeslali jste žádost o kontakt uživateli %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Toto uživatelské jméno jste vyhráli";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Vše je připraveno. Ostatní uživatelé vám nyní mohou posílat žádosti o kontakt — a vy můžete posílat ty své.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaše identita Dash Platform se zde zobrazí, jakmile si zaregistrujete uživatelské jméno.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaše historie, uspořádaná";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vaše identita potřebuje dva další klíče, aby se žádosti o kontakt daly šifrovat mezi vámi a ostatními uživateli. Povolení je přidá jedinou síťovou transakcí. Děje se to pouze jednou.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaše pozvánka pokryje registrační poplatek za toto uživatelské jméno.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Váš hlavní zůstatek Dash v blockchainu Core — to, co posíláte a přijímáte s ostatními peněženkami, burzami a obchodníky.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaše smíchané mince byly přesunuty do zůstatku peněženky Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaše smíchané mince byly přesunuty do stíněného zůstatku. Pro co nejlepší soukromí počkejte před použitím těchto prostředků alespoň 2 hodiny.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Váš zůstatek Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Váš soukromý zůstatek. Částky a adresy jsou v řetězci zašifrované, takže vaše prostředky i historie zůstávají důvěrné.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Váš stíněný zůstatek";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Váš stíněný zůstatek je téměř připraven — soukromě se budete moci zaregistrovat přibližně v %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Váš stíněný zůstatek je připraven — zaregistrujte si nyní uživatelské jméno soukromě";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Váš stíněný zůstatek odpočívá — soukromě se budete moci zaregistrovat přibližně v %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Váš stíněný zůstatek ještě dozrává. Připraven bude přibližně v %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Váš transparentní zůstatek";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Tvoje uživatelské jméno %@ bylo úspěšně vytvořeno na Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše uživatelské jméno je viditelné pro všechny. Pokud jej financujete ze stíněného zůstatku — poté, co prostředky nechá pár hodin odpočívat —, nikdo nedokáže spojit vaše uživatelské jméno s ostatními vašimi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše uživatelské jméno, profil a kontakty patří k této identitě.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše uživatelské jméno, profil a kontakty budou patřit k této identitě.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Vaše hlasy";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Peněženka je teď zabezpečena. Frázi pro obnovení můžete kdykoliv použít pro obnovení na jiném zařízení.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaše peněženka se stále synchronizuje se sítí Dash. Odesílání bude k dispozici po dokončení synchronizace.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaše peněženka se stále synchronizuje. Odesílání z transparentního zůstatku bude k dispozici po dokončení synchronizace.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ se nepodařilo přečíst jako uživatelské jméno Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ bylo zaregistrováno. Poslat žádost o kontakt osobě, která vás pozvala?";

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Všechny uzly najednou";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všechny vaše masternody o tomto uživatelském jménu hlasovaly. Chcete‑li hlas změnit, hlasujte znovu od uchazeče, kterého nyní upřednostňujete.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všechny vaše masternody o tomto uživatelském jménu hlasovaly. Chcete‑li hlas změnit, hlasujte znovu pro uchazeče, kterého nyní upřednostňujete.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/cs.lproj/Localizable.stringsdict
+++ b/DashWallet/cs.lproj/Localizable.stringsdict
@@ -89,7 +89,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ započítáno pro „%2$@“</string>
+		<string>%#@votes@ pro „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -97,13 +97,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u hlas</string>
+			<string>%1$u započítaný hlas</string>
 			<key>few</key>
-			<string>%1$u hlasy</string>
+			<string>%1$u započítané hlasy</string>
 			<key>many</key>
-			<string>%1$u hlasu</string>
+			<string>%1$u započítaného hlasu</string>
 			<key>other</key>
-			<string>%1$u hlasů</string>
+			<string>%1$u započítaných hlasů</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<string>Hlasování: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -169,7 +169,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<string>Hlasování: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/cs.lproj/Localizable.stringsdict
+++ b/DashWallet/cs.lproj/Localizable.stringsdict
@@ -86,5 +86,305 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ započítáno pro „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u hlas</string>
+			<key>few</key>
+			<string>%1$u hlasy</string>
+			<key>many</key>
+			<string>%1$u hlasu</string>
+			<key>other</key>
+			<string>%1$u hlasů</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Hlasováno o %1$d z %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uživatelského jména</string>
+			<key>few</key>
+			<string>%2$d uživatelských jmen</string>
+			<key>many</key>
+			<string>%2$d uživatelského jména</string>
+			<key>other</key>
+			<string>%2$d uživatelských jmen</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Odevzdat %u hlas</string>
+			<key>few</key>
+			<string>Odevzdat %u hlasy</string>
+			<key>many</key>
+			<string>Odevzdat %u hlasu</string>
+			<key>other</key>
+			<string>Odevzdat %u hlasů</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>few</key>
+			<string>%2$d masternode</string>
+			<key>many</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uzlu</string>
+			<key>few</key>
+			<string>%2$d uzly</string>
+			<key>many</key>
+			<string>%2$d uzlu</string>
+			<key>other</key>
+			<string>%2$d uzlů</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>many</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>celkem %u hlas</string>
+			<key>few</key>
+			<string>celkem %u hlasy</string>
+			<key>many</key>
+			<string>celkem %u hlasu</string>
+			<key>other</key>
+			<string>celkem %u hlasů</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>few</key>
+			<string>%d masternode</string>
+			<key>many</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vybrán</string>
+			<key>few</key>
+			<string>%d vybrány</string>
+			<key>many</key>
+			<string>%d vybráno</string>
+			<key>other</key>
+			<string>%d vybráno</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d váš uzel zde již hlasoval a není uveden.</string>
+			<key>few</key>
+			<string>%d vaše uzly zde již hlasovaly a nejsou uvedeny.</string>
+			<key>many</key>
+			<string>%d vašeho uzlu zde již hlasovalo a není uvedeno.</string>
+			<key>other</key>
+			<string>%d vašich uzlů zde již hlasovalo a nejsou uvedeny.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hlas na spor — evonode se počítají jako 4, masternode jako 1</string>
+			<key>few</key>
+			<string>%u hlasy na spor — evonode se počítají jako 4, masternode jako 1</string>
+			<key>many</key>
+			<string>%u hlasu na spor — evonode se počítají jako 4, masternode jako 1</string>
+			<key>other</key>
+			<string>%u hlasů na spor — evonode se počítají jako 4, masternode jako 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hlasovat o %d uživatelském jménu</string>
+			<key>few</key>
+			<string>Hlasovat o %d uživatelských jménech</string>
+			<key>many</key>
+			<string>Hlasovat o %d uživatelských jménech</string>
+			<key>other</key>
+			<string>Hlasovat o %d uživatelských jménech</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hlas</string>
+			<key>few</key>
+			<string>%u hlasy</string>
+			<key>many</key>
+			<string>%u hlasu</string>
+			<key>other</key>
+			<string>%u hlasů</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hlasovat ×%d</string>
+			<key>few</key>
+			<string>Hlasovat ×%d</string>
+			<key>many</key>
+			<string>Hlasovat ×%d</string>
+			<key>other</key>
+			<string>Hlasovat ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d žádost</string>
+			<key>few</key>
+			<string>%d žádosti</string>
+			<key>many</key>
+			<string>%d žádosti</string>
+			<key>other</key>
+			<string>%d žádostí</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " eller ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ kunne ikke findes på Dash-netværket, så der kan ikke sendes en kontaktanmodning.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash tilgængelig";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ har accepteret din kontaktanmodning";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld af %ld indbetalinger";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "En kreditsaldo på Dash Platform, der bruges til øjeblikkelige betalinger mellem Platform-adresser og til funktioner som brugernavne.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "En enhedsadgangskode er nødvendig for at sikre din tegnebog. Gå til indstillinger for aktivér adgangskode for at fortsætte.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Om";
 
+/* DashPay FAQ title */
+"About DashPay" = "Om DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Undlad at stemme";
+
+"Abstain on “%@”" = "Undlad at stemme om “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiv";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivitet";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktiviteten er offentlig, men ikke let at spore";
+
 /* No comment provided by engineer. */
 "Add" = "Tilføj";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Tilføj %@ som kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Tilføj %@ som kontakt for at betale direkte til brugernavnet og bevare den fælles transaktionshistorik";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Læg %@ Dash i din skærmede saldo, og lad den hvile et par timer, så du kan registrere dig uden at knytte dit brugernavn til dine øvrige midler.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Læg mindst %@ Dash i din skærmede saldo";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Fyld din skærmede saldo op nu, og registrer dit brugernavn privat om et par timer";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Alle noder på én gang";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle dine masternoder har stemt om dette brugernavn. Stem igen fra den ansøger, du nu foretrækker, for at ændre en stemme.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Næsten øjeblikkelig synkronisering af saldi";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Beløb og adresser er offentlige på blockchainen";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "En Ethereum-konto er én genbrugt adresse: hele din saldo og din betalingshistorik ligger offentligt under den, og et navn (for eksempel et ENS-domæne) peger typisk direkte på den adresse, så alle kan slå den op. DashPay er lige omvendt — navnet fører til en identitet, ikke til en betalingsadresse, og de egentlige betalingsadresser bliver inde i krypterede kontaktudvekslinger, nye for hver kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Alle, der kender en adresse, kan se dens historik";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Godkend";
+
+"Approving a specific request can only be done one username at a time." = "En bestemt anmodning kan kun godkendes for ét brugernavn ad gangen.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Som tekst";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Godkendelsen blev annulleret. Din stemme blev ikke afgivet.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Godkendelsen mislykkedes. Din stemme blev ikke afgivet.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Tildel “%@” til denne ansøger";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Saldo bagefter";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldi og overførsler er ikke offentligt synlige";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Starthøjde gemt — den hævede scanningsgrænse gælder fra næste opstart.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Bundet til kontrakt";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Bundet til kontrakt, dokumenttype “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Kun gennemsyn";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Samler de seneste diagnostiklogfiler i en zip-fil, så du kan AirDroppe, maile eller gemme dem i Filer";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Afgiv stemme";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Skift peers";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrollerer…";
+
+"Choice" = "Valg";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Indløs din invitation";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo til afhentning";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Ryd og gensynkronisér";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Vil du rydde kædedata og gensynkronisere?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Lukker";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nye mønter)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin understøttes ikke længere — vælg, hvor dine blandede mønter skal flyttes hen.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Sikkerhedsstillelse";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Kommer snart";
+
+/* Shielded transfer status */
+"Completed" = "Fuldført";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Bekræftet";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Bekræftelsen gemmer starthøjden %u og rydder dette netværks kædedata ved næste appstart, henter dem igen og scanner filtrene på ny fra den højde. Den kørende session beholder sin gamle scanningsgrænse — luk appen, og åbn den igen for at begynde.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Forbundne peers";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Ulemper";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktanmodningen mislykkedes";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktanmodning sendt til %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktanmodninger";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Ansøger %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Fortsæt for at vælge dit brugernavn. Invitationen betaler registreringsgebyret.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiér rå transaktion";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Logarkivet kunne ikke oprettes: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Kunne ikke finde vekselkurs.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Kunne ikke opdatere %d identiteter";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Kunne ikke hente saldoen (netværksfejl). Prøv at opdatere.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Opret dit brugernavn, find venner og familie via deres brugernavne, og føj dem til dine kontakter";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kreditter";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform har endnu ikke indekseret denne tvist. Stemmetal vises her, når det sker.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform er ikke forbundet endnu. Vent, til synkroniseringen er færdig, og prøv igen.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash sendt til en forkert adresse kan ikke hentes tilbage. Sørg for, at adressen præcis er den, du har til hensigt at betale.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash gemmer brugernavne i en form, der er sikret mod forvekslinger, så det gemte navn kan afvige fra det, den enkelte har skrevet.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo i Dash-tegnebogen";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay er aktiveret";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay er Dashs sociale betalingsoplevelse, bygget på Dash Platform. Du registrerer et brugernavn, tilføjer andre brugere som kontakter og betaler dem med navn — ikke mere kopiering af adresser.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay erstatter lange kryptiske adresser med brugernavne. Tilføj venner som kontakter, send penge til et navn, og hold hver betaling ordnet efter person.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Frist ukendt";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Afledningssti";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Deaktiveret";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Færdig — din saldo har hvilet længe nok";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Tjek adressen en ekstra gang";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Hver masternode har én gyldig stemme pr. tvist. Du kan ændre den senere, men Dash Platform tillader kun 5 stemmer i alt pr. masternode pr. tvist.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Hvert tryk stemmer med én node mere, så du vælger, hvor mange du knytter sammen.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Rediger starthøjde";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktivér";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Aktivér DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "At aktivere DashPay koster et lille engangsgebyr til netværket, som betales fra din identitets kreditsaldo. Det præcise estimat vises, før du bekræfter. At sende kontaktanmodninger og betalinger koster de sædvanlige netværksgebyrer.";
+
+"Ending soonest" = "Slutter først";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Anslået netværksgebyr";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Alle noder stemmer sammen. Hurtigere, men det knytter offentligt dine masternoder til hinanden.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operatørnøgler til Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Eksportér logfiler";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Ekstern adresse";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Mislykkedes";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Henter…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filterheadere";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Find en bruger på Dash-netværket";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Find identiteter";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Fandt %d nye identiteter";
+
+/* Identities */
+"Found 1 new identity" = "Fandt 1 ny identitet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finansiér dit brugernavn fra din skærmede saldo. Læg midlerne ind et par timer i forvejen — den korte hvile gør, at dit brugernavn ikke kan knyttes til dine øvrige Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finansieret fra din skærmede saldo — dit brugernavn kan ikke knyttes til dine øvrige Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Midlerne er låst — overførslen afsluttes";
+
+/* CoinJoin */
+"Funds moved" = "Midlerne er flyttet";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Gør dig klar til at blive en del af DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Forstået";
+
+/* Governance */
+"Governance" = "Styring";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "har bedt om at blive din ven";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Har du en invitation?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Headere";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Højde %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Højere gebyrer omkring 7 cent (stadig lavere end andre blockchains med tilsvarende privatliv)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Hvordan står det i forhold til Bitcoin med hensyn til privatliv?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Hvordan står det i forhold til Ethereum-konti med hensyn til privatliv?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Hvor privat er DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Jeg skrev den ned";
 
+/* Identities */
+"Identities" = "Identiteter";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identitetskreditter";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identitetsindeks";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identitetsregistrering";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Optankning af identitet";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inaktiv";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Input (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitation fra %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Inviter nogen til Dash-netværket";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Inviter dine venner og din familie til Dash-netværket";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Hold disse mønter private. Der gælder netværks- og privatlivsgebyrer.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Nøgle nr. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Nøgledata";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Nøgleejerskab";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Nøgler";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Fører";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Læs mere";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Indlæser transaktioner";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Kun lokalt";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Lås";
+
+"Lock the name" = "Lås navnet";
+
+"Lock “%@” so nobody gets it" = "Lås “%@”, så ingen får det";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Låst — ingen får dette brugernavn";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Lave gebyrer til dagligt forbrug";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Primær";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Nøglering til masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternodeliste";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternodestemmer";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternoder";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternoder og evonoder, der er registreret med denne tegnebogs nøgler, vises her, når tegnebogen er synkroniseret.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternoder og evonoder, der bruger denne tegnebogs nøgler";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternoder stemmer om navne, som mere end én person har bedt om. Du får besked, når afstemningen slutter.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum er nået";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Flere forslag";
+
+"Most lock votes" = "Flest låsestemmer";
+
+"Most votes" = "Flest stemmer";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Flyt til din almindelige saldo til forbrug.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Flytter midler";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Navnetjenester som Unstoppable Domains knytter et læsbart navn til en fast offentlig adresse på kæden. Alle kan slå navnet op og se hver eneste betaling, der nogensinde er sendt til det. Et DashPay-brugernavn fører aldrig offentligt til en betalingsadresse — adresser afsløres kun inde i den krypterede udveksling med hver kontakt, så dit navn og dine penge forbliver uforbundne for udenforstående.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Kræver opmærksomhed";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Der blev ikke fundet nogen diagnostiklogfiler på denne enhed. Logfiler skrives fra næste opstart.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Ingen identiteter";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ingen masternoder endnu";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Ingen matchende tvister";
+
+/* Identities */
+"No new identities were found for this wallet" = "Der blev ikke fundet nye identiteter til denne tegnebog";
+
+"No open contest matches that search." = "Ingen åben tvist matcher den søgning.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ingen åben tvist matcher den søgning. Navne gemmes i normaliseret form, så “alice” står som “a11ce”.";
+
+"No open contests" = "Ingen åbne tvister";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Der blev ikke fundet nogen gemt tegnebogspost for den tilknyttede tegnebog.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Der er endnu ingen Platform-adresse til rådighed for den skærmede reserveregistrering. Prøv igen, når tegnebogen er færdig med at synkronisere.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Der er ingen omstridte brugernavne lige nu. Tvister opstår, når to eller flere personer beder om det samme navn.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Der blev ikke afgivet nogen stemmer";
+
+"Nobody gets it" = "Ingen får det";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Ikke-standard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Ikke tilgængelig endnu";
+
+"Not cast" = "Ikke afgivet";
+
+/* Masternodes */
+"Not checked yet" = "Endnu ikke kontrolleret";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Ikke nok skærmet saldo til at registrere en identitet";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ikke i tegnebogens historik";
+
+"Not now" = "Ikke nu";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Ikke bredt accepteret af forhandlere";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Endnu ikke bredt accepteret af forhandlere";
+
+/* Masternode keys */
+"Not yet used" = "Endnu ikke brugt";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "På Bitcoin findes der ikke et navnelag, så folk deler og genbruger adresser helt åbent — når først en adresse er kendt, kan alt, den nogensinde har modtaget, knyttes til ejeren. Med DashPay er dit brugernavn offentligt, men det peger aldrig på en betalingsadresse: adresser udveksles privat pr. kontakt og roterer, så det at betale til et navn afslører ikke, hvor dine penge går hen. Begge er transparente kæder, så kædeanalyse gælder stadig for selve mønterne.";
+
+/* Identities */
+"On Network" = "På netværket";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Når %@ accepterer din anmodning, kan du betale direkte til brugernavnet";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Én node ad gangen";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Kun masternoder og evonoder kan stemme om brugernavne. Denne tegnebog har ingen aktive afstemningsnøgler til masternoder.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operatør";
+
+/* Masternode keys */
+"Operator keys" = "Operatørnøgler";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operatørens offentlige nøgle (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "eller";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Andre udfald";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Output (%d)";
+
+/* Masternodes */
+"Owner" = "Ejer";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Ejerens adresse";
+
+/* Masternodes */
+"Owner key hash" = "Hash af ejernøgle";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Betales fra din identitets kreditsaldo.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Indsæt det invitationslink, du har modtaget, eller scan dets QR-kode. Det betaler registreringen af dit brugernavn.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "betale direkte til brugernavnet";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Betal mennesker, ikke adresser";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Nyttelast (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Betalinger er private: de adresser, du udveksler med en kontakt, rejser inde i en krypteret nyttelast, som kun I to kan læse, og de offentliggøres aldrig — derfor kan dine betalinger ikke let knyttes til dit brugernavn. Det er dog stadig helt almindelige betalinger på en transparent kæde: avanceret kædeanalyse kan lække oplysninger. Shielded DashPay (kommer snart) lukker det hul. Selve kontaktanmodningerne er i øjeblikket IKKE private: alle kan se, at to identiteter er forbundet. Private kontaktanmodninger er en funktion, der kommer snart. Dit brugernavn og din profil er også offentlige på Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Betalinger bekræftes på sekunder med InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Betalinger foretaget direkte til adresser bevares ikke i aktiviteten.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Betalingerne med hver kontakt samles ét sted, med navne og profiler i stedet for rå transaktioner.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Udbetalingsadresse";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-adresse";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-node";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-node-id";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-betalinger identificerer ikke afsenderen. Denne betaling blev registreret, da tegnebogen bemærkede saldoændringen — den kan være ankommet tidligere.";
+
+"Platform SDK not ready" = "Platform-SDK'et er ikke klar";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform-synkroniseringen kører ikke. Åbn Synkroniseringsinfo → Platform-synkroniseringsstatus for at starte den.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Skærmet";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Tidligere brugt den: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat af design";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Private kontaktanmodninger (så det forbliver privat, hvem du forbinder dig med), Shielded DashPay — kontaktbetalinger fra din private skærmede saldo — og betalinger til brugere, der endnu ikke er blandt dine kontakter, kommer alle snart.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Private kontaktanmodninger er under udvikling og forventes omkring september–oktober 2026. I dag er selve anmodningen offentlig — alle kan se, at to identiteter er forbundet, selv om betalingsoplysningerne i den er krypterede. Når private kontaktanmodninger kommer, kan du vælge, om dit venskab skal være offentligt eller privat.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Private kontaktanmodninger, Shielded DashPay og betalinger til folk, der endnu ikke er kontakter.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Private betalingsadresser udveksles mellem dig og dine kontakter. Kun du og din kontakt ved, hvem der er modtager og afsender af betalingerne mellem jer.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Private betalinger";
+
+/* Usernames */
+"Private registration" = "Privat registrering";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Behandlingstid";
+
+/* Balance info sheet section */
+"Pros" = "Fordele";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Udbydertransaktioner";
+
+/* Masternode keys */
+"Public key" = "Offentlig nøgle";
+
+/* Masternode keys */
+"Public key (legacy)" = "Offentlig nøgle (ældre)";
+
+/* Identities */
+"Public keys" = "Offentlige nøgler";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Formål";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Rå transaktion";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Rå transaktion er ikke tilgængelig";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Kontrollerer de kompakte blokfiltre fra den valgte højde igen for denne tegnebogs transaktioner ved at hente og sammenholde dem på ny. Genscanninger er nedadtil begrænset af tegnebogens oprettelseshøjde og af lokalt gemte kædedata — sænk i stedet tegnebogens starthøjde for at genskabe historik under det niveau.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Skrivebeskyttet";
+
+/* Usernames */
+"Ready around %@" = "Klar omkring %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Årsag";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Modtaget fra %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Registrerer, at dine masternoder har stemt, uden at tage parti.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Opdater";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registreret den";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privat registrering kræver mindst %@ Dash på din skærmede saldo plus et par timers hvile — de næste skærme guider dig igennem.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrering";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Beder om dette navn";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Gendannede tegnebøger kan ikke altid genskabe handlingstypen. Denne post er rekonstrueret ud fra notedata på kæden.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Gensynkronisering klargjort fra højde %u — luk appen, og åbn den igen for at begynde.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "bevare den fælles transaktionshistorik";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Udgået";
 
 /* No comment provided by engineer. */
 "Retry" = "Prøv igen";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Tilbagekaldelse";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Skærmbilleder er synlige for andre apps og enheder. Lav en ny gendannelsessætning og hold den hemmelig.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Scriptsignatur";
+
+/* Raw transaction inspector */
+"Script type" = "Scripttype";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Søg efter en kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Søg efter en kontaktanmodning";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Søg efter en bruger på Dash-netværket";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Søg efter et brugernavn";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Søgeresultater for \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Søg efter brugernavne";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Søger efter brugernavnet %@ på Dash-netværket";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Sikkerhedsniveau";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Vælg alle";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Vælg mindst én masternode at stemme med.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Vælger du færre noder, afsløres der mindre om, hvilke masternoder du driver.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Send til en kontakt";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Send til et brugernavn, du faktisk kan huske og bekræfte.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Send din første kontaktanmodning";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Sender kontaktanmodning";
+
+/* No comment provided by engineer. */
+"Sending to" = "Sender til";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Sendt til %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Tjeneste";
+
+/* Identities */
+"Set as Main" = "Angiv som primær";
+
+/* Identities */
+"Set as Main Identity" = "Angiv som primær identitet";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Den delte privatlivspulje er på minimumsstørrelse";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Skærmet adresse";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Skærmet forbrug";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Starter den skærmede tegnebog…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Skærmet → Platform";
+
+"Shielded → Transparent" = "Skærmet → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Størrelse";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Nogle af dine masternoder mangler måske på denne liste — tegnebogen kunne ikke læse hele dit sæt af afstemningsnøgler. Afslut synkroniseringen, og åbn denne skærm igen.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortér kontakter";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Særlig nyttelast";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Begynder, når du tilføjer midler";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Gemt som";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Synkroniseringsinfo";
+
+/* SPV sync */
+"Sync too slow?" = "Går synkroniseringen for langsomt?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Tag ikke parti";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tryk for at kopiere";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-nodenøgle (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash når modtagerens adresse, efter at netværket har behandlet udbetalingen — det kan tage op til 10 minutter.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash når modtagerens adresse, så snart netværket behandler udbetalingen.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash når din transparente saldo, så snart netværket behandler udbetalingen.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Den primære identitet kan kun vælges fra den aktive tegnebog";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Det mest private sted at opbevare dine Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Den gemte tegnebogspost har intet netværk — gensynkronisering kan ikke klargøres.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registreringen blev indsendt, men resultatet kunne ikke bekræftes. Vent et minut, mens tegnebogen synkroniserer, og prøv så igen — undlad at indsende igen med det samme.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Den delte privatlivspulje vokser stadig (%1$ld af %2$ld indbetalinger). Privat registrering låses op, når den når minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Den delte privatlivspulje vokser stadig (%1$ld af %2$ld indbetalinger). Prøv igen, når den når minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Tegnebogens oprettelseshøjde — den nedre grænse for filterscanninger og for genscanninger af typen “Fra tegnebogens oprettelse”. Sæt den ved eller under tegnebogens første indbetaling; import bruger som standard 200000 på mainnet og 0 på testnet. Hvis du gemmer en højde, der er lig med eller lavere end den nuværende, ryddes dette netværks kædedata ved næste opstart, og der scannes på ny derfra.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "ham (henter info)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Der er ingen nye notifikationer";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Der er ingen brugere, der matcher navnet %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Der er ingen brugere blandt dine kontakter, der matcher navnet %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Disse midler flyttes til din Platform-saldo og er klar til brug, så snart overførslen er gennemført.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Denne adresse kan ikke betales fra din %@-saldo";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Dette føjer to nøgler til din identitet, så andre brugere kan sende dig kontaktanmodninger, og så du kan acceptere deres. Det sker kun én gang.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Dette anvender ét valg på alle %d valgte brugernavne.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Dette invitationslink er ikke gyldigt.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Dette er ikke en gyldig Dash-adresse til dette netværk";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Dette er ikke et gyldigt invitationslink";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Dette er din primære identitet";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Denne masternode har endnu ingen Platform-identitet.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Det tæller stadig som, at dine masternoder har stemt i denne tvist.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Denne transaktions rå byte er ikke gemt på denne enhed.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Dette brugernavn gik til en anden";
+
+"This wallet could not derive the voting key for this node." = "Denne tegnebog kunne ikke aflede afstemningsnøglen til denne node.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Denne tegnebog har ingen aktive afstemningsnøgler til masternoder og kan derfor ikke stemme. Registrerede noder vises under Værktøjer → Masternoder.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dette hæver hele din Platform-saldo i én overførsel. Dash når modtagerens adresse, så snart netværket behandler udbetalingen.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dette hæver hele din Platform-saldo i én overførsel. Dash når din transparente saldo, så snart netværket behandler udbetalingen.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Transaktionshistorikken er ikke tilgængelig";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaktions-id";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Overførsel ind";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Overførsel ud";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Overførsler tager længere tid — det tager tid at bygge privatlivsbeviserne";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Overførsler til andre Platform-adresser og til skærmede adresser er øjeblikkelige og endelige";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Transparent adresse";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparent saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparent finansiering knytter offentligt dit brugernavn til disse midler.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Skærmet";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Kan ikke give forslag";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Ukendt specialtype %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Uskærmet";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Opgradér til Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Brug den transparente saldo i stedet";
+
+/* Masternode keys */
+"Used" = "Brugt";
+
+/* Masternode keys */
+"Used at: " = "Brugt den: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Bruger (henter info)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Brugernavne";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Brugernavne gemmes i normaliseret form for at undgå navne, der ligner hinanden, så dette kan afvige fra det, den enkelte har skrevet.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Brugernavne, ikke adresser";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Brugere, der matcher %@, og som lige nu ikke er blandt dine kontakter";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Bruger et af de mest gennemgåede og testede zero-knowledge-biblioteker (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Gyldig invitation";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Bekræftet under registreringen";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Version";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Meget effektiv med lave gebyrer";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Vis alle";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Vis transaktion";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Stem";
+
+"Vote cast" = "Stemme afgivet";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Stem om omstridte brugernavne";
+
+"Vote on several" = "Stem om flere";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Stem med";
+
+"Votes that nobody should receive these usernames." = "Stemmer for, at ingen skal have disse brugernavne.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Afstemningsadresse";
+
+"Voting ended with no winner" = "Afstemningen sluttede uden vinder";
+
+"Voting ends" = "Afstemningen slutter";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Afstemning i gang";
+
+"Voting in progress — lock votes are ahead" = "Afstemning i gang — låsestemmerne fører";
+
+"Voting in progress — you are ahead" = "Afstemning i gang — du fører";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash af afstemningsnøgle";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Afstemningen om dette brugernavn er lukket. Tallene nedenfor er de senest aflæste.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Afstemningen om “%@” er allerede lukket. Opdater for at se resultatet.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Venter på Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Tegnebogens starthøjde";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Hvad med Unstoppable Domains og lignende navnetjenester?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Hvad koster det?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Hvad er DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Hvad kommer der herefter?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Hvornår bliver kontaktanmodninger private?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Hvem beder om dette navn";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Hvorfor skal jeg aktivere det?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Hæver hele saldoen";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Virker med alle Dash-tegnebøger, børser og forhandlere";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Dig";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Du accepterede kontaktanmodningen fra %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Du har ingen kontakter i øjeblikket";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Du har %@ Dash indtil videre";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Du sendte kontaktanmodningen til %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Du vandt dette brugernavn";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Alt er klar. Andre brugere kan nu sende dig kontaktanmodninger — og du kan sende dine.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Din Dash Platform-identitet vises her, når du registrerer et brugernavn.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Din historik, ordnet";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Din identitet har brug for to ekstra nøgler, så kontaktanmodninger kan krypteres mellem dig og andre brugere. Aktiveringen tilføjer dem med en enkelt netværkstransaktion. Det sker kun én gang.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Din invitation betaler registreringsgebyret for dette brugernavn.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Din primære Dash-saldo på Core-blockchainen — det, du sender og modtager med andre tegnebøger, børser og forhandlere.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Dine blandede mønter er flyttet til saldoen i din Dash-tegnebog.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Dine blandede mønter er flyttet til din skærmede saldo. For det bedste privatliv bør du vente mindst 2 timer, før du bruger disse midler.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Din Platform-saldo";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Din private saldo. Beløb og adresser er krypteret på kæden, så din beholdning og din historik forbliver fortrolige.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Din skærmede saldo";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Din skærmede saldo er næsten klar — du kan registrere dig privat omkring %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Din skærmede saldo er klar — registrer dit brugernavn privat nu";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Din skærmede saldo hviler — du kan registrere dig privat omkring %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Din skærmede saldo modner stadig. Den er klar omkring %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Din transparente saldo";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Dit brugernavn er synligt for alle. Hvis du finansierer det fra din skærmede saldo — efter at have ladet midlerne hvile et par timer — kan ingen knytte dit brugernavn til dine øvrige Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Dit brugernavn, din profil og dine kontakter følger denne identitet.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Dit brugernavn, din profil og dine kontakter vil følge denne identitet.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Dine stemmer";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Din tegnebog synkroniserer stadig med Dash-netværket. Du kan sende, når synkroniseringen er færdig.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Din tegnebog synkroniserer stadig. Du kan sende fra din transparente saldo, når synkroniseringen er færdig.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@” kunne ikke læses som et Dash-brugernavn.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” er blevet registreret. Vil du sende en kontaktanmodning til den person, der inviterede dig?";

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Alle noder på én gang";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle dine masternoder har stemt om dette brugernavn. Stem igen fra den ansøger, du nu foretrækker, for at ændre en stemme.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle dine masternoder har stemt om dette brugernavn. Stem igen på den ansøger, du nu foretrækker, for at ændre en stemme.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/da.lproj/Localizable.stringsdict
+++ b/DashWallet/da.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ talt for “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u stemme</string>
+			<key>other</key>
+			<string>%1$u stemmer</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Stemt på %1$d af %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d brugernavn</string>
+			<key>other</key>
+			<string>%2$d brugernavne</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Afgiv %u stemme</string>
+			<key>other</key>
+			<string>Afgiv %u stemmer</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d af %#@nodes@ har stemt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d af %#@nodes@ har stemt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d node</string>
+			<key>other</key>
+			<string>%2$d noder</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonoder</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme i alt</string>
+			<key>other</key>
+			<string>%u stemmer i alt</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d valgt</string>
+			<key>other</key>
+			<string>%d valgt</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d af dine noder har allerede stemt her og vises ikke.</string>
+			<key>other</key>
+			<string>%d af dine noder har allerede stemt her og vises ikke.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme pr. tvist — evonoder tæller som 4, masternoder som 1</string>
+			<key>other</key>
+			<string>%u stemmer pr. tvist — evonoder tæller som 4, masternoder som 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stem om %d brugernavn</string>
+			<key>other</key>
+			<string>Stem om %d brugernavne</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme</string>
+			<key>other</key>
+			<string>%u stemmer</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stem ×%d</string>
+			<key>other</key>
+			<string>Stem ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d anmodning</string>
+			<key>other</key>
+			<string>%d anmodninger</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " oder ";
+
 /* CrowdNode */
 " Privacy Policy " = "Datenschutzerklärung";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ konnte im Dash-Netzwerk nicht gefunden werden, um eine Kontaktanfrage zu senden.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash verfügbar";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ hat deine Kontaktanfrage angenommen";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu Kontakte/ %3$lu Profil-Updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d Bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d Duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d die Stimmen werden abgegeben, da du mehrere Abstimmungs-Schlüssel in deiner Wallet gespeichert hast";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld Duplikate";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld von %ld Einzahlungen";
 
 /* Voting */
 "%ld requests" = "%ld Anfragen";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" ist kein Wort der Wiederherstellungsphrase. Möchtest du versuchen, das korrekt Wort wiederherzustellen, das an dieser Stelle stehen sollte?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Ein Credit-Guthaben auf Dash Platform, das für Sofortzahlungen zwischen Platform-Adressen und für Funktionen wie Benutzernamen verwendet wird.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Ein Gerätecode wird benötigt um Ihr Wallet zu schützen. Stellen Sie in Ihren Einstellungen Ihren Code ein um fortzufahren.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Über";
 
+/* DashPay FAQ title */
+"About DashPay" = "Über DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Über mich";
+
+"Abstain" = "Enthalten";
+
+"Abstain on “%@”" = "Bei „%@“ enthalten";
 
 /* No comment provided by engineer. */
 "Accept" = "Akzeptieren";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Kontowiederherstellung";
 
+/* Masternode status */
+"Active" = "Aktiv";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivität";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivität ist öffentlich, aber nicht leicht nachzuverfolgen";
+
 /* No comment provided by engineer. */
 "Add" = "Hinzufügen";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ als Kontakt hinzufügen";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Füge %@ als Kontakt hinzu, um direkt an den Benutzernamen zu zahlen und den gemeinsamen Transaktionsverlauf zu behalten";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Füge %@ Dash zu deinem abgeschirmten Guthaben hinzu und lass es einige Stunden ruhen, damit die Registrierung deinen Benutzernamen nicht mit deinen übrigen Mitteln verknüpft.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Neuen Kontakt hinzufügen";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Füge mindestens %@ Dash zu deinem abgeschirmten Guthaben hinzu";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Füge jetzt Mittel zu deinem abgeschirmten Guthaben hinzu und registriere deinen Benutzernamen einige Stunden später privat";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Alles";
 
+"All nodes at once" = "Alle Nodes auf einmal";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle deine Masternodes haben über diesen Benutzernamen abgestimmt. Um eine Stimme zu ändern, stimme erneut über den Bewerber ab, den du jetzt bevorzugst.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Erlaubst du, dass alle Transaktionen von der Dash Wallet an Zenledger gesendet werden?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Nahezu sofortige Synchronisierung der Guthaben";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Beträge und Adressen sind in der Blockchain öffentlich";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Ein Fehler ist aufgetreten";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ein Ethereum-Konto ist eine einzige wiederverwendbare Adresse: dein gesamtes Guthaben und dein Zahlungsverlauf liegen öffentlich darunter, und ein Name (etwa eine ENS-Domain) verweist üblicherweise direkt auf diese Adresse, sodass jeder sie auflösen kann. DashPay ist genau umgekehrt aufgebaut — der Name verweist auf eine Identität, nicht auf eine Zahlungsadresse, und die tatsächlichen Zahlungsadressen bleiben in verschlüsselten Kontaktaustauschen, für jeden Kontakt neu.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Eine intuitive und gewohnte Erfahrung über alle Gerätetypen hinweg";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Jeder Nutzername, der die Nummern 2-9 beinhaltet, länger als 20 Zeichen ist oder einen Bindestrich beinhaltet, wird automatisch genehmigt.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Jeder, der eine Adresse kennt, kann ihren Verlauf einsehen";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Anfragen";
 
+"Approve" = "Zustimmen";
+
+"Approving a specific request can only be done one username at a time." = "Das Zustimmen zu einer bestimmten Anfrage ist nur für einen Benutzernamen gleichzeitig möglich.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Bist du sicher, dass du diesen Handel stornieren möchtest?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Als Text";
 
 /* DashSpend */
 "at" = "bei";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Authentifizierung abgebrochen. Deine Stimme wurde nicht abgegeben.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Authentifizierung fehlgeschlagen. Deine Stimme wurde nicht abgegeben.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentifizierung nicht verfügbar";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "„%@“ diesem Bewerber zusprechen";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Guthaben";
 
 /* CrowdNode */
+"Balance after" = "Guthaben danach";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "CrowdNode Guthaben";
 
 /* CrowdNode */
 "Balance: " = "Guthaben:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Guthaben und Transfers sind nicht öffentlich sichtbar";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bankkonto";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrischer Zugang erforderlich";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Starthöhe gespeichert — die angehobene Scan-Untergrenze gilt ab dem nächsten Start.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Nutzername '%@' blockiert";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "An Contract gebunden";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "An Contract gebunden, Dokumenttyp „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Nur zum Ansehen";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Aktuelle Diagnoseprotokolle in einer ZIP-Datei bündeln, um sie per AirDrop oder E-Mail zu senden oder in Dateien zu speichern";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Stimme abgeben";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Peers wechseln";
 
 /* No comment provided by engineer. */
 "Change PIN" = "PIN ändern";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Wird geprüft…";
+
+"Choice" = "Auswahl";
+
 /* Choose your Dash username */
 "Choose your" = "Wähle deinen";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Wähle deinen Benutzernamen";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Löse deine Einladung ein";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Beanspruchbares Guthaben";
+
 /* No comment provided by engineer. */
 "Claimed" = "Beansprucht";
+
+/* SPV diagnostics */
+"Clear & resync" = "Löschen & neu synchronisieren";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Chain-Daten löschen und neu synchronisieren?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "App schließen";
 
+"Closing" = "Wird geschlossen";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (neue Coins)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA Code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin wird nicht mehr unterstützt — wähle aus, wohin deine gemixten Coins verschoben werden sollen.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Sicherheitsleistung";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Demnächst verfügbar";
+
+/* Shielded transfer status */
+"Completed" = "Abgeschlossen";
 
 /* No comment provided by engineer. */
 "Confirm" = "Bestätigen";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Bestätigt";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Beim Bestätigen wird die Starthöhe %u gespeichert und die Chain-Daten dieses Netzwerks werden beim nächsten App-Start gelöscht, neu heruntergeladen und die Filter ab dieser Höhe erneut durchsucht. Die laufende Sitzung behält ihre bisherige Scan-Untergrenze — beende die App und öffne sie erneut, um zu starten.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Verbinde deine Krypto-Wallets mit der Zenledger Plattform. Lerne mehr darüber und beginne mit deinen Transaktionen in der Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Dash Adresse verknüpfen";
 
+/* SPV sync */
+"Connected peers" = "Verbundene Peers";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nachteile";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktanfrage fehlgeschlagen";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktanfrage an %@ gesendet";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktanfragen";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kontakte";
 
+"Contender %@" = "Bewerber %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Fortfahren";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Fahre fort, um deinen Benutzernamen zu wählen. Die Einladung übernimmt die Registrierungsgebühr.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Einladungslink kopieren";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Rohtransaktion kopieren";
+
 /* No comment provided by engineer. */
 "Copy text" = "Text kopieren";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Konnte fehlende / falsche Wörter nicht automatisch wiederherstellen";
 
+/* Log export */
+"Could not create the log archive: %@" = "Das Protokollarchiv konnte nicht erstellt werden: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Kann Wechselkurs nicht finden.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d Identitäten konnten nicht aktualisiert werden";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Guthaben konnte nicht abgerufen werden (Netzwerkfehler). Versuche es mit Aktualisieren.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Zahlung konnte nicht durchgeführt werden";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Benutzernamen erstellen";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Erstelle deinen Benutzernamen, finde Freunde und Familie über ihre Benutzernamen und füge sie zu deinen Kontakten hinzu";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Kreditkarte";
+
+/* Masternodes */
+"Credits" = "Credits";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash-Zahlungen können nicht kleiner als %@ sein";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform hat diesen Wettbewerb noch nicht indexiert. Die Stimmenzahlen erscheinen hier, sobald das geschehen ist.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ist noch nicht verbunden. Warte, bis die Synchronisierung abgeschlossen ist, und versuche es erneut.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "An eine falsche Adresse gesendete Dash können nicht zurückgeholt werden. Stelle sicher, dass die Adresse genau die ist, an die du zahlen möchtest.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash speichert Benutzernamen in einer verwechslungssicheren Form, daher kann der gespeicherte Name von dem abweichen, was die jeweilige Person eingegeben hat.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash-Benutzername";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash-Wallet-Guthaben";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet auf diesem Gerät";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay aktiviert";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Einladung";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay ist das soziale Zahlungserlebnis von Dash, aufgebaut auf Dash Platform. Du registrierst einen Benutzernamen, fügst andere Nutzer als Kontakte hinzu und zahlst ihnen per Name — kein Kopieren von Adressen mehr.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay ersetzt lange kryptische Adressen durch Benutzernamen. Füge Freunde als Kontakte hinzu, sende Geld an einen Namen und halte jede Zahlung nach Person geordnet.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay-Upgradegebühr";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Datum: Alt nach neu";
+
+"Deadline unknown" = "Frist unbekannt";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Einzahlung versendet";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Ableitungspfad";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "GERÄTESICHERHEIT KOMPROMITTIERT\nJede 'Jailbreak'-App kann auf die Schlüsselbund-Daten anderer Apps zugreifen (und so Ihre Dash stehlen). Löschen Sie dieses Wallet umgehend und stellen Sie dieses auf einem sicheren Gerät wieder her.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Deaktiviert";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Coinbase Konto trennen";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Fertig";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Fertig — dein Guthaben hat lange genug geruht";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Überprüfe die Adresse noch einmal";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Jede Einladung wird mit diesem Betrag versehen damit der Empfänger schnell einen eigenen Nutzernamen im Dash-Netzwerk beanspruchen kann";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Jeder Masternode hat eine gültige Stimme pro Wettbewerb. Du kannst sie später ändern, aber Dash Platform erlaubt insgesamt nur 5 Stimmen pro Masternode und Wettbewerb.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Bei jedem Tippen stimmt ein weiterer Node mit ab, sodass du wählst, wie viele miteinander verknüpft werden.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Früher";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Dash staken und passives Einkommen generieren.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Starthöhe bearbeiten";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Profil bearbeiten";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-Mail";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktivieren";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay aktivieren";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Face ID aktivieren";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Touch ID aktivieren";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Die Aktivierung von DashPay kostet eine kleine einmalige Netzwerkgebühr, die von dem Credit-Guthaben deiner Identität bezahlt wird. Die genaue Schätzung wird dir vor der Bestätigung angezeigt. Das Senden von Kontaktanfragen und Zahlungen kostet die üblichen Netzwerkgebühren.";
+
+"Ending soonest" = "Endet am frühesten";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Fehler beim Updaten deines Profils";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Geschätzte Netzwerkgebühr";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Jeder Node stimmt gemeinsam ab. Schneller, verknüpft aber deine Masternodes öffentlich miteinander.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode-Operator-Schlüssel";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "CSV exportieren";
 
+/* Log export */
+"Export Logs" = "Protokolle exportieren";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended Public Key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Externe Adresse";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face-ID Limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Fehlgeschlagen";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Fehler beim Laden des Barcodes";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Preise abrufen ...";
 
+/* Masternodes */
+"Fetching…" = "Wird abgerufen…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Konto";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filter-Header";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Transaktionen filtern";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Einen Nutzer im Dash-Netzwerk finden";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Geldautomaten finden, an denen du Dash kaufen oder verkaufen kannst.";
+
+/* Identities */
+"Find identities" = "Identitäten finden";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "PIN vergessen?";
 
+/* Identities */
+"Found %d new identities" = "%d neue Identitäten gefunden";
+
+/* Identities */
+"Found 1 new identity" = "1 neue Identität gefunden";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Fehlenden Begriff gefunden:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finanziere deinen Benutzernamen aus deinem abgeschirmten Guthaben. Füge die Mittel einige Stunden im Voraus hinzu — die kurze Ruhezeit sorgt dafür, dass dein Benutzername nicht mit deinen übrigen Dash verknüpfbar ist.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Aus deinem abgeschirmten Guthaben finanziert — dein Benutzername kann nicht mit deinen übrigen Dash verknüpft werden.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Mittel gesperrt — Transfer wird abgeschlossen";
+
+/* CoinJoin */
+"Funds moved" = "Mittel verschoben";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Erhalte Erträge für Einzahlungen in Dash Masternodes bereits ab 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Angebot einholen";
+
+/* Usernames */
+"Get ready to join DashPay" = "Mach dich bereit, DashPay beizutreten";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Rewards direkt erhalten";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Verstanden";
+
+/* Governance */
+"Governance" = "Governance";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Gib uns GPS-Berechtigungen, damit wir dir Standorte in deiner Nähe anzeigen können.";
 
 /* Voting */
 "Has blocked votes" = "Beinhalted blockierte Votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "hat angefragt, dein Freund zu werden";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Hast du eine Einladung?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Habe die volle Kontrolle über deine Wallet und passe sie an deine Bedürfnisse an";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "Header #%1$d von %2$d";
+
+/* SPV sync phase */
+"Headers" = "Header";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Höhe %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Hier ist die Dash Adresse, die für dein CrowdNode Konto in der Dash Wallet auf diesem Gerät bestimmt ist.";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Absteigend";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Höhere Gebühren um die 7 Cent (immer noch niedriger als bei anderen Blockchains mit vergleichbarer Privatsphäre)";
+
 /* No comment provided by engineer. */
 "History" = "Verlauf";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Wie bekomme ich Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Wie ist das im Vergleich zu Bitcoin in Bezug auf Privatsphäre?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Wie ist das im Vergleich zu Ethereum-Konten in Bezug auf Privatsphäre?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Wie privat ist DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Wie du deine API Dash Adresse bestätigst";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Ich habe es aufgeschrieben";
 
+/* Identities */
+"Identities" = "Identitäten";
+
 /* Voting */
 "Identity" = "Identität";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identitäts-Credits";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identitäts-Index";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identitätsregistrierung";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Identitäts-Aufladung";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Wähle bei den Zahlungsoptionen im Checkout „Geschenkkarte“ und gebe deine Kartennummer und deine Pin ein.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inaktiv";
+
+/* No comment provided by engineer. */
 "Income" = "Einnahmen";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initialisierung";
+
+/* Raw transaction inspector */
+"Input %d" = "Eingang %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Eingang %d — Outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Eingänge (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Guthaben nicht ausreichend";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Einladungsgebühr";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Einladung von %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Einladung genutzt von";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Einladen";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Lade jemanden ein, dem Dash-Netzwerk beizutreten";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Lade Freund und Familie ein, indem du ihre Nutzernamen suchst";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Lade deine Freunde und Familie zum Dash-Netzwerk ein.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Lade deine Freunde und Familie in das Dash-Netzwerk ein";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ gemeldete Probleme";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Eintritt in den Pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Diese Coins privat halten. Es fallen Netzwerk- und Privatsphäre-Gebühren an.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Bewahre deine Passphrase sicher auf.";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Schlüssel #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Schlüsseldaten";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Schlüsselbesitz";
+
 /* No comment provided by engineer. */
 "Keypair" = "Schlüsselpaar";
+
+/* Masternodes */
+"Keys" = "Schlüssel";
 
 /* Explore Dash */
 "Last device sync" = "Letzte Gerätesynchronisierung";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Führend";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Mehr erfahren";
 
 /* Info Screen */
 "Learn More..." = "Mehr erfahren...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Transaktionen werden geladen";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Lokale Währung";
 
+/* Identities */
+"Local Only" = "Nur lokal";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Lokal angefragter Betrag: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Ort";
 
+"Lock" = "Sperren";
+
+"Lock the name" = "Den Namen sperren";
+
+"Lock “%@” so nobody gets it" = "„%@“ sperren, sodass ihn niemand bekommt";
+
 /* No comment provided by engineer. */
 "Locked" = "Gesichert";
 
+"Locked — nobody receives this username" = "Gesperrt — niemand erhält diesen Benutzernamen";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Einloggen";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Niedrig";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Niedrige Gebühren für alltägliche Ausgaben";
+
 /* Voting */
 "Low to high" = "Aufsteigend";
+
+/* Identities — the wallet's main identity */
+"Main" = "Haupt";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Masternode IP-Adresse";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode-Schlüsselbund";
+
+/* Masternode keys */
 "Masternode keys" = "Masternode Keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternode-Liste";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "Masternode-Liste #%1$d von %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode-Update";
 
+"Masternode votes" = "Masternode-Stimmen";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting-Schlüssel";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodes und Evonodes, die mit den Schlüsseln dieser Wallet registriert sind, erscheinen hier, sobald die Wallet synchronisiert ist.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes und Evonodes, die die Schlüssel dieser Wallet verwenden";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodes stimmen über Namen ab, die mehr als eine Person angefragt hat. Du wirst benachrichtigt, wenn die Abstimmung endet.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Minimum: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum erreicht";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Mehr Kontrolle";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Weitere Vorschläge";
+
+"Most lock votes" = "Meiste Sperrstimmen";
+
+"Most votes" = "Meiste Stimmen";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Verschiebe und zoome dein Foto, um die perfekte Passform zu finden";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "In dein normales verfügbares Guthaben verschieben.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Verschoben zur Adresse";
+
+/* CoinJoin */
+"Moving funds" = "Mittel werden verschoben";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Namensdienste wie Unstoppable Domains ordnen einem menschenlesbaren Namen eine feste öffentliche Adresse auf der Blockchain zu. Jeder kann den Namen auflösen und jede jemals daran getätigte Zahlung sehen. Ein DashPay-Benutzername löst sich niemals öffentlich zu einer Zahlungsadresse auf — Adressen werden nur innerhalb des verschlüsselten Austauschs mit jedem Kontakt offengelegt, sodass dein Name und dein Geld für Außenstehende unverknüpft bleiben.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Benötigst du Hilfe?";
+
+"Needs attention" = "Erfordert Aufmerksamkeit";
 
 /* No comment provided by engineer. */
 "Network" = "Netzwerk";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Auf diesem Gerät wurden keine Diagnoseprotokolle gefunden. Protokolle werden ab dem nächsten Start geschrieben.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Keine Identitäten";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Noch keine Masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Keine passenden Wettbewerbe";
+
+/* Identities */
+"No new identities were found for this wallet" = "Für diese Wallet wurden keine neuen Identitäten gefunden";
+
+"No open contest matches that search." = "Kein offener Wettbewerb passt zu dieser Suche.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Kein offener Wettbewerb passt zu dieser Suche. Namen werden in normalisierter Form gespeichert, „alice“ wird also als „a11ce“ geführt.";
+
+"No open contests" = "Keine offenen Wettbewerbe";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Keine Zahlungsmethode";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Kein gespeicherter Wallet-Eintrag für die verbundene Wallet gefunden.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Für den abgeschirmten Registrierungs-Fallback ist noch keine Platform-Adresse verfügbar. Versuche es erneut, nachdem die Wallet die Synchronisierung abgeschlossen hat.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Kein Ergebniss gefunden";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Derzeit ist kein Benutzername umstritten. Wettbewerbe entstehen, wenn zwei oder mehr Personen denselben Namen anfragen.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Kein Vote übrig";
+
+"No votes were cast" = "Es wurden keine Stimmen abgegeben";
+
+"Nobody gets it" = "Niemand bekommt ihn";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nicht standardkonform";
 
 /* adjective, security level */
 "None" = "Kein";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Nicht verfügbar";
 
+"Not available yet" = "Noch nicht verfügbar";
+
+"Not cast" = "Nicht abgegeben";
+
+/* Masternodes */
+"Not checked yet" = "Noch nicht geprüft";
+
 /* Location Service Status */
 "Not Determined" = "Nicht festgelegt";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nicht genug abgeschirmtes Guthaben, um eine Identität zu registrieren";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nicht im Wallet-Verlauf";
+
+"Not now" = "Jetzt nicht";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Bei Händlern nicht weit verbreitet";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Bei Händlern noch nicht weit verbreitet";
+
+/* Masternode keys */
+"Not yet used" = "Noch nicht verwendet";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Alt nach neu";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bei Bitcoin gibt es keine Namensebene, also teilen und verwenden Menschen Adressen offen mehrfach — ist eine Adresse einmal bekannt, lässt sich alles, was sie je erhalten hat, mit ihrem Besitzer verknüpfen. Bei DashPay ist dein Benutzername öffentlich, verweist aber nie auf eine Zahlungsadresse: Adressen werden pro Kontakt privat ausgetauscht und rotieren, sodass die Zahlung per Name nicht veröffentlicht, wohin dein Geld fließt. Beide sind transparente Chains, sodass die Chain-Analyse für die Coins selbst weiterhin gilt.";
+
+/* Identities */
+"On Network" = "Im Netzwerk";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Sobald %@ deine Anfrage annimmt, kannst du direkt an den Benutzernamen zahlen";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Ein Node nach dem anderen";
 
 /* Voting */
 "One vote left" = "Ein Vote übrig";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Nur Duplikate";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Nur Masternodes und Evonodes können über Benutzernamen abstimmen. Diese Wallet enthält keine aktiven Masternode-Abstimmungsschlüssel.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Nur Anfragen mit Links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Nur mit Links";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Operator-Schlüssel";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Öffentlicher Operator-Schlüssel (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "oder";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Vorschau bestellen";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Andere Ergebnisse";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Ausgang %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Ausgänge (%d)";
+
+/* Masternodes */
+"Owner" = "Besitzer";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Besitzer-Adresse";
+
+/* Masternodes */
+"Owner address" = "Besitzer-Adresse";
+
+/* Masternodes */
+"Owner key hash" = "Besitzer-Schlüssel-Hash";
 
 /* Owner keys */
 "Owner keys" = "Owner Keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Bezahlt aus dem Credit-Guthaben deiner Identität.";
 
 /* DashSpend */
 "Password" = "Passwort";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Füge den Link hier ein";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Füge den erhaltenen Einladungslink ein oder scanne dessen QR-Code. Er finanziert die Registrierung deines Benutzernamens.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Füge deine Bild-URL ein";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Zahle und lass dich bezahlen, ohne Wartezeit und auf einfache Art und Weise";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "direkt an den Benutzernamen zahlen";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Zahle an Menschen, nicht an Adressen";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Nutzernamen bezahlen. Keine alphanumerischen Adressen mehr";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Bezahle...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload-Hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Zahlungsmethode";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Zahlungen sind privat: die Adressen, die du mit einem Kontakt austauschst, werden in einer verschlüsselten Nutzlast übertragen, die nur ihr beide lesen könnt, und werden nie veröffentlicht — deine Zahlungen sind also nicht ohne Weiteres mit deinem Benutzernamen verknüpfbar. Es handelt sich dennoch um gewöhnliche Zahlungen auf einer transparenten Chain: eine ausgefeilte Chain-Analyse könnte Informationen preisgeben. Shielded DashPay (demnächst verfügbar) wird diese Lücke schließen. Kontaktanfragen selbst sind derzeit NICHT privat: jeder kann sehen, dass zwei Identitäten verbunden sind. Private Kontaktanfragen sind eine Funktion, die demnächst kommt. Dein Benutzername und dein Profil sind auf Dash Platform ebenfalls öffentlich.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Zahlungen werden mit InstantSend in Sekunden bestätigt";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Direkt an Adressen getätigte Zahlungen werden nicht in der Aktivität aufbewahrt.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Zahlungen mit jedem Kontakt sind an einem Ort gebündelt, mit Namen und Profilen statt roher Transaktionen.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Auszahlungsadresse";
 
 /* CrowdNode */
 "Payout Options" = "Auszahlungsoptionen";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-Adresse";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-Guthaben";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-Node";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-Node-ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-Zahlungen weisen den Absender nicht aus. Diese Zahlung wurde erfasst, als die Wallet die Guthabenänderung bemerkt hat — sie kann früher eingegangen sein.";
+
+"Platform SDK not ready" = "Platform-SDK nicht bereit";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Die Platform-Synchronisierung läuft nicht. Öffne Sync-Info → Platform-Sync-Status, um sie zu starten.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Abgeschirmt";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Bitte hinterlege eine Zahlungsmethode auf Coinbase.";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Einladung begutachten";
 
+/* Masternode keys */
+"Previously used at: " = "Zuvor verwendet am: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Die Preise sind mindestens 30 Minuten alt. Es ist möglich, dass die Fiat-Werte nicht korrekt sind.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat durch Design";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Private Kontaktanfragen (damit privat bleibt, mit wem du dich verbindest), Shielded DashPay — Kontaktzahlungen aus deinem privaten abgeschirmten Guthaben — und Zahlungen an Nutzer, die noch nicht in deinen Kontakten sind, kommen alle demnächst.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Private Kontaktanfragen sind in Entwicklung und werden etwa im September–Oktober 2026 erwartet. Heute ist die Anfrage selbst öffentlich — jeder kann sehen, dass zwei Identitäten verbunden sind, auch wenn die darin enthaltenen Zahlungsdaten verschlüsselt sind. Sobald private Kontaktanfragen verfügbar sind, kannst du wählen, ob deine Verbindung öffentlich oder privat sein soll.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Private Kontaktanfragen, Shielded DashPay und Zahlungen an Personen, die noch keine Kontakte sind.";
+
 /* No comment provided by engineer. */
 "Private key" = "Privater Schlüssel";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Private Zahlungsadressen werden zwischen dir und deinen Kontakten ausgetauscht. Nur du und dein Kontakt kennen Empfänger und Absender der Zahlungen zwischen euch.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Private Zahlungen";
+
+/* Usernames */
+"Private registration" = "Private Registrierung";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Bearbeitungszeit";
+
+/* Balance info sheet section */
+"Pros" = "Vorteile";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Sichere deine Sparanlagen";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider-Adresse";
 
+/* Masternodes */
+"Provider transactions" = "Provider-Transaktionen";
+
+/* Masternode keys */
+"Public key" = "Öffentlicher Schlüssel";
+
+/* Masternode keys */
+"Public key (legacy)" = "Öffentlicher Schlüssel (Legacy)";
+
+/* Identities */
+"Public keys" = "Öffentliche Schlüssel";
+
 /* No comment provided by engineer. */
 "Public URL" = "Öffentliche URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Kauf fehlgeschlagen";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Zweck";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Kurs: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Rohtransaktion";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Rohtransaktion nicht verfügbar";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Prüft die kompakten Blockfilter ab der gewählten Höhe erneut auf Transaktionen dieser Wallet, indem sie neu heruntergeladen und neu abgeglichen werden. Erneute Scans sind auf die Erstellungshöhe der Wallet und die lokal gespeicherten Chain-Daten begrenzt — um den Verlauf darunter wiederherzustellen, senke stattdessen die Starthöhe der Wallet.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Lese die Auszahlungsrichtlinie";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Schreibgeschützt";
+
+/* Usernames */
+"Ready around %@" = "Bereit gegen %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Grund";
 
 /* No comment provided by engineer. */
 "Receive" = "Empfange";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Empfangen von";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Erhalten von %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Rewards erhalten";
+
+"Records your masternodes as having voted, without taking a side." = "Erfasst deine Masternodes als abgestimmt, ohne Partei zu ergreifen.";
 
 /* No comment provided by engineer. */
 "Recover" = "Wiederherstellen";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Wiederherstellungsphrasen müssen 12, 15, 18, 21 oder 24 Worte enthalten";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Aktualisieren";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registrieren?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registriert am";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registriert von";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registrierte Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Für eine private Registrierung sind mindestens %@ Dash in deinem abgeschirmten Guthaben sowie einige Stunden Ruhezeit nötig — die nächsten Bildschirme führen dich durch den Vorgang.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrierung";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Fragt diesen Namen an";
+
 /* An action */
 "Rescan" = "Erneut scannen";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Bei wiederhergestellten Wallets lässt sich der Vorgangstyp nicht immer ermitteln. Dieser Eintrag wurde aus On-Chain-Notizdaten rekonstruiert.";
+
+/* Location Service Status */
 "Restricted" = "Eingeschränkt";
 
 /* Usernames */
 "Results" = "Ergebnisse";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Neusynchronisierung ab Höhe %u vorbereitet — beende die App und öffne sie erneut, um zu starten.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "den gemeinsamen Transaktionsverlauf behalten";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Ausgemustert";
 
 /* No comment provided by engineer. */
 "Retry" = "Wiederholen";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Begutachte den unten stehenden Beitrag, um den Besitz dieses Nutzernamens zu verifizieren.";
+
+/* Masternodes */
+"Revocation" = "Rücknahme";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots sind sichtbar für andere Apps und Geräte. Generieren Sie eine neue Wiederherstellungs-Wortfolge und halten Sie diese geheim.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Script-Signatur";
+
+/* Raw transaction inspector */
+"Script type" = "Script-Typ";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Nach einem Kontakt suchen";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Nach einer Kontaktanfrage suchen";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Nach einem Nutzer im Dash-Netzwerk suchen";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Nach einem Benutzernamen suchen";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Suchergebnisse für \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Gebiete durchsuchen";
+
+"Search usernames" = "Benutzernamen suchen";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Suche nach Benutzername %@ im Dash-Netzwerk";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Sichere deine Wallet";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Sicherheitsstufe";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Sicherheitsstufe";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Wähle einen Dienstleister für den Kauf, Verkauf und Transfer von Dash.";
 
+"Select all" = "Alle auswählen";
+
 /* DashSpend denomination selection */
 "Select amount" = "Betrag auswählen";
+
+"Select at least one masternode to vote with." = "Wähle mindestens einen Masternode aus, mit dem abgestimmt werden soll.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Wähle einen Coin aus";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Weniger Nodes auszuwählen verrät weniger darüber, welche Masternodes du betreibst.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-Checkout";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Senden an";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "An einen Kontakt senden";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Sende an einen Benutzernamen, den du dir wirklich merken und überprüfen kannst.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "An Adresse senden";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Sende deine erste Kontaktanfrage";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Versenden";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Kontaktanfrage wird gesendet";
+
+/* No comment provided by engineer. */
+"Sending to" = "Senden an";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sendet zu deinem CrowdNode Konto";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Senden an";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Gesendet an %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Ein Server-Fehler ist aufgetreten. Bitte versuche es später wieder.";
+
+/* Masternodes */
+"Service" = "Dienst";
+
+/* Identities */
+"Set as Main" = "Als Haupt festlegen";
+
+/* Identities */
+"Set as Main Identity" = "Als Hauptidentität festlegen";
 
 /* No comment provided by engineer. */
 "Set PIN" = "PIN festsetzen";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Key teilen";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Gemeinsamer Privatsphäre-Pool hat Mindestgröße erreicht";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Abgeschirmte Adresse";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Abgeschirmtes Ausgeben";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Abgeschirmte Wallet wird gestartet…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Abgeschirmt → Platform";
+
+"Shielded → Transparent" = "Abgeschirmt → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Alle Standorte anzeigen";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Größe";
+
 /* No comment provided by engineer. */
 "Skip" = "Überspringen";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Einige deiner Masternodes fehlen möglicherweise in dieser Liste — die Wallet konnte deinen vollständigen Abstimmungsschlüssel-Bestand nicht lesen. Schließe die Synchronisierung ab und öffne diesen Bildschirm erneut.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Manche Benutzernamen können blockiert werden";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sortieren nach";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Kontakte sortieren";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Nach Rabatthöhe sortiert";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Nach Name sortiert";
+
+/* Raw transaction inspector */
+"Special payload" = "Spezielle Payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Betrag festsetzen";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Beginnt, nachdem du Mittel hinzugefügt hast";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Schritt %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Gespeichert als";
 
 /* Voting */
 "Submit" = "Einreichen";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Synchronisierung läuft... Ergebnisse können unvollständig sein.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Sync-Info";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronisierung zu langsam?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Ein Foto mit der Kamera aufnehmen";
 
+"Take no side" = "Keine Seite ergreifen";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tippe auf die Adresse in der Zwischenablage, um sie einzufügen.";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Zum Kopieren tippen";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Zum Verbergen des Guthabens tippen";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Zur Zeit nicht verfügbar";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-Node-Schlüssel (Base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "AGB";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Diese Code ist falsch. Bitte kontrollieren und erneut versuchen!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Die Dash treffen an der Adresse des Empfängers ein, nachdem das Netzwerk die Auszahlung verarbeitet hat — das kann bis zu 10 Minuten dauern.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Die Dash treffen an der Adresse des Empfängers ein, sobald das Netzwerk die Auszahlung verarbeitet hat.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Die Dash treffen in deinem transparenten Guthaben ein, sobald das Netzwerk die Auszahlung verarbeitet hat.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Das Dash-Netzwerk muss gewisse Nutzernamen bestätigen, bevor diese erstellt werden";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Der Link, den du sendest, ist nur für die Betreiber des Netzwerkes sichtbar";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Die Hauptidentität kann nur aus der aktiven Wallet gewählt werden";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Der Mindestbetrag für eine Transaktion ist %@.";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Der privateste Ort, um deine Dash aufzubewahren";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Der gespeicherte Wallet-Eintrag hat kein Netzwerk — eine Neusynchronisierung kann nicht vorbereitet werden.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Die Registrierung wurde übermittelt, aber ihr Ergebnis konnte nicht bestätigt werden. Warte eine Minute, bis die Wallet synchronisiert ist, und versuche es dann erneut — sende sie nicht sofort erneut.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Der gemeinsame Privatsphäre-Pool wächst noch (%1$ld von %2$ld Einzahlungen). Die private Registrierung wird freigeschaltet, sobald er das Minimum erreicht.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Der gemeinsame Privatsphäre-Pool wächst noch (%1$ld von %2$ld Einzahlungen). Versuche es erneut, sobald er das Minimum erreicht.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Der Nutzername '%@' wurde vom Dash-Netzwerk blockiert. Bitte versuche es erneut, aber mit einem anderen Nutzernamen.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Die Erstellungshöhe der Wallet — die Untergrenze für Filter-Scans und für erneute Scans „Ab Wallet-Erstellung“. Setze sie auf oder unter die erste Finanzierung der Wallet; Importe verwenden standardmäßig 200000 im Mainnet und 0 im Testnet. Das Speichern einer Höhe auf oder unter der aktuellen löscht die Chain-Daten dieses Netzwerks beim nächsten Start und scannt ab dieser Höhe neu.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "ihn (Infos werden abgerufen)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Es gibt keine neuen Benachrichtigungen";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Es existieren keine anzuzeigenden Transaktionen";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Es gibt keine Nutzer, die zum Namen %@ passen";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Es gibt in deinen Kontakten keine Nutzer, die zum Namen %@ passen";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Bei dem Exportieren deiner Transaktionshistorie ist ein Fehler aufgetreten.";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Es ist ein Fehler aufgetreten. Bitte versuche es später noch einmal.";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Diese Mittel werden in dein Platform-Guthaben verschoben und stehen zum Ausgeben bereit, sobald der Transfer abgeschlossen ist.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Diese Adresse kann nicht aus deinem %@-Guthaben bezahlt werden";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Dadurch werden deiner Identität zwei Schlüssel hinzugefügt, damit andere Nutzer dir Kontaktanfragen senden können und du ihre annehmen kannst. Dies geschieht nur einmal.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Dies wendet eine Auswahl auf alle %d ausgewählten Benutzernamen an.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Dieser zusätzliche Schritt beweist, dass es wirklich du bist der die Transaktion ausführt.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Dieser Einladungslink ist nicht gültig.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Dies ist keine gültige Dash-Adresse für dieses Netzwerk";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Dies ist kein gültiger Einladungslink";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Dies ist deine Hauptidentität";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Dieser Masternode hat noch keine Platform-Identität.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Dieser Händler ist derzeit nicht verfügbar.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Dies ist die aktuelle jährliche prozentuale Rendite eines ganzen Masternodes abzüglich 15% CrowdNode-Gebühren. Es handelt sich nicht um eine garantierte Rendite, die je nach Größe des CrowdNode Pools und Höhe des Dash Preises nach oben oder unten gehen kann.";
 
+"This still counts as your masternodes having voted in this contest." = "Dies zählt weiterhin als Abstimmung deiner Masternodes in diesem Wettbewerb.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Die Rohbytes dieser Transaktion sind auf diesem Gerät nicht gespeichert.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Dieser Benutzername ging an jemand anderen";
+
+"This wallet could not derive the voting key for this node." = "Diese Wallet konnte den Abstimmungsschlüssel für diesen Node nicht ableiten.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Diese Wallet enthält keine aktiven Masternode-Abstimmungsschlüssel und kann daher nicht abstimmen. Registrierte Nodes erscheinen unter Tools → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Damit wird dein gesamtes Platform-Guthaben in einem Transfer ausgezahlt. Die Dash treffen an der Adresse des Empfängers ein, sobald das Netzwerk die Auszahlung verarbeitet hat.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Damit wird dein gesamtes Platform-Guthaben in einem Transfer ausgezahlt. Die Dash treffen in deinem transparenten Guthaben ein, sobald das Netzwerk die Auszahlung verarbeitet hat.";
 
 /* Send Screen: to address */
 "to" = "nach";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaktionshistorie";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Transaktionsverlauf ist nicht verfügbar";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaktions-ID";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaktions-ID";
 
 /* A verb, button title. */
 "Transfer" = "Transferieren";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Eingang";
 
+/* Balance breakdown */
+"Transfer in" = "Transfer ein";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Ausgang";
+
+/* Balance breakdown */
+"Transfer out" = "Transfer aus";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transfers dauern länger — der Aufbau von Privatsphäre-Beweisen braucht Zeit";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transfers an andere Platform-Adressen und abgeschirmte Adressen sind sofortig und endgültig";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Transparente Adresse";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentes Guthaben";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Eine transparente Finanzierung verknüpft deinen Benutzernamen öffentlich mit diesen Mitteln.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Abgeschirmt";
 
 /* An action */
 "Try again" = "Wiederholen";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Vorschläge können nicht bereitgestellt werden";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Guthaben nicht erkannt";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Unbekannter Spezialtyp %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nicht abgeschirmt";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "URL nicht unterstützt";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Auf DashPay upgraden";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Auf Evolution upgraden";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Stattdessen transparentes Guthaben verwenden";
+
+/* Masternode keys */
+"Used" = "Verwendet";
+
+/* Masternode keys */
+"Used at: " = "Verwendet am: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Nutzer (Infos werden abgerufen)";
 
 /* Voting */
 "Username" = "Nutzername";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Nutzername wurde erfolgreich angefragt";
 
+/* Identities */
+"Usernames" = "Benutzernamen";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Benutzernamen werden in normalisierter Form gespeichert, um verwechselbare Namen zu verhindern; dies kann daher von dem abweichen, was die jeweilige Person eingegeben hat.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Benutzernamen statt Adressen";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Nutzer, die zu %@ passen und derzeit nicht in deinen Kontakten sind";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Verwendet eine der am gründlichsten auditierten und getesteten Zero-Knowledge-Bibliotheken (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Gültige Einladung";
+
 /* CrowdNode Portal */
 "Validating address…" = "Adresse validieren...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verifizierung notwendig";
 
+/* Usernames */
+"Verified during registration" = "Bei der Registrierung überprüft";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Erfolgreich verifiziert";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Überprüfe deine Identität";
 
+/* Raw transaction inspector */
+"Version" = "Version";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Sehr effizient bei niedrigen Gebühren";
+
 /* adjective, security level */
 "Very High" = "Sehr hoch";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Es werden nun kleine Dash Beträge nach und von Crowdnode gesendet um dich als Besitzer deiner Adresse zu verifizieren.";
+
+/* No comment provided by engineer. */
+"View All" = "Alle anzeigen";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Im Explorer ansehen";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Wiederherstellungsphrase ansehen";
 
+/* Raw transaction inspector */
+"View Transaction" = "Transaktion anzeigen";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Transaktionsdetails begutachten";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Abstimmen";
+
+"Vote cast" = "Stimme abgegeben";
+
 /* Voting */
 "Vote for All" = "Stimme für alle";
 
 /* Voting */
+"Vote on contested usernames" = "Über umstrittene Benutzernamen abstimmen";
+
+"Vote on several" = "Über mehrere abstimmen";
+
+/* Voting */
 "Vote to Approve" = "Abstimmung über die Genehmigung";
+
+"Vote with" = "Abstimmen mit";
+
+"Votes that nobody should receive these usernames." = "Stimmt dafür, dass niemand diese Benutzernamen erhalten soll.";
 
 /* Voting */
 "Votes: High to low" = "Stimmen: Absteigend";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Abstimmungs-Adresse";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Abstimmungs-Adresse";
+
+"Voting ended with no winner" = "Die Abstimmung endete ohne Gewinner";
+
+"Voting ends" = "Abstimmung endet";
+
 /* Voting */
 "Voting ends in %dd" = "Die Abstimmung endet in %d Tag(en)";
+
+"Voting in progress" = "Abstimmung läuft";
+
+"Voting in progress — lock votes are ahead" = "Abstimmung läuft — Sperrstimmen liegen vorn";
+
+"Voting in progress — you are ahead" = "Abstimmung läuft — du liegst vorn";
 
 /* Usernames */
 "Voting is only required in some cases" = "Abstimmung ist nur in manchen Fällen notwendig";
 
+/* Masternodes */
+"Voting key hash" = "Abstimmungs-Schlüssel-Hash";
+
 /* Voting keys */
 "Voting keys" = "Voting Keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Die Abstimmung über diesen Benutzernamen ist geschlossen. Die untenstehenden Zahlen sind die zuletzt gelesenen.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Die Abstimmung über „%@“ ist bereits geschlossen. Aktualisiere, um das Ergebnis zu sehen.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Warte, bis die Wallet synchronisiert ist, um die Transaktion abzuschließen.";
 
+"Waiting for Dash Platform" = "Warte auf Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Adresse der Wallet";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Wallet-Starthöhe";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet deaktiviert";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Willkommen bei DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Was ist mit Unstoppable Domains und ähnlichen Namensdiensten?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Was kostet das?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Was ist DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Was ist das Abstimmen über Nutzernamen?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Was kommt als Nächstes?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Wann werden Kontaktanfragen privat?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Wo bezahlen";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Wo bezahlen?";
+
+"Who is requesting this name" = "Wer diesen Namen anfragt";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Warum muss ich es aktivieren?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Warum sehe ich all diese Transaktionen?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Auszahlen beantragt";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Zahlt das gesamte Guthaben aus";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funktioniert mit jeder Dash-Wallet, jeder Börse und jedem Händler";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Möchtest du die Einladung akzeptieren?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Gestern";
+
+"You" = "Du";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Du hast die Kontaktanfrage von %@ angenommen";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Du hast “%@” als deinen Nutzernamen gewählt.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Du hast derzeit keine Kontakte";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Dein Guthaben reicht nicht aus, um diese Transaktion zu tätigen";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Du hast den Berechtigungsrahmen von Coinbase überschritten.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Du hast bisher %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Du hast %1$@ Dash.\nManche Nutzernamen kosten bis zu %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Du hast die Kontaktanfrage an %@ gesendet";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Du solltest einen positiven Saldo in deiner Dash Wallet haben";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Du hast diesen Benutzernamen gewonnen";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Alles bereit. Andere Nutzer können dir jetzt Kontaktanfragen senden — und du kannst deine senden.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Deine Dash-Platform-Identität erscheint hier, sobald du einen Benutzernamen registrierst.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Deine E-Mail wird nur benötigt, um dir ein einmaliges Password zu senden.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Dein Verlauf, geordnet";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Deine Identität benötigt zwei zusätzliche Schlüssel, damit Kontaktanfragen zwischen dir und anderen Nutzern verschlüsselt werden können. Beim Aktivieren werden sie mit einer einzigen Netzwerktransaktion hinzugefügt. Dies geschieht nur einmal.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Deine Einladung von %@ wurde bereits beansprucht";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Deine Einladung von %@ ist nicht gültig";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Deine Einladung übernimmt die Registrierungsgebühr für diesen Benutzernamen.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Dein Standort wird genutzt um deine Position in der Karte darzustellen,  Automaten in deinem Radius anzuzeigen und Suchergebnisse zu verbessern.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Dein Standort wird benutzt um deine Position auf der Karte anzuzeigen, Händler in dem ausgewählten Radius anzuzeigen und um Suchergebnisse zu verbessern.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Dein Haupt-Dash-Guthaben auf der Core-Blockchain — das, was du mit anderen Wallets, Börsen und Händlern sendest und empfängst.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Deine gemixten Coins wurden in dein Dash-Wallet-Guthaben verschoben.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Deine gemixten Coins wurden in dein abgeschirmtes Guthaben verschoben. Warte für die beste Privatsphäre mindestens 2 Stunden, bevor du diese Mittel verwendest.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Dein Platform-Guthaben";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Deine primäre Dash Adresse, die du derzeit für dein CrowdNode Konto nutzt";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Dein privates Guthaben. Beträge und Adressen sind on-chain verschlüsselt, sodass deine Bestände und dein Verlauf vertraulich bleiben.";
+
 /* Usernames */
 "Your request was cancelled" = "Deine Anfrage wurde abgebrochen.";
 
 /* DashSpend */
 "Your session expired" = "Deine Session ist abgelaufen";
+
+/* Usernames */
+"Your Shielded balance" = "Dein abgeschirmtes Guthaben";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Dein abgeschirmtes Guthaben ist fast bereit — du kannst dich gegen %@ privat registrieren.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Dein abgeschirmtes Guthaben ist bereit — registriere deinen Benutzernamen jetzt privat";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Dein abgeschirmtes Guthaben ruht — du kannst dich gegen %@ privat registrieren";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Dein abgeschirmtes Guthaben reift noch. Es wird gegen %@ bereit sein.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Dein transparentes Guthaben";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Dein Benutzername %@ wurde erfolgreich im Dash-Netzwerk erstellt";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Dein Nutzername wurde erfolgreich erstellt";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Dein Benutzername ist für alle sichtbar. Ihn aus deinem abgeschirmten Guthaben zu finanzieren — nachdem die Mittel einige Stunden geruht haben — bedeutet, dass niemand deinen Benutzernamen mit deinen übrigen Dash verknüpfen kann.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Dein Benutzername, dein Profil und deine Kontakte folgen dieser Identität.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Dein Benutzername, dein Profil und deine Kontakte werden dieser Identität folgen.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Deine Stimmabgabe wurde abgebrochen.";
 
 /* Voting */
 "Your vote was submitted" = "Deine Stimme wurde abgegeben.";
 
+"Your votes" = "Deine Stimmen";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Deine Wallet ist jetzt gesichert. Du kannst die Phrase jederzeit nutzen, um die Wallet auf einem anderen Gerät wiederherzustellen.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Deine Wallet synchronisiert sich noch mit dem Dash-Netzwerk. Das Senden ist verfügbar, sobald die Synchronisierung abgeschlossen ist.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Deine Wallet synchronisiert sich noch. Das Senden aus deinem transparenten Guthaben ist verfügbar, sobald die Synchronisierung abgeschlossen ist.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ konnte nicht als Dash-Benutzername gelesen werden.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ wurde registriert. Möchtest du der Person, die dich eingeladen hat, eine Kontaktanfrage senden?";

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Alle Nodes auf einmal";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle deine Masternodes haben über diesen Benutzernamen abgestimmt. Um eine Stimme zu ändern, stimme erneut über den Bewerber ab, den du jetzt bevorzugst.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle deine Masternodes haben über diesen Benutzernamen abgestimmt. Um eine Stimme zu ändern, stimme erneut für den Bewerber, den du jetzt bevorzugst.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/de.lproj/Localizable.stringsdict
+++ b/DashWallet/de.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d Schlüssel</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ gezählt für „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u Stimme</string>
+			<key>other</key>
+			<string>%1$u Stimmen</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d von %#@names@ abgestimmt</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d Benutzernamen</string>
+			<key>other</key>
+			<string>%2$d Benutzernamen</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u Stimme abgeben</string>
+			<key>other</key>
+			<string>%u Stimmen abgeben</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d von %#@nodes@ haben abgestimmt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d Masternode</string>
+			<key>other</key>
+			<string>%2$d Masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d von %#@nodes@ haben abgestimmt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d Node</string>
+			<key>other</key>
+			<string>%2$d Nodes</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Evonode</string>
+			<key>other</key>
+			<string>%d Evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u Stimme insgesamt</string>
+			<key>other</key>
+			<string>%u Stimmen insgesamt</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Masternode</string>
+			<key>other</key>
+			<string>%d Masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ausgewählt</string>
+			<key>other</key>
+			<string>%d ausgewählt</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d deiner Nodes hat hier bereits abgestimmt und wird nicht aufgeführt.</string>
+			<key>other</key>
+			<string>%d deiner Nodes haben hier bereits abgestimmt und werden nicht aufgeführt.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u Stimme pro Wettbewerb — Evonodes zählen als 4, Masternodes als 1</string>
+			<key>other</key>
+			<string>%u Stimmen pro Wettbewerb — Evonodes zählen als 4, Masternodes als 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Über %d Benutzernamen abstimmen</string>
+			<key>other</key>
+			<string>Über %d Benutzernamen abstimmen</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u Stimme</string>
+			<key>other</key>
+			<string>%u Stimmen</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Abstimmen ×%d</string>
+			<key>other</key>
+			<string>Abstimmen ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Anfrage</string>
+			<key>other</key>
+			<string>%d Anfragen</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/de.lproj/Localizable.stringsdict
+++ b/DashWallet/de.lproj/Localizable.stringsdict
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d von %#@nodes@ haben abgestimmt</string>
+		<string>Abgestimmt: %1$d von %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d von %#@nodes@ haben abgestimmt</string>
+		<string>Abgestimmt: %1$d von %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Όλοι οι κόμβοι μαζί";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Όλα τα masternodes σας έχουν ψηφίσει για αυτό το όνομα χρήστη. Για να αλλάξετε ψήφο, ψηφίστε ξανά από τον διεκδικητή που προτιμάτε τώρα.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Όλα τα masternodes σας έχουν ψηφίσει για αυτό το όνομα χρήστη. Για να αλλάξετε ψήφο, ψηφίστε ξανά υπέρ του διεκδικητή που προτιμάτε τώρα.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ή ";
+
 /* CrowdNode */
 " Privacy Policy " = "Πολιτική απορρήτου";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Ο χρήστης %@ δεν βρέθηκε στο δίκτυο Dash για να του σταλεί αίτημα επαφής.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash διαθέσιμα";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "Ο χρήστης %@ αποδέχτηκε το αίτημα επαφής σας";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@~ %2$lu επαφές /  %3$lu ενημερώσεις προφίλ";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d ψήφοι θα δοθούν καθώς έχετε αποθηκεύσει πολλαπλά κλειδιά ψηφοφορίας στο πορτοφόλι";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld διπλότυπα";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld από %ld καταθέσεις";
 
 /* Voting */
 "%ld requests" = "%ld αιτήματα";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" δεν είναι μια λέξη ανάκτησης. Θα θέλατε να προσπαθήσετε να ανακτήσετε τη σωστή λέξη που θα πρέπει να είναι στη θέση της;";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Ένα υπόλοιπο credits στο Dash Platform που χρησιμοποιείται για άμεσες πληρωμές μεταξύ διευθύνσεων Platform και για λειτουργίες όπως τα ονόματα χρήστη.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Ένας κωδικός φράσης για την συσκευή είναι απαραίτητος για τη διαφύλαξη του πορτοφολιού σας. Μεταβείτε στην επιλογή Ρυθμίσεις και ενεργοποιήστε τον κωδικό για να συνεχίσετε.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Σχετικά";
 
+/* DashPay FAQ title */
+"About DashPay" = "Σχετικά με το DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Σχετικά με εμένα";
+
+"Abstain" = "Αποχή";
+
+"Abstain on “%@”" = "Αποχή στο «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Αποδοχή";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Ανάκτηση λογαριασμού";
 
+/* Masternode status */
+"Active" = "Ενεργό";
+
+/* No comment provided by engineer. */
+"Activity" = "Δραστηριότητα";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Η δραστηριότητα είναι δημόσια αλλά δεν είναι εύκολο να εντοπιστεί";
+
 /* No comment provided by engineer. */
 "Add" = "Προσθήκη";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Προσθήκη του %@ ως επαφή";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Προσθέστε τον %@ ως επαφή για να πληρώνετε απευθείας στο όνομα χρήστη και να διατηρείτε το κοινό ιστορικό συναλλαγών";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Προσθέστε %@ Dash στο θωρακισμένο υπόλοιπό σας και αφήστε τα να ωριμάσουν λίγες ώρες, ώστε η εγγραφή να μη συνδέει το όνομα χρήστη σας με τα υπόλοιπα κεφάλαιά σας.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Προσθήκη Νέας Επαφής";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Προσθέστε τουλάχιστον %@ Dash στο θωρακισμένο υπόλοιπό σας";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Προσθέστε τώρα κεφάλαια στο θωρακισμένο υπόλοιπό σας και καταχωρίστε το όνομα χρήστη σας ιδιωτικά λίγες ώρες αργότερα";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Όλα";
 
+"All nodes at once" = "Όλοι οι κόμβοι μαζί";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Όλα τα masternodes σας έχουν ψηφίσει για αυτό το όνομα χρήστη. Για να αλλάξετε ψήφο, ψηφίστε ξανά από τον διεκδικητή που προτιμάτε τώρα.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Να επιτρέπεται η αποστολή όλων των συναλλαγών από το Dash Wallet στο Zenledger;";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Σχεδόν άμεσος συγχρονισμός υπολοίπων";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Τα ποσά και οι διευθύνσεις είναι δημόσια στο blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Εμφανίστηκε σφάλμα";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ένας λογαριασμός Ethereum είναι μία επαναχρησιμοποιούμενη διεύθυνση: όλο το υπόλοιπο και το ιστορικό πληρωμών σας βρίσκονται δημόσια κάτω από αυτήν, και ένα όνομα (όπως ένα domain ENS) συνήθως δείχνει απευθείας σε αυτή τη διεύθυνση, ώστε ο καθένας να μπορεί να την επιλύσει. Το DashPay έχει την αντίθετη μορφή — το όνομα οδηγεί σε μια ταυτότητα, όχι σε διεύθυνση πληρωμής, και οι πραγματικές διευθύνσεις πληρωμής παραμένουν μέσα σε κρυπτογραφημένες ανταλλαγές επαφών, καινούριες για κάθε επαφή.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Μια διαισθητική και οικεία εμπειρία σε όλες τις συσκευές σας";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Οποιοδήποτε όνομα χρήστη που έχει αριθμό 2-9 ή είναι μεγαλύτερο από 20 χαρακτήρες ή που έχει παύλα θα εγκριθεί αυτόματα.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Όποιος γνωρίζει μια διεύθυνση μπορεί να δει το ιστορικό της";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Εφαρμογή";
 
+"Approve" = "Έγκριση";
+
+"Approving a specific request can only be done one username at a time." = "Η έγκριση συγκεκριμένου αιτήματος μπορεί να γίνει μόνο για ένα όνομα χρήστη κάθε φορά.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Σίγουρα θέλετε να ακυρώσετε αυτή την παραγγελία;";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Ως κείμενο";
 
 /* DashSpend */
 "at" = "σε";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Η ταυτοποίηση ακυρώθηκε. Η ψήφος σας δεν καταχωρίστηκε.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Η ταυτοποίηση απέτυχε. Η ψήφος σας δεν καταχωρίστηκε.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Η ταυτοποίηση δεν είναι διαθέσιμη";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Απονομή του «%@» σε αυτόν τον διεκδικητή";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Υπόλοιπο";
 
 /* CrowdNode */
+"Balance after" = "Υπόλοιπο μετά";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Υπόλοιπο στο CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Υπόλοιπο:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Τα υπόλοιπα και οι μεταφορές δεν είναι δημόσια ορατά";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Τραπεζικός λογαριασμός";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Απαιτείται βιομετρική πρόσβαση";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Το ύψος έναρξης αποθηκεύτηκε — το ανυψωμένο κατώφλι σάρωσης ισχύει από την επόμενη εκκίνηση.";
+
 /* Voting */
 "Block" = "Μπλόκ";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Αποκλείστηκε το όνομα χρήστη %@";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Δεσμευμένο σε συμβόλαιο";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Δεσμευμένο σε συμβόλαιο, τύπος εγγράφου «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Μόνο περιήγηση";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Συγκεντρώνει τα πρόσφατα διαγνωστικά αρχεία καταγραφής σε ένα zip για αποστολή με AirDrop, email ή αποθήκευση στα Αρχεία";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Καταχώριση ψήφου";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Αλλαγή peers";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Αλλαγή PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Έλεγχος…";
+
+"Choice" = "Επιλογή";
+
 /* Choose your Dash username */
 "Choose your" = "Επιλέξτε ";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Επιλέξτε το όνομα χρήστη σας";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Εξαργυρώστε την πρόσκλησή σας";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Διεκδικήσιμο υπόλοιπο";
+
 /* No comment provided by engineer. */
 "Claimed" = "Διεκδικήθηκε";
+
+/* SPV diagnostics */
+"Clear & resync" = "Εκκαθάριση και επανασυγχρονισμός";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Εκκαθάριση δεδομένων αλυσίδας και επανασυγχρονισμός;";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Κλείσιμο Εφαρμογής";
 
+"Closing" = "Κλείνει";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (νέα νομίσματα)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Κωδικός Coinbase 2FA";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "Το CoinJoin δεν υποστηρίζεται πλέον — επιλέξτε πού θα μεταφερθούν τα αναμειγμένα νομίσματά σας.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Εγγύηση";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Έρχεται σύντομα";
+
+/* Shielded transfer status */
+"Completed" = "Ολοκληρώθηκε";
 
 /* No comment provided by engineer. */
 "Confirm" = "Επιβεβαίωση";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Επιβεβαιωμένη";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Η επιβεβαίωση αποθηκεύει το ύψος έναρξης %u και εκκαθαρίζει τα δεδομένα αλυσίδας αυτού του δικτύου κατά την επόμενη εκκίνηση της εφαρμογής, τα κατεβάζει ξανά και σαρώνει εκ νέου τα φίλτρα από εκείνο το ύψος. Η τρέχουσα συνεδρία διατηρεί το παλιό της κατώφλι σάρωσης — κλείστε και ανοίξτε ξανά την εφαρμογή για να ξεκινήσει.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Συνδέστε τα πορτοφόλια σας με την πλατφόρμα ZenLedger. Μάθετε περισσότερα και ξεκινήστε τις συναλλαγές σας με το Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Συνδεδεμένη διεύθυνση Dash";
 
+/* SPV sync */
+"Connected peers" = "Συνδεδεμένοι peers";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Μειονεκτήματα";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Το αίτημα επαφής απέτυχε";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Το αίτημα επαφής στάλθηκε στον %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Αιτήματα Επαφής";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Επαφές";
 
+"Contender %@" = "Διεκδικητής %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Συνέχεια";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Συνεχίστε για να επιλέξετε το όνομα χρήστη σας. Η πρόσκληση καλύπτει το τέλος εγγραφής.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Αντιγραφή συνδέσμου πρόσκλησης";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Αντιγραφή ακατέργαστης συναλλαγής";
+
 /* No comment provided by engineer. */
 "Copy text" = "Αντιγράψτε το κείμενο";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Δεν ήταν δυνατή η αυτόματη ανάκτηση των χαμένων λέξεων ";
 
+/* Log export */
+"Could not create the log archive: %@" = "Δεν ήταν δυνατή η δημιουργία του αρχείου καταγραφών: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Δε βρέθηκε η ισοτιμία.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Δεν ήταν δυνατή η ανανέωση %d ταυτοτήτων";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Δεν ήταν δυνατή η ανάκτηση του υπολοίπου (σφάλμα δικτύου). Δοκιμάστε ανανέωση.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Δεν ήταν δυνατή η πληρωμή";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Δημιουργήστε το όνομα χρήστη σας";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Δημιουργήστε το Όνομα Χρήστη σας, βρείτε φίλους και οικογένεια με τα ονόματα χρήστη τους και προσθέστε τους στις επαφές σας";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Πιστωτική Κάρτα";
+
+/* Masternodes */
+"Credits" = "Credits";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Οι Dash πληρωμές δεν μπορεί να είναι μικρότερες από %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Το Dash Platform δεν έχει ευρετηριάσει ακόμη αυτή τη διαμάχη. Οι μετρήσεις ψήφων θα εμφανιστούν εδώ μόλις γίνει.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Το Dash Platform δεν έχει συνδεθεί ακόμη. Περιμένετε να ολοκληρωθεί ο συγχρονισμός και δοκιμάστε ξανά.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Τα Dash που στάλθηκαν σε λάθος διεύθυνση δεν μπορούν να ανακτηθούν. Βεβαιωθείτε ότι η διεύθυνση είναι ακριβώς αυτή στην οποία θέλετε να πληρώσετε.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Το Dash αποθηκεύει τα ονόματα χρήστη σε μορφή ανθεκτική σε παρόμοιες γραφές, οπότε το αποθηκευμένο όνομα μπορεί να διαφέρει από αυτό που πληκτρολόγησε ο καθένας.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Όνομα Χρήστη Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Πορτοφόλι";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Υπόλοιπο πορτοφολιού Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet σε αυτή τη συσκευή";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "Το DashPay ενεργοποιήθηκε";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Πρόσκληση DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "Το DashPay είναι η κοινωνική εμπειρία πληρωμών του Dash, χτισμένη πάνω στο Dash Platform. Καταχωρίζετε ένα όνομα χρήστη, προσθέτετε άλλους χρήστες ως επαφές και τους πληρώνετε με το όνομά τους — τέλος στην αντιγραφή διευθύνσεων.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "Το DashPay αντικαθιστά τις μακροσκελείς κρυπτικές διευθύνσεις με ονόματα χρήστη. Προσθέστε φίλους ως επαφές, στείλτε χρήματα σε ένα όνομα και κρατήστε κάθε πληρωμή οργανωμένη ανά άτομο.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Προμήθεια αναβάθμισης σε DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Ημερομηνία: Παλαιά προς νέα";
+
+"Deadline unknown" = "Άγνωστη προθεσμία";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Η κατάθεση απεστάλη";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Διαδρομή παραγωγής";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "Η ΑΣΦΑΛΕΙΑ ΤΗΣ ΣΥΣΚΕΥΗΣ ΕΧΕΙ ΤΕΘΕΙ ΣΕ ΚΙΝΔΥΝΟ\nΟποιαδήποτε 'σπασμένη' εφαρμογή μπορεί να έχει πρόσβαση σε οποιαδήποτε άλλης εφαρμογής τα δεδομένα (και να κλέψει τα Dash σας). Καθαρίστε το πορτοφόλι σας άμεσα και επαναφέρετε το σε μια ασφαλή συσκευή.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Απενεργοποιημένο";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Αποσύνδεση λογαριασμού Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Έγινε";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Έτοιμο — το υπόλοιπό σας ωρίμασε αρκετά";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Ελέγξτε ξανά τη διεύθυνση";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Κάθε πρόσκληση θα χρηματοδοτείται με αυτό το ποσό, ώστε ο παραλήπτης να μπορεί να δημιουργήσει γρήγορα το όνομα χρήστη του στο δίκτυο Dash.";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Κάθε masternode έχει μία ενεργή ψήφο ανά διαμάχη. Μπορείτε να την αλλάξετε αργότερα, αλλά το Dash Platform επιτρέπει συνολικά μόνο 5 ψήφους ανά masternode ανά διαμάχη.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Κάθε πάτημα ψηφίζει με έναν επιπλέον κόμβο, οπότε επιλέγετε πόσους θα συνδέσετε μεταξύ τους.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Νωρίτερα";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Κάντε εύκολα Stake το Dash και κερδίστε παθητικό εισόδημα με μερικά απλά κλικ.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Επεξεργασία ύψους έναρξης";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Επεξεργασία Προφίλ";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Ενεργοποίηση";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Ενεργοποίηση DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Ενεργοποίηση Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Ενεργοποίηση Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Η ενεργοποίηση του DashPay κοστίζει ένα μικρό εφάπαξ τέλος δικτύου, που πληρώνεται από το υπόλοιπο credits της ταυτότητάς σας. Η ακριβής εκτίμηση εμφανίζεται πριν την επιβεβαίωση. Η αποστολή αιτημάτων επαφής και πληρωμών κοστίζει τα συνήθη τέλη δικτύου.";
+
+"Ending soonest" = "Λήγει νωρίτερα";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Σφάλμα ενημέρωσης του προφίλ σας";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Εκτιμώμενο τέλος δικτύου";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Κάθε κόμβος ψηφίζει μαζί. Πιο γρήγορο, αλλά συνδέει δημόσια τα masternodes σας μεταξύ τους.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Κλειδιά χειριστή Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Εξαγωγή CSV";
 
+/* Log export */
+"Export Logs" = "Εξαγωγή Καταγραφών";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Εξωτερική διεύθυνση";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "όριο Face ID ";
+
+/* No comment provided by engineer. */
+"Failed" = "Απέτυχε";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Αποτυχία φόρτωσης barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Λαμβάνοντας τιμές...";
 
+/* Masternodes */
+"Fetching…" = "Ανάκτηση…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Λογαριασμός χρημάτων";
 
 /* No comment provided by engineer. */
 "Filter" = "Φίλτρο";
+
+/* SPV sync phase */
+"Filter headers" = "Κεφαλίδες φίλτρων";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Φίλτρο Συναλλαγών";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Βρείτε έναν χρήστη στο Δίκτυο Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Βρείτε ΑΤΜ όπου μπορείτε να αγοράσετε ή να πουλήσετε Dash.";
+
+/* Identities */
+"Find identities" = "Εύρεση ταυτοτήτων";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Ξεχάσατε το PIN;";
 
+/* Identities */
+"Found %d new identities" = "Βρέθηκαν %d νέες ταυτότητες";
+
+/* Identities */
+"Found 1 new identity" = "Βρέθηκε 1 νέα ταυτότητα";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Βρέθηκε η χαμένη λέξη:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Χρηματοδοτήστε το όνομα χρήστη σας από το θωρακισμένο υπόλοιπο. Προσθέστε κεφάλαια λίγες ώρες νωρίτερα — η σύντομη αναμονή κρατά το όνομα χρήστη σας μη συνδέσιμο με τα υπόλοιπα Dash σας.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Χρηματοδοτήθηκε από το θωρακισμένο υπόλοιπό σας — το όνομα χρήστη σας δεν μπορεί να συνδεθεί με τα υπόλοιπα Dash σας.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Τα κεφάλαια είναι κλειδωμένα — ολοκλήρωση μεταφοράς";
+
+/* CoinJoin */
+"Funds moved" = "Τα κεφάλαια μεταφέρθηκαν";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Κερδίστε ανταμοιβές από καταθέσεις σε Dash Masternodes με μόλις 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Αποκτήστε προσφορά";
+
+/* Usernames */
+"Get ready to join DashPay" = "Ετοιμαστείτε να μπείτε στο DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Αποκτήστε ανταμοιβές άμεσα";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Κατάλαβα";
+
+/* Governance */
+"Governance" = "Διακυβέρνηση";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Χορηγήστε δικαιώματα GPS ώστε να μπορούμε να σας δείξουμε τοποθεσίες κοντά σας.";
 
 /* Voting */
 "Has blocked votes" = "Έχει αποκλεισμένες ψήφους";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ζήτησε να γίνει φίλος σας";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Έχετε πρόσκληση;";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Έχετε τον πλήρη έλεγχο να προσαρμόσετε το πορτοφόλι σας ανάλογα με τις ανάγκες σας";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Κεφαλίδες";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Ύψος %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Αυτή είναι μια διεύθυνση Dash που έχει οριστεί για το λογαριασμό σας CrowdNode στο πορτοφόλι Dash σε αυτή τη συσκευή";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Υψηλά σε χαμηλά";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Υψηλότερα τέλη, γύρω στα 7 σεντς (και πάλι χαμηλότερα από άλλα blockchain με παρόμοια ιδιωτικότητα)";
+
 /* No comment provided by engineer. */
 "History" = "Ιστορικό";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Πώς μπορώ να αποκτήσω Test Dash;";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Πώς συγκρίνεται με το Bitcoin ως προς την ιδιωτικότητα;";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Πώς συγκρίνεται με τους λογαριασμούς Ethereum ως προς την ιδιωτικότητα;";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Πόσο ιδιωτικό είναι το DashPay;";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Πώς να επιβεβαιώσετε τη διεύθυνση API Dash σας";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Το έγραψα";
 
+/* Identities */
+"Identities" = "Ταυτότητες";
+
 /* Voting */
 "Identity" = "Ταυτότητα";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Credits ταυτότητας";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Ευρετήριο ταυτότητας";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Εγγραφή ταυτότητας";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Ανανέωση ταυτότητας";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Στην ενότητα πληρωμής του checkout, επιλέξτε «gift card» και πληκτρολογήστε τον αριθμό και το pin της κάρτας σας.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Ανενεργό";
+
+/* No comment provided by engineer. */
 "Income" = "Εισόδημα";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Έναρξη λειτουργίας";
+
+/* Raw transaction inspector */
+"Input %d" = "Είσοδος %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Είσοδος %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Είσοδοι (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Ανεπαρκή χρήματα";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Παράβολο πρόσκλησης";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Πρόσκληση από %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Η πρόσκληση χρησιμοποιείται από";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Πρόσκληση";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Προσκαλέστε κάποιον να μπει στο Δίκτυο Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Προσκαλέστε την οικογένειά σας, βρείτε τους φίλους σας αναζητώντας τα ονόματα χρήστη τους";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Προσκαλέστε τους φίλους και την οικογένειά σας να ενταχθούν στο δίκτυο Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Προσκαλέστε φίλους και οικογένεια στο Δίκτυο Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Αναφέρθηκε ζήτημα";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Συμμετοχή στην δεξαμενή";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Διατηρήστε αυτά τα νομίσματα ιδιωτικά. Ισχύουν τέλη δικτύου και ιδιωτικότητας.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Διατηρήστε την φράση πρόσβασής σας ασφαλή.";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Κλειδί #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Δεδομένα κλειδιού";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Ιδιοκτησία κλειδιού";
+
 /* No comment provided by engineer. */
 "Keypair" = "Ζεύγος κλειδιών";
+
+/* Masternodes */
+"Keys" = "Κλειδιά";
 
 /* Explore Dash */
 "Last device sync" = "Τελευταίος συγχρονισμός συσκευής";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Προηγείται";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Μάθετε περισσότερα";
 
 /* Info Screen */
 "Learn More..." = "Μάθετε περισσότερα";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Φόρτωση συναλλαγών";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Τοπικό νόμισμα";
 
+/* Identities */
+"Local Only" = "Μόνο τοπικά";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Τοπικό ποσό που ζητήθηκε: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Τοποθεσία";
 
+"Lock" = "Κλείδωμα";
+
+"Lock the name" = "Κλείδωμα του ονόματος";
+
+"Lock “%@” so nobody gets it" = "Κλείδωμα του «%@» ώστε να μην το πάρει κανείς";
+
 /* No comment provided by engineer. */
 "Locked" = "Κλείδωσε";
 
+"Locked — nobody receives this username" = "Κλειδωμένο — κανείς δεν λαμβάνει αυτό το όνομα χρήστη";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Είσοδος";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "χαμηλά";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Χαμηλά τέλη για καθημερινές δαπάνες";
+
 /* Voting */
 "Low to high" = "Χαμηλά σε υψηλά";
+
+/* Identities — the wallet's main identity */
+"Main" = "Κύρια";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Διεύθυνση IP του Masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Μπρελόκ Masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Κλειδιά Masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Λίστα masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "Λίστα masternode #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Ανανέωση Masternode";
 
+"Masternode votes" = "Ψήφοι masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Κλειδί ψήφου του Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Τα masternodes και τα evonodes που έχουν καταχωριστεί με τα κλειδιά αυτού του πορτοφολιού θα εμφανιστούν εδώ μετά τον συγχρονισμό του πορτοφολιού.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes και evonodes που χρησιμοποιούν τα κλειδιά αυτού του πορτοφολιού";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Τα masternodes ψηφίζουν για ονόματα που ζήτησαν περισσότερα από ένα άτομα. Θα ειδοποιηθείτε όταν λήξει η ψηφοφορία.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Μέγιστο";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Ελάχιστο: %@";
 
+/* Usernames */
+"Minimum met" = "Το ελάχιστο καλύφθηκε";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Περισσότερος Έλεγχος";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Περισσότερες Προτάσεις";
+
+"Most lock votes" = "Περισσότερες ψήφοι κλειδώματος";
+
+"Most votes" = "Περισσότερες ψήφοι";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Μετακινήστε και μεγεθύνετε τη φωτογραφία σας για να βρείτε την τέλεια εφαρμογή";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Μεταφορά στο κανονικό διαθέσιμο υπόλοιπό σας.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Μετακινήθηκε στην διεύθυνση";
+
+/* CoinJoin */
+"Moving funds" = "Μεταφορά κεφαλαίων";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Όνομα";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Υπηρεσίες ονομάτων όπως το Unstoppable Domains αντιστοιχίζουν ένα αναγνώσιμο όνομα σε μια σταθερή δημόσια διεύθυνση στην αλυσίδα. Οποιοσδήποτε μπορεί να επιλύσει το όνομα και να δει κάθε πληρωμή που έγινε ποτέ σε αυτό. Ένα όνομα χρήστη DashPay δεν οδηγεί ποτέ δημόσια σε διεύθυνση πληρωμής — οι διευθύνσεις αποκαλύπτονται μόνο μέσα στην κρυπτογραφημένη ανταλλαγή με κάθε επαφή, ώστε το όνομα και τα χρήματά σας να παραμένουν ασύνδετα για τους εξωτερικούς παρατηρητές.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Χρειάζεστε βοήθεια ?";
+
+"Needs attention" = "Χρειάζεται προσοχή";
 
 /* No comment provided by engineer. */
 "Network" = "Δίκτυο";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Δεν βρέθηκαν διαγνωστικά αρχεία καταγραφής σε αυτή τη συσκευή. Οι καταγραφές γράφονται από την επόμενη εκκίνηση και μετά.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Καμία Ταυτότητα";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Δεν υπάρχουν ακόμη masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Καμία διαμάχη δεν ταιριάζει";
+
+/* Identities */
+"No new identities were found for this wallet" = "Δεν βρέθηκαν νέες ταυτότητες για αυτό το πορτοφόλι";
+
+"No open contest matches that search." = "Καμία ανοιχτή διαμάχη δεν ταιριάζει με αυτή την αναζήτηση.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Καμία ανοιχτή διαμάχη δεν ταιριάζει με αυτή την αναζήτηση. Τα ονόματα αποθηκεύονται σε κανονικοποιημένη μορφή, οπότε το «alice» καταχωρείται ως «a11ce».";
+
+"No open contests" = "Καμία ανοιχτή διαμάχη";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Δεν υπάρχουν τρόποι πληρωμής";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Δεν βρέθηκε αποθηκευμένη εγγραφή πορτοφολιού για το συνδεδεμένο πορτοφόλι.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Δεν υπάρχει ακόμη διαθέσιμη διεύθυνση Platform για την εφεδρική θωρακισμένη εγγραφή. Δοκιμάστε ξανά αφού ολοκληρωθεί ο συγχρονισμός του πορτοφολιού.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Δεν βρέθηκαν αποτελέσματα";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Κανένα όνομα χρήστη δεν αμφισβητείται αυτή τη στιγμή. Οι διαμάχες ανοίγουν όταν δύο ή περισσότερα άτομα ζητούν το ίδιο όνομα.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Δεν έχουν απομείνει ψήφοι";
+
+"No votes were cast" = "Δεν καταχωρίστηκαν ψήφοι";
+
+"Nobody gets it" = "Κανείς δεν το παίρνει";
+
+/* SPV sync peer type */
+"Node" = "Κόμβος";
+
+/* Raw transaction inspector */
+"Non-standard" = "Μη τυπικό";
 
 /* adjective, security level */
 "None" = "κανενα";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Μη διαθέσιμο";
 
+"Not available yet" = "Μη διαθέσιμο ακόμη";
+
+"Not cast" = "Δεν καταχωρίστηκε";
+
+/* Masternodes */
+"Not checked yet" = "Δεν έχει ελεγχθεί ακόμη";
+
 /* Location Service Status */
 "Not Determined" = "Δεν έχει καθοριστεί";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Δεν επαρκεί το θωρακισμένο υπόλοιπο για την εγγραφή ταυτότητας";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Δεν υπάρχει στο ιστορικό του πορτοφολιού";
+
+"Not now" = "Όχι τώρα";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Δεν γίνεται ευρέως αποδεκτό από εμπόρους";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Δεν γίνεται ακόμη ευρέως αποδεκτό από εμπόρους";
+
+/* Masternode keys */
+"Not yet used" = "Δεν έχει χρησιμοποιηθεί ακόμη";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Παλαιά προς νέα";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Στο Bitcoin δεν υπάρχει επίπεδο ονομάτων, οπότε οι άνθρωποι μοιράζονται και επαναχρησιμοποιούν διευθύνσεις ανοιχτά — μόλις γίνει γνωστή μια διεύθυνση, ό,τι έλαβε ποτέ μπορεί να συνδεθεί με τον κάτοχό της. Με το DashPay το όνομα χρήστη σας είναι δημόσιο, αλλά δεν δείχνει ποτέ σε διεύθυνση πληρωμής: οι διευθύνσεις ανταλλάσσονται ιδιωτικά ανά επαφή και εναλλάσσονται, οπότε η πληρωμή με όνομα δεν δημοσιοποιεί πού πηγαίνουν τα χρήματά σας. Και οι δύο είναι διαφανείς αλυσίδες, οπότε η ανάλυση αλυσίδας εξακολουθεί να ισχύει για τα ίδια τα νομίσματα.";
+
+/* Identities */
+"On Network" = "Στο Δίκτυο";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Μόλις ο %@ αποδεχτεί το αίτημά σας θα μπορείτε να πληρώνετε απευθείας στο όνομα χρήστη";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Ένας κόμβος τη φορά";
 
 /* Voting */
 "One vote left" = "Μία ψήφος έμεινε";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Μόνο διπλότυπα";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Μόνο masternodes και evonodes μπορούν να ψηφίζουν για ονόματα χρήστη. Αυτό το πορτοφόλι δεν διαθέτει ενεργά κλειδιά ψήφου masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Μόνο αιτήματα με συνδέσμους";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Μόνο με συνδέσμους";
+
+/* Masternodes */
+"Operator" = "Χειριστής";
+
+/* Masternode keys */
+"Operator keys" = "Κλειδιά χειριστή";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Δημόσιο κλειδί χειριστή (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ή";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Προεπισκόπηση παραγγελίας";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Άλλες εκβάσεις";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Έξοδος %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Έξοδοι (%d)";
+
+/* Masternodes */
+"Owner" = "Ιδιοκτήτης";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Διεύθυνση Κατόχου";
+
+/* Masternodes */
+"Owner address" = "Διεύθυνση ιδιοκτήτη";
+
+/* Masternodes */
+"Owner key hash" = "Hash κλειδιού ιδιοκτήτη";
 
 /* Owner keys */
 "Owner keys" = "Κλειδιά ιδιοκτήτη";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Πληρώνεται από το υπόλοιπο credits της ταυτότητάς σας.";
 
 /* DashSpend */
 "Password" = "Κωδικός";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Επικολλήστε το σύνδεσμο εδώ";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Επικολλήστε τον σύνδεσμο πρόσκλησης που λάβατε ή σαρώστε τον κωδικό QR του. Καλύπτει την εγγραφή του ονόματος χρήστη σας.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Επικολλήστε τη διεύθυνση URL της εικόνας σας";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Πληρώστε και πληρωθείτε άμεσα με εύκολες στην χρήση πληρωμές";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "να πληρώνετε απευθείας στο όνομα χρήστη";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Πληρώστε ανθρώπους, όχι διευθύνσεις";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Πληρωμή σε ονόματα χρηστών. Όχι άλλες αλφαριθμητικές διευθύνσεις";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Πληρωμή...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Μέθοδος πληρωμής";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Οι πληρωμές είναι ιδιωτικές: οι διευθύνσεις που ανταλλάσσετε με μια επαφή ταξιδεύουν μέσα σε κρυπτογραφημένο φορτίο που μόνο εσείς οι δύο μπορείτε να διαβάσετε και δεν δημοσιεύονται ποτέ — έτσι οι πληρωμές σας δεν συνδέονται εύκολα με το όνομα χρήστη σας. Παραμένουν ωστόσο κανονικές πληρωμές σε διαφανή αλυσίδα: εξελιγμένη ανάλυση αλυσίδας ενδέχεται να διαρρεύσει πληροφορίες. Το Shielded DashPay (έρχεται σύντομα) θα καλύψει αυτό το κενό. Τα ίδια τα αιτήματα επαφής ΔΕΝ είναι προς το παρόν ιδιωτικά: οποιοσδήποτε μπορεί να δει ότι δύο ταυτότητες συνδέονται. Τα ιδιωτικά αιτήματα επαφής είναι λειτουργία που έρχεται σύντομα. Το όνομα χρήστη και το προφίλ σας είναι επίσης δημόσια στο Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Οι πληρωμές επιβεβαιώνονται σε δευτερόλεπτα με το InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Οι πληρωμές που γίνονται απευθείας σε διευθύνσεις δεν θα διατηρούνται στη δραστηριότητα.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Οι πληρωμές με κάθε επαφή ομαδοποιούνται σε ένα σημείο, με ονόματα και προφίλ αντί για ακατέργαστες συναλλαγές.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Διεύθυνση πληρωμής";
 
 /* CrowdNode */
 "Payout Options" = "Επιλογές πληρωμής";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Διεύθυνση Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Υπόλοιπο Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Κόμβος Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "Αναγνωριστικό κόμβου Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Οι πληρωμές Platform δεν ταυτοποιούν τον αποστολέα. Αυτή η πληρωμή καταγράφηκε όταν το πορτοφόλι αντιλήφθηκε τη μεταβολή υπολοίπου — μπορεί να είχε φτάσει νωρίτερα.";
+
+"Platform SDK not ready" = "Το SDK του Platform δεν είναι έτοιμο";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Ο συγχρονισμός Platform δεν εκτελείται. Ανοίξτε Πληροφορίες Συγχρονισμού → Κατάσταση Συγχρονισμού Platform για να τον ξεκινήσετε.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Θωρακισμένο";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Παρακαλώ προσθέστε έναν τρόπο πληρωμής στην Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Προεπισκόπηση πρόσκλησης";
 
+/* Masternode keys */
+"Previously used at: " = "Χρησιμοποιήθηκε προηγουμένως στις: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Οι τιμές είναι τουλάχιστον 30 λεπτά παλαιότερες. Οι τιμές Fiat ενδέχεται να είναι λανθασμένες.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Ιδιωτικό εκ σχεδιασμού";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Τα ιδιωτικά αιτήματα επαφής (ώστε να παραμένει ιδιωτικό με ποιον συνδέεστε), το Shielded DashPay — πληρωμές σε επαφές από το ιδιωτικό θωρακισμένο υπόλοιπό σας — και οι πληρωμές σε χρήστες που δεν είναι ακόμη στις επαφές σας έρχονται όλα σύντομα.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Τα ιδιωτικά αιτήματα επαφής βρίσκονται υπό ανάπτυξη και αναμένονται γύρω στον Σεπτέμβριο–Οκτώβριο 2026. Σήμερα το ίδιο το αίτημα είναι δημόσιο — οποιοσδήποτε μπορεί να δει ότι δύο ταυτότητες συνδέονται, ακόμη κι αν τα στοιχεία πληρωμής μέσα σε αυτό είναι κρυπτογραφημένα. Μόλις κυκλοφορήσουν τα ιδιωτικά αιτήματα επαφής, θα μπορείτε να επιλέγετε αν η φιλία σας θα είναι δημόσια ή ιδιωτική.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Ιδιωτικά αιτήματα επαφής, Shielded DashPay και πληρωμές σε άτομα που δεν είναι ακόμη επαφές.";
+
 /* No comment provided by engineer. */
 "Private key" = "Ιδιωτικό κλειδί";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Οι ιδιωτικές διευθύνσεις πληρωμής ανταλλάσσονται ανάμεσα σε εσάς και τις επαφές σας. Μόνο εσείς και η επαφή σας γνωρίζετε τον παραλήπτη και τον αποστολέα των πληρωμών μεταξύ σας.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Ιδιωτικές πληρωμές";
+
+/* Usernames */
+"Private registration" = "Ιδιωτική εγγραφή";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Χρόνος επεξεργασίας";
+
+/* Balance info sheet section */
+"Pros" = "Πλεονεκτήματα";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Προστατέψτε τις οικονομίες σας";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Διεύθυνση Παρόχου";
 
+/* Masternodes */
+"Provider transactions" = "Συναλλαγές παρόχου";
+
+/* Masternode keys */
+"Public key" = "Δημόσιο κλειδί";
+
+/* Masternode keys */
+"Public key (legacy)" = "Δημόσιο κλειδί (παλαιού τύπου)";
+
+/* Identities */
+"Public keys" = "Δημόσια κλειδιά";
+
 /* No comment provided by engineer. */
 "Public URL" = "Δημόσια διεύθυνση URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Η αγορά απέτυχε";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Σκοπός";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Ρυθμός: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Ακατέργαστη συναλλαγή";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Η ακατέργαστη συναλλαγή δεν είναι διαθέσιμη";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ελέγχει ξανά τα συμπαγή φίλτρα μπλοκ από το επιλεγμένο ύψος για συναλλαγές αυτού του πορτοφολιού, κατεβάζοντάς τα και αντιπαραβάλλοντάς τα εκ νέου. Οι επανασαρώσεις έχουν ως κατώτατο όριο το ύψος δημιουργίας του πορτοφολιού και τα τοπικά αποθηκευμένα δεδομένα αλυσίδας — για να ανακτήσετε ιστορικό κάτω από αυτό, μειώστε αντ' αυτού το ύψος έναρξης του πορτοφολιού.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Διαβάστε την Πολιτική απόσυρσης";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Μόνο για ανάγνωση";
+
+/* Usernames */
+"Ready around %@" = "Έτοιμο γύρω στις %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Αιτία";
 
 /* No comment provided by engineer. */
 "Receive" = "Λήψη";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Ελήφθησαν από";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Ελήφθη από %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Λήψη ανταμοιβών";
+
+"Records your masternodes as having voted, without taking a side." = "Καταγράφει τα masternodes σας ως να έχουν ψηφίσει, χωρίς να πάρουν θέση.";
 
 /* No comment provided by engineer. */
 "Recover" = "Επαναφορά";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Η φράση ανάκτησης πρέπει να έχει 12, 15, 18, 21 ή 24 λέξεις";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Ανανέωση";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Εγγραφή;";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Καταχωρίστηκε στις";
+
+/* No comment provided by engineer. */
 "Registered from" = "Εγγεγραμμένο από";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Εγγεγραμμένο Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Η ιδιωτική εγγραφή απαιτεί τουλάχιστον %@ Dash στο θωρακισμένο υπόλοιπό σας και μερικές ώρες αναμονής — οι επόμενες οθόνες σας καθοδηγούν.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Εγγραφή";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Ζητά αυτό το όνομα";
+
 /* An action */
 "Rescan" = "Επανάληψη της σάρωσης";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Τα αποκατεστημένα πορτοφόλια δεν μπορούν πάντα να ανακτήσουν τον τύπο της λειτουργίας. Αυτή η καταχώριση ανακατασκευάστηκε από δεδομένα σημείωσης στην αλυσίδα.";
+
+/* Location Service Status */
 "Restricted" = "Περιορισμένο";
 
 /* Usernames */
 "Results" = "Αποτελέσματα";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ο επανασυγχρονισμός προγραμματίστηκε από το ύψος %u — κλείστε και ανοίξτε ξανά την εφαρμογή για να ξεκινήσει.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "να διατηρείτε το κοινό ιστορικό συναλλαγών";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Αποσυρμένο";
 
 /* No comment provided by engineer. */
 "Retry" = "Επανάληψη";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Ελέγξτε την ανάρτηση παρακάτω για να επαληθεύσετε την ιδιοκτησία αυτού του ονόματος χρήστη.";
+
+/* Masternodes */
+"Revocation" = "Ανάκληση";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Οι λήψεις οθόνης είναι ορατές σε άλλες εφαρμογές και συσκευές. Δημιουργήστε μια νέα φράση ανάκτησης και κρατήστε την μυστική. ";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Υπογραφή script";
+
+/* Raw transaction inspector */
+"Script type" = "Τύπος script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Αναζήτηση επαφής";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Αναζήτηση αιτήματος επαφής";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Αναζήτηση Χρήστη στο Δίκτυο Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Αναζήτηση ονόματος χρήστη";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Αποτελέσματα αναζήτησης για \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Αναζήτηση περιοχών";
+
+"Search usernames" = "Αναζήτηση ονομάτων χρήστη";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Αναζήτηση του ονόματος χρήστη %@ στο Δίκτυο Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Ασφαλίστε το πορτοφόλι σας";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Επίπεδο Ασφάλειας";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Επίπεδο ασφαλείας";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Επιλέξτε μια υπηρεσία για αγορά, πώληση, μετατροπή και μεταφορά Dash";
 
+"Select all" = "Επιλογή όλων";
+
 /* DashSpend denomination selection */
 "Select amount" = "επιλεξτε ποσό";
+
+"Select at least one masternode to vote with." = "Επιλέξτε τουλάχιστον ένα masternode για να ψηφίσετε.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Επιλέξτε το νόμισμα";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Επιλέγοντας λιγότερους κόμβους αποκαλύπτετε λιγότερα για το ποια masternodes λειτουργείτε.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Εστάλη στο";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Αποστολή σε Επαφή";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Στείλτε σε ένα όνομα χρήστη που μπορείτε πραγματικά να θυμάστε και να επαληθεύσετε.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Αποστολή στη διεύθυνση";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Στείλτε το πρώτο σας αίτημα επαφής";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Αποστολή";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Αποστολή Αιτήματος Επαφής";
+
+/* No comment provided by engineer. */
+"Sending to" = "Αποστολή σε";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Αποστολή σε λογαριασμό CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Αποστόλη στο";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Στάλθηκε στον %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Εμφανίστηκε σφάλμα διακομιστή. Προσπαθήστε ξανά αργότερα.";
+
+/* Masternodes */
+"Service" = "Υπηρεσία";
+
+/* Identities */
+"Set as Main" = "Ορισμός ως Κύρια";
+
+/* Identities */
+"Set as Main Identity" = "Ορισμός ως Κύρια Ταυτότητα";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Ορίστε PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Μοιράστε το κλειδί";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Η κοινή δεξαμενή ιδιωτικότητας στο ελάχιστο μέγεθος";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Θωρακισμένη διεύθυνση";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Θωρακισμένη δαπάνη";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Εκκίνηση θωρακισμένου πορτοφολιού…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Θωρακισμένο → Platform";
+
+"Shielded → Transparent" = "Θωρακισμένο → Διαφανές";
 
 /* Explore Dash */
 "Show all locations" = "Εμφάνιση όλων των τοποθεσιών";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Μέγεθος";
+
 /* No comment provided by engineer. */
 "Skip" = "Παράλειψη";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Ορισμένα από τα masternodes σας μπορεί να λείπουν από αυτή τη λίστα — το πορτοφόλι δεν μπόρεσε να διαβάσει όλο το σύνολο των κλειδιών ψήφου σας. Ολοκληρώστε τον συγχρονισμό και ανοίξτε ξανά αυτή την οθόνη.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Ορισμένα ονόματα χρηστών μπορούν να μπλοκαριστούν";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Ταξινόμηση κατά";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ταξινόμηση Επαφών";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Ταξινόμηση ανά έκπτωση";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Ταξινόμηση κατά όνομα";
+
+/* Raw transaction inspector */
+"Special payload" = "Ειδικό payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Καθορίστε το ποσό";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Ξεκινά αφού προσθέσετε κεφάλαια";
+
+/* Transaction details */
+"Status" = "Κατάσταση";
+
 /* Step 1 */
 "Step %ld" = "Βήμα %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Αποθηκευμένο ως";
 
 /* Voting */
 "Submit" = "Υποβολή";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Συγχρονισμός σε εξέλιξη... Τα αποτελέσματα μπορεί να μην είναι πλήρη.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Πληροφορίες Συγχρονισμού";
+
+/* SPV sync */
+"Sync too slow?" = "Πολύ αργός συγχρονισμός;";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Τραβήξτε μια φωτογραφία από την κάμερα";
 
+"Take no side" = "Χωρίς να πάρετε θέση";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Πατήστε τη διεύθυνση από το πρόχειρο για να την επικολλήσετε";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Πατήστε για αντιγραφή";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Πατήστε για να κρύψετε το υπόλοιπο";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Προσωρινά μη διαθέσιμο";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Κλειδί κόμβου Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Όροι και Προϋποθέσεις";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Ο κωδικός είναι λανθασμένος. Παρακαλώ ελέγξτε και δοκιμάστε ξανά!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Τα Dash φτάνουν στη διεύθυνση του παραλήπτη αφού το δίκτυο επεξεργαστεί την ανάληψη — αυτό μπορεί να διαρκέσει έως 10 λεπτά.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Τα Dash φτάνουν στη διεύθυνση του παραλήπτη μόλις το δίκτυο επεξεργαστεί την ανάληψη.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Τα Dash φτάνουν στο διαφανές υπόλοιπό σας μόλις το δίκτυο επεξεργαστεί την ανάληψη.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Το δίκτυο Dash πρέπει να ψηφίσει για να εγκρίνει ορισμένα ονόματα χρηστών πριν δημιουργηθούν.";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Ο σύνδεσμος που στέλνετε θα είναι ορατός μόνο στους ιδιοκτήτες του δικτύου.";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Η κύρια ταυτότητα μπορεί να επιλεγεί μόνο από το ενεργό πορτοφόλι";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Το ελάχιστο ποσό που μπορείτε να στείλετε είναι %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Το πιο ιδιωτικό μέρος για να κρατάτε τα Dash σας";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Η αποθηκευμένη εγγραφή πορτοφολιού δεν έχει δίκτυο — δεν είναι δυνατός ο προγραμματισμός επανασυγχρονισμού.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Η εγγραφή υποβλήθηκε αλλά δεν ήταν δυνατή η επιβεβαίωση του αποτελέσματός της. Περιμένετε ένα λεπτό να συγχρονιστεί το πορτοφόλι και δοκιμάστε ξανά — μην την υποβάλετε αμέσως εκ νέου.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Η κοινή δεξαμενή ιδιωτικότητας μεγαλώνει ακόμη (%1$ld από %2$ld καταθέσεις). Η ιδιωτική εγγραφή ξεκλειδώνει μόλις φτάσει το ελάχιστο.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Η κοινή δεξαμενή ιδιωτικότητας μεγαλώνει ακόμη (%1$ld από %2$ld καταθέσεις). Δοκιμάστε ξανά μόλις φτάσει το ελάχιστο.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Το όνομα χρήστη %@ αποκλείστηκε από το  δίκτυο Dash. Παρακαλώ δοκιμάστε ξανά ζητώντας άλλο όνομα χρήστη.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Το ύψος δημιουργίας του πορτοφολιού — το κατώτατο όριο για τις σαρώσεις φίλτρων και τις επανασαρώσεις «Από τη δημιουργία πορτοφολιού». Ορίστε το στο ύψος της πρώτης χρηματοδότησης του πορτοφολιού ή χαμηλότερα· οι εισαγωγές χρησιμοποιούν εξ ορισμού 200000 στο mainnet και 0 στο testnet. Η αποθήκευση ύψους ίσου ή μικρότερου από το τρέχον εκκαθαρίζει τα δεδομένα αλυσίδας αυτού του δικτύου στην επόμενη εκκίνηση και σαρώνει ξανά από εκεί.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "αυτόν (Ανάκτηση Πληροφοριών)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Δεν υπάρχουν νέες ειδοποιήσεις";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Δεν υπάρχουν συναλλαγές για προβολή";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Δεν υπάρχουν χρήστες που να ταιριάζουν με το όνομα %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Δεν υπάρχουν χρήστες που να ταιριάζουν με το όνομα %@ στις επαφές σας";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Υπήρξε σφάλμα κατά την εξαγωγή του ιστορικού των συναλλαγών σας στο ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Υπήρξε ένα σφάλμα, παρακαλώ δοκιμάστε ξανά αργότερα";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Αυτά τα κεφάλαια μεταφέρονται στο υπόλοιπο Platform και είναι έτοιμα για δαπάνη μόλις ολοκληρωθεί η μεταφορά.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Αυτή η διεύθυνση δεν μπορεί να πληρωθεί από το υπόλοιπο %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Αυτό προσθέτει δύο κλειδιά στην ταυτότητά σας ώστε άλλοι χρήστες να μπορούν να σας στέλνουν αιτήματα επαφής και εσείς να μπορείτε να αποδέχεστε τα δικά τους. Γίνεται μία μόνο φορά.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Αυτό εφαρμόζει μία επιλογή σε όλα τα %d επιλεγμένα ονόματα χρήστη.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Αυτό το επιπλέον βήμα δείχνει ότι πραγματικά προσπαθείτε να κάνετε μια συναλλαγή.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Αυτός ο σύνδεσμος πρόσκλησης δεν είναι έγκυρος.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Αυτή δεν είναι έγκυρη διεύθυνση Dash για αυτό το δίκτυο";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Αυτός δεν είναι έγκυρος σύνδεσμος πρόσκλησης";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Αυτή είναι η κύρια ταυτότητά σας";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Αυτό το masternode δεν έχει ακόμη ταυτότητα Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Αυτός ο έμπορος δεν είναι προς το παρόν διαθέσιμος.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Αυτό αντιπροσωπεύει την τρέχουσα Ετήσια Ποσοστιαία Απόδοση ενός πλήρους Masternode μείον το τέλος CrowdNode 15%. Δεν αποτελεί εγγυημένο ποσοστό απόδοσης και μπορεί να αυξηθεί ή να μειωθεί ανάλογα με το μέγεθος των δεξαμενών CrowdNode και την τιμή του Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Αυτό εξακολουθεί να μετρά ως ψήφος των masternodes σας σε αυτή τη διαμάχη.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Τα ακατέργαστα bytes αυτής της συναλλαγής δεν είναι αποθηκευμένα σε αυτή τη συσκευή.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Αυτό το όνομα χρήστη πήγε σε κάποιον άλλον";
+
+"This wallet could not derive the voting key for this node." = "Αυτό το πορτοφόλι δεν μπόρεσε να παραγάγει το κλειδί ψήφου για αυτόν τον κόμβο.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Αυτό το πορτοφόλι δεν διαθέτει ενεργά κλειδιά ψήφου masternode, οπότε δεν μπορεί να ψηφίσει. Οι καταχωρισμένοι κόμβοι εμφανίζονται στο Εργαλεία → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Αυτό αποσύρει ολόκληρο το υπόλοιπο Platform σε μία μεταφορά. Τα Dash φτάνουν στη διεύθυνση του παραλήπτη μόλις το δίκτυο επεξεργαστεί την ανάληψη.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Αυτό αποσύρει ολόκληρο το υπόλοιπο Platform σε μία μεταφορά. Τα Dash φτάνουν στο διαφανές υπόλοιπό σας μόλις το δίκτυο επεξεργαστεί την ανάληψη.";
 
 /* Send Screen: to address */
 "to" = "στο";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Ιστορικό συναλλαγών";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Το ιστορικό συναλλαγών δεν είναι διαθέσιμο";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Ταυτότητα συναλλαγής";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Αναγνωριστικό Συναλλαγής";
 
 /* A verb, button title. */
 "Transfer" = "Μεταφορά";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Μεταφορά στο";
 
+/* Balance breakdown */
+"Transfer in" = "Εισερχόμενη μεταφορά";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Μεταφορά προς";
+
+/* Balance breakdown */
+"Transfer out" = "Εξερχόμενη μεταφορά";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Οι μεταφορές διαρκούν περισσότερο — η κατασκευή των αποδείξεων ιδιωτικότητας χρειάζεται χρόνο";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Οι μεταφορές σε άλλες διευθύνσεις Platform και σε θωρακισμένες διευθύνσεις είναι άμεσες και οριστικές";
+
+/* Balance breakdown */
+"Transparent" = "Διαφανές";
+
+/* Send screen destination type */
+"Transparent address" = "Διαφανής διεύθυνση";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Διαφανές υπόλοιπο";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Η διαφανής χρηματοδότηση συνδέει δημόσια το όνομα χρήστη σας με αυτά τα κεφάλαια.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Διαφανές → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Διαφανές → Θωρακισμένο";
 
 /* An action */
 "Try again" = "Προσπαθήστε ξανά";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Δεν είναι δυνατή η παροχή προτάσεων";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Άγνωστο Υπόλοιπο";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Άγνωστος ειδικός τύπος %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Μη θωρακισμένο";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Μη υποστηριζόμενο url";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Αναβάθμιση σε DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Αναβάθμιση σε Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Χρήση διαφανούς υπολοίπου αντ' αυτού";
+
+/* Masternode keys */
+"Used" = "Χρησιμοποιήθηκε";
+
+/* Masternode keys */
+"Used at: " = "Χρησιμοποιήθηκε στις: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Χρήστης (Ανάκτηση Πληροφοριών)";
 
 /* Voting */
 "Username" = "Όνομα Χρήστη:";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Το όνομα χρήστη αιτήθηκε επιτυχώς";
 
+/* Identities */
+"Usernames" = "Ονόματα χρήστη";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Τα ονόματα χρήστη αποθηκεύονται σε κανονικοποιημένη μορφή για να αποτρέπονται τα παρόμοια ονόματα, οπότε αυτό μπορεί να διαφέρει από αυτό που πληκτρολόγησε ο καθένας.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Ονόματα χρήστη, όχι διευθύνσεις";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Χρήστες που ταιριάζουν με %@ και δεν βρίσκονται αυτή τη στιγμή στις επαφές σας";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Χρησιμοποιεί μία από τις πιο ελεγμένες και δοκιμασμένες βιβλιοθήκες μηδενικής γνώσης (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Έγκυρη πρόσκληση";
+
 /* CrowdNode Portal */
 "Validating address…" = "Επικύρωση διεύθυνσης...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Απαιτείται επαλήθευση";
 
+/* Usernames */
+"Verified during registration" = "Επαληθεύτηκε κατά την εγγραφή";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Επιβεβαιώθηκε με επιτυχία";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Επαληθεύστε την ταυτότητά σας";
 
+/* Raw transaction inspector */
+"Version" = "Έκδοση";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Πολύ αποδοτικό με χαμηλά τέλη";
+
 /* adjective, security level */
 "Very High" = "Πολύ Υψηλά";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Πολύ μικρές ποσότητες Dash θα αποστέλλονται από και προς το CrowdNode για να επαληθεύσετε ότι είστε ο ιδιοκτήτης αυτής της διεύθυνσης πορτοφολιού.";
+
+/* No comment provided by engineer. */
+"View All" = "Προβολή Όλων";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Προβολή στον Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Προβολή Φράσης Ανάκτησης";
 
+/* Raw transaction inspector */
+"View Transaction" = "Προβολή Συναλλαγής";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Προβολή λεπτομερειών συναλλαγής";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Ψήφος";
+
+"Vote cast" = "Η ψήφος καταχωρίστηκε";
+
 /* Voting */
 "Vote for All" = "Ψηφίστε για Όλους";
 
 /* Voting */
+"Vote on contested usernames" = "Ψηφίστε για αμφισβητούμενα ονόματα χρήστη";
+
+"Vote on several" = "Ψήφος σε πολλά";
+
+/* Voting */
 "Vote to Approve" = "Ψηφίστε για Έγκριση";
+
+"Vote with" = "Ψήφος με";
+
+"Votes that nobody should receive these usernames." = "Ψηφίζει ώστε κανείς να μη λάβει αυτά τα ονόματα χρήστη.";
 
 /* Voting */
 "Votes: High to low" = "Ψήφοι: Υψηλές προς χαμηλές";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Διεύθυνση Ψήφου";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Διεύθυνση Ψήφου";
+
+"Voting ended with no winner" = "Η ψηφοφορία έληξε χωρίς νικητή";
+
+"Voting ends" = "Η ψηφοφορία λήγει";
+
 /* Voting */
 "Voting ends in %dd" = "Η ψηφοφορία λήγει σε %d μέρες";
+
+"Voting in progress" = "Ψηφοφορία σε εξέλιξη";
+
+"Voting in progress — lock votes are ahead" = "Ψηφοφορία σε εξέλιξη — οι ψήφοι κλειδώματος προηγούνται";
+
+"Voting in progress — you are ahead" = "Ψηφοφορία σε εξέλιξη — προηγείστε";
 
 /* Usernames */
 "Voting is only required in some cases" = "Η ψηφοφορία απαιτείται μόνο σε ορισμένες περιπτώσεις";
 
+/* Masternodes */
+"Voting key hash" = "Hash κλειδιού ψήφου";
+
 /* Voting keys */
 "Voting keys" = "Κλειδιά ψηφοφορίας";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Η ψηφοφορία για αυτό το όνομα χρήστη έχει κλείσει. Οι παρακάτω μετρήσεις είναι οι τελευταίες που διαβάστηκαν.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Η ψηφοφορία για το «%@» έχει ήδη κλείσει. Ανανεώστε για να δείτε το αποτέλεσμα.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Περιμένετε μέχρι να συγχρονιστεί το πορτοφόλι για να ολοκληρώσετε τη συναλλαγή";
 
+"Waiting for Dash Platform" = "Αναμονή για το Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Διεύθυνση πορτοφόλιού";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Ύψος έναρξης πορτοφολιού";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Το πορτοφόλι απενεργοποιήθηκε";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Καλώς ήρθατε στο DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Τι γίνεται με το Unstoppable Domains και παρόμοιες υπηρεσίες ονομάτων;";
+
+/* DashPay FAQ */
+"What does it cost?" = "Πόσο κοστίζει;";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Τι είναι το DashPay;";
+
 /* Usernames */
 "What is username voting?" = "Τι είναι η ψηφοφορία ονόματος χρήστη;";
+
+/* DashPay FAQ */
+"What's coming next?" = "Τι έρχεται στη συνέχεια;";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Πότε θα γίνουν ιδιωτικά τα αιτήματα επαφής;";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Πού να ξοδέψετε";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Πού να ξοδέψετε;";
+
+"Who is requesting this name" = "Ποιος ζητά αυτό το όνομα";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Γιατί πρέπει να το ενεργοποιήσω;";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Γιατί βλέπω όλες αυτές τις συναλλαγές;";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Ζητήθηκε απόσυρση";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Αποσύρει ολόκληρο το υπόλοιπο";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Λειτουργεί με κάθε πορτοφόλι, ανταλλακτήριο και έμπορο Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Θέλετε να αποδεχθείτε την πρόσκληση;";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Εχθές";
+
+"You" = "Εσείς";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Αποδεχτήκατε το αίτημα επαφής από τον %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Επιλέξατε το \"%@\" ως όνομα χρήστη.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Δεν έχετε καμία επαφή αυτή τη στιγμή";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Δεν έχετε αρκετά χρήματα για να ολοκληρώσετε αυτή την συναλλαγή";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Υπερβήκατε το όριο εξουσιοδότησης στην Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Έχετε %@ Dash μέχρι στιγμής";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Έχετε %1$@ Dash.\nΟρισμένα ονόματα χρηστών κοστίζουν έως και %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Στείλατε το αίτημα επαφής στον %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Θα πρέπει να έχετε θετικό υπόλοιπο στο Dash Wallet";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Κερδίσατε αυτό το όνομα χρήστη";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Όλα έτοιμα. Άλλοι χρήστες μπορούν τώρα να σας στέλνουν αιτήματα επαφής — και εσείς μπορείτε να στέλνετε τα δικά σας.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Η ταυτότητά σας στο Dash Platform εμφανίζεται εδώ μόλις καταχωρίσετε ένα όνομα χρήστη.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Το email σας χρησιμοποιείται μόνο για την αποστολή ενός κωδικού πρόσβασης μιας χρήσης.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Το ιστορικό σας, οργανωμένο";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Η ταυτότητά σας χρειάζεται δύο επιπλέον κλειδιά ώστε τα αιτήματα επαφής να μπορούν να κρυπτογραφούνται ανάμεσα σε εσάς και άλλους χρήστες. Η ενεργοποίηση τα προσθέτει με μία μόνο συναλλαγή δικτύου. Γίνεται μία μόνο φορά.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Η πρόσκλησή σας από %@ έχει ήδη διεκδικηθεί";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Η πρόσκλησή σας από %@ δεν είναι έγκυρη";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Η πρόσκλησή σας καλύπτει το τέλος εγγραφής για αυτό το όνομα χρήστη.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Η τοποθεσία σας χρησιμοποιείται για να δείξει τη θέση σας στο χάρτη, τα ΑΤΜ στο επιλεγμένο περιοχή και να βελτιώσει τα αποτελέσματα αναζήτησης.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Η τοποθεσία σας χρησιμοποιείται για να δείξει τη θέση σας στο χάρτη, τους εμπόρους στην επιλεγμένη περιοχή και να βελτιώσει τα αποτελέσματα αναζήτησης.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Το κύριο υπόλοιπο Dash σας στο blockchain Core — αυτό που στέλνετε και λαμβάνετε με άλλα πορτοφόλια, ανταλλακτήρια και εμπόρους.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Τα αναμειγμένα νομίσματά σας μεταφέρθηκαν στο υπόλοιπο του πορτοφολιού Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Τα αναμειγμένα νομίσματά σας μεταφέρθηκαν στο θωρακισμένο υπόλοιπο. Για καλύτερη ιδιωτικότητα, περιμένετε τουλάχιστον 2 ώρες πριν χρησιμοποιήσετε αυτά τα κεφάλαια.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Το υπόλοιπο Platform σας";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Η κύρια διεύθυνση Dash που χρησιμοποιείτε επί του παρόντος για τον λογαριασμό σας στο CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Το ιδιωτικό σας υπόλοιπο. Τα ποσά και οι διευθύνσεις είναι κρυπτογραφημένα στην αλυσίδα, ώστε τα διαθέσιμα και το ιστορικό σας να παραμένουν εμπιστευτικά.";
+
 /* Usernames */
 "Your request was cancelled" = "Το αίτημά σας ακυρώθηκε";
 
 /* DashSpend */
 "Your session expired" = "Η συνεδρία σας έληξε";
+
+/* Usernames */
+"Your Shielded balance" = "Το θωρακισμένο υπόλοιπό σας";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Το θωρακισμένο υπόλοιπό σας είναι σχεδόν έτοιμο — μπορείτε να κάνετε ιδιωτική εγγραφή γύρω στις %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Το θωρακισμένο υπόλοιπό σας είναι έτοιμο — καταχωρίστε τώρα το όνομα χρήστη σας ιδιωτικά";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Το θωρακισμένο υπόλοιπό σας ωριμάζει — μπορείτε να κάνετε ιδιωτική εγγραφή γύρω στις %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Το θωρακισμένο υπόλοιπό σας ωριμάζει ακόμη. Θα είναι έτοιμο γύρω στις %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Το διαφανές υπόλοιπό σας";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Το όνομα χρήστη %@ δημιουργήθηκε με επιτυχία στο Dash Δίκτυο";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Το όνομα χρήστη σας δημιουργήθηκε με επιτυχία";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Το όνομα χρήστη σας είναι ορατό σε όλους. Η χρηματοδότησή του από το θωρακισμένο υπόλοιπο — αφού αφήσετε τα κεφάλαια να ωριμάσουν μερικές ώρες — σημαίνει ότι κανείς δεν μπορεί να συνδέσει το όνομα χρήστη σας με τα υπόλοιπα Dash σας.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Το όνομα χρήστη, το προφίλ και οι επαφές σας ακολουθούν αυτή την ταυτότητα.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Το όνομα χρήστη, το προφίλ και οι επαφές σας θα ακολουθούν αυτή την ταυτότητα.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Η ψήφος σας ακυρώθηκε.";
 
 /* Voting */
 "Your vote was submitted" = "Η ψήφος σας υποβλήθηκε.";
 
+"Your votes" = "Οι ψήφοι σας";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Το πορτοφόλι σας είναι ασφαλές τώρα. Μπορείτε να χρησιμοποιήσετε τη φράση ανάκτησης ανά πάσα στιγμή για να ανακτήσετε το λογαριασμό σας σε άλλη συσκευή.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Το πορτοφόλι σας συγχρονίζεται ακόμη με το δίκτυο Dash. Η αποστολή θα είναι διαθέσιμη μόλις ολοκληρωθεί ο συγχρονισμός.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Το πορτοφόλι σας συγχρονίζεται ακόμη. Η αποστολή από το διαφανές υπόλοιπό σας θα είναι διαθέσιμη μόλις ολοκληρωθεί ο συγχρονισμός.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Το «%@» δεν μπόρεσε να διαβαστεί ως όνομα χρήστη Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "Το «%@» καταχωρίστηκε. Να σταλεί αίτημα επαφής στο άτομο που σας προσκάλεσε;";

--- a/DashWallet/el.lproj/Localizable.stringsdict
+++ b/DashWallet/el.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ καταμετρήθηκαν για «%2$@»</string>
+		<string>%#@votes@ για «%2$@»</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,15 +93,15 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u ψήφος</string>
+			<string>%1$u ψήφος καταμετρήθηκε</string>
 			<key>other</key>
-			<string>%1$u ψήφοι</string>
+			<string>%1$u ψήφοι καταμετρήθηκαν</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Ψηφίστηκαν %1$d από %#@names@</string>
+		<string>Ψηφοφορία: %1$d από %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d από %#@nodes@ ψήφισαν</string>
+		<string>Ψηφοφορία: %1$d από %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d από %#@nodes@ ψήφισαν</string>
+		<string>Ψηφοφορία: %1$d από %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/el.lproj/Localizable.stringsdict
+++ b/DashWallet/el.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d κλειδιά</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ καταμετρήθηκαν για «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u ψήφος</string>
+			<key>other</key>
+			<string>%1$u ψήφοι</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Ψηφίστηκαν %1$d από %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d όνομα χρήστη</string>
+			<key>other</key>
+			<string>%2$d ονόματα χρήστη</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Καταχώριση %u ψήφου</string>
+			<key>other</key>
+			<string>Καταχώριση %u ψήφων</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d από %#@nodes@ ψήφισαν</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d από %#@nodes@ ψήφισαν</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d κόμβος</string>
+			<key>other</key>
+			<string>%2$d κόμβοι</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ψήφος συνολικά</string>
+			<key>other</key>
+			<string>%u ψήφοι συνολικά</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d επιλεγμένο</string>
+			<key>other</key>
+			<string>%d επιλεγμένα</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d από τους κόμβους σας έχει ήδη ψηφίσει εδώ και δεν εμφανίζεται.</string>
+			<key>other</key>
+			<string>%d από τους κόμβους σας έχουν ήδη ψηφίσει εδώ και δεν εμφανίζονται.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ψήφος ανά διαμάχη — τα evonodes μετρούν ως 4, τα masternodes ως 1</string>
+			<key>other</key>
+			<string>%u ψήφοι ανά διαμάχη — τα evonodes μετρούν ως 4, τα masternodes ως 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Ψηφίστε για %d όνομα χρήστη</string>
+			<key>other</key>
+			<string>Ψηφίστε για %d ονόματα χρήστη</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ψήφος</string>
+			<key>other</key>
+			<string>%u ψήφοι</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Ψήφος ×%d</string>
+			<key>other</key>
+			<string>Ψήφος ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d αίτημα</string>
+			<key>other</key>
+			<string>%d αιτήματα</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/el.lproj/Localizable.stringsdict
+++ b/DashWallet/el.lproj/Localizable.stringsdict
@@ -157,9 +157,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d κόμβος</string>
+			<string>%2$d κόμβο</string>
 			<key>other</key>
-			<string>%2$d κόμβοι</string>
+			<string>%2$d κόμβους</string>
 		</dict>
 	</dict>
 	<key>%d evonodes</key>

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " aŭ ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ ne troviĝis en la reto Dash por sendi al ri kontaktpeton.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponeblaj";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ akceptis vian kontaktpeton";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtoj";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld el %ld deponoj";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kredita saldo en Dash Platform uzata por tujaj pagoj inter Platform-adresoj kaj por funkcioj kiel uzantnomoj.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Pri";
 
+/* DashPay FAQ title */
+"About DashPay" = "Pri DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Deteni sin";
+
+"Abstain on “%@”" = "Deteni sin pri „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiva";
+
+/* No comment provided by engineer. */
+"Activity" = "Agado";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "La agado estas publika sed ne facile spurebla";
+
 /* No comment provided by engineer. */
 "Add" = "Aldoni";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Aldoni %@ kiel kontakton";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Aldonu %@ kiel kontakton por pagi rekte al la uzantnomo kaj konservi la komunan transakcian historion";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Aldonu %@ Dash al via ŝirmita saldo kaj lasu ĝin ripozi kelkajn horojn por registriĝi sen ligi vian uzantnomon al viaj ceteraj monrimedoj.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Aldonu almenaŭ %@ Dash al via ŝirmita saldo";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Aldonu monrimedojn al via ŝirmita saldo nun kaj registru vian uzantnomon private post kelkaj horoj";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Ĉiuj nodoj samtempe";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Ĉiuj viaj masternodoj voĉdonis pri ĉi tiu uzantnomo. Por ŝanĝi voĉon, voĉdonu denove de la kandidato kiun vi nun preferas.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Preskaŭ tuja sinkronigo de saldoj";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Sumoj kaj adresoj estas publikaj en la blokĉeno";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum-konto estas unu reuzata adreso: via tuta saldo kaj paga historio kuŝas publike sub ĝi, kaj nomo (ekzemple ENS-domajno) kutime montras rekte al tiu adreso, do iu ajn povas ĝin solvi. DashPay havas la malan formon — la nomo solviĝas al identeco, ne al paga adreso, kaj la realaj pagaj adresoj restas ene de ĉifritaj kontaktinterŝanĝoj, novaj por ĉiu kontakto.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Iu ajn kiu konas adreson povas vidi ĝian historion";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Aprobi";
+
+"Approving a specific request can only be done one username at a time." = "Aprobi konkretan peton eblas nur por unu uzantnomo samtempe.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Kiel tekston";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Aŭtentigo nuligita. Via voĉo ne estis donita.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Aŭtentigo malsukcesis. Via voĉo ne estis donita.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Aljuĝi „%@“ al ĉi tiu kandidato";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Saldo poste";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldoj kaj transpagoj ne estas publike videblaj";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Komenca alto konservita — la altigita skana limo validas ekde la sekva lanĉo.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Ligita al kontrakto";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Ligita al kontrakto, dokumenttipo „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Nur foliumado";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Kolektas la lastajn diagnozajn protokolojn en zip-dosieron por sendi per AirDrop, retpoŝte aŭ konservi en Dosieroj";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Doni voĉon";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Ŝanĝi samtavolanojn";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrolado…";
+
+"Choice" = "Elekto";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Elaĉetu vian inviton";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Elprenebla saldo";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Forviŝi kaj resinkronigi";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Ĉu forviŝi la ĉendatumojn kaj resinkronigi?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Fermiĝas";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (novaj moneroj)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ne plu estas subtenata — elektu kien movi viajn miksitajn monerojn.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Garantiaĵo";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Baldaŭ";
+
+/* Shielded transfer status */
+"Completed" = "Finita";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Konfirmita";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Konfirmo konservas la komencan alton %u kaj forviŝas la ĉendatumojn de ĉi tiu reto ĉe la sekva lanĉo de la aplikaĵo, elŝutas ilin denove kaj reskanas la filtrilojn ekde tiu alto. La kuranta seanco konservas sian malnovan skanan limon — fermu kaj remalfermu la aplikaĵon por komenci.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Konektitaj samtavolanoj";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Malavantaĝoj";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktpeto malsukcesis";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktpeto sendita al %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktpetoj";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidato %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Daŭrigu por elekti vian uzantnomon. La invito pagas la registran kotizon.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopii krudan transakcion";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Ne eblis krei la protokolarkivon: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Ne eblis refreŝigi %d identecojn";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Ne eblis akiri la saldon (reta eraro). Provu refreŝigi.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Kreu vian uzantnomon, trovu amikojn kaj familion per iliaj uzantnomoj kaj aldonu ilin al viaj kontaktoj";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kreditoj";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ankoraŭ ne indeksis ĉi tiun disputon. La voĉnombroj aperos ĉi tie kiam ĝi tion faros.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ankoraŭ ne konektiĝis. Atendu ĝis la sinkronigo finiĝos kaj provu denove.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash sendita al malĝusta adreso ne reakireblas. Certiĝu ke la adreso estas ĝuste tiu al kiu vi intencas pagi.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash konservas uzantnomojn en formo rezista al similaspektaj skribmanieroj, do la konservita nomo povas malsami de tio kion ĉiu persono tajpis.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo de la monujo Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay ŝaltita";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay estas la socia paga sperto de Dash, konstruita sur Dash Platform. Vi registras uzantnomon, aldonas aliajn uzantojn kiel kontaktojn kaj pagas al ili laŭ nomo — ne plu kopiado de adresoj.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay anstataŭigas longajn kriptajn adresojn per uzantnomoj. Aldonu amikojn kiel kontaktojn, sendu monon al nomo kaj tenu ĉiun pagon ordigita laŭ persono.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Limdato nekonata";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Derivada vojo";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Malŝaltita";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Farita — via saldo ripozis sufiĉe longe";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Duoble kontrolu la adreson";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Ĉiu masternodo havas unu validan voĉon por ĉiu disputo. Vi povas ĝin ŝanĝi poste, sed Dash Platform permesas entute nur 5 voĉojn por ĉiu masternodo por ĉiu disputo.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Ĉiu frapeto voĉdonas per unu plia nodo, do vi elektas kiom da ili ligiĝos kune.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Redakti la komencan alton";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Ŝalti";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Ŝalti DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Ŝalti DashPay kostas malgrandan unufojan retan kotizon, pagatan el la kredita saldo de via identeco. La preciza takso montriĝas antaŭ ol vi konfirmas. Sendi kontaktpetojn kaj pagojn kostas la kutimajn retajn kotizojn.";
+
+"Ending soonest" = "Finiĝas plej frue";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Taksita reta kotizo";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Ĉiuj nodoj voĉdonas kune. Pli rapide, sed tio publike ligas viajn masternodojn inter si.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operatoraj ŝlosiloj de Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Eksporti protokolojn";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Ekstera adreso";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Malsukcesis";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Akirado…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filtrilaj kapoj";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Trovu uzanton en la reto Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Trovi identecojn";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Troviĝis %d novaj identecoj";
+
+/* Identities */
+"Found 1 new identity" = "Troviĝis 1 nova identeco";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financu vian uzantnomon el via ŝirmita saldo. Aldonu la monrimedojn kelkajn horojn antaŭe — la mallonga ripozo malebligas ligi vian uzantnomon al viaj ceteraj Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financita el via ŝirmita saldo — via uzantnomo ne ligeblas al viaj ceteraj Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Monrimedoj ŝlositaj — la transpago finiĝas";
+
+/* CoinJoin */
+"Funds moved" = "Monrimedoj movitaj";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Preparu vin aliĝi al DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Komprenite";
+
+/* Governance */
+"Governance" = "Regado";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "petis esti via amiko";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Ĉu vi havas inviton?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Kapoj";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Alto %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Pli altaj kotizoj ĉirkaŭ 7 cendoj (tamen pli malaltaj ol ĉe aliaj blokĉenoj kun simila privateco)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kiel tio kompariĝas kun Bitcoin rilate al privateco?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kiel tio kompariĝas kun Ethereum-kontoj rilate al privateco?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Kiom privata estas DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identecoj";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kreditoj de identeco";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indekso de identeco";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registrado de identeco";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Rekreditado de identeco";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktiva";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Enigo %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Enigo %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Enigoj (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invito de %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invitu iun aliĝi al la reto Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invitu viajn amikojn kaj familion al la reto Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Konservu ĉi tiujn monerojn privataj. Aplikiĝas retaj kaj privatecaj kotizoj.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ŝlosilo n-ro %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Datumoj de la ŝlosilo";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Posedo de la ŝlosilo";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ŝlosiloj";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Antaŭas";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Lerni pli";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Ŝargado de transakcioj";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Nur loke";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Ŝlosi";
+
+"Lock the name" = "Ŝlosi la nomon";
+
+"Lock “%@” so nobody gets it" = "Ŝlosi „%@“ por ke neniu ĝin ricevu";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Ŝlosita — neniu ricevas ĉi tiun uzantnomon";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Malaltaj kotizoj por ĉiutaga elspezado";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Ĉefa";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Ŝlosilaro de masternodo";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Listo de masternodoj";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Voĉoj de masternodoj";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodoj";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodoj kaj evonodoj registritaj per la ŝlosiloj de ĉi tiu monujo aperos ĉi tie post kiam la monujo sinkroniĝos.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodoj kaj evonodoj uzantaj la ŝlosilojn de ĉi tiu monujo";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodoj voĉdonas pri nomoj petitaj de pli ol unu persono. Vi ricevos sciigon kiam la voĉdonado finiĝos.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimumo atingita";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Pliaj sugestoj";
+
+"Most lock votes" = "Plej multe da ŝlosaj voĉoj";
+
+"Most votes" = "Plej multe da voĉoj";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Movi al via kutima elspezebla saldo.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Movado de monrimedoj";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Nomservoj kiel Unstoppable Domains ligas legeblan nomon al fiksa publika adreso en la ĉeno. Iu ajn povas solvi la nomon kaj vidi ĉiun pagon iam ajn faritan al ĝi. DashPay-uzantnomo neniam solviĝas publike al paga adreso — adresoj malkaŝiĝas nur ene de la ĉifrita interŝanĝo kun ĉiu kontakto, do via nomo kaj via mono restas nekunligitaj por eksteraj observantoj.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Bezonas atenton";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Neniuj diagnozaj protokoloj troviĝis en ĉi tiu aparato. Protokoloj skribiĝas ekde la sekva lanĉo.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Neniuj identecoj";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ankoraŭ neniuj masternodoj";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Neniuj kongruaj disputoj";
+
+/* Identities */
+"No new identities were found for this wallet" = "Neniuj novaj identecoj troviĝis por ĉi tiu monujo";
+
+"No open contest matches that search." = "Neniu malfermita disputo kongruas kun tiu serĉo.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Neniu malfermita disputo kongruas kun tiu serĉo. Nomoj konserviĝas en normigita formo, do „alice“ listiĝas kiel „a11ce“.";
+
+"No open contests" = "Neniuj malfermitaj disputoj";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Neniu konservita monuja registro troviĝis por la ligita monujo.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Ankoraŭ ne disponeblas Platform-adreso por la ŝirmita rezerva registrado. Provu denove post kiam la monujo finos sinkronigi.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Nuntempe neniu uzantnomo estas disputata. Disputoj malfermiĝas kiam du aŭ pli da homoj petas la saman nomon.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Neniuj voĉoj estis donitaj";
+
+"Nobody gets it" = "Neniu ricevas ĝin";
+
+/* SPV sync peer type */
+"Node" = "Nodo";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nenorma";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Ankoraŭ ne disponebla";
+
+"Not cast" = "Ne donita";
+
+/* Masternodes */
+"Not checked yet" = "Ankoraŭ ne kontrolita";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nesufiĉa ŝirmita saldo por registri identecon";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ne en la historio de la monujo";
+
+"Not now" = "Ne nun";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Ne vaste akceptata de komercistoj";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Ankoraŭ ne vaste akceptata de komercistoj";
+
+/* Masternode keys */
+"Not yet used" = "Ankoraŭ ne uzita";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "En Bitcoin ne ekzistas nomtavolo, do homoj malkaŝe kunhavigas kaj reuzas adresojn — kiam adreso iĝas konata, ĉio kion ĝi iam ricevis ligiĝas al ĝia posedanto. Kun DashPay via uzantnomo estas publika, sed ĝi neniam montras al paga adreso: adresoj interŝanĝiĝas private kun ĉiu kontakto kaj rotacias, do pagi laŭ nomo ne publikigas kien iras via mono. Ambaŭ estas travideblaj ĉenoj, do ĉenanalizo ankoraŭ validas por la moneroj mem.";
+
+/* Identities */
+"On Network" = "En la reto";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kiam %@ akceptos vian peton, vi povos pagi rekte al la uzantnomo";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Unu nodo samtempe";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Nur masternodoj kaj evonodoj povas voĉdoni pri uzantnomoj. Ĉi tiu monujo havas neniujn aktivajn voĉdonajn ŝlosilojn de masternodo.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operatoro";
+
+/* Masternode keys */
+"Operator keys" = "Operatoraj ŝlosiloj";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Publika ŝlosilo de la operatoro (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "aŭ";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Aliaj rezultoj";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Eligo %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Eligoj (%d)";
+
+/* Masternodes */
+"Owner" = "Posedanto";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adreso de la posedanto";
+
+/* Masternodes */
+"Owner key hash" = "Haketaĵo de la posedanta ŝlosilo";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Pagata el la kredita saldo de via identeco.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Algluu la invitan ligilon kiun vi ricevis, aŭ skanu ĝian QR-kodon. Ĝi financas la registradon de via uzantnomo.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "pagi rekte al la uzantnomo";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Pagu al homoj, ne al adresoj";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Ŝarĝo (deksesuma)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Pagoj estas privataj: la adresoj kiujn vi interŝanĝas kun kontakto vojaĝas ene de ĉifrita enhavo kiun nur vi du povas legi, kaj neniam publikiĝas — do viaj pagoj ne facile ligiĝas al via uzantnomo. Tamen ili restas ordinaraj pagoj en travidebla ĉeno: altnivela ĉenanalizo povus liki informojn. Shielded DashPay (baldaŭ) fermos tiun breĉon. La kontaktpetoj mem nuntempe NE estas privataj: iu ajn povas vidi ke du identecoj estas ligitaj. Privataj kontaktpetoj estas funkcio venonta baldaŭ. Via uzantnomo kaj profilo ankaŭ estas publikaj en Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Pagoj konfirmiĝas en sekundoj per InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Pagoj faritaj rekte al adresoj ne konserviĝos en la agado.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "La pagoj kun ĉiu kontakto grupiĝas en unu loko, kun nomoj kaj profiloj anstataŭ krudaj transakcioj.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Elpaga adreso";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-adreso";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-nodo";
+
+/* Masternode keys */
+"Platform Node ID" = "Identigilo de Platform-nodo";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-pagoj ne identigas la sendanton. Ĉi tiu pago registriĝis kiam la monujo rimarkis la saldoŝanĝon — ĝi eble alvenis pli frue.";
+
+"Platform SDK not ready" = "La SDK de Platform ne pretas";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "La sinkronigo de Platform ne funkcias. Malfermu Sinkroniga informo → Stato de Platform-sinkronigo por ĝin startigi.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Ŝirmita";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Antaŭe uzita je: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privata laŭ dezajno";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privataj kontaktpetoj (por ke restu privata kun kiu vi konektiĝas), Shielded DashPay — pagoj al kontaktoj el via privata ŝirmita saldo — kaj pagado al uzantoj kiuj ankoraŭ ne estas en viaj kontaktoj, ĉio venos baldaŭ.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privataj kontaktpetoj estas en evoluigo kaj atendiĝas ĉirkaŭ septembro–oktobro 2026. Hodiaŭ la peto mem estas publika — iu ajn povas vidi ke du identecoj estas ligitaj, eĉ se la pagaj detaloj ene estas ĉifritaj. Kiam privataj kontaktpetoj aperos, vi povos elekti ĉu via amikeco estu publika aŭ privata.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privataj kontaktpetoj, Shielded DashPay kaj pagado al homoj kiuj ankoraŭ ne estas kontaktoj.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privataj pagaj adresoj interŝanĝiĝas inter vi kaj viaj kontaktoj. Nur vi kaj via kontakto scias la ricevanton kaj sendanton de la pagoj inter vi.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privataj pagoj";
+
+/* Usernames */
+"Private registration" = "Privata registrado";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Prilabora tempo";
+
+/* Balance info sheet section */
+"Pros" = "Avantaĝoj";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transakcioj de provizanto";
+
+/* Masternode keys */
+"Public key" = "Publika ŝlosilo";
+
+/* Masternode keys */
+"Public key (legacy)" = "Publika ŝlosilo (malnova)";
+
+/* Identities */
+"Public keys" = "Publikaj ŝlosiloj";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Celo";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Kruda transakcio";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Kruda transakcio ne disponeblas";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Rekontrolas la kompaktajn blokfiltrilojn ekde la elektita alto por transakcioj de ĉi tiu monujo, reelŝutante kaj rekomparante ilin. Reskanoj estas malsupre limigitaj de la krea alto de la monujo kaj de la loke konservitaj ĉendatumoj — por reakiri pli malnovan historion, prefere malaltigu la komencan alton de la monujo.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Nur legebla";
+
+/* Usernames */
+"Ready around %@" = "Preta ĉirkaŭ %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Kialo";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Ricevita de %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Registras viajn masternodojn kiel voĉdonintajn, sen preni flankon.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Refreŝigi";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrita je";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privata registrado postulas almenaŭ %@ Dash en via ŝirmita saldo plus kelkajn horojn da ripozo — la sekvaj ekranoj gvidos vin tra la procezo.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrado";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Petas ĉi tiun nomon";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Restaŭritaj monujoj ne ĉiam povas reakiri la tipon de operacio. Ĉi tiu enskribo estis rekonstruita el la notaj datumoj en la ĉeno.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Resinkronigo preparita ekde alto %u — fermu kaj remalfermu la aplikaĵon por komenci.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "konservi la komunan transakcian historion";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Emeritigita";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Nuligo";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skripto";
+
+/* Raw transaction inspector */
+"Script signature" = "Subskribo de la skripto";
+
+/* Raw transaction inspector */
+"Script type" = "Tipo de la skripto";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Serĉi kontakton";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Serĉi kontaktpeton";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Serĉi uzanton en la reto Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Serĉi uzantnomon";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Serĉrezultoj por \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Serĉi uzantnomojn";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Serĉado de la uzantnomo %@ en la reto Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Sekureca nivelo";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Elekti ĉion";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Elektu almenaŭ unu masternodon per kiu voĉdoni.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Elekti malpli da nodoj malkaŝas malpli pri tio kiujn masternodojn vi funkciigas.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Sendi al kontakto";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Sendu al uzantnomo kiun vi vere povas memori kaj kontroli.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Sendu vian unuan kontaktpeton";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Sendado de kontaktpeto";
+
+/* No comment provided by engineer. */
+"Sending to" = "Sendado al";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Sendita al %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Servo";
+
+/* Identities */
+"Set as Main" = "Agordi kiel ĉefan";
+
+/* Identities */
+"Set as Main Identity" = "Agordi kiel ĉefan identecon";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "La komuna privateca staplo estas ĉe la minimuma grandeco";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Ŝirmita adreso";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Ŝirmita elspezo";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Startigado de la ŝirmita monujo…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Ŝirmita → Platform";
+
+"Shielded → Transparent" = "Ŝirmita → Travidebla";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Grandeco";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Kelkaj el viaj masternodoj eble mankas en ĉi tiu listo — la monujo ne povis legi vian tutan aron da voĉdonaj ŝlosiloj. Finu la sinkronigon kaj remalfermu ĉi tiun ekranon.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ordigi kontaktojn";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Speciala ŝarĝo";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Komenciĝas post kiam vi aldonos monrimedojn";
+
+/* Transaction details */
+"Status" = "Stato";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Konservita kiel";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Sinkroniga informo";
+
+/* SPV sync */
+"Sync too slow?" = "Ĉu la sinkronigo estas tro malrapida?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne preni flankon";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Frapetu por kopii";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-noda ŝlosilo (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash alvenas al la adreso de la ricevanto post kiam la reto prilaboros la elprenon — tio povas daŭri ĝis 10 minutoj.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash alvenas al la adreso de la ricevanto tuj kiam la reto prilaboros la elprenon.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash alvenas al via travidebla saldo tuj kiam la reto prilaboros la elprenon.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "La ĉefa identeco elekteblas nur el la aktiva monujo";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "La plej privata loko por konservi viajn Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "La konservita monuja registro ne havas reton — ne eblas prepari resinkronigon.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "La registrado estis sendita sed ĝia rezulto ne konfirmeblis. Atendu minuton ĝis la monujo sinkroniĝos, poste provu denove — ne resendu tuj.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "La komuna privateca staplo ankoraŭ kreskas (%1$ld el %2$ld deponoj). Privata registrado malŝlosiĝas kiam ĝi atingos la minimumon.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "La komuna privateca staplo ankoraŭ kreskas (%1$ld el %2$ld deponoj). Provu denove kiam ĝi atingos la minimumon.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "La krea alto de la monujo — la malsupra limo por filtrilaj skanoj kaj por reskanoj „De la kreo de la monujo“. Agordu ĝin je aŭ sub la unua financado de la monujo; importoj implicite uzas 200000 en mainnet kaj 0 en testnet. Konservi alton egalan aŭ pli malaltan ol la nuna forviŝas la ĉendatumojn de ĉi tiu reto ĉe la sekva lanĉo kaj reskanas ekde ĝi.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "lin (akirado de informoj)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Ne estas novaj sciigoj";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Ne estas uzantoj kongruaj kun la nomo %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "En viaj kontaktoj ne estas uzantoj kongruaj kun la nomo %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ĉi tiuj monrimedoj transiras al via Platform-saldo kaj pretas por elspezo tuj kiam la transpago finiĝos.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Ĉi tiu adreso ne pageblas el via saldo %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ĉi tio aldonas du ŝlosilojn al via identeco por ke aliaj uzantoj povu sendi al vi kontaktpetojn kaj por ke vi povu akcepti la iliajn. Tio okazas nur unufoje.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ĉi tio aplikas unu elekton al ĉiuj %d elektitaj uzantnomoj.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ĉi tiu invita ligilo ne validas.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ĉi tio ne estas valida Dash-adreso por ĉi tiu reto";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ĉi tio ne estas valida invita ligilo";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ĉi tio estas via ĉefa identeco";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ĉi tiu masternodo ankoraŭ ne havas Platform-identecon.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Tio tamen kalkuliĝas kiel voĉdono de viaj masternodoj en ĉi tiu disputo.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "La krudaj bajtoj de ĉi tiu transakcio ne estas konservitaj en ĉi tiu aparato.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ĉi tiu uzantnomo iris al iu alia";
+
+"This wallet could not derive the voting key for this node." = "Ĉi tiu monujo ne povis derivi la voĉdonan ŝlosilon por ĉi tiu nodo.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ĉi tiu monujo havas neniujn aktivajn voĉdonajn ŝlosilojn de masternodo, do ĝi ne povas voĉdoni. Registritaj nodoj aperas sub Iloj → Masternodoj.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ĉi tio elprenas vian tutan Platform-saldon per unu transpago. Dash alvenas al la adreso de la ricevanto tuj kiam la reto prilaboros la elprenon.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ĉi tio elprenas vian tutan Platform-saldon per unu transpago. Dash alvenas al via travidebla saldo tuj kiam la reto prilaboros la elprenon.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "La transakcia historio ne disponeblas";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Identigilo de transakcio";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Enira transpago";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Elira transpago";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transpagoj daŭras pli longe — konstrui la privatecajn pruvojn postulas tempon";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transpagoj al aliaj Platform-adresoj kaj al ŝirmitaj adresoj estas tujaj kaj definitivaj";
+
+/* Balance breakdown */
+"Transparent" = "Travidebla";
+
+/* Send screen destination type */
+"Transparent address" = "Travidebla adreso";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Travidebla saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Travidebla financado publike ligas vian uzantnomon al ĉi tiuj monrimedoj.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Travidebla → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Travidebla → Ŝirmita";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Ne eblas provizi sugestojn";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Nekonata speciala tipo %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Neŝirmita";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Ĝisdatigi al Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Uzi anstataŭe la travideblan saldon";
+
+/* Masternode keys */
+"Used" = "Uzita";
+
+/* Masternode keys */
+"Used at: " = "Uzita je: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Uzanto (akirado de informoj)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Uzantnomoj";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Uzantnomoj konserviĝas en normigita formo por eviti similaspektajn nomojn, do tio povas malsami de tio kion ĉiu persono tajpis.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Uzantnomoj, ne adresoj";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Uzantoj kongruaj kun %@ kiuj nuntempe ne estas en viaj kontaktoj";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uzas unu el la plej reviziitaj kaj testitaj nulsciaj bibliotekoj (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Valida invito";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Kontrolita dum la registrado";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versio";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Tre efika kun malaltaj kotizoj";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Vidi ĉion";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Vidi transakcion";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Voĉdoni";
+
+"Vote cast" = "Voĉo donita";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Voĉdonu pri disputataj uzantnomoj";
+
+"Vote on several" = "Voĉdoni pri pluraj";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Voĉdoni per";
+
+"Votes that nobody should receive these usernames." = "Voĉdonas ke neniu ricevu ĉi tiujn uzantnomojn.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Voĉdona adreso";
+
+"Voting ended with no winner" = "La voĉdonado finiĝis sen gajninto";
+
+"Voting ends" = "La voĉdonado finiĝas";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Voĉdonado daŭras";
+
+"Voting in progress — lock votes are ahead" = "Voĉdonado daŭras — la ŝlosaj voĉoj antaŭas";
+
+"Voting in progress — you are ahead" = "Voĉdonado daŭras — vi antaŭas";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Haketaĵo de la voĉdona ŝlosilo";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "La voĉdonado pri ĉi tiu uzantnomo fermiĝis. La suba nombrado estas la laste legita.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "La voĉdonado pri „%@“ jam fermiĝis. Refreŝigu por vidi la rezulton.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Atendado de Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Komenca alto de la monujo";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Kio pri Unstoppable Domains kaj similaj nomservoj?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Kiom ĝi kostas?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Kio estas DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Kio venos poste?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kiam kontaktpetoj iĝos privataj?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kiu petas ĉi tiun nomon";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Kial mi devas ĝin ŝalti?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Elprenas la tutan saldon";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funkcias kun ĉiu Dash-monujo, borso kaj komercisto";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vi";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Vi akceptis la kontaktpeton de %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Vi nuntempe havas neniujn kontaktojn";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Vi ĝis nun havas %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Vi sendis la kontaktpeton al %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Vi gajnis ĉi tiun uzantnomon";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Ĉio pretas. Aliaj uzantoj nun povas sendi al vi kontaktpetojn — kaj vi povas sendi la viajn.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Via Dash Platform-identeco aperos ĉi tie kiam vi registros uzantnomon.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Via historio, ordigita";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Via identeco bezonas du kromajn ŝlosilojn por ke kontaktpetoj ĉifreblu inter vi kaj aliaj uzantoj. La ŝaltado aldonas ilin per unu sola reta transakcio. Tio okazas nur unufoje.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Via invito pagas la registran kotizon por ĉi tiu uzantnomo.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Via ĉefa Dash-saldo en la blokĉeno Core — tio kion vi sendas kaj ricevas kun aliaj monujoj, borsoj kaj komercistoj.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Viaj miksitaj moneroj estis movitaj al la saldo de via monujo Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Viaj miksitaj moneroj estis movitaj al via ŝirmita saldo. Por plej bona privateco, atendu almenaŭ 2 horojn antaŭ ol uzi ĉi tiujn monrimedojn.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Via Platform-saldo";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Via privata saldo. Sumoj kaj adresoj estas ĉifritaj en la ĉeno, do viaj havaĵoj kaj historio restas konfidencaj.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Via ŝirmita saldo";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Via ŝirmita saldo estas preskaŭ preta — vi povos registriĝi private ĉirkaŭ %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Via ŝirmita saldo pretas — registru vian uzantnomon private nun";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Via ŝirmita saldo ripozas — vi povos registriĝi private ĉirkaŭ %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Via ŝirmita saldo ankoraŭ maturiĝas. Ĝi pretos ĉirkaŭ %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Via travidebla saldo";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Via uzantnomo videblas por ĉiuj. Financi ĝin el via ŝirmita saldo — post lasi la monrimedojn ripozi kelkajn horojn — signifas ke neniu povas ligi vian uzantnomon al viaj ceteraj Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Via uzantnomo, profilo kaj kontaktoj sekvas ĉi tiun identecon.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Via uzantnomo, profilo kaj kontaktoj sekvos ĉi tiun identecon.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Viaj voĉoj";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Via monujo ankoraŭ sinkroniĝas kun la reto Dash. Sendado disponeblos kiam la sinkronigo finiĝos.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Via monujo ankoraŭ sinkroniĝas. Sendado el via travidebla saldo disponeblos kiam la sinkronigo finiĝos.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ ne legeblis kiel Dash-uzantnomo.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ estis registrita. Ĉu sendi kontaktpeton al la persono kiu vin invitis?";

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Ĉiuj nodoj samtempe";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Ĉiuj viaj masternodoj voĉdonis pri ĉi tiu uzantnomo. Por ŝanĝi voĉon, voĉdonu denove de la kandidato kiun vi nun preferas.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Ĉiuj viaj masternodoj voĉdonis pri ĉi tiu uzantnomo. Por ŝanĝi voĉon, voĉdonu denove por la kandidato kiun vi nun preferas.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/eo.lproj/Localizable.stringsdict
+++ b/DashWallet/eo.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ kalkulitaj por „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u voĉo</string>
+			<key>other</key>
+			<string>%1$u voĉoj</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Voĉdonite pri %1$d el %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uzantnomo</string>
+			<key>other</key>
+			<string>%2$d uzantnomoj</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Doni %u voĉon</string>
+			<key>other</key>
+			<string>Doni %u voĉojn</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d el %#@nodes@ voĉdonis</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternodo</string>
+			<key>other</key>
+			<string>%2$d masternodoj</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d el %#@nodes@ voĉdonis</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nodo</string>
+			<key>other</key>
+			<string>%2$d nodoj</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonodo</string>
+			<key>other</key>
+			<string>%d evonodoj</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voĉo entute</string>
+			<key>other</key>
+			<string>%u voĉoj entute</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternodo</string>
+			<key>other</key>
+			<string>%d masternodoj</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d elektita</string>
+			<key>other</key>
+			<string>%d elektitaj</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d el viaj nodoj jam voĉdonis ĉi tie kaj ne estas listigita.</string>
+			<key>other</key>
+			<string>%d el viaj nodoj jam voĉdonis ĉi tie kaj ne estas listigitaj.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voĉo por disputo — evonodoj kalkuliĝas kiel 4, masternodoj kiel 1</string>
+			<key>other</key>
+			<string>%u voĉoj por disputo — evonodoj kalkuliĝas kiel 4, masternodoj kiel 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voĉdoni pri %d uzantnomo</string>
+			<key>other</key>
+			<string>Voĉdoni pri %d uzantnomoj</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voĉo</string>
+			<key>other</key>
+			<string>%u voĉoj</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voĉdoni ×%d</string>
+			<key>other</key>
+			<string>Voĉdoni ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d peto</string>
+			<key>other</key>
+			<string>%d petoj</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/eo.lproj/Localizable.stringsdict
+++ b/DashWallet/eo.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ kalkulitaj por „%2$@“</string>
+		<string>%#@votes@ por „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u voĉo</string>
+			<string>%1$u voĉo kalkulita</string>
 			<key>other</key>
-			<string>%1$u voĉoj</string>
+			<string>%1$u voĉoj kalkulitaj</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Todos los nodos a la vez";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos tus masternodes han votado sobre este nombre de usuario. Para cambiar un voto, vuelve a votar desde el aspirante que ahora prefieras.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos tus masternodes han votado sobre este nombre de usuario. Para cambiar un voto, vuelve a votar por el aspirante que ahora prefieras.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " o ";
+
 /* CrowdNode */
 " Privacy Policy " = "Política de privacidad";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "No se pudo encontrar a %@ en la red Dash para enviarle una solicitud de contacto.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponible";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ ha aceptado tu solicitud de contacto";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contactos / %3$lu actualizaciones de perfil";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d Los votos se emitirán ya que tienes múltiples llaves de votación almacenadas en la billetera.";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicados";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld de %ld depósitos";
 
 /* Voting */
 "%ld requests" = "%ld pedidos";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\"no es una palabra de la frase de recuperación. ¿Te gustaría intentar recuperar la palabra correcta que debería estar en su lugar??";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Un saldo de crédito en Dash Platform que se usa para pagos instantáneos entre direcciones de Platform y para funciones como los nombres de usuario.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Es necesario que tu dispositivo esté resguardado por una clave para proteger tu billetera. Ve a configuraciones y habilita una clave de acceso para continuar";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Acerca de";
 
+/* DashPay FAQ title */
+"About DashPay" = "Acerca de DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Sobre mí";
+
+"Abstain" = "Abstenerse";
+
+"Abstain on “%@”" = "Abstenerse en «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Aceptar";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Recuperación de cuenta";
 
+/* Masternode status */
+"Active" = "Activo";
+
+/* No comment provided by engineer. */
+"Activity" = "Actividad";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "La actividad es pública, pero no es fácil de rastrear";
+
 /* No comment provided by engineer. */
 "Add" = "Añadir";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Añadir a %@ como contacto";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Añade a %@ como contacto para pagar directamente al nombre de usuario y conservar el historial de transacciones mutuo";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Añade %@ Dash a tu saldo blindado y deja que repose unas horas para registrarte sin vincular tu nombre de usuario con el resto de tus fondos.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Agregar un nuevo contacto";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Añade al menos %@ Dash a tu saldo blindado";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Añade fondos a tu saldo blindado ahora y registra tu nombre de usuario de forma privada unas horas después";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Todos";
 
+"All nodes at once" = "Todos los nodos a la vez";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos tus masternodes han votado sobre este nombre de usuario. Para cambiar un voto, vuelve a votar desde el aspirante que ahora prefieras.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "¿Permitir el envío de todas las transacciones desde Dash Wallet a Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sincronización de saldos casi instantánea";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Los importes y las direcciones son públicos en la blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Ocurrió un error";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Una cuenta de Ethereum es una única dirección reutilizable: todo tu saldo y tu historial de pagos quedan públicamente bajo ella, y un nombre (como un dominio ENS) normalmente apunta directamente a esa dirección para que cualquiera la resuelva. DashPay tiene la forma opuesta: el nombre resuelve a una identidad, no a una dirección de pago, y las direcciones de pago reales permanecen dentro de intercambios de contacto cifrados, nuevas para cada contacto.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Una experiencia intuitiva y familiar a través de todos tus dispositivos";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Cualquier nombre de usuario que contenga un número del 2-9, o tenga más de 20 caracteres de largo, o que contenga un guion, será automáticamente aprobado";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Cualquiera que conozca una dirección puede ver su historial";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Aplicar";
 
+"Approve" = "Aprobar";
+
+"Approving a specific request can only be done one username at a time." = "Aprobar una solicitud concreta solo se puede hacer de un nombre de usuario a la vez.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "¿Estás seguro de que deseas cancelar este pedido?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Como texto";
 
 /* DashSpend */
 "at" = "en";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autenticación cancelada. Tu voto no se emitió.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Falló la autenticación. Tu voto no se emitió.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Autenticación no disponible";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Conceder «%@» a este aspirante";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo después";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance en CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Los saldos y las transferencias no son visibles públicamente";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Cuenta bancaria";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Acceso biométrico requerido";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Altura de origen guardada: el límite inferior de escaneo elevado se aplica a partir del próximo inicio.";
+
 /* Voting */
 "Block" = "Bloque";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Bloqueado el nombre de usuario '%@' ";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vinculada a un contrato";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vinculada a un contrato, tipo de documento «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Solo consulta";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Agrupa los registros de diagnóstico recientes en un zip para enviarlos por AirDrop, correo o guardarlos en Archivos";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Emitir voto";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Cambiar de pares";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Cambiar PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Comprobando…";
+
+"Choice" = "Opción";
+
 /* Choose your Dash username */
 "Choose your" = "Escoge tu";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Elige tu nombre de usuario";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Reclama tu invitación";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo reclamable";
+
 /* No comment provided by engineer. */
 "Claimed" = "Reclamado";
+
+/* SPV diagnostics */
+"Clear & resync" = "Borrar y resincronizar";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "¿Borrar los datos de la cadena y resincronizar?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Cerrar App";
 
+"Closing" = "Cerrando";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (monedas nuevas)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Código 2FA para Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ya no es compatible: elige a dónde mover tus monedas mezcladas.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Colateral";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Próximamente";
+
+/* Shielded transfer status */
+"Completed" = "Completada";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirmar";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confirmada";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Al confirmar se guarda la altura de origen %u y se borran los datos de la cadena de esta red en el próximo inicio de la app, volviendo a descargarlos y reescaneando los filtros desde esa altura. La sesión en curso conserva su límite de escaneo anterior: cierra y vuelve a abrir la app para empezar.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Conecta tus billeteras criptográficas a la plataforma ZenLedger. Obten más información y comienza con tus transacciones de Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Dirección de Dash conectada";
 
+/* SPV sync */
+"Connected peers" = "Pares conectados";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Contras";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Solicitud de contacto fallida";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Solicitud de contacto enviada a %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Solicitudes de contacto";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contactos";
 
+"Contender %@" = "Aspirante %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continuar";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continúa para elegir tu nombre de usuario. La invitación paga la comisión de registro.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copiar enlace de invitación";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copiar transacción sin procesar";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copiar texto";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "No se pudieron recuperar automáticamente las palabras faltantes o incorrectas";
 
+/* Log export */
+"Could not create the log archive: %@" = "No se pudo crear el archivo de registros: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "No se encuentra la tasa de cambio.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "No se pudieron actualizar %d identidades";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "No se pudo obtener el saldo (error de red). Prueba a actualizar.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "No se pudo realizar el pago";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Crea tu nombre de usuario";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Crea tu nombre de usuario, encuentra a amigos y familiares por sus nombres de usuario y añádelos a tus contactos";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Tarjeta de crédito";
+
+/* Masternodes */
+"Credits" = "Créditos";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Los pagos en Dash no pueden ser inferiores a %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform aún no ha indexado esta disputa. Los recuentos de votos aparecerán aquí cuando lo haga.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform aún no está conectado. Espera a que termine la sincronización e inténtalo de nuevo.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Los Dash enviados a una dirección equivocada no se pueden recuperar. Asegúrate de que la dirección es exactamente aquella a la que quieres pagar.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash guarda los nombres de usuario en una forma segura frente a nombres parecidos, así que el nombre guardado puede diferir de lo que escribió cada persona.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nombre de usuario de Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Billetera de Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo de la billetera Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Billetera de Dash en este dispositivo";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay activado";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Invitación de DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay es la experiencia de pagos sociales de Dash, construida sobre Dash Platform. Registras un nombre de usuario, añades a otros usuarios como contactos y les pagas por su nombre: se acabó copiar direcciones.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay sustituye las largas direcciones crípticas por nombres de usuario. Añade amigos como contactos, envía dinero a un nombre y mantén cada pago organizado por persona.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Tarifa de actualización de DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Fecha: Viejo a nuevo";
+
+"Deadline unknown" = "Plazo desconocido";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Depósito enviado";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Ruta de derivación";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DISPOSITIVO DE SEGURIDAD DUDOSA\nCualquier aplicación de 'jailbreak' puede acceder a la cadena de datos de otras aplicaciones (y robar tus Dash). Borra inmediatamente esta cartera para restablecerla en un dispositivo seguro.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Deshabilitada";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Desconectar la cuenta de Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Hecho";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Listo: tu saldo ha reposado el tiempo suficiente";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Comprueba dos veces la dirección";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Cada invitación se financiará con esta cantidad para que el receptor pueda crear rápidamente su nombre de usuario en la red de Dash.";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Cada masternode tiene un voto vigente por disputa. Puedes cambiarlo después, pero Dash Platform solo permite 5 votos en total por masternode y disputa.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Cada toque vota con un nodo más, así eliges cuántos vincular entre sí.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Antes";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Haz fácilmente staking de tus Dash y obtén ingresos pasivos con unos pocos clics.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Editar la altura de origen";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Editar perfil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Activar";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Activar DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Habilitar Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Habilitar Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Activar DashPay cuesta una pequeña comisión de red única, pagada con el saldo de crédito de tu identidad. La estimación exacta se muestra antes de que confirmes. Enviar solicitudes de contacto y pagos cuesta las comisiones de red habituales.";
+
+"Ending soonest" = "Termina antes";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error al actualizar tu perfil";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Comisión de red estimada";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Todos los nodos votan juntos. Es más rápido, pero vincula públicamente tus masternodes entre sí.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Llaves de operador de Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Exportar CSV";
 
+/* Log export */
+"Export Logs" = "Exportar registros";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Llave pública extendida (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Dirección externa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Límite de Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Fallida";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Error al cargar codigo de barras.";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Buscando tarifas…";
 
+/* Masternodes */
+"Fetching…" = "Obteniendo…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Cuenta fiduciaria";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtrar";
+
+/* SPV sync phase */
+"Filter headers" = "Cabeceras de filtro";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtrar transacciones";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Encuentra a un usuario en la red Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Encuentre ATM's donde puede comprar y vender Dash";
+
+/* Identities */
+"Find identities" = "Buscar identidades";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "¿Olvidaste el PIN?";
 
+/* Identities */
+"Found %d new identities" = "Se encontraron %d identidades nuevas";
+
+/* Identities */
+"Found 1 new identity" = "Se encontró 1 identidad nueva";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Se encontró la palabra faltante:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financia tu nombre de usuario con tu saldo blindado. Añade fondos unas horas antes: el breve reposo mantiene tu nombre de usuario no vinculable con el resto de tus Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financiado con tu saldo blindado: tu nombre de usuario no se puede vincular con el resto de tus Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fondos bloqueados: finalizando la transferencia";
+
+/* CoinJoin */
+"Funds moved" = "Fondos movidos";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Obtén recompensas de depósitos en Masternodes de Dash con tan solo 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Obtener cotización";
+
+/* Usernames */
+"Get ready to join DashPay" = "Prepárate para unirte a DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Obtén recompensas al instante";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Entendido";
+
+/* Governance */
+"Governance" = "Gobernanza";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Otorgar permisos de GPS para que podamos mostrarte ubicaciones cerca de ti.";
 
 /* Voting */
 "Has blocked votes" = "Tiene votos bloqueados";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ha solicitado ser tu amigo";
+
+/* DashPay Invitations */
+"Have an invitation?" = "¿Tienes una invitación?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Ten control completo y configura tu billetera de acuerdo a tus necesidades";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "encabezado #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Cabeceras";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Altura %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Aquí hay una dirección de Dash designada para tu cuenta de CrowdNode en la billetera de Dash en este dispositivo.";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Alto a bajo";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Comisiones más altas, en torno a 7 céntimos (aun así más bajas que las de otras blockchains que ofrecen una privacidad similar)";
+
 /* No comment provided by engineer. */
 "History" = "Historial";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "¿Cómo obtengo Dash de prueba?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "¿Cómo se compara esto con Bitcoin en términos de privacidad?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "¿Cómo se compara esto con las cuentas de Ethereum en términos de privacidad?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "¿Qué tan privado es DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Cómo confirmar tu dirección API de Dash";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Ya la escribí";
 
+/* Identities */
+"Identities" = "Identidades";
+
 /* Voting */
 "Identity" = "Identidad";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Créditos de identidad";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Índice de identidad";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registro de identidad";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Recarga de identidad";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Cuando usted efectúe el pago en su comercio, elija \"gift card\" al momento de pagar, e ingrese su número de tarjeta y PIN.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactivo";
+
+/* No comment provided by engineer. */
 "Income" = "Ingreso";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Inicializando";
+
+/* Raw transaction inspector */
+"Input %d" = "Entrada %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Entrada %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Entradas (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Fondos insuficientes";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Tarifa de invitación";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitación de %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitación utilizada por";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invitar";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invita a alguien a unirse a la red Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invita a tu familia, encuentra a tus amigos buscando sus nombres de usuario";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invita a sus amigos y familiares a unirse a la red de Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invita a tus amigos y familiares a la red Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "La billetera IOS: ' %@ ' ha reportado un problema";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Entrar al grupo";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Mantén estas monedas privadas. Se aplican comisiones de red y de privacidad.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Mantén tu contraseña segura";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Llave n.º %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Datos de la llave";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Propiedad de la llave";
+
 /* No comment provided by engineer. */
 "Keypair" = "Par de llaves";
+
+/* Masternodes */
+"Keys" = "Llaves";
 
 /* Explore Dash */
 "Last device sync" = "Sincronización del último dispositivo";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "En cabeza";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Saber más";
 
 /* Info Screen */
 "Learn More..." = "Aprender más...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Cargando transacciones";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Moneda Local";
 
+/* Identities */
+"Local Only" = "Solo local";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Cantidad local solicitada: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Ubicación";
 
+"Lock" = "Bloquear";
+
+"Lock the name" = "Bloquear el nombre";
+
+"Lock “%@” so nobody gets it" = "Bloquear «%@» para que no lo obtenga nadie";
+
 /* No comment provided by engineer. */
 "Locked" = "Asegurado";
 
+"Locked — nobody receives this username" = "Bloqueado: nadie recibe este nombre de usuario";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Iniciar sesión";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Bajo";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Comisiones bajas para el gasto diario";
+
 /* Voting */
 "Low to high" = "Bajo a alto";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principal";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Red principal";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Dirección IP de Masternode ";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Llavero de Masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Llaves del Masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Lista de masternodes";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "Lista de masternode #%1$d de %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Actualizar Masternode";
 
+"Masternode votes" = "Votos de masternodes";
+
 /* Voting */
 "Masternode Voting Key" = "Llave de votación de Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Los masternodes y evonodes registrados con las llaves de esta billetera aparecerán aquí después de que la billetera se sincronice.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes y evonodes que usan las llaves de esta billetera";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Los masternodes votan sobre los nombres que ha pedido más de una persona. Se te notificará cuando termine la votación.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Máx";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Mínimo: %@";
 
+/* Usernames */
+"Minimum met" = "Mínimo alcanzado";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Más Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Más sugerencias";
+
+"Most lock votes" = "Más votos de bloqueo";
+
+"Most votes" = "Más votos";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Mueve y haz zoom en tu foto para encontrar el ajuste perfecto";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Mover a tu saldo disponible habitual.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Movido a la Dirección";
+
+/* CoinJoin */
+"Moving funds" = "Moviendo fondos";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Nombre";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Los servicios de nombres como Unstoppable Domains asocian un nombre legible con una dirección pública fija en la cadena. Cualquiera puede resolver el nombre y ver todos los pagos que se le han hecho. Un nombre de usuario de DashPay nunca resuelve públicamente a una dirección de pago: las direcciones solo se revelan dentro del intercambio cifrado con cada contacto, de modo que tu nombre y tu dinero permanecen desvinculados para observadores externos.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "¿Necesitas ayuda?";
+
+"Needs attention" = "Requiere atención";
 
 /* No comment provided by engineer. */
 "Network" = "Red de trabajo";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "No se encontraron registros de diagnóstico en este dispositivo. Los registros se escriben a partir del próximo inicio.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Sin identidades";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Aún no hay masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "No hay disputas coincidentes";
+
+/* Identities */
+"No new identities were found for this wallet" = "No se encontraron identidades nuevas para esta billetera";
+
+"No open contest matches that search." = "Ninguna disputa abierta coincide con esa búsqueda.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ninguna disputa abierta coincide con esa búsqueda. Los nombres se guardan en una forma normalizada, así que «alice» aparece como «a11ce».";
+
+"No open contests" = "No hay disputas abiertas";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Sin métodos de pago";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "No se encontró ninguna fila de billetera guardada para la billetera vinculada.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Todavía no hay ninguna dirección de Platform disponible para el registro blindado alternativo. Inténtalo de nuevo cuando la billetera termine de sincronizarse.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No se han encontrado resultados";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Ahora mismo no hay ningún nombre de usuario en disputa. Las disputas se abren cuando dos o más personas piden el mismo nombre.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No quedan votos";
+
+"No votes were cast" = "No se emitió ningún voto";
+
+"Nobody gets it" = "Que no lo obtenga nadie";
+
+/* SPV sync peer type */
+"Node" = "Nodo";
+
+/* Raw transaction inspector */
+"Non-standard" = "No estándar";
 
 /* adjective, security level */
 "None" = "Ninguna";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "No disponible";
 
+"Not available yet" = "Aún no disponible";
+
+"Not cast" = "Sin emitir";
+
+/* Masternodes */
+"Not checked yet" = "Aún sin comprobar";
+
 /* Location Service Status */
 "Not Determined" = "No determinado";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "No hay suficiente saldo blindado para registrar una identidad";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "No está en el historial de la billetera";
+
+"Not now" = "Ahora no";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "No es ampliamente aceptado por los comercios";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Aún no es ampliamente aceptado por los comercios";
+
+/* Masternode keys */
+"Not yet used" = "Aún sin usar";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Viejo a nuevo";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "En Bitcoin no hay una capa de nombres, así que la gente comparte y reutiliza direcciones a la vista de todos: una vez que se conoce una dirección, todo lo que ha recibido se puede vincular con su dueño. Con DashPay tu nombre de usuario es público, pero nunca apunta a una dirección de pago: las direcciones se intercambian en privado con cada contacto y rotan, así que pagar por nombre no publica a dónde va tu dinero. Ambas son cadenas transparentes, por lo que el análisis de cadena sigue aplicándose a las monedas en sí.";
+
+/* Identities */
+"On Network" = "En la red";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Cuando %@ acepte tu solicitud podrás pagar directamente al nombre de usuario";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Un nodo cada vez";
 
 /* Voting */
 "One vote left" = "Queda un voto";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Sólo duplicados";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Solo los masternodes y evonodes pueden votar sobre los nombres de usuario. Esta billetera no tiene llaves de voto de masternode activas.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Sólo solicitudes con enlaces";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Sólo con enlaces";
+
+/* Masternodes */
+"Operator" = "Operador";
+
+/* Masternode keys */
+"Operator keys" = "Llaves de operador";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Llave pública del operador (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "o";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Vista previa del pedido";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Otros resultados";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Salida %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Salidas (%d)";
+
+/* Masternodes */
+"Owner" = "Dueño";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Dirección de Propietario";
+
+/* Masternodes */
+"Owner address" = "Dirección del dueño";
+
+/* Masternodes */
+"Owner key hash" = "Hash de la llave del dueño";
 
 /* Owner keys */
 "Owner keys" = "Llaves del dueño";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Pagado con el saldo de crédito de tu identidad.";
 
 /* DashSpend */
 "Password" = "Contraseña";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Pegué el enlace aquí";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Pega el enlace de invitación que recibiste o escanea su código QR. Paga el registro de tu nombre de usuario.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Pega la URL de tu imagen";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Paga y recibe instantáneamente con flujos de pagos fáciles de usar";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "pagar directamente al nombre de usuario";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Paga a personas, no a direcciones";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pagar a los nombres de usuario. No más direcciones alfanuméricas";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Pagando...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Hex de la carga útil";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Método de pago";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Los pagos son privados: las direcciones que intercambias con un contacto viajan dentro de una carga cifrada que solo vosotros dos podéis leer, y nunca se publican, así que tus pagos no son fácilmente vinculables a tu nombre de usuario. Aun así, siguen siendo pagos normales en una cadena transparente: un análisis de cadena sofisticado podría filtrar información. Shielded DashPay (próximamente) cerrará esa brecha. Las solicitudes de contacto en sí NO son privadas por ahora: cualquiera puede ver que dos identidades están conectadas. Las solicitudes de contacto privadas son una función que llegará próximamente. Tu nombre de usuario y tu perfil también son públicos en Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Los pagos se confirman en segundos con InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Los pagos hechos directamente a direcciones no se conservarán en la actividad.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Los pagos con cada contacto se agrupan en un solo lugar, con nombres y perfiles en vez de transacciones sin procesar.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Dirección de pago";
 
 /* CrowdNode */
 "Payout Options" = "Opciones de pago";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Dirección de Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo de Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nodo de Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID del nodo de Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Los pagos de Platform no identifican al remitente. Este pago se registró cuando la billetera detectó el cambio de saldo; puede haber llegado antes.";
+
+"Platform SDK not ready" = "El SDK de Platform no está listo";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "La sincronización de Platform no se está ejecutando. Abre Información de sincronización → Estado de sincronización de Platform para iniciarla.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Blindado";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Agrega por favor un método de pago en Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Invitación de vista previa";
 
+/* Masternode keys */
+"Previously used at: " = "Usada anteriormente el: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Los precios mostrados tienen al menos 30 minutos de antiguedad. Los valores en FIAT pueden ser incorrectos.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privado por diseño";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Las solicitudes de contacto privadas (para que con quién te conectas siga siendo privado), Shielded DashPay —pagos a contactos desde tu saldo blindado privado— y los pagos a usuarios que aún no están en tus contactos llegarán próximamente.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Las solicitudes de contacto privadas están en desarrollo y se esperan alrededor de septiembre-octubre de 2026. Hoy la solicitud en sí es pública: cualquiera puede ver que dos identidades están conectadas, aunque los datos de pago que contiene estén cifrados. Cuando lleguen las solicitudes de contacto privadas, podrás elegir si tu amistad es pública o privada.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Solicitudes de contacto privadas, Shielded DashPay y pagos a personas que aún no son contactos.";
+
 /* No comment provided by engineer. */
 "Private key" = "Llave privada";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Las direcciones de pago privadas se intercambian entre tú y tus contactos. Solo tú y tu contacto conocéis el destinatario y el remitente de los pagos entre vosotros.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pagos privados";
+
+/* Usernames */
+"Private registration" = "Registro privado";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Tiempo de procesamiento";
+
+/* Balance info sheet section */
+"Pros" = "Pros";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protege tus ahorros";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Dirección de Proveedor";
 
+/* Masternodes */
+"Provider transactions" = "Transacciones de proveedor";
+
+/* Masternode keys */
+"Public key" = "Llave pública";
+
+/* Masternode keys */
+"Public key (legacy)" = "Llave pública (heredada)";
+
+/* Identities */
+"Public keys" = "Llaves públicas";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL pública";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Compra fallida";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Propósito";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Taza: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transacción sin procesar";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transacción sin procesar no disponible";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Vuelve a comprobar los filtros de bloque compactos desde la altura elegida en busca de transacciones de esta billetera, descargándolos y volviéndolos a comparar. Los reescaneos tienen como límite inferior la altura de creación de la billetera y los datos de la cadena guardados localmente; para recuperar el historial por debajo de eso, baja la altura de origen de la billetera.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Leer política de retiro";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Solo lectura";
+
+/* Usernames */
+"Ready around %@" = "Listo hacia las %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motivo";
 
 /* No comment provided by engineer. */
 "Receive" = "Recibir";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Recibido de";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Recibido de %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Recibir recompensas";
+
+"Records your masternodes as having voted, without taking a side." = "Registra tus masternodes como que han votado, sin tomar partido.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recuperar";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "La frase de recuperación debe tener 12, 15, 18, 21 o 24 palabras";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Actualizar";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registrarse?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrado el";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registrado de";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternodo Registrado";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "El registro privado requiere al menos %@ Dash en tu saldo blindado más unas horas de reposo; las siguientes pantallas te guían en el proceso.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registro";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Pide este nombre";
+
 /* An action */
 "Rescan" = "Escanear nuevamente";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Las billeteras restauradas no siempre pueden recuperar el tipo de operación. Esta entrada se reconstruyó a partir de los datos de nota en la cadena.";
+
+/* Location Service Status */
 "Restricted" = "Restringido";
 
 /* Usernames */
 "Results" = "Resultados";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Resincronización preparada desde la altura %u: cierra y vuelve a abrir la app para empezar.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "conservar el historial de transacciones mutuo";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retirado";
 
 /* No comment provided by engineer. */
 "Retry" = "Reintentar";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Revisa la publicación a continuación para verificar la propiedad de este nombre de usuario";
+
+/* Masternodes */
+"Revocation" = "Revocación";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Las capturas de pantalla son visibles para otras aplicaciones y dispositivos. Genere una nueva frase de recuperación y téngala en secreto.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Firma del script";
+
+/* Raw transaction inspector */
+"Script type" = "Tipo de script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Buscar un contacto";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Buscar una solicitud de contacto";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Buscar un usuario en la red Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Buscar un nombre de usuario";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Resultados de búsqueda para \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Buscar territorios";
+
+"Search usernames" = "Buscar nombres de usuario";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Buscando el nombre de usuario %@ en la red Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Asegura tu billetera";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Nível de Segurida";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Nivel de seguridad";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Selecciona un servicio para comprar, vender, convertir y transferir Dash";
 
+"Select all" = "Seleccionar todo";
+
 /* DashSpend denomination selection */
 "Select amount" = "Selecciona el monto";
+
+"Select at least one masternode to vote with." = "Selecciona al menos un masternode con el que votar.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Selecciona la moneda";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Seleccionar menos nodos revela menos sobre qué masternodes gestionas.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Autoverificación";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Enviar para";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Enviar a un contacto";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Envía a un nombre de usuario que realmente puedas recordar y verificar.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Enviar a Dirección";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Envía tu primera solicitud de contacto";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Enviando";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Enviando solicitud de contacto";
+
+/* No comment provided by engineer. */
+"Sending to" = "Enviando a";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Envío a la cuenta de CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Enviado para";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Enviado a %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Error del servidor. Por favor, intenta nuevamente más tarde.";
+
+/* Masternodes */
+"Service" = "Servicio";
+
+/* Identities */
+"Set as Main" = "Establecer como principal";
+
+/* Identities */
+"Set as Main Identity" = "Establecer como identidad principal";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Establecer PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Compartir llave";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Grupo de privacidad compartido en su tamaño mínimo";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Dirección blindada";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Gasto blindado";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Iniciando la billetera blindada…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Blindado → Platform";
+
+"Shielded → Transparent" = "Blindado → Transparente";
 
 /* Explore Dash */
 "Show all locations" = "Mostrar todas las ubicaciones";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Tamaño";
+
 /* No comment provided by engineer. */
 "Skip" = "Salta";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Puede que falten algunos de tus masternodes en esta lista: la billetera no pudo leer tu conjunto completo de llaves de voto. Termina la sincronización y vuelve a abrir esta pantalla.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Algunos nombres de usuario pueden ser bloqueados";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Ordenar por";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ordenar contactos";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Ordenado por descuento";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Ordenado por nombre";
+
+/* Raw transaction inspector */
+"Special payload" = "Carga útil especial";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Especificar Monto";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Empieza cuando añadas fondos";
+
+/* Transaction details */
+"Status" = "Estado";
+
 /* Step 1 */
 "Step %ld" = "Paso %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Guardado como";
 
 /* Voting */
 "Submit" = "Entregar";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sincronización en curso… Es posible que los resultados no estén completos.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Información de sincronización";
+
+/* SPV sync */
+"Sync too slow?" = "¿La sincronización va muy lenta?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Tomar una foto desde la cámara";
 
+"Take no side" = "No tomar partido";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Toca la dirección del portapapeles para pegarla.";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Toca para copiar";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tocar para ocultar saldo";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporalmente no disponible";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Llave de nodo de Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Términos y condiciones";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Red de prueba";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "El código es incorrecto. ¡Por favor revisa e intenta de nuevo!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Los Dash llegan a la dirección del destinatario después de que la red procese la retirada; esto puede tardar hasta 10 minutos.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Los Dash llegan a la dirección del destinatario en cuanto la red procese la retirada.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Los Dash llegan a tu saldo transparente en cuanto la red procese la retirada.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "La red Dash debe votar para aprobar ciertos nombres de usuario antes de que sean creados";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "El enlace que envíes será visible solo para los propietarios de la red.";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "La identidad principal solo se puede elegir desde la billetera activa";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "El monto mínimo que puedes enviar es %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "El lugar más privado para guardar tus Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "La fila de billetera guardada no tiene red: no se puede preparar una resincronización.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "El registro se envió, pero no se pudo confirmar su resultado. Espera un minuto a que la billetera se sincronice y vuelve a intentarlo; no lo reenvíes de inmediato.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "El grupo de privacidad compartido aún está creciendo (%1$ld de %2$ld depósitos). El registro privado se desbloquea cuando alcance el mínimo.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "El grupo de privacidad compartido aún está creciendo (%1$ld de %2$ld depósitos). Inténtalo de nuevo cuando alcance el mínimo.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "El nombre de usuario ' 1%@ ' fué bloqueado por la red Dash. Inténtalo nuevamente solicitando otro nombre de usuario.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "La altura de creación de la billetera: el límite inferior para los escaneos de filtros y los reescaneos «Desde la creación de la billetera». Establécela en o por debajo de la primera financiación de la billetera; las importaciones usan 200000 por defecto en mainnet y 0 en testnet. Guardar una altura igual o inferior a la actual borra los datos de la cadena de esta red en el próximo inicio y reescanea desde ahí.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "él (obteniendo información)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "No hay notificaciones nuevas";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "No hay transacciones para mostrar";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "No hay usuarios que coincidan con el nombre %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "No hay usuarios que coincidan con el nombre %@ en tus contactos";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Hubo un error al exportar tu historial de transacciones a ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Hubo un error, inténtalo de nuevo más tarde";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Estos fondos se mueven a tu saldo de Platform y estarán listos para gastar en cuanto se complete la transferencia.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Esta dirección no se puede pagar desde tu saldo %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Esto añade dos llaves a tu identidad para que otros usuarios puedan enviarte solicitudes de contacto y para que tú puedas aceptar las suyas. Esto ocurre una sola vez.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Esto aplica una opción a los %d nombres de usuario seleccionados.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Este paso adicional muestra que realmente eres tú quien intenta realizar una transacción.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Este enlace de invitación no es válido.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Esta no es una dirección Dash válida para esta red";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Este no es un enlace de invitación válido";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Esta es tu identidad principal";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Este masternode aún no tiene identidad en Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Este proveedor no está disponible en este momento.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Esto representa el rendimiento porcentual anual actual de un Masternode completo menos la tarifa de CrowdNode del 15%. No es una tasa de rendimiento garantizada y puede aumentar o disminuir según el tamaño de los grupos de CrowdNode y el precio de Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Esto sigue contando como que tus masternodes han votado en esta disputa.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Los bytes sin procesar de esta transacción no están guardados en este dispositivo.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Este nombre de usuario fue para otra persona";
+
+"This wallet could not derive the voting key for this node." = "Esta billetera no pudo derivar la llave de voto de este nodo.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Esta billetera no tiene llaves de voto de masternode activas, así que no puede votar. Los nodos registrados aparecen en Herramientas → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Esto retira todo tu saldo de Platform en una sola transferencia. Los Dash llegan a la dirección del destinatario en cuanto la red procese la retirada.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Esto retira todo tu saldo de Platform en una sola transferencia. Los Dash llegan a tu saldo transparente en cuanto la red procese la retirada.";
 
 /* Send Screen: to address */
 "to" = "a";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Historial de transacciones";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "El historial de transacciones no está disponible";
+
 /* No comment provided by engineer. */
 "Transaction id" = "id de transacción";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID de transacción";
 
 /* A verb, button title. */
 "Transfer" = "Transferencia";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transferencia entrante";
 
+/* Balance breakdown */
+"Transfer in" = "Transferencia entrante";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transferencia de salida";
+
+/* Balance breakdown */
+"Transfer out" = "Transferencia saliente";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Las transferencias tardan más: construir las pruebas de privacidad lleva tiempo";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Las transferencias a otras direcciones de Platform y a direcciones blindadas son instantáneas y definitivas";
+
+/* Balance breakdown */
+"Transparent" = "Transparente";
+
+/* Send screen destination type */
+"Transparent address" = "Dirección transparente";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo transparente";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "La financiación transparente vincula públicamente tu nombre de usuario con estos fondos.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparente → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparente → Blindado";
 
 /* An action */
 "Try again" = "Intenta nuevamente";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "No se pueden ofrecer sugerencias";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Saldo desconocido";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tipo especial desconocido %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Sin blindar";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Dirección no soportada";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Mejora tu billetera a DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Actualizar a Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Usar el saldo transparente en su lugar";
+
+/* Masternode keys */
+"Used" = "Usada";
+
+/* Masternode keys */
+"Used at: " = "Usada el: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Usuario (obteniendo información)";
 
 /* Voting */
 "Username" = "Nombre de usuario";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "El nombre de usuario fue solicitado exitosamente";
 
+/* Identities */
+"Usernames" = "Nombres de usuario";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Los nombres de usuario se guardan en una forma normalizada para evitar nombres parecidos, así que esto puede diferir de lo que escribió cada persona.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nombres de usuario, no direcciones";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Usuarios que coinciden con %@ y que actualmente no están en tus contactos";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Usa una de las bibliotecas de conocimiento cero más auditadas y probadas (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Invitación válida";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validando dirección…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verificación requerida";
 
+/* Usernames */
+"Verified during registration" = "Verificado durante el registro";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verificado exitosamente";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verifica tu identidad";
 
+/* Raw transaction inspector */
+"Version" = "Versión";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Muy eficiente y con comisiones bajas";
+
 /* adjective, security level */
 "Very High" = "Muy alto";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Se enviarán cantidades muy pequeñas de Dash hacia y desde CrowdNode para verificar que tu eres el propietario de esta dirección de billetera.";
+
+/* No comment provided by engineer. */
+"View All" = "Ver todo";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Ver en el explorador";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Ver frase de recuperación";
 
+/* Raw transaction inspector */
+"View Transaction" = "Ver transacción";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Ver detalles de la transacción";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Votar";
+
+"Vote cast" = "Voto emitido";
+
 /* Voting */
 "Vote for All" = "Vota por todas";
 
 /* Voting */
+"Vote on contested usernames" = "Votar sobre nombres de usuario en disputa";
+
+"Vote on several" = "Votar sobre varios";
+
+/* Voting */
 "Vote to Approve" = "Vota para aprobar";
+
+"Vote with" = "Votar con";
+
+"Votes that nobody should receive these usernames." = "Vota para que nadie reciba estos nombres de usuario.";
 
 /* Voting */
 "Votes: High to low" = "Votos: Alto a bajo";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Dirección de voto";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Dirección de voto";
+
+"Voting ended with no winner" = "La votación terminó sin ganador";
+
+"Voting ends" = "La votación termina";
+
 /* Voting */
 "Voting ends in %dd" = "La votación termina en %d días";
+
+"Voting in progress" = "Votación en curso";
+
+"Voting in progress — lock votes are ahead" = "Votación en curso: los votos de bloqueo van por delante";
+
+"Voting in progress — you are ahead" = "Votación en curso: vas por delante";
 
 /* Usernames */
 "Voting is only required in some cases" = "El voto sólo es necesario en algunos casos";
 
+/* Masternodes */
+"Voting key hash" = "Hash de la llave de voto";
+
 /* Voting keys */
 "Voting keys" = "Llaves de votación";
+
+"Voting on this username has closed. The counts below are the last ones read." = "La votación sobre este nombre de usuario se ha cerrado. Los recuentos de abajo son los últimos leídos.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "La votación sobre «%@» ya se ha cerrado. Actualiza para ver el resultado.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Espera hasta que la billetera esté sincronizada para completar la transacción";
 
+"Waiting for Dash Platform" = "Esperando a Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Dirección de billetera";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Altura de origen de la billetera";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Billetera deshabilitada";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Bienvenido a DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "¿Y Unstoppable Domains y servicios de nombres similares?";
+
+/* DashPay FAQ */
+"What does it cost?" = "¿Cuánto cuesta?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "¿Qué es DashPay?";
+
 /* Usernames */
 "What is username voting?" = "¿Qué es la votación por nombre de usuario?";
+
+/* DashPay FAQ */
+"What's coming next?" = "¿Qué viene a continuación?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "¿Cuándo serán privadas las solicitudes de contacto?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Donde gastar?";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Donde gastar?";
+
+"Who is requesting this name" = "Quién pide este nombre";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "¿Por qué necesito activarlo?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "¿Por qué veo todas estas transacciones?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Retiro solicitado";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Retira todo el saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funciona con todas las billeteras, casas de cambio y comercios de Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "¿Te gustaría aceptar la invitación?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Ayer";
+
+"You" = "Tú";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Aceptaste la solicitud de contacto de %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Usted escogió \" ' 1%@ ' \" como nombre de usuario.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "No tienes ningún contacto por el momento";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "No tienes fondos suficientes para completar esta transacción.";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Excediste el límite de autorización en Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Tienes %@ Dash hasta ahora";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Tiene ' %1$@ ' Dash. Algunos nombres de usuario pueden llegar a costar hasta ' 2%2$@ ' Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Enviaste la solicitud de contacto a %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Deberías tener un saldo positivo en la billetera de Dash ";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Ganaste este nombre de usuario";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Todo listo. Otros usuarios ya pueden enviarte solicitudes de contacto, y tú puedes enviar las tuyas.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Tu identidad de Dash Platform aparecerá aquí cuando registres un nombre de usuario.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Tu correo electrónico sólo se utiliza para enviar una contraseña de un solo uso.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Tu historial, organizado";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Tu identidad necesita dos llaves adicionales para que las solicitudes de contacto puedan cifrarse entre tú y otros usuarios. Al activarlo se añaden con una única transacción de red. Esto ocurre una sola vez.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Tu invitación desde %@ ya ha sido reclamada";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Tu invitación desde %@ no es válida";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Tu invitación paga la comisión de registro de este nombre de usuario.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Tu ubicación se utiliza para mostrar tu posición en el mapa, cajeros automáticos en el radio seleccionado y mejorar los resultados de búsqueda.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Tu ubicación se utiliza para mostrar tu posición en el mapa, comerciantes en el radio seleccionado y mejorar los resultados de búsqueda.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Tu saldo principal de Dash en la blockchain de Core: lo que envías y recibes con otras billeteras, casas de cambio y comercios.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Tus monedas mezcladas se movieron al saldo de tu billetera Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Tus monedas mezcladas se movieron a tu saldo blindado. Para una mejor privacidad, espera al menos 2 horas antes de usar estos fondos.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Tu saldo de Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Tu dirección principal de Dash que usas actualmente para tu cuenta de CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Tu saldo privado. Los importes y las direcciones están cifrados en la cadena, así que tus fondos y tu historial se mantienen confidenciales.";
+
 /* Usernames */
 "Your request was cancelled" = "Tu solicitud fue cancelada";
 
 /* DashSpend */
 "Your session expired" = "Su sesión ha expirado";
+
+/* Usernames */
+"Your Shielded balance" = "Tu saldo blindado";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Tu saldo blindado está casi listo: podrás registrarte de forma privada hacia las %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Tu saldo blindado está listo: registra tu nombre de usuario de forma privada ahora";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Tu saldo blindado está reposando: podrás registrarte de forma privada hacia las %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Tu saldo blindado todavía está madurando. Estará listo hacia las %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Tu saldo transparente";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Tu nombre de usuario %@ se ha creado con éxito en la red Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Tu nombre de usuario se ha creado con éxito";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Tu nombre de usuario es visible para todos. Financiarlo con tu saldo blindado, después de dejar reposar los fondos unas horas, hace que nadie pueda vincular tu nombre de usuario con el resto de tus Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Tu nombre de usuario, tu perfil y tus contactos siguen a esta identidad.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Tu nombre de usuario, tu perfil y tus contactos seguirán a esta identidad.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Tu voto fue cancelado";
 
 /* Voting */
 "Your vote was submitted" = "Tu voto fue enviado";
 
+"Your votes" = "Tus votos";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Tu billetera está segura ahora. Podrás utilizar tu frase de recuperación en cualquier momento para recuperar tu cuenta en otro dispositivo.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Tu billetera todavía se está sincronizando con la red Dash. Podrás enviar cuando termine la sincronización.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Tu billetera todavía se está sincronizando. Podrás enviar desde tu saldo transparente cuando termine la sincronización.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "«%@» no se pudo leer como un nombre de usuario de Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» se ha registrado. ¿Quieres enviar una solicitud de contacto a la persona que te invitó?";

--- a/DashWallet/es.lproj/Localizable.stringsdict
+++ b/DashWallet/es.lproj/Localizable.stringsdict
@@ -95,7 +95,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ contados para «%2$@»</string>
+		<string>%#@votes@ para «%2$@»</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -103,9 +103,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u voto</string>
+			<string>%1$u voto contado</string>
 			<key>other</key>
-			<string>%1$u votos</string>
+			<string>%1$u votos contados</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -143,7 +143,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ han votado</string>
+		<string>Votado: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -159,7 +159,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ han votado</string>
+		<string>Votado: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/es.lproj/Localizable.stringsdict
+++ b/DashWallet/es.lproj/Localizable.stringsdict
@@ -92,5 +92,245 @@
 			<string>%d llaves</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ contados para «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u voto</string>
+			<key>other</key>
+			<string>%1$u votos</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Se ha votado en %1$d de %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nombre de usuario</string>
+			<key>other</key>
+			<string>%2$d nombres de usuario</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Emitir %u voto</string>
+			<key>other</key>
+			<string>Emitir %u votos</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ han votado</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ han votado</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nodo</string>
+			<key>other</key>
+			<string>%2$d nodos</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto en total</string>
+			<key>other</key>
+			<string>%u votos en total</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d seleccionado</string>
+			<key>other</key>
+			<string>%d seleccionados</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d de tus nodos ya ha votado aquí y no aparece en la lista.</string>
+			<key>other</key>
+			<string>%d de tus nodos ya han votado aquí y no aparecen en la lista.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto por disputa: los evonodes cuentan como 4 y los masternodes como 1</string>
+			<key>other</key>
+			<string>%u votos por disputa: los evonodes cuentan como 4 y los masternodes como 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votar sobre %d nombre de usuario</string>
+			<key>other</key>
+			<string>Votar sobre %d nombres de usuario</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto</string>
+			<key>other</key>
+			<string>%u votos</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votar ×%d</string>
+			<key>other</key>
+			<string>Votar ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d solicitud</string>
+			<key>other</key>
+			<string>%d solicitudes</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " või ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Kasutajat %@ ei leitud Dashi võrgust, seega ei saa talle kontaktitaotlust saata.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash saadaval";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ võttis su kontaktitaotluse vastu";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d baiti";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffi";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld sissemaksest";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Krediidijääk Dash Platformil, mida kasutatakse Platformi aadresside vaheliste kiirmaksete ja selliste funktsioonide jaoks nagu kasutajanimed.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Rahakoti turvamiseks on seadmele tarvis pääsukoodi. Jätkamiseks mine seadetesse ja lülita pääsukoodi küsimine sisse.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Teave";
 
+/* DashPay FAQ title */
+"About DashPay" = "DashPay teave";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Jää erapooletuks";
+
+"Abstain on “%@”" = "Jää erapooletuks nime „%@“ osas";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiivne";
+
+/* No comment provided by engineer. */
+"Activity" = "Tegevus";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Tegevus on avalik, kuid seda pole lihtne jälitada";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Lisa %@ kontaktiks";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Lisa %@ kontaktiks, et maksta otse kasutajanimele ja säilitada ühine tehingute ajalugu";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Lisa oma varjatud jäägile %@ Dash ja lase sel paar tundi seista, et saaksid registreeruda ilma kasutajanime ülejäänud vahenditega sidumata.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Lisa oma varjatud jäägile vähemalt %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Täienda varjatud jääki nüüd ja registreeri kasutajanimi privaatselt mõne tunni pärast";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Kõik sõlmed korraga";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kõik su masternode'id on selle kasutajanime üle hääletanud. Hääle muutmiseks hääleta uuesti selle taotleja juurest, keda nüüd eelistad.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Jääkide sünkroonimine on peaaegu kohene";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Summad ja aadressid on plokiahelas avalikud";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereumi konto on üksainus korduvkasutatav aadress: kogu su jääk ja maksete ajalugu on avalikult selle all ning nimi (näiteks ENS-domeen) osutab tavaliselt otse sellele aadressile, nii et igaüks saab selle lahendada. DashPay on täpselt vastupidine — nimi viib identiteedini, mitte makseaadressini, ja tegelikud makseaadressid jäävad krüptitud kontaktivahetuste sisse, iga kontakti jaoks uued.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Igaüks, kes aadressi teab, saab vaadata selle ajalugu";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Kiida heaks";
+
+"Approving a specific request can only be done one username at a time." = "Konkreetse taotluse heakskiitmine on võimalik korraga ainult ühe kasutajanime kohta.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Tekstina";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autentimine tühistati. Su häält ei antud.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autentimine ebaõnnestus. Su häält ei antud.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Määra „%@“ sellele taotlejale";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Jääk";
 
 /* CrowdNode */
+"Balance after" = "Jääk pärast";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Jäägid ja ülekanded pole avalikult nähtavad";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Alguskõrgus salvestatud — tõstetud skannimispiir kehtib järgmisest käivitusest.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Seotud lepinguga";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Seotud lepinguga, dokumenditüüp „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Ainult sirvimine";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Koondab hiljutised diagnostikalogid zip-failiks, et saaksid need AirDropiga saata, meilida või Failidesse salvestada";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Anna hääl";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Vaheta partnerid";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrollimine…";
+
+"Choice" = "Valik";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Lunasta oma kutse";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Väljanõutav jääk";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Kustuta ja sünkrooni uuesti";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Kas kustutada ahela andmed ja sünkroonida uuesti?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Sulgub";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (uued mündid)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoini enam ei toetata — vali, kuhu su segatud mündid liigutada.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Tagatis";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Tulekul";
+
+/* Shielded transfer status */
+"Completed" = "Lõpetatud";
 
 /* No comment provided by engineer. */
 "Confirm" = "Kinnita";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Kinnitatud";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Kinnitamine salvestab alguskõrguse %u ja kustutab selle võrgu ahela andmed rakenduse järgmisel käivitamisel, laadib need uuesti alla ning skannib filtrid sellest kõrgusest uuesti läbi. Käimasolev seanss säilitab oma vana skannimispiiri — alustamiseks sulge rakendus ja ava see uuesti.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Ühendatud partnerid";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Miinused";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktitaotlus ebaõnnestus";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktitaotlus saadetud kasutajale %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktitaotlused";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Taotleja %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Jätka, et valida oma kasutajanimi. Kutse maksab registreerimistasu.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopeeri toortehing";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Logiarhiivi ei õnnestunud luua: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d identiteeti ei õnnestunud värskendada";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Jääki ei õnnestunud hankida (võrguviga). Proovi värskendada.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Loo oma kasutajanimi, leia sõbrad ja pereliikmed nende kasutajanime järgi ning lisa nad oma kontaktidesse";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediidid";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform pole seda vaidlust veel indekseerinud. Häälte arv ilmub siia, kui see on tehtud.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platformiga pole veel ühendust. Oota, kuni sünkroonimine lõpeb, ja proovi uuesti.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Valele aadressile saadetud Dashi ei saa tagasi. Veendu, et aadress on täpselt see, millele soovid maksta.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash salvestab kasutajanimed sarnasuse eest kaitstud kujul, seega võib salvestatud nimi erineda sellest, mida iga inimene sisestas.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dashi rahakoti jääk";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay on lubatud";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay on Dashi sotsiaalne maksekogemus, mis on ehitatud Dash Platformile. Registreerid kasutajanime, lisad teisi kasutajaid kontaktideks ja maksad neile nime järgi — enam pole vaja aadresse kopeerida.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay asendab pikad ja arusaamatud aadressid kasutajanimedega. Lisa sõbrad kontaktideks, saada raha nimele ja hoia iga makse inimeste kaupa korras.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Tähtaeg teadmata";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Tuletustee";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Keelatud";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Tehtud";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Valmis — su jääk on piisavalt kaua seisnud";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Kontrolli aadressi veel kord";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Igal masternode'il on iga vaidluse kohta üks kehtiv hääl. Saad seda hiljem muuta, kuid Dash Platform lubab vaidluse kohta masternode'i kohta kokku ainult 5 häält.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Iga koputus lisab hääletamisse ühe sõlme, nii et sa valid ise, mitu neist omavahel siduda.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Muuda alguskõrgust";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Luba";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Luba DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPay lubamine maksab väikese ühekordse võrgutasu, mis tasutakse su identiteedi krediidijäägist. Täpne hinnang kuvatakse enne kinnitamist. Kontaktitaotluste ja maksete saatmine maksab tavapärased võrgutasud.";
+
+"Ending soonest" = "Lõpeb kõige varem";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Hinnanguline võrgutasu";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Kõik sõlmed hääletavad koos. Kiirem, kuid see seob su masternode'id avalikult üksteisega.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode'i operaatorivõtmed";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Ekspordi logid";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Väline aadress";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limiit";
+
+/* No comment provided by engineer. */
+"Failed" = "Ebaõnnestus";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Hankimine…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filtripäised";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Leia kasutaja Dashi võrgust";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Leia identiteedid";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Leiti %d uut identiteeti";
+
+/* Identities */
+"Found 1 new identity" = "Leiti 1 uus identiteet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Rahasta oma kasutajanime varjatud jäägist. Lisa vahendid paar tundi ette — lühike seismine hoiab su kasutajanime ülejäänud Dashiga sidumata.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Rahastatud su varjatud jäägist — su kasutajanime ei saa siduda su ülejäänud Dashiga.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Vahendid lukustatud — ülekannet lõpetatakse";
+
+/* CoinJoin */
+"Funds moved" = "Vahendid liigutatud";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Valmistu DashPayga liituma";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Selge";
+
+/* Governance */
+"Governance" = "Juhtimine";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "on palunud saada su sõbraks";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Kas sul on kutse?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Päised";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Kõrgus %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Kõrgemad tasud, umbes 7 senti (siiski madalamad kui teistes sarnase privaatsusega plokiahelates)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kuidas see privaatsuse poolest Bitcoiniga võrdleb?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kuidas see privaatsuse poolest Ethereumi kontodega võrdleb?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Kui privaatne on DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Ma kirjutasin endale välja";
 
+/* Identities */
+"Identities" = "Identiteedid";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identiteedi krediidid";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identiteedi indeks";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identiteedi registreerimine";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Identiteedi täiendamine";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Mitteaktiivne";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Sisend %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Sisend %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Sisendid (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Kutse kasutajalt %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Kutsu keegi Dashi võrguga liituma";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Kutsu oma sõbrad ja pere Dashi võrku";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Hoia need mündid privaatsena. Kehtivad võrgu- ja privaatsustasud.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Võti nr %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Võtme andmed";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Võtme omandiõigus";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Võtmed";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Juhib";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Loe rohkem";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Tehingute laadimine";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Ainult kohalik";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Lukusta";
+
+"Lock the name" = "Lukusta nimi";
+
+"Lock “%@” so nobody gets it" = "Lukusta „%@“, et keegi seda ei saaks";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Lukustatud — keegi ei saa seda kasutajanime";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Madalad tasud igapäevaseks kulutamiseks";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Peamine";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode'i võtmehoidja";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternode'ide loend";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternode'ide hääled";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode'id";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Selle rahakoti võtmetega registreeritud masternode'id ja evonode'id ilmuvad siia pärast rahakoti sünkroonimist.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Selle rahakoti võtmeid kasutavad masternode'id ja evonode'id";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode'id hääletavad nimede üle, mida on taotlenud rohkem kui üks inimene. Anname teada, kui hääletamine lõpeb.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Miinimum on täidetud";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Rohkem soovitusi";
+
+"Most lock votes" = "Kõige rohkem lukustushääli";
+
+"Most votes" = "Kõige rohkem hääli";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Liiguta oma tavalisse kulutatavasse jääki.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Vahendite liigutamine";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Nimeteenused nagu Unstoppable Domains seovad loetava nime ahelas oleva püsiva avaliku aadressiga. Igaüks saab nime lahendada ja näha iga makset, mis sellele kunagi tehtud on. DashPay kasutajanimi ei lahendu kunagi avalikult makseaadressiks — aadressid avaldatakse ainult krüptitud vahetuses iga kontaktiga, seega jäävad su nimi ja raha kõrvalseisjate jaoks sidumata.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Vajab tähelepanu";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Selles seadmes ei leitud ühtki diagnostikalogi. Logisid kirjutatakse alates järgmisest käivitusest.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Identiteete pole";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Masternode'e veel pole";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Sobivaid vaidlusi pole";
+
+/* Identities */
+"No new identities were found for this wallet" = "Selle rahakoti jaoks ei leitud uusi identiteete";
+
+"No open contest matches that search." = "Ükski avatud vaidlus ei vasta sellele otsingule.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ükski avatud vaidlus ei vasta sellele otsingule. Nimed salvestatakse normaliseeritud kujul, seega „alice“ on loendis „a11ce“.";
+
+"No open contests" = "Avatud vaidlusi pole";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Seotud rahakoti jaoks ei leitud salvestatud kirjet.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Varjatud varuregistreerimise jaoks pole veel Platformi aadressi saadaval. Proovi uuesti, kui rahakott on sünkroonimise lõpetanud.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Praegu pole ükski kasutajanimi vaidlusalune. Vaidlus avaneb, kui kaks või enam inimest taotlevad sama nime.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Ühtki häält ei antud";
+
+"Nobody gets it" = "Keegi ei saa seda";
+
+/* SPV sync peer type */
+"Node" = "Sõlm";
+
+/* Raw transaction inspector */
+"Non-standard" = "Mittestandardne";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Pole veel saadaval";
+
+"Not cast" = "Andmata";
+
+/* Masternodes */
+"Not checked yet" = "Pole veel kontrollitud";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Varjatud jääki ei ole identiteedi registreerimiseks piisavalt";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Pole rahakoti ajaloos";
+
+"Not now" = "Mitte praegu";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Kaupmehed ei aktsepteeri laialdaselt";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Kaupmehed ei aktsepteeri veel laialdaselt";
+
+/* Masternode keys */
+"Not yet used" = "Pole veel kasutatud";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoinis pole nimekihti, nii et inimesed jagavad ja kasutavad aadresse avalikult korduvalt — kui aadress on kord teada, saab kõik, mida see kunagi vastu on võtnud, siduda selle omanikuga. DashPays on su kasutajanimi avalik, kuid see ei osuta kunagi makseaadressile: aadresse vahetatakse iga kontaktiga privaatselt ja need vahelduvad, nii et nimele maksmine ei avalda, kuhu su raha läheb. Mõlemad on läbipaistvad ahelad, seega ahelaanalüüs kehtib endiselt müntide endi kohta.";
+
+/* Identities */
+"On Network" = "Võrgus";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kui %@ su taotluse vastu võtab, saad maksta otse kasutajanimele";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Üks sõlm korraga";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Kasutajanimede üle saavad hääletada ainult masternode'id ja evonode'id. Selles rahakotis pole aktiivseid masternode'i hääletusvõtmeid.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operaator";
+
+/* Masternode keys */
+"Operator keys" = "Operaatorivõtmed";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operaatori avalik võti (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "või";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Muud tulemused";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Väljund %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Väljundid (%d)";
+
+/* Masternodes */
+"Owner" = "Omanik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Omaniku aadress";
+
+/* Masternodes */
+"Owner key hash" = "Omaniku võtme räsi";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Tasutud su identiteedi krediidijäägist.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Kleebi saadud kutselink või skanni selle QR-kood. See rahastab su kasutajanime registreerimise.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "maksta otse kasutajanimele";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Maksa inimestele, mitte aadressidele";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Kasulik koormus (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Maksed on privaatsed: aadressid, mida kontaktiga vahetad, liiguvad krüptitud sisu sees, mida saate lugeda ainult teie kaks, ja neid ei avaldata kunagi — seega ei saa su makseid kergesti kasutajanimega siduda. Siiski on need endiselt tavalised maksed läbipaistvas ahelas: keerukas ahelaanalüüs võib infot lekitada. Shielded DashPay (tulekul) sulgeb selle lünga. Kontaktitaotlused ise EI ole praegu privaatsed: igaüks näeb, et kaks identiteeti on seotud. Privaatsed kontaktitaotlused on peagi tulev funktsioon. Su kasutajanimi ja profiil on Dash Platformil samuti avalikud.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Maksed kinnitatakse sekunditega InstantSendi abil";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Otse aadressidele tehtud makseid tegevuses ei säilitata.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Iga kontaktiga tehtud maksed on koondatud ühte kohta, nimede ja profiilidega toortehingute asemel.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Väljamakse aadress";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platformi aadress";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platformi jääk";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platformi sõlm";
+
+/* Masternode keys */
+"Platform Node ID" = "Platformi sõlme ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platformi maksed ei tuvasta saatjat. See makse salvestati siis, kui rahakott märkas jäägi muutust — see võis saabuda varem.";
+
+"Platform SDK not ready" = "Platformi SDK pole valmis";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platformi sünkroonimine ei tööta. Selle käivitamiseks ava Sünkroonimisteave → Platformi sünkroonimise olek.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Varjatud";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Varem kasutatud: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privaatne juba oma ülesehituselt";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privaatsed kontaktitaotlused (et see, kellega sa ühendust hoiad, jääks privaatseks), Shielded DashPay — maksed kontaktidele su privaatsest varjatud jäägist — ja maksmine kasutajatele, keda su kontaktides veel pole, on kõik peagi tulekul.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privaatsed kontaktitaotlused on arendamisel ja neid oodatakse umbes 2026. aasta septembris–oktoobris. Praegu on taotlus ise avalik — igaüks näeb, et kaks identiteeti on seotud, kuigi selles olevad makseandmed on krüptitud. Kui privaatsed kontaktitaotlused saabuvad, saad valida, kas su sõprus on avalik või privaatne.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privaatsed kontaktitaotlused, Shielded DashPay ja maksmine inimestele, kes pole veel kontaktid.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privaatseid makseaadresse vahetate sina ja su kontaktid. Ainult sina ja su kontakt teate, kes on teie vaheliste maksete saaja ja saatja.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privaatsed maksed";
+
+/* Usernames */
+"Private registration" = "Privaatne registreerimine";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Töötlemisaeg";
+
+/* Balance info sheet section */
+"Pros" = "Plussid";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Teenusepakkuja tehingud";
+
+/* Masternode keys */
+"Public key" = "Avalik võti";
+
+/* Masternode keys */
+"Public key (legacy)" = "Avalik võti (vana)";
+
+/* Identities */
+"Public keys" = "Avalikud võtmed";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Otstarve";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Toortehing";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Toortehing pole saadaval";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Kontrollib valitud kõrgusest alates kompaktseid plokifiltreid selle rahakoti tehingute suhtes uuesti, laadides need uuesti alla ja sobitades uuesti. Uuesti skannimise alampiiriks on rahakoti loomise kõrgus ja kohapeal salvestatud ahela andmed — sellest varasema ajaloo taastamiseks vähenda pigem rahakoti alguskõrgust.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Ainult lugemiseks";
+
+/* Usernames */
+"Ready around %@" = "Valmis umbes %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Põhjus";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Saadud kasutajalt %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Märgib su masternode'id hääletanuks, ilma poolt valimata.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Värskenda";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registreeritud";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privaatne registreerimine nõuab vähemalt %@ Dashi su varjatud jäägil ning paari tundi seismist — järgmised vaated juhendavad sind.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registreerimine";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Taotleb seda nime";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Taastatud rahakotid ei suuda alati toimingu tüüpi taastada. See kirje on rekonstrueeritud ahelas olevatest märkmeandmetest.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Uuesti sünkroonimine on ette valmistatud kõrgusest %u — alustamiseks sulge rakendus ja ava see uuesti.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "säilitada ühine tehingute ajalugu";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Kasutuselt kõrvaldatud";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Tühistamine";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Skripti allkiri";
+
+/* Raw transaction inspector */
+"Script type" = "Skripti tüüp";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Otsi kontakti";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Otsi kontaktitaotlust";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Otsi kasutajat Dashi võrgust";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Otsi kasutajanime";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Otsingutulemused päringule \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Otsi kasutajanimesid";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Kasutajanime %@ otsimine Dashi võrgust";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Turvatase";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Vali kõik";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Vali vähemalt üks masternode, millega hääletada.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Vähemate sõlmede valimine paljastab vähem selle kohta, milliseid masternode'e sa haldad.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Saada kontaktile";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Saada kasutajanimele, mida sa tegelikult mäletad ja kontrollida saad.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Saada oma esimene kontaktitaotlus";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Kontaktitaotluse saatmine";
+
+/* No comment provided by engineer. */
+"Sending to" = "Saadetakse";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Saadetud kasutajale %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Teenus";
+
+/* Identities */
+"Set as Main" = "Määra peamiseks";
+
+/* Identities */
+"Set as Main Identity" = "Määra peamiseks identiteediks";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Jagatud privaatsusbassein on miinimumsuuruses";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Varjatud aadress";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Varjatud kulutus";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Varjatud rahakoti käivitamine…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Varjatud → Platform";
+
+"Shielded → Transparent" = "Varjatud → Läbipaistev";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Suurus";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Mõned su masternode'idest võivad sellest loendist puududa — rahakott ei suutnud lugeda kogu su hääletusvõtmete komplekti. Lõpeta sünkroonimine ja ava see vaade uuesti.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sordi kontaktid";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Eriline kasulik koormus";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Algab pärast vahendite lisamist";
+
+/* Transaction details */
+"Status" = "Olek";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Salvestatud kujul";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Sünkroonimisteave";
+
+/* SPV sync */
+"Sync too slow?" = "Kas sünkroonimine on liiga aeglane?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ära asu kummalegi poolele";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Kopeerimiseks koputa";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdashi sõlmevõti (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash jõuab saaja aadressile pärast seda, kui võrk on väljamakse töödelnud — see võib võtta kuni 10 minutit.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash jõuab saaja aadressile kohe, kui võrk väljamakse töötleb.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash jõuab su läbipaistvasse jääki kohe, kui võrk väljamakse töötleb.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Peamist identiteeti saab valida ainult aktiivsest rahakotist";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Kõige privaatsem koht oma Dashi hoidmiseks";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Salvestatud rahakoti kirjel puudub võrk — uuesti sünkroonimist ei saa ette valmistada.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registreerimine saadeti, kuid selle tulemust ei õnnestunud kinnitada. Oota minut, kuni rahakott sünkroonib, ja proovi siis uuesti — ära saada kohe uuesti.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Jagatud privaatsusbassein alles kasvab (%1$ld / %2$ld sissemaksest). Privaatne registreerimine avaneb, kui see saavutab miinimumi.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Jagatud privaatsusbassein alles kasvab (%1$ld / %2$ld sissemaksest). Proovi uuesti, kui see saavutab miinimumi.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Rahakoti loomise kõrgus — filtriskannimiste ja „Rahakoti loomisest“ uuesti skannimiste alampiir. Määra see rahakoti esimese laekumise tasemele või sellest madalamale; importimisel on vaikeväärtus mainnetis 200000 ja testnetis 0. Praegusega võrdse või madalama kõrguse salvestamine kustutab järgmisel käivitusel selle võrgu ahela andmed ja skannib sealt uuesti.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "teda (teabe hankimine)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Uusi teavitusi pole";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nimele %@ vastavaid kasutajaid pole";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Su kontaktides pole nimele %@ vastavaid kasutajaid";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Need vahendid liiguvad su Platformi jääki ja on kulutamiseks valmis kohe, kui ülekanne lõpeb.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Sellele aadressile ei saa maksta su %@ jäägist";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "See lisab su identiteedile kaks võtit, et teised kasutajad saaksid sulle kontaktitaotlusi saata ja et sina saaksid nende omi vastu võtta. See toimub ainult üks kord.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "See rakendab ühe valiku kõigile %d valitud kasutajanimele.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "See kutselink pole kehtiv.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "See pole selle võrgu jaoks kehtiv Dashi aadress";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "See pole kehtiv kutselink";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "See on su peamine identiteet";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Sellel masternode'il pole veel Platformi identiteeti.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "See loeb ikkagi selleks, et su masternode'id on selles vaidluses hääletanud.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Selle tehingu toorbaite pole selles seadmes salvestatud.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "See kasutajanimi läks kellelegi teisele";
+
+"This wallet could not derive the voting key for this node." = "See rahakott ei suutnud selle sõlme hääletusvõtit tuletada.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Selles rahakotis pole aktiivseid masternode'i hääletusvõtmeid, seega ei saa see hääletada. Registreeritud sõlmed kuvatakse jaotises Tööriistad → Masternode'id.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "See võtab kogu su Platformi jäägi välja ühe ülekandega. Dash jõuab saaja aadressile kohe, kui võrk väljamakse töötleb.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "See võtab kogu su Platformi jäägi välja ühe ülekandega. Dash jõuab su läbipaistvasse jääki kohe, kui võrk väljamakse töötleb.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Tehingute ajalugu pole saadaval";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Tehingu ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Sissetulev ülekanne";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Väljaminev ülekanne";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Ülekanded võtavad kauem aega — privaatsustõendite koostamine nõuab aega";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Ülekanded teistele Platformi aadressidele ja varjatud aadressidele on kohesed ja lõplikud";
+
+/* Balance breakdown */
+"Transparent" = "Läbipaistev";
+
+/* Send screen destination type */
+"Transparent address" = "Läbipaistev aadress";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Läbipaistev jääk";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Läbipaistev rahastamine seob su kasutajanime avalikult nende vahenditega.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Läbipaistev → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Läbipaistev → Varjatud";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Soovitusi ei saa pakkuda";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tundmatu eritüüp %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Varjamata";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Uuenda Evolutionile";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Kasuta selle asemel läbipaistvat jääki";
+
+/* Masternode keys */
+"Used" = "Kasutatud";
+
+/* Masternode keys */
+"Used at: " = "Kasutatud: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Kasutaja (teabe hankimine)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Kasutajanimed";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Kasutajanimed salvestatakse normaliseeritud kujul, et vältida sarnase välimusega nimesid, seega võib see erineda sellest, mida iga inimene sisestas.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Kasutajanimed, mitte aadressid";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Kasutajad, kes vastavad päringule %@ ja keda praegu su kontaktides pole";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Kasutab üht enim auditeeritud ja testitud nullteadmusteeki (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Kehtiv kutse";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Kontrollitud registreerimise ajal";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versioon";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Väga tõhus ja madalate tasudega";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Vaata kõiki";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Vaata tehingut";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Hääleta";
+
+"Vote cast" = "Hääl antud";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Hääleta vaidlusaluste kasutajanimede üle";
+
+"Vote on several" = "Hääleta mitme üle";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Hääleta järgmisega";
+
+"Votes that nobody should receive these usernames." = "Hääletab selle poolt, et keegi ei saaks neid kasutajanimesid.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Hääletusaadress";
+
+"Voting ended with no winner" = "Hääletamine lõppes võitjata";
+
+"Voting ends" = "Hääletamine lõpeb";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Hääletamine käib";
+
+"Voting in progress — lock votes are ahead" = "Hääletamine käib — lukustushääled juhivad";
+
+"Voting in progress — you are ahead" = "Hääletamine käib — sina juhid";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hääletusvõtme räsi";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Hääletamine selle kasutajanime üle on suletud. Allolevad arvud on viimased loetud.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Hääletamine nime „%@“ üle on juba suletud. Tulemuse nägemiseks värskenda.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Dash Platformi ootamine";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Rahakoti alguskõrgus";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Aga Unstoppable Domains ja sarnased nimeteenused?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Kui palju see maksab?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Mis on DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Mis tuleb järgmisena?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Millal muutuvad kontaktitaotlused privaatseks?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kes seda nime taotleb";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Miks pean selle lubama?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Võtab välja kogu jäägi";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Töötab iga Dashi rahakoti, börsi ja kaupmehega";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Sina";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Võtsid vastu kontaktitaotluse kasutajalt %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Sul pole praegu ühtki kontakti";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Sul on seni %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Saatsid kontaktitaotluse kasutajale %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Võitsid selle kasutajanime";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Kõik on valmis. Teised kasutajad saavad nüüd sulle kontaktitaotlusi saata — ja sina saad saata enda omi.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Su Dash Platformi identiteet ilmub siia, kui registreerid kasutajanime.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Su ajalugu, korrastatult";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Su identiteet vajab kahte lisavõtit, et kontaktitaotlusi saaks sinu ja teiste kasutajate vahel krüptida. Lubamine lisab need ühe võrgutehinguga. See toimub ainult üks kord.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Su kutse maksab selle kasutajanime registreerimistasu.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Su peamine Dashi jääk Core'i plokiahelas — see, mida saadad ja võtad vastu teiste rahakottide, börside ja kaupmeestega.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Su segatud mündid liigutati Dashi rahakoti jääki.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Su segatud mündid liigutati varjatud jääki. Parima privaatsuse huvides oota enne nende vahendite kasutamist vähemalt 2 tundi.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Su Platformi jääk";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Su privaatne jääk. Summad ja aadressid on ahelas krüptitud, nii et su varad ja ajalugu jäävad konfidentsiaalseks.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Su varjatud jääk";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Su varjatud jääk on peaaegu valmis — saad end privaatselt registreerida umbes %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Su varjatud jääk on valmis — registreeri oma kasutajanimi privaatselt kohe";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Su varjatud jääk seisab — saad end privaatselt registreerida umbes %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Su varjatud jääk veel küpseb. See on valmis umbes %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Su läbipaistev jääk";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Su kasutajanime näevad kõik. Kui rahastad seda varjatud jäägist — pärast seda, kui oled lasknud vahenditel paar tundi seista —, ei saa keegi siduda su kasutajanime ülejäänud Dashiga.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Su kasutajanimi, profiil ja kontaktid järgivad seda identiteeti.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Su kasutajanimi, profiil ja kontaktid hakkavad seda identiteeti järgima.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Sinu hääled";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Su rahakott alles sünkroonib Dashi võrguga. Saatmine on võimalik, kui sünkroonimine on lõppenud.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Su rahakott alles sünkroonib. Läbipaistvast jäägist saatmine on võimalik, kui sünkroonimine on lõppenud.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Väärtust „%@“ ei õnnestunud lugeda Dashi kasutajanimena.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ on registreeritud. Kas saata kontaktitaotlus inimesele, kes sind kutsus?";

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Kõik sõlmed korraga";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kõik su masternode'id on selle kasutajanime üle hääletanud. Hääle muutmiseks hääleta uuesti selle taotleja juurest, keda nüüd eelistad.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kõik su masternode'id on selle kasutajanime üle hääletanud. Hääle muutmiseks hääleta uuesti selle taotleja poolt, keda nüüd eelistad.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/et.lproj/Localizable.stringsdict
+++ b/DashWallet/et.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ loetud kirje „%2$@“ kasuks</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u hääl</string>
+			<key>other</key>
+			<string>%1$u häält</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Hääletatud %1$d / %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d kasutajanimi</string>
+			<key>other</key>
+			<string>%2$d kasutajanime</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Anna %u hääl</string>
+			<key>other</key>
+			<string>Anna %u häält</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d / %#@nodes@ on hääletanud</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode'i</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d / %#@nodes@ on hääletanud</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d sõlm</string>
+			<key>other</key>
+			<string>%2$d sõlme</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode'i</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hääl kokku</string>
+			<key>other</key>
+			<string>%u häält kokku</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode'i</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d valitud</string>
+			<key>other</key>
+			<string>%d valitud</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d sinu sõlmedest on siin juba hääletanud ja seda ei kuvata.</string>
+			<key>other</key>
+			<string>%d sinu sõlme on siin juba hääletanud ja neid ei kuvata.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hääl vaidluse kohta — evonode'id loevad neljana, masternode'id ühena</string>
+			<key>other</key>
+			<string>%u häält vaidluse kohta — evonode'id loevad neljana, masternode'id ühena</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hääleta %d kasutajanime üle</string>
+			<key>other</key>
+			<string>Hääleta %d kasutajanime üle</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hääl</string>
+			<key>other</key>
+			<string>%u häält</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hääleta ×%d</string>
+			<key>other</key>
+			<string>Hääleta ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d taotlus</string>
+			<key>other</key>
+			<string>%d taotlust</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " یا ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "‏%@ در شبکه دش پیدا نشد تا بتوان برایش درخواست تماس فرستاد.";
+
+/* Usernames */
+"%@ Dash available" = "‏%@ دش در دسترس";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "‏%@ درخواست تماس شما را پذیرفت";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "‏%d بایت";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "‏%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%dرای در نظر گرفته می شود چون چند کلید رای‌دهی در کیف پول‌تان دارید";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "‏%ld از %ld واریز";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "موجودی اعتباری روی Dash Platform که برای پرداخت‌های آنی میان نشانی‌های Platform و برای قابلیت‌هایی مانند نام کاربری به کار می‌رود.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "اطلاعات بیشتر";
 
+/* DashPay FAQ title */
+"About DashPay" = "درباره DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "درباره م";
+
+"Abstain" = "رأی ممتنع";
+
+"Abstain on “%@”" = "درباره «%@» ممتنع بمان";
 
 /* No comment provided by engineer. */
 "Accept" = "قبول";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "بازیابی حساب";
 
+/* Masternode status */
+"Active" = "فعال";
+
+/* No comment provided by engineer. */
+"Activity" = "فعالیت";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "فعالیت عمومی است اما ردگیری آن آسان نیست";
+
 /* No comment provided by engineer. */
 "Add" = "اضافه کردن";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "افزودن %@ به‌عنوان مخاطب";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "‏%@ را به‌عنوان مخاطب اضافه کنید تا مستقیماً به نام کاربری پرداخت کنید و تاریخچه تراکنش‌های مشترک را نگه دارید";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "‏%@ دش به موجودی محافظت‌شده خود بیفزایید و بگذارید چند ساعت بماند تا ثبت‌نام، نام کاربری‌تان را به دیگر دارایی‌هایتان پیوند ندهد.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "یک تماس جدید اضافه کنید";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "دست‌کم %@ دش به موجودی محافظت‌شده خود بیفزایید";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "همین حالا موجودی محافظت‌شده را شارژ کنید و چند ساعت بعد نام کاربری‌تان را به‌صورت خصوصی ثبت کنید";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "همه";
 
+"All nodes at once" = "همه گره‌ها یکجا";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "همه مسترنودهای شما به این نام کاربری رأی داده‌اند. برای تغییر رأی، از داوطلبی که اکنون ترجیح می‌دهید دوباره رأی دهید.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "اجازه ارسال همه تراکنش‌‌ها از دش والت به ذن‌لجر را می‌دهید؟ ";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "همزمان‌سازی موجودی‌ها تقریباً آنی است";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "مبالغ و نشانی‌ها روی بلاک‌چین عمومی هستند";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "حساب اتریوم یک نشانی قابل‌استفاده مکرر است: کل موجودی و تاریخچه پرداخت‌های شما به‌صورت عمومی زیر آن قرار دارد و یک نام (مانند دامنه ENS) معمولاً مستقیماً به همان نشانی اشاره می‌کند تا هر کسی بتواند آن را بازگشایی کند. DashPay درست برعکس است — نام به یک هویت بازگشایی می‌شود نه به نشانی پرداخت، و نشانی‌های پرداخت واقعی درون تبادل‌های رمزگذاری‌شده با مخاطبان می‌مانند و برای هر مخاطب تازه‌اند.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "تجربه‌ای ساده و آشنا روی همه دستگاه‌ها";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "هر کسی که یک نشانی را بداند می‌تواند تاریخچه‌اش را ببیند";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "اعمال";
 
+"Approve" = "تأیید";
+
+"Approving a specific request can only be done one username at a time." = "تأیید یک درخواست مشخص تنها برای یک نام کاربری در هر بار ممکن است.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "به‌صورت متن";
 
 /* DashSpend */
 "at" = "در";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "احراز هویت لغو شد. رأی شما ثبت نشد.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "احراز هویت ناموفق بود. رأی شما ثبت نشد.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "«%@» را به این داوطلب بده";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "موجودی";
 
 /* CrowdNode */
+"Balance after" = "موجودی پس از آن";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "موجودی‌ها و انتقال‌ها به‌صورت عمومی دیده نمی‌شوند";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "ارتفاع آغاز ذخیره شد — کف پویش بالا رفته از اجرای بعدی اعمال می‌شود.";
+
 /* Voting */
 "Block" = "بلاک";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "مقیدشده به قرارداد";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "مقیدشده به قرارداد، نوع سند «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "فقط مرور";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "گزارش‌های تشخیصی اخیر را در یک فایل zip جمع می‌کند تا با AirDrop یا ایمیل بفرستید یا در «فایل‌ها» ذخیره کنید";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "ثبت رأی";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "تغییر همتاها";
 
 /* No comment provided by engineer. */
 "Change PIN" = "تغییر پین کد";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "در حال بررسی…";
+
+"Choice" = "انتخاب";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "نام کاربری‌تان را انتخاب کنید";
 
+/* DashPay Invitations */
+"Claim your invitation" = "دعوتنامه‌تان را دریافت کنید";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "موجودی قابل دریافت";
+
 /* No comment provided by engineer. */
 "Claimed" = "پذیرفته‌شده";
+
+/* SPV diagnostics */
+"Clear & resync" = "پاک‌سازی و همزمان‌سازی مجدد";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "داده‌های زنجیره پاک و دوباره همزمان‌سازی شود؟";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "در حال بسته شدن";
+
 /* Dash Portal */
 "Coinbase" = "کوین‌بیس";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (سکه‌های جدید)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "کد 2FA کوین‌بیس";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "‏CoinJoin دیگر پشتیبانی نمی‌شود — انتخاب کنید سکه‌های ترکیب‌شده‌تان کجا منتقل شوند.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "وثیقه";
+
+/* DashPay intro: feature title */
+"Coming soon" = "به‌زودی";
+
+/* Shielded transfer status */
+"Completed" = "تکمیل شد";
 
 /* No comment provided by engineer. */
 "Confirm" = "تائید";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "تأییدشده";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "تأیید، ارتفاع آغاز %u را ذخیره می‌کند و در اجرای بعدی برنامه داده‌های زنجیره این شبکه را پاک کرده، دوباره دانلود می‌کند و فیلترها را از آن ارتفاع بازپویش می‌کند. نشست جاری کف پویش قبلی خود را نگه می‌دارد — برنامه را ببندید و دوباره باز کنید تا آغاز شود.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "کیف‌های پول‌تان را به پلتفرم ذن‌لجر متصل کنید. اطلاعات بیشتر و آغاز به کار با تراکنش‌هایتان در دش والت";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "اتصال به نشانی دش برقرار است";
 
+/* SPV sync */
+"Connected peers" = "همتاهای متصل";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "معایب";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "درخواست تماس ناموفق بود";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "درخواست تماس برای %@ فرستاده شد";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "درخواست‌های تماس";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "تماس‌ها";
 
+"Contender %@" = "داوطلب %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "ادامه";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "ادامه دهید تا نام کاربری‌تان را انتخاب کنید. دعوتنامه هزینه ثبت را می‌پردازد.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "کپی لینک دعوتنامه";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "کپی تراکنش خام";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "ساخت بایگانی گزارش‌ها ممکن نشد: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = " نرخ‌های تبدیل پیدا نشد.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "به‌روزرسانی %d هویت ممکن نشد";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "دریافت موجودی ممکن نشد (خطای شبکه). به‌روزرسانی را امتحان کنید.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "نام کاربری‌تان را ایجاد کنید";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "نام کاربری‌تان را بسازید، دوستان و خانواده را با نام کاربری‌شان بیابید و به مخاطبانتان بیفزایید";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "کارت اعتباری";
+
+/* Masternodes */
+"Credits" = "اعتبارها";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "‏Dash Platform هنوز این رقابت را نمایه نکرده است. شمارش رأی‌ها پس از آن اینجا نمایان می‌شود.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "‏Dash Platform هنوز متصل نشده است. تا پایان همزمان‌سازی صبر کنید و دوباره تلاش کنید.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "دشی که به نشانی اشتباه فرستاده شود بازیابی‌پذیر نیست. مطمئن شوید نشانی دقیقاً همانی است که قصد پرداخت به آن را دارید.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "دش نام‌های کاربری را به شکلی مقاوم در برابر شباهت ظاهری ذخیره می‌کند، پس نام ذخیره‌شده ممکن است با آنچه هر کس تایپ کرده متفاوت باشد.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "دش والت";
+
+/* CoinJoin */
+"Dash Wallet balance" = "موجودی کیف پول دش";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "دش والت روی این دستگاه";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "‏DashPay فعال شد";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "‏DashPay تجربه پرداخت اجتماعی دش است که روی Dash Platform ساخته شده. یک نام کاربری ثبت می‌کنید، کاربران دیگر را به‌عنوان مخاطب می‌افزایید و با نام به آنها پرداخت می‌کنید — دیگر خبری از کپی کردن نشانی نیست.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "‏DashPay نشانی‌های بلند و نامفهوم را با نام کاربری جایگزین می‌کند. دوستان را به‌عنوان مخاطب بیفزایید، به یک نام پول بفرستید و هر پرداخت را بر اساس شخص مرتب نگه دارید.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "مهلت نامعلوم";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "ارسال واریز";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "مسیر اشتقاق";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "غیرفعال";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "قطع اتصال به حساب کوین‌بیس";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "انجام شد";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "انجام شد — موجودی شما به اندازه کافی مانده است";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "نشانی را دوباره بررسی کنید";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "برای هر دعوت، مبلغی اختصاص می‌یابد تا دریافت‌کننده بتواند نام کاربری‌اش را در شبکه دش ایجاد کتد.";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "هر مسترنود در هر رقابت یک رأی معتبر دارد. می‌توانید بعداً آن را تغییر دهید، اما Dash Platform در هر رقابت تنها ۵ رأی در مجموع برای هر مسترنود اجازه می‌دهد.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "هر ضربه یک گره دیگر را به رأی‌گیری می‌افزاید، پس خودتان انتخاب می‌کنید چند تا را به هم پیوند دهید.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "قدیمی‌تر";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "با چند کلیک ساده، به راحتی دش را سپرده‌گذاری کرده و درآمدی جانبی برای خودتان ایجاد کنید. ";
+
+/* SPV diagnostics */
+"Edit birth height" = "ویرایش ارتفاع آغاز";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "ویرایش پروفایل";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "ایمیل";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "فعال‌سازی";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "فعال‌سازی DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "فعال‌سازی DashPay یک کارمزد شبکه کوچک و یک‌باره دارد که از موجودی اعتباری هویت شما پرداخت می‌شود. برآورد دقیق پیش از تأیید نشان داده می‌شود. فرستادن درخواست تماس و پرداخت، کارمزدهای معمول شبکه را دارد.";
+
+"Ending soonest" = "زودتر از همه پایان می‌یابد";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "کارمزد شبکه برآوردی";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "همه گره‌ها با هم رأی می‌دهند. سریع‌تر است، اما مسترنودهای شما را به‌صورت عمومی به هم پیوند می‌زند.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "کلیدهای اپراتور Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "برون‌بری گزارش‌ها";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "نشانی بیرونی";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "ناموفق";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "در حال دریافت…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "فیلتر";
+
+/* SPV sync phase */
+"Filter headers" = "سرآیندهای فیلتر";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "کاربری را در شبکه دش بیابید";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "یافتن هویت‌ها";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "پین کد را فراموش کردید؟";
 
+/* Identities */
+"Found %d new identities" = "‏%d هویت جدید پیدا شد";
+
+/* Identities */
+"Found 1 new identity" = "۱ هویت جدید پیدا شد";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "نام کاربری‌تان را از موجودی محافظت‌شده تأمین کنید. چند ساعت پیش‌تر وجه را بیفزایید — این توقف کوتاه، نام کاربری‌تان را از دیگر دش‌هایتان غیرقابل‌پیوند نگه می‌دارد.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "از موجودی محافظت‌شده تأمین شد — نام کاربری‌تان به دیگر دش‌هایتان پیوند نمی‌خورد.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "وجوه قفل شد — در حال تکمیل انتقال";
+
+/* CoinJoin */
+"Funds moved" = "وجوه منتقل شد";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "با سپرده‌گذاری در مسترنودهای دش، حتی به میزان ۰.۵ دش، پاداش دریافت کنید. ";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "دریافت قیمت تخمینی";
+
+/* Usernames */
+"Get ready to join DashPay" = "برای پیوستن به DashPay آماده شوید";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "دریافت آنی پاداش";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "متوجه شدم";
+
+/* Governance */
+"Governance" = "حاکمیت";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "دریافت اجازه استفاده از جی‌پی‌اس به منظور نمایش موقعیت‌های نزدیک به شما";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "درخواست کرده دوست شما باشد";
+
+/* DashPay Invitations */
+"Have an invitation?" = "دعوتنامه دارید؟";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "کنترل بیشتری روی کیف پول‌تان داشته باشید و آن را بر اساس نیازهایتان، تغییر دهید. ";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "سرآیندها";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "ارتفاع %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "زیاد به کم";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "کارمزدهای بالاتر حدود ۷ سنت (باز هم کمتر از بلاک‌چین‌های دیگر با حریم خصوصی مشابه)";
+
 /* No comment provided by engineer. */
 "History" = "سابقه";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "چگونه تست دش دریافت کنم؟ ";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "از نظر حریم خصوصی در مقایسه با بیت‌کوین چگونه است؟";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "از نظر حریم خصوصی در مقایسه با حساب‌های اتریوم چگونه است؟";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "‏DashPay چقدر خصوصی است؟";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "چطور نشانی ای‌پی‌آی دش‌تان را تائید کنید";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "عبارت بازیابی را نوشتم";
 
+/* Identities */
+"Identities" = "هویت‌ها";
+
 /* Voting */
 "Identity" = "هویت";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "اعتبارهای هویت";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "نمایه هویت";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "ثبت هویت";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "شارژ هویت";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "غیرفعال";
+
+/* No comment provided by engineer. */
 "Income" = "درآمد";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "ورودی %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "ورودی %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "ورودی‌ها (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "موجودی ناکافی";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "کارمزد دعوت";
 
+/* DashPay Invitations */
+"Invitation from %@" = "دعوتنامه از %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "دعوتنامه‌های استفاده شده توسط";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "دعوت";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "کسی را به شبکه دش دعوت کنید";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "با جستجوی نام‌های کاربری، دوستان‌تان را بیابید و اعضای خانواده‌تان را دعوت کنید.";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "دوستان و اعضای خانواده‌تان را به شبکه دش دعوت کنید";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "دوستان و خانواده‌تان را به شبکه دش دعوت کنید";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "پیوستن به مجموعه";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "این سکه‌ها را خصوصی نگه دارید. کارمزد شبکه و کارمزد حریم خصوصی اعمال می‌شود.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "عبارت بازیابی را در جایی امن نگه دارید.";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "کلید #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "داده کلید";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "مالکیت کلید";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "کلیدها";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "پیشتاز";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "بیشتر بدانید";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "در حال بارگذاری تراکنش‌ها";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "واحد پول محلی";
 
+/* Identities */
+"Local Only" = "فقط محلی";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "موقعیت";
 
+"Lock" = "قفل";
+
+"Lock the name" = "قفل کردن نام";
+
+"Lock “%@” so nobody gets it" = "«%@» را قفل کن تا هیچ‌کس آن را نگیرد";
+
 /* No comment provided by engineer. */
 "Locked" = "قفل‌شده";
 
+"Locked — nobody receives this username" = "قفل‌شده — هیچ‌کس این نام کاربری را نمی‌گیرد";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "ورود به حساب";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "پائین";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "کارمزد کم برای خرج روزمره";
+
 /* Voting */
 "Low to high" = "م به زیاد";
+
+/* Identities — the wallet's main identity */
+"Main" = "اصلی";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "آی‌پی‌ آدرس مسترنود";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "جاکلیدی مسترنود";
+
+/* Masternode keys */
 "Masternode keys" = "کلیدهای مسترنود";
+
+/* SPV sync phase */
+"Masternode list" = "فهرست مسترنودها";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "به‌روزرسانی مسترند";
 
+"Masternode votes" = "رأی‌های مسترنود";
+
 /* Voting */
 "Masternode Voting Key" = "کلید رای‌گیری مسترنود";
+
+/* Tools menu */
+"Masternodes" = "مسترنودها";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "مسترنودها و evonodeهایی که با کلیدهای این کیف پول ثبت شده‌اند پس از همزمان‌سازی کیف پول اینجا نمایان می‌شوند.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "مسترنودها و evonodeهایی که از کلیدهای این کیف پول استفاده می‌کنند";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "مسترنودها به نام‌هایی رأی می‌دهند که بیش از یک نفر خواسته است. پس از پایان رأی‌گیری به شما اطلاع داده می‌شود.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "حداکثر";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "حداقل تأمین شد";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "مدیریت بیشتر";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "پیشنهادهای بیشتر";
+
+"Most lock votes" = "بیشترین رأی قفل";
+
+"Most votes" = "بیشترین رأی";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "حرکت دهید و روی عکس‌تان زوم کنید تا بهترین حالت را بیابید";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "به موجودی عادی قابل‌خرج منتقل کنید.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "در حال انتقال وجوه";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "نام";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "سرویس‌های نام مانند Unstoppable Domains یک نام خوانا را به یک نشانی عمومی ثابت روی زنجیره نگاشت می‌کنند. هر کسی می‌تواند آن نام را بازگشایی کند و همه پرداخت‌هایی را که تا کنون به آن انجام شده ببیند. نام کاربری DashPay هرگز به‌صورت عمومی به نشانی پرداخت بازگشایی نمی‌شود — نشانی‌ها فقط درون تبادل رمزگذاری‌شده با هر مخاطب فاش می‌شوند، بنابراین نام و پول شما برای ناظران بیرونی بی‌ارتباط می‌ماند.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "نیازمند توجه";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "هیچ گزارش تشخیصی روی این دستگاه پیدا نشد. گزارش‌ها از اجرای بعدی نوشته می‌شوند.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "بدون هویت";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "هنوز مسترنودی نیست";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "رقابت منطبقی نیست";
+
+/* Identities */
+"No new identities were found for this wallet" = "هویت جدیدی برای این کیف پول پیدا نشد";
+
+"No open contest matches that search." = "هیچ رقابت بازی با این جستجو منطبق نیست.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "هیچ رقابت بازی با این جستجو منطبق نیست. نام‌ها به شکل هنجارشده ذخیره می‌شوند، پس «alice» به‌صورت «a11ce» فهرست می‌شود.";
+
+"No open contests" = "رقابت بازی نیست";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "برای کیف پول مرتبط، ردیف ذخیره‌شده‌ای پیدا نشد.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "هنوز نشانی Platform برای ثبت محافظت‌شده جایگزین در دسترس نیست. پس از پایان همزمان‌سازی کیف پول دوباره تلاش کنید.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "هیچ نتیجه‌ای یافت نشد";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "هم‌اکنون هیچ نام کاربری‌ای مورد رقابت نیست. رقابت زمانی باز می‌شود که دو نفر یا بیشتر یک نام را بخواهند.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "هیچ رایی باقی نمانده است. ";
+
+"No votes were cast" = "هیچ رأیی ثبت نشد";
+
+"Nobody gets it" = "هیچ‌کس آن را نمی‌گیرد";
+
+/* SPV sync peer type */
+"Node" = "گره";
+
+/* Raw transaction inspector */
+"Non-standard" = "غیر استاندارد";
 
 /* adjective, security level */
 "None" = "هیچ کدام";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "در دسترس نیست";
 
+"Not available yet" = "هنوز در دسترس نیست";
+
+"Not cast" = "ثبت نشده";
+
+/* Masternodes */
+"Not checked yet" = "هنوز بررسی نشده";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "موجودی محافظت‌شده برای ثبت هویت کافی نیست";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "در تاریخچه کیف پول نیست";
+
+"Not now" = "الان نه";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "پذیرش گسترده‌ای نزد فروشندگان ندارد";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "هنوز پذیرش گسترده‌ای نزد فروشندگان ندارد";
+
+/* Masternode keys */
+"Not yet used" = "هنوز استفاده نشده";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "از قدیم به جدید";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "در بیت‌کوین لایه نام وجود ندارد، پس مردم نشانی‌ها را آشکارا به اشتراک می‌گذارند و دوباره به کار می‌برند — همین‌که نشانی‌ای شناخته شود، هر چه تا کنون دریافت کرده به مالکش قابل پیوند است. در DashPay نام کاربری شما عمومی است اما هرگز به نشانی پرداخت اشاره نمی‌کند: نشانی‌ها به‌صورت خصوصی برای هر مخاطب تبادل می‌شوند و می‌چرخند، پس پرداخت با نام آشکار نمی‌کند پول شما کجا می‌رود. هر دو زنجیره شفاف‌اند، پس تحلیل زنجیره همچنان درباره خود سکه‌ها برقرار است.";
+
+/* Identities */
+"On Network" = "روی شبکه";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "به‌محض اینکه %@ درخواستتان را بپذیرد می‌توانید مستقیماً به نام کاربری پرداخت کنید";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "هر بار یک گره";
 
 /* Voting */
 "One vote left" = "فقط یک رای باقی مانده است. ";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "فقط تکراری‌ها";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "تنها مسترنودها و evonodeها می‌توانند به نام‌های کاربری رأی دهند. این کیف پول کلید رأی‌گیری مسترنود فعالی ندارد.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "فقط درخواست‌ها با لینگ";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "اپراتور";
+
+/* Masternode keys */
+"Operator keys" = "کلیدهای اپراتور";
+
+/* Masternodes */
+"Operator public key (BLS)" = "کلید عمومی اپراتور (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "یا";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "پیش‌نمایش سفارش";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "نتایج دیگر";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "خروجی %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "خروجی‌ها (%d)";
+
+/* Masternodes */
+"Owner" = "مالک";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "نشانی مالک";
+
+/* Masternodes */
+"Owner key hash" = "درهم‌سازی کلید مالک";
 
 /* Owner keys */
 "Owner keys" = "کلیدهای مالک";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "از موجودی اعتباری هویت شما پرداخت می‌شود.";
 
 /* DashSpend */
 "Password" = "گذرواژه";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "پیوند دعوتی را که دریافت کرده‌اید بچسبانید یا کد QR آن را اسکن کنید. هزینه ثبت نام کاربری‌تان را تأمین می‌کند.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "نشانی اینترنتی را اینجا بچسبانید";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "به شکلی ساده و سریع مبلغی را پرداخت یا دریافت کنید";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "مستقیماً به نام کاربری پرداخت کنید";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "به آدم‌ها پرداخت کنید، نه به نشانی‌ها";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "بار داده (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "روش پرداخت";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "پرداخت‌ها خصوصی هستند: نشانی‌هایی که با یک مخاطب تبادل می‌کنید درون بار رمزگذاری‌شده‌ای جابه‌جا می‌شوند که تنها شما دو نفر می‌توانید بخوانید و هرگز منتشر نمی‌شوند — پس پرداخت‌هایتان به‌سادگی به نام کاربری‌تان پیوند نمی‌خورد. با این حال اینها همچنان پرداخت‌های معمولی روی زنجیره‌ای شفاف‌اند: تحلیل پیشرفته زنجیره ممکن است اطلاعاتی را فاش کند. Shielded DashPay (به‌زودی) این شکاف را خواهد بست. خودِ درخواست‌های تماس در حال حاضر خصوصی نیستند: هر کسی می‌تواند ببیند دو هویت به هم متصل‌اند. درخواست‌های تماس خصوصی قابلیتی است که به‌زودی می‌آید. نام کاربری و نمایه شما نیز روی Dash Platform عمومی است.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "پرداخت‌ها با InstantSend در چند ثانیه تأیید می‌شوند";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "پرداخت‌هایی که مستقیماً به نشانی‌ها انجام شوند در فعالیت نگهداری نمی‌شوند.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "پرداخت‌ها با هر مخاطب در یک جا گرد می‌آیند، با نام و نمایه به‌جای تراکنش‌های خام.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "نشانی پرداخت";
 
 /* CrowdNode */
 "Payout Options" = "گزینه‌های پاداش";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "نشانی Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "موجودی Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "گره Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "شناسه گره Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "پرداخت‌های Platform فرستنده را مشخص نمی‌کنند. این پرداخت زمانی ثبت شد که کیف پول تغییر موجودی را دید — ممکن است پیش‌تر رسیده باشد.";
+
+"Platform SDK not ready" = "‏SDK پلتفرم آماده نیست";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "همزمان‌سازی Platform در حال اجرا نیست. برای آغاز آن، اطلاعات همزمان‌سازی ← وضعیت همزمان‌سازی Platform را باز کنید.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform ← محافظت‌شده";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "مشاهده دعوتنامه";
 
+/* Masternode keys */
+"Previously used at: " = "پیش‌تر استفاده شده در: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "قیمت‌ها متعلق به حداقل ۳۰ دقیقه یش است. قیمت‌های پول رسمی شاید درست نباشد. ";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "خصوصی از پایه";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "درخواست‌های تماس خصوصی (تا اینکه با چه کسی در ارتباطید خصوصی بماند)، Shielded DashPay — پرداخت به مخاطبان از موجودی محافظت‌شده خصوصی‌تان — و پرداخت به کاربرانی که هنوز در مخاطبانتان نیستند، همگی به‌زودی می‌آیند.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "درخواست‌های تماس خصوصی در دست توسعه‌اند و حدود شهریور–مهر ۱۴۰۵ (سپتامبر–اکتبر ۲۰۲۶) انتظار می‌روند. امروز خودِ درخواست عمومی است — هر کسی می‌تواند ببیند دو هویت به هم متصل‌اند، حتی اگر جزئیات پرداخت درون آن رمزگذاری شده باشد. پس از عرضه درخواست‌های تماس خصوصی، می‌توانید انتخاب کنید دوستی‌تان عمومی باشد یا خصوصی.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "درخواست‌های تماس خصوصی، Shielded DashPay و پرداخت به افرادی که هنوز مخاطب شما نیستند.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "نشانی‌های پرداخت خصوصی میان شما و مخاطبانتان تبادل می‌شوند. تنها شما و مخاطبتان گیرنده و فرستنده پرداخت‌های میان خودتان را می‌دانید.";
+
+/* DashPay intro: feature title */
+"Private payments" = "پرداخت‌های خصوصی";
+
+/* Usernames */
+"Private registration" = "ثبت خصوصی";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "زمان پردازش";
+
+/* Balance info sheet section */
+"Pros" = "مزایا";
 
 /* CrowdNode Portal */
 "Protect your savings" = " از پس‌اندازهایتان محافظت کنید";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "تراکنش‌های ارائه‌دهنده";
+
+/* Masternode keys */
+"Public key" = "کلید عمومی";
+
+/* Masternode keys */
+"Public key (legacy)" = "کلید عمومی (قدیمی)";
+
+/* Identities */
+"Public keys" = "کلیدهای عمومی";
+
 /* No comment provided by engineer. */
 "Public URL" = "نشانی اینترنتی عمومی";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "عملیات خرید ناموفق بود";
+
+/* Identities: what a public key is used for */
+"Purpose" = "هدف";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "تراکنش خام";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "تراکنش خام در دسترس نیست";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "فیلترهای فشرده بلاک را از ارتفاع انتخابی برای یافتن تراکنش‌های این کیف پول دوباره بررسی می‌کند و آنها را دوباره دانلود و تطبیق می‌دهد. بازپویش‌ها به ارتفاع ساخت کیف پول و داده‌های زنجیره ذخیره‌شده محلی محدودند — برای بازیابی تاریخچه پایین‌تر از آن، به‌جای این کار ارتفاع آغاز کیف پول را کاهش دهید.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "شرایط برداشت را بخوانید";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "فقط‌خواندنی";
+
+/* Usernames */
+"Ready around %@" = "حدود %@ آماده می‌شود";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "دلیل";
 
 /* No comment provided by engineer. */
 "Receive" = "دریافت";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "دریافت از";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "دریافت‌شده از %@";
+
 /* CrowdNode */
 "Receiving rewards" = "دریافت پاداش";
+
+"Records your masternodes as having voted, without taking a side." = "مسترنودهای شما را به‌عنوان رأی‌داده ثبت می‌کند، بدون جانبداری.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "به‌روزرسانی";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "ثبت‌شده در";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "ثبت خصوصی دست‌کم %@ دش در موجودی محافظت‌شده و چند ساعت زمان توقف نیاز دارد — صفحه‌های بعدی شما را راهنمایی می‌کنند.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "ثبت";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "این نام را می‌خواهد";
+
 /* An action */
 "Rescan" = "اسکن دوباره";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "کیف پول‌های بازیابی‌شده همیشه نمی‌توانند نوع عملیات را بازیابی کنند. این مورد از داده‌های یادداشت روی زنجیره بازسازی شده است.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "نتایج";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "همزمان‌سازی مجدد از ارتفاع %u آماده شد — برنامه را ببندید و دوباره باز کنید تا آغاز شود.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "تاریخچه تراکنش‌های مشترک را نگه دارید";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "بازنشسته";
 
 /* No comment provided by engineer. */
 "Retry" = "تلاش دوباره";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "ابطال";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "اسکریپت";
+
+/* Raw transaction inspector */
+"Script signature" = "امضای اسکریپت";
+
+/* Raw transaction inspector */
+"Script type" = "نوع اسکریپت";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "جستجوی مخاطب";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "جستجوی درخواست تماس";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "جستجوی کاربر در شبکه دش";
+
+/* No comment provided by engineer. */
+"Search for a username" = "جستجوی نام کاربری";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "نتایج جستجو برای \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "جستجوی نام‌های کاربری";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "در حال جستجوی نام کاربری %@ در شبکه دش";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "کیف پول‌تان را امن کنید";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "سطح امنیتی";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "سطح امنیت";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "یک سرویس را برای خرید، فروش، تبدیل یا انتقال دش انتخاب کنید";
 
+"Select all" = "انتخاب همه";
+
 /* DashSpend denomination selection */
 "Select amount" = "مبلغ را انتخاب کنید";
+
+"Select at least one masternode to vote with." = "دست‌کم یک مسترنود برای رأی دادن انتخاب کنید.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "یک رمزارز انتخاب کنید";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "انتخاب گره‌های کمتر، کمتر آشکار می‌کند که چه مسترنودهایی را اداره می‌کنید.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "خرید نهایی خودکار";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "ارسال به";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "ارسال به یک مخاطب";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "به نام کاربری‌ای بفرستید که واقعاً بتوانید به یاد بسپارید و راستی‌آزمایی کنید.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "ارسال به نشانی";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "نخستین درخواست تماس‌تان را بفرستید";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "در حال ارسال";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "در حال فرستادن درخواست تماس";
+
+/* No comment provided by engineer. */
+"Sending to" = "ارسال به";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "ارسال به حساب کراودنود";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "ارسال شد به";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "ارسال‌شده به %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "سرویس";
+
+/* Identities */
+"Set as Main" = "تنظیم به‌عنوان اصلی";
+
+/* Identities */
+"Set as Main Identity" = "تنظیم به‌عنوان هویت اصلی";
 
 /* No comment provided by engineer. */
 "Set PIN" = "پین کد را تعیین کنید";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "به اشتراک‌گذاری کلید";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "استخر حریم خصوصی مشترک در کمینه اندازه";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "نشانی محافظت‌شده";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "خرج محافظت‌شده";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "در حال راه‌اندازی کیف پول محافظت‌شده…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "محافظت‌شده ← Platform";
+
+"Shielded → Transparent" = "محافظت‌شده ← شفاف";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "اندازه";
+
 /* No comment provided by engineer. */
 "Skip" = "رد کردن";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "شاید برخی از مسترنودهای شما در این فهرست نباشند — کیف پول نتوانست مجموعه کامل کلیدهای رأی‌گیری شما را بخواند. همزمان‌سازی را کامل کنید و این صفحه را دوباره باز کنید.";
 
 /* Usernames */
 "Some usernames can be blocked" = "برخی از نام‌های کاربری ممکن است بلاک شوند";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "مرتب کردن بر اساس";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "مرتب‌سازی مخاطبان";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "بار داده ویژه";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "مبلغ را مشخص کنید";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "سپرده‌گذاری";
 
+/* Usernames */
+"Starts after you add funds" = "پس از افزودن وجه آغاز می‌شود";
+
+/* Transaction details */
+"Status" = "وضعیت";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "ذخیره‌شده به‌صورت";
 
 /* Voting */
 "Submit" = "ثبت";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "فرآیند همزمان‌سازی در جریان است...نتایج شاید کامل نباشد. ";
 
+/* No comment provided by engineer. */
+"Sync Info" = "اطلاعات همزمان‌سازی";
+
+/* SPV sync */
+"Sync too slow?" = "همزمان‌سازی خیلی کند است؟";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "جانب هیچ‌کس را نگیر";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "روی نشانی موجود در کلیپ‌برد لمس کنید تا چسبانده شود";
+
+/* Raw transaction inspector */
+"Tap to copy" = "برای کپی ضربه بزنید";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "مخفی کردن موجودی";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "به صورت موقت در دسترس نیست";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "کلید گره Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "کد وارد شده درست نیست. لطفا دوباره آن را بررسی کرده و وارد کنید! ";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "پس از آنکه شبکه برداشت را پردازش کند دش به نشانی گیرنده می‌رسد — این کار می‌تواند تا ۱۰ دقیقه طول بکشد.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "به‌محض اینکه شبکه برداشت را پردازش کند دش به نشانی گیرنده می‌رسد.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "به‌محض اینکه شبکه برداشت را پردازش کند دش به موجودی شفاف شما می‌رسد.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "لینکی که فرستادید فقط برای مالکان شبکه قابل مشاهده خواهد بود.";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "هویت اصلی را تنها می‌توان از کیف پول فعال انتخاب کرد";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "خصوصی‌ترین جا برای نگهداری دش‌های شما";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "ردیف ذخیره‌شده کیف پول شبکه ندارد — نمی‌توان همزمان‌سازی مجدد را آماده کرد.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "ثبت ارسال شد اما نتیجه‌اش تأیید نشد. یک دقیقه صبر کنید تا کیف پول همزمان شود، سپس دوباره تلاش کنید — بلافاصله دوباره ارسال نکنید.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "استخر حریم خصوصی مشترک هنوز در حال رشد است (%1$ld از %2$ld واریز). ثبت خصوصی با رسیدن به حداقل باز می‌شود.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "استخر حریم خصوصی مشترک هنوز در حال رشد است (%1$ld از %2$ld واریز). با رسیدن به حداقل دوباره تلاش کنید.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "ارتفاع ساخت کیف پول — کف پویش فیلترها و بازپویش‌های «از زمان ساخت کیف پول». آن را برابر یا پایین‌تر از نخستین تأمین وجه کیف پول تنظیم کنید؛ درون‌ریزی‌ها به‌صورت پیش‌فرض روی mainnet از ۲۰۰۰۰۰ و روی testnet از ۰ استفاده می‌کنند. ذخیره ارتفاعی برابر یا کمتر از ارتفاع کنونی، داده‌های زنجیره این شبکه را در اجرای بعدی پاک می‌کند و از آنجا بازپویش می‌کند.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "او (در حال دریافت اطلاعات)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "اعلان جدیدی نیست";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "هیچ تراکنشی برای نمایش وجود ندارد";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "کاربری با نام %@ مطابقت ندارد";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "در مخاطبان شما کاربری با نام %@ مطابقت ندارد";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "این وجوه به موجودی Platform شما می‌روند و به‌محض تکمیل انتقال آماده خرج‌اند.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "این نشانی را نمی‌توان از موجودی %@ شما پرداخت کرد";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "این کار دو کلید به هویت شما می‌افزاید تا کاربران دیگر بتوانند برایتان درخواست تماس بفرستند و شما هم بتوانید درخواست‌های آنها را بپذیرید. این تنها یک بار رخ می‌دهد.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "این کار یک انتخاب را روی هر %d نام کاربری انتخاب‌شده اعمال می‌کند.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "این گام اضافه نشان می‌دهد واقعا خودتان قصد انجام این تراکنش را دارید. ";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "این پیوند دعوت معتبر نیست.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "این یک نشانی معتبر دش برای این شبکه نیست";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "این یک پیوند دعوت معتبر نیست";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "این هویت اصلی شماست";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "این مسترنود هنوز هویت Platform ندارد.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "این رقم نشانگر درصد بازدهی سالانه یک مسترنود منهای کارمزد ۱۵ درصدی کراودنود است. این نرخ بازگشت سرمایه تضمینی نیست و ممکن است بر اساس تعداد حاضران در کراودنود و قیمت دش پائین و بالا رود. ";
 
+"This still counts as your masternodes having voted in this contest." = "این همچنان به‌عنوان رأی دادن مسترنودهای شما در این رقابت به شمار می‌آید.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "بایت‌های خام این تراکنش روی این دستگاه ذخیره نشده‌اند.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "این نام کاربری به شخص دیگری رسید";
+
+"This wallet could not derive the voting key for this node." = "این کیف پول نتوانست کلید رأی‌گیری این گره را اشتقاق دهد.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "این کیف پول کلید رأی‌گیری مسترنود فعالی ندارد، پس نمی‌تواند رأی دهد. گره‌های ثبت‌شده در ابزارها ← مسترنودها نمایان می‌شوند.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "این کار کل موجودی Platform شما را در یک انتقال برداشت می‌کند. به‌محض اینکه شبکه برداشت را پردازش کند دش به نشانی گیرنده می‌رسد.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "این کار کل موجودی Platform شما را در یک انتقال برداشت می‌کند. به‌محض اینکه شبکه برداشت را پردازش کند دش به موجودی شفاف شما می‌رسد.";
 
 /* Send Screen: to address */
 "to" = "به";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "سابقه تراکنش‌ها";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "تاریخچه تراکنش‌ها در دسترس نیست";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "شناسه تراکنش";
 
 /* A verb, button title. */
 "Transfer" = "انتقال";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "انتقال ورودی";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "انتقال خروجی";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "انتقال‌ها بیشتر طول می‌کشند — ساخت اثبات‌های حریم خصوصی زمان می‌برد";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "انتقال به دیگر نشانی‌های Platform و نشانی‌های محافظت‌شده آنی و نهایی است";
+
+/* Balance breakdown */
+"Transparent" = "شفاف";
+
+/* Send screen destination type */
+"Transparent address" = "نشانی شفاف";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "موجودی شفاف";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "تأمین شفاف، نام کاربری‌تان را به‌صورت عمومی به این وجوه پیوند می‌زند.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "شفاف ← Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "شفاف ← محافظت‌شده";
 
 /* An action */
 "Try again" = "دوباره تلاش کنید";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "ارائه پیشنهاد ممکن نیست";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "نوع ویژه ناشناخته %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "محافظت‌نشده";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "ارتقا به Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "آپهولد";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "به‌جای آن از موجودی شفاف استفاده کن";
+
+/* Masternode keys */
+"Used" = "استفاده‌شده";
+
+/* Masternode keys */
+"Used at: " = "استفاده‌شده در: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "کاربر (در حال دریافت اطلاعات)";
 
 /* Voting */
 "Username" = "نام کاربری";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "نام‌های کاربری";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "نام‌های کاربری برای جلوگیری از نام‌های شبیه‌به‌هم به شکل هنجارشده ذخیره می‌شوند، پس ممکن است با آنچه هر کس تایپ کرده متفاوت باشد.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "نام کاربری، نه نشانی";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "کاربرانی که با %@ مطابقت دارند و هم‌اکنون در مخاطبان شما نیستند";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "از یکی از بیشترین کتابخانه‌های دانش‌صفر ممیزی‌شده و آزموده‌شده (Orchard) استفاده می‌کند";
+
+/* DashPay Invitations */
+"Valid invitation" = "دعوتنامه معتبر";
+
 /* CrowdNode Portal */
 "Validating address…" = "در حال اعتبارسنجی نشانی...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "نیازمند تائید";
 
+/* Usernames */
+"Verified during registration" = "هنگام ثبت راستی‌آزمایی شد";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "با موفقیت تائید شد";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "احراز هویت کنید";
 
+/* Raw transaction inspector */
+"Version" = "نسخه";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "بسیار کارآمد با کارمزد کم";
+
 /* adjective, security level */
 "Very High" = "بسیار بالا";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "یک مبلغ جزئی دش از کراودنود به این حساب فرستاده می‌شود تا از اینکه شما صاحب این نشانی هستید اطمینان حاصل شود. ";
+
+/* No comment provided by engineer. */
+"View All" = "مشاهده همه";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "مشاهده عبارت بازیابی";
 
+/* Raw transaction inspector */
+"View Transaction" = "مشاهده تراکنش";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "رأی";
+
+"Vote cast" = "رأی ثبت شد";
+
 /* Voting */
 "Vote for All" = "رای‌دهی برای همه";
 
 /* Voting */
+"Vote on contested usernames" = "به نام‌های کاربری مورد رقابت رأی دهید";
+
+"Vote on several" = "رأی به چند مورد";
+
+/* Voting */
 "Vote to Approve" = "رای‌گیری برای تائید";
+
+"Vote with" = "رأی دادن با";
+
+"Votes that nobody should receive these usernames." = "رأی می‌دهد که هیچ‌کس این نام‌های کاربری را نگیرد.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "نشانی رأی‌گیری";
+
+"Voting ended with no winner" = "رأی‌گیری بدون برنده پایان یافت";
+
+"Voting ends" = "پایان رأی‌گیری";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "رأی‌گیری در جریان است";
+
+"Voting in progress — lock votes are ahead" = "رأی‌گیری در جریان است — رأی‌های قفل جلوترند";
+
+"Voting in progress — you are ahead" = "رأی‌گیری در جریان است — شما جلوترید";
 
 /* Usernames */
 "Voting is only required in some cases" = "در برخی موارد، نیاز به رای‌گیری است";
 
+/* Masternodes */
+"Voting key hash" = "درهم‌سازی کلید رأی‌گیری";
+
 /* Voting keys */
 "Voting keys" = "کلیدهای رأی‌دهی";
+
+"Voting on this username has closed. The counts below are the last ones read." = "رأی‌گیری درباره این نام کاربری بسته شده است. شمارش‌های زیر آخرین مقادیر خوانده‌شده‌اند.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "رأی‌گیری درباره «%@» پیش‌تر بسته شده است. برای دیدن نتیجه به‌روزرسانی کنید.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "در انتظار Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "نشانی کیف پول";
+
+/* SPV diagnostics */
+"Wallet birth height" = "ارتفاع آغاز کیف پول";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "کیف پول غیرفعال شد";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "به دش‌پی خوش آمدید";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "‏Unstoppable Domains و سرویس‌های نام مشابه چطور؟";
+
+/* DashPay FAQ */
+"What does it cost?" = "هزینه‌اش چقدر است؟";
+
+/* DashPay FAQ */
+"What is DashPay?" = "‏DashPay چیست؟";
+
 /* Usernames */
 "What is username voting?" = "رای‌گیری نام کاربری چیست؟";
+
+/* DashPay FAQ */
+"What's coming next?" = "بعد از این چه می‌آید؟";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "درخواست‌های تماس کِی خصوصی می‌شوند؟";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "کجا خرج کنیم؟ ";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "کجا خرج کنیم؟ ";
+
+"Who is requesting this name" = "چه کسی این نام را می‌خواهد";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "چرا باید آن را فعال کنم؟";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "چرا همه این تراکنش‌ها را می‌بینم؟ ";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "درخواست برداشت صورت گرفته است";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "کل موجودی را برداشت می‌کند";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "با هر کیف پول، صرافی و فروشنده دش کار می‌کند";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "دیروز";
+
+"You" = "شما";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "شما درخواست تماس از %@ را پذیرفتید";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "در حال حاضر هیچ مخاطبی ندارید";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "موجودی‌تان برای انجام این تراکنش، کافی نیست";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "از حد تعریف‌شده در کوین‌بیس فراتر رفتید.";
+
+/* Usernames */
+"You have %@ Dash so far" = "تا کنون %@ دش دارید";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "شما درخواست تماس را برای %@ فرستادید";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "موجودی دش ولت شما باید مثبت باشد";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "این نام کاربری را بردید";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "همه چیز آماده است. کاربران دیگر حالا می‌توانند برایتان درخواست تماس بفرستند — و شما هم می‌توانید درخواست‌های خود را بفرستید.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "هویت Dash Platform شما به‌محض ثبت نام کاربری اینجا نمایان می‌شود.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "ایمیل‌تان فقط برای ارسال گذرواژه یک‌بارمصرف استفاده می‌شود. ";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "تاریخچه شما، مرتب‌شده";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "هویت شما به دو کلید اضافی نیاز دارد تا درخواست‌های تماس میان شما و کاربران دیگر رمزگذاری شود. فعال‌سازی آنها را با یک تراکنش شبکه می‌افزاید. این تنها یک بار رخ می‌دهد.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "دعوتنامه شما هزینه ثبت این نام کاربری را می‌پردازد.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "موجودی اصلی دش شما روی بلاک‌چین Core — همان چیزی که با کیف پول‌ها، صرافی‌ها و فروشندگان دیگر می‌فرستید و می‌گیرید.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "سکه‌های ترکیب‌شده شما به موجودی کیف پول دش منتقل شد.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "سکه‌های ترکیب‌شده شما به موجودی محافظت‌شده منتقل شد. برای بهترین حریم خصوصی، دست‌کم ۲ ساعت پیش از استفاده از این وجوه صبر کنید.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "موجودی Platform شما";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "نشانی اصلی دش شما که از آن در حال حاضر برای حساب کراودنود  استفاده می‌کنید. ";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "موجودی خصوصی شما. مبالغ و نشانی‌ها روی زنجیره رمزگذاری می‌شوند، پس دارایی‌ها و تاریخچه شما محرمانه می‌مانند.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "جلسه شما به اتمام رسید. ";
+
+/* Usernames */
+"Your Shielded balance" = "موجودی محافظت‌شده شما";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "موجودی محافظت‌شده شما تقریباً آماده است — حدود %@ می‌توانید به‌صورت خصوصی ثبت کنید.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "موجودی محافظت‌شده شما آماده است — همین حالا نام کاربری‌تان را خصوصی ثبت کنید";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "موجودی محافظت‌شده شما در حال توقف است — حدود %@ می‌توانید به‌صورت خصوصی ثبت کنید";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "موجودی محافظت‌شده شما هنوز در حال رسیدن است. حدود %@ آماده می‌شود.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "موجودی شفاف شما";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "نام کاربری شما برای همه دیدنی است. تأمین آن از موجودی محافظت‌شده — پس از آنکه وجوه چند ساعت بمانند — یعنی هیچ‌کس نمی‌تواند نام کاربری‌تان را به دیگر دش‌هایتان پیوند دهد.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "نام کاربری، نمایه و مخاطبان شما به این هویت وابسته‌اند.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "نام کاربری، نمایه و مخاطبان شما به این هویت وابسته خواهند بود.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "رای‌تان لغو شد";
 
 /* Voting */
 "Your vote was submitted" = "رای‌تان ثبت شد";
 
+"Your votes" = "رأی‌های شما";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "کیف پول‌تان اکنون امن است. هر گاه خواستید می‌توانید از این عبارت بازیابی برای بازگرداندن حساب‌تان روی دستگاهی دیگر استفاده کنید. ";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "کیف پول شما هنوز با شبکه دش همزمان می‌شود. ارسال پس از پایان همزمان‌سازی در دسترس خواهد بود.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "کیف پول شما هنوز همزمان می‌شود. ارسال از موجودی شفاف پس از پایان همزمان‌سازی در دسترس خواهد بود.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ذن‌لجر";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "«%@» به‌عنوان نام کاربری دش خوانده نشد.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» ثبت شد. برای کسی که شما را دعوت کرده درخواست تماس فرستاده شود؟";

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "همه گره‌ها یکجا";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "همه مسترنودهای شما به این نام کاربری رأی داده‌اند. برای تغییر رأی، از داوطلبی که اکنون ترجیح می‌دهید دوباره رأی دهید.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "همه مسترنودهای شما به این نام کاربری رأی داده‌اند. برای تغییر رأی، به داوطلبی که اکنون ترجیح می‌دهید دوباره رأی دهید.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/fa.lproj/Localizable.stringsdict
+++ b/DashWallet/fa.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ برای «%2$@» شمرده شد</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u رأی</string>
+			<key>other</key>
+			<string>%1$u رأی</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>به %1$d از %#@names@ رأی داده شد</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d نام کاربری</string>
+			<key>other</key>
+			<string>%2$d نام کاربری</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>دادن %u رأی</string>
+			<key>other</key>
+			<string>دادن %u رأی</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d از %#@nodes@ رأی دادند</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d مسترنود</string>
+			<key>other</key>
+			<string>%2$d مسترنود</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d از %#@nodes@ رأی دادند</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d گره</string>
+			<key>other</key>
+			<string>%2$d گره</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>در مجموع %u رأی</string>
+			<key>other</key>
+			<string>در مجموع %u رأی</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d مسترنود</string>
+			<key>other</key>
+			<string>%d مسترنود</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d انتخاب‌شده</string>
+			<key>other</key>
+			<string>%d انتخاب‌شده</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d از گره‌های شما پیش‌تر اینجا رأی داده و فهرست نشده است.</string>
+			<key>other</key>
+			<string>%d از گره‌های شما پیش‌تر اینجا رأی داده‌اند و فهرست نشده‌اند.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u رأی در هر رقابت — evonode ها ۴ و مسترنودها ۱ حساب می‌شوند</string>
+			<key>other</key>
+			<string>%u رأی در هر رقابت — evonode ها ۴ و مسترنودها ۱ حساب می‌شوند</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>رأی به %d نام کاربری</string>
+			<key>other</key>
+			<string>رأی به %d نام کاربری</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u رأی</string>
+			<key>other</key>
+			<string>%u رأی</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>رأی ×%d</string>
+			<key>other</key>
+			<string>رأی ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d درخواست</string>
+			<key>other</key>
+			<string>%d درخواست</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/fa.lproj/Localizable.stringsdict
+++ b/DashWallet/fa.lproj/Localizable.stringsdict
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d از %#@nodes@ رأی دادند</string>
+		<string>رأی داده: %1$d از %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d از %#@nodes@ رأی دادند</string>
+		<string>رأی داده: %1$d از %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " tai ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Käyttäjää %@ ei löytynyt Dash-verkosta, joten hänelle ei voi lähettää yhteyspyyntöä.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash käytettävissä";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ hyväksyi yhteyspyyntösi";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d tavua";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffia";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld/%ld talletusta";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platformin krediittisaldo, jota käytetään Platform-osoitteiden välisiin pikamaksuihin ja ominaisuuksiin, kuten käyttäjätunnuksiin.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Tietoja";
 
+/* DashPay FAQ title */
+"About DashPay" = "Tietoja DashPaysta";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Pidättäydy";
+
+"Abstain on “%@”" = "Pidättäydy kohteesta ”%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiivinen";
+
+/* No comment provided by engineer. */
+"Activity" = "Toiminta";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Toiminta on julkista, mutta sitä ei ole helppo jäljittää";
+
 /* No comment provided by engineer. */
 "Add" = "Lisää";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Lisää %@ yhteystiedoksi";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Lisää %@ yhteystiedoksi, jotta voit maksaa suoraan käyttäjätunnukselle ja säilyttää yhteisen tapahtumahistorian";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Lisää %@ Dash suojattuun saldoosi ja anna sen levätä muutaman tunnin, jotta voit rekisteröityä ilman että käyttäjätunnuksesi yhdistyy muihin varoihisi.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Lisää suojattuun saldoosi vähintään %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Lisää varoja suojattuun saldoosi nyt ja rekisteröi käyttäjätunnuksesi yksityisesti muutaman tunnin kuluttua";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Kaikki solmut kerralla";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kaikki masternodesi ovat äänestäneet tästä käyttäjätunnuksesta. Muuttaaksesi ääntä äänestä uudelleen siltä hakijalta, jota nyt suosit.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Saldojen synkronointi on lähes välitöntä";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Summat ja osoitteet ovat julkisia lohkoketjussa";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum-tili on yksi uudelleen käytettävä osoite: koko saldosi ja maksuhistoriasi ovat julkisesti sen alla, ja nimi (esimerkiksi ENS-verkkotunnus) osoittaa yleensä suoraan siihen osoitteeseen, jonka kuka tahansa voi selvittää. DashPay on päinvastainen — nimi johtaa identiteettiin, ei maksuosoitteeseen, ja varsinaiset maksuosoitteet pysyvät salatuissa yhteystietovaihdoissa, uusina jokaiselle yhteystiedolle.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Kuka tahansa osoitteen tunteva voi katsoa sen historian";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Hyväksy";
+
+"Approving a specific request can only be done one username at a time." = "Tietyn pyynnön voi hyväksyä vain yhdelle käyttäjätunnukselle kerrallaan.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Tekstinä";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Todennus peruutettiin. Ääntäsi ei annettu.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Todennus epäonnistui. Ääntäsi ei annettu.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Myönnä ”%@” tälle hakijalle";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Saldo jälkeenpäin";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldot ja siirrot eivät näy julkisesti";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Aloituskorkeus tallennettu — korotettu skannausraja on voimassa seuraavasta käynnistyksestä.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Sidottu sopimukseen";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Sidottu sopimukseen, asiakirjatyyppi ”%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Vain selaus";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Kokoaa viimeisimmät diagnostiikkalokit zip-tiedostoksi, jonka voit lähettää AirDropilla tai sähköpostilla tai tallentaa Tiedostoihin";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Anna ääni";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Vaihda vertaisia";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Tarkistetaan…";
+
+"Choice" = "Valinta";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Lunasta kutsusi";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Nostettavissa oleva saldo";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Tyhjennä ja synkronoi uudelleen";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Tyhjennetäänkö ketjutiedot ja synkronoidaanko uudelleen?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Sulkeutuu";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (uudet kolikot)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoinia ei enää tueta — valitse, minne sekoitetut kolikkosi siirretään.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Vakuus";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Tulossa pian";
+
+/* Shielded transfer status */
+"Completed" = "Valmis";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Vahvistettu";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Vahvistus tallentaa aloituskorkeuden %u ja tyhjentää tämän verkon ketjutiedot sovelluksen seuraavalla käynnistyksellä, lataa ne uudelleen ja skannaa suodattimet uudelleen tuosta korkeudesta. Käynnissä oleva istunto säilyttää vanhan skannausrajansa — sulje sovellus ja avaa se uudelleen aloittaaksesi.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Yhdistetyt vertaiset";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Haitat";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Yhteyspyyntö epäonnistui";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Yhteyspyyntö lähetetty käyttäjälle %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Yhteyspyynnöt";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Hakija %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Jatka valitaksesi käyttäjätunnuksesi. Kutsu maksaa rekisteröintimaksun.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopioi raakatapahtuma";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Lokiarkiston luonti epäonnistui: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Rahanvaihtokurssia ei löytynyt.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d identiteetin päivitys epäonnistui";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Saldoa ei saatu haettua (verkkovirhe). Kokeile päivittää.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Luo käyttäjätunnuksesi, etsi ystäviä ja perhettä heidän käyttäjätunnuksillaan ja lisää heidät yhteystietoihisi";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediitit";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ei ole vielä indeksoinut tätä kiistaa. Äänimäärät näkyvät tässä, kun se on tehty.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platformiin ei ole vielä yhdistetty. Odota, että synkronointi valmistuu, ja yritä uudelleen.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Väärään osoitteeseen lähetettyä Dashia ei voi saada takaisin. Varmista, että osoite on täsmälleen se, jolle aiot maksaa.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash tallentaa käyttäjätunnukset samannäköisyydeltä suojatussa muodossa, joten tallennettu nimi voi poiketa siitä, mitä kukin on kirjoittanut.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash-lompakon saldo";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay otettu käyttöön";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay on Dashin sosiaalinen maksukokemus, joka on rakennettu Dash Platformin päälle. Rekisteröit käyttäjätunnuksen, lisäät muita käyttäjiä yhteystiedoiksi ja maksat heille nimellä — ei enää osoitteiden kopiointia.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay korvaa pitkät ja käsittämättömät osoitteet käyttäjätunnuksilla. Lisää ystäviä yhteystiedoiksi, lähetä rahaa nimelle ja pidä jokainen maksu järjestyksessä henkilöittäin.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Määräaika tuntematon";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Johtamispolku";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Poistettu käytöstä";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Valmis — saldosi on levännyt riittävän kauan";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Tarkista osoite vielä kerran";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Jokaisella masternodella on yksi voimassa oleva ääni kiistaa kohden. Voit muuttaa sitä myöhemmin, mutta Dash Platform sallii yhteensä vain 5 ääntä masternodea ja kiistaa kohden.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Jokainen napautus ottaa mukaan yhden solmun lisää, joten valitset itse, kuinka monta yhdistät.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Muokkaa aloituskorkeutta";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Ota käyttöön";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Ota DashPay käyttöön";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPayn käyttöönotto maksaa pienen kertaluonteisen verkkomaksun, joka veloitetaan identiteettisi krediittisaldosta. Tarkka arvio näytetään ennen vahvistusta. Yhteyspyyntöjen ja maksujen lähettäminen maksaa tavanomaiset verkkomaksut.";
+
+"Ending soonest" = "Päättyy ensimmäisenä";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Arvioitu verkkomaksu";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Kaikki solmut äänestävät yhdessä. Nopeampaa, mutta se yhdistää masternodesi julkisesti toisiinsa.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonoden operaattoriavaimet";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Vie lokit";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Ulkoinen osoite";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Epäonnistui";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Haetaan…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Suodata";
+
+/* SPV sync phase */
+"Filter headers" = "Suodatinotsikot";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Etsi käyttäjä Dash-verkosta";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Etsi identiteettejä";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Löytyi %d uutta identiteettiä";
+
+/* Identities */
+"Found 1 new identity" = "Löytyi 1 uusi identiteetti";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Rahoita käyttäjätunnuksesi suojatusta saldostasi. Lisää varat muutamaa tuntia aiemmin — lyhyt lepo pitää käyttäjätunnuksesi erillään muista Dasheistasi.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Rahoitettu suojatusta saldostasi — käyttäjätunnustasi ei voi yhdistää muihin Dasheihisi.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Varat lukittu — siirtoa viimeistellään";
+
+/* CoinJoin */
+"Funds moved" = "Varat siirretty";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Valmistaudu liittymään DashPayhin";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Selvä";
+
+/* Governance */
+"Governance" = "Hallinto";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "on pyytänyt sinua ystäväkseen";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Onko sinulla kutsu?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Otsikot";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Korkeus %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Korkeammat maksut, noin 7 senttiä (silti matalammat kuin muissa vastaavaa yksityisyyttä tarjoavissa lohkoketjuissa)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Miten tämä vertautuu Bitcoiniin yksityisyyden kannalta?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Miten tämä vertautuu Ethereum-tileihin yksityisyyden kannalta?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Kuinka yksityinen DashPay on?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identiteetit";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identiteetin krediitit";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identiteetin indeksi";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identiteetin rekisteröinti";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Identiteetin lataus";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Ei aktiivinen";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Syöte %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Syöte %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Syötteet (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Kutsu käyttäjältä %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Kutsu joku mukaan Dash-verkkoon";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Kutsu ystäväsi ja perheesi Dash-verkkoon";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Pidä nämä kolikot yksityisinä. Verkko- ja yksityisyysmaksut ovat voimassa.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Avain nro %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Avaintiedot";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Avaimen omistus";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Avaimet";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Johdossa";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Lue lisää";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Ladataan tapahtumia";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Vain paikallinen";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Lukitse";
+
+"Lock the name" = "Lukitse nimi";
+
+"Lock “%@” so nobody gets it" = "Lukitse ”%@”, jotta kukaan ei saa sitä";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Lukittu — kukaan ei saa tätä käyttäjätunnusta";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Matalat maksut arkiseen käyttöön";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Pää";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternoden avainnippu";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternode-luettelo";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternodejen äänet";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodet";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Tämän lompakon avaimilla rekisteröidyt masternodet ja evonodet näkyvät tässä, kun lompakko on synkronoitu.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodet ja evonodet, jotka käyttävät tämän lompakon avaimia";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodet äänestävät nimistä, joita useampi kuin yksi henkilö on pyytänyt. Saat ilmoituksen, kun äänestys päättyy.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Vähimmäismäärä saavutettu";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Lisää ehdotuksia";
+
+"Most lock votes" = "Eniten lukitusääniä";
+
+"Most votes" = "Eniten ääniä";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Siirrä tavalliseen käytettävissä olevaan saldoosi.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Siirretään varoja";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domainsin kaltaiset nimipalvelut liittävät luettavan nimen kiinteään julkiseen osoitteeseen ketjussa. Kuka tahansa voi selvittää nimen ja nähdä jokaisen sille koskaan tehdyn maksun. DashPay-käyttäjätunnus ei koskaan johda julkisesti maksuosoitteeseen — osoitteet paljastetaan vain salatussa vaihdossa kunkin yhteystiedon kanssa, joten nimesi ja rahasi pysyvät ulkopuolisille toisistaan erillisinä.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Vaatii huomiota";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Tästä laitteesta ei löytynyt diagnostiikkalokeja. Lokeja kirjoitetaan seuraavasta käynnistyksestä alkaen.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Ei identiteettejä";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ei vielä masternodeja";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Ei osuvia kiistoja";
+
+/* Identities */
+"No new identities were found for this wallet" = "Tälle lompakolle ei löytynyt uusia identiteettejä";
+
+"No open contest matches that search." = "Yksikään avoin kiista ei vastaa tätä hakua.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Yksikään avoin kiista ei vastaa tätä hakua. Nimet tallennetaan normalisoidussa muodossa, joten ”alice” näkyy muodossa ”a11ce”.";
+
+"No open contests" = "Ei avoimia kiistoja";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Sidotulle lompakolle ei löytynyt tallennettua lompakkoriviä.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Suojatun rekisteröinnin varajärjestelylle ei ole vielä käytettävissä Platform-osoitetta. Yritä uudelleen, kun lompakko on synkronoitu.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Yksikään käyttäjätunnus ei ole tällä hetkellä kiistanalainen. Kiista avautuu, kun kaksi tai useampi henkilö pyytää samaa nimeä.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Ääniä ei annettu";
+
+"Nobody gets it" = "Kukaan ei saa sitä";
+
+/* SPV sync peer type */
+"Node" = "Solmu";
+
+/* Raw transaction inspector */
+"Non-standard" = "Ei-standardi";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Ei vielä saatavilla";
+
+"Not cast" = "Ei annettu";
+
+/* Masternodes */
+"Not checked yet" = "Ei vielä tarkistettu";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Suojattu saldo ei riitä identiteetin rekisteröintiin";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ei lompakon historiassa";
+
+"Not now" = "Ei nyt";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Kauppiaat eivät hyväksy laajalti";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Kauppiaat eivät vielä hyväksy laajalti";
+
+/* Masternode keys */
+"Not yet used" = "Ei vielä käytetty";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoinissa ei ole nimikerrosta, joten ihmiset jakavat ja käyttävät osoitteita uudelleen avoimesti — kun osoite kerran tunnetaan, kaikki mitä se on koskaan vastaanottanut voidaan yhdistää sen omistajaan. DashPayssa käyttäjätunnuksesi on julkinen, mutta se ei koskaan osoita maksuosoitteeseen: osoitteet vaihdetaan yksityisesti yhteystietokohtaisesti ja ne vaihtuvat, joten nimelle maksaminen ei paljasta, minne rahasi menevät. Molemmat ovat läpinäkyviä ketjuja, joten ketjuanalyysi koskee edelleen itse kolikoita.";
+
+/* Identities */
+"On Network" = "Verkossa";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kun %@ hyväksyy pyyntösi, voit maksaa suoraan käyttäjätunnukselle";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Yksi solmu kerrallaan";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Vain masternodet ja evonodet voivat äänestää käyttäjätunnuksista. Tässä lompakossa ei ole aktiivisia masternodejen äänestysavaimia.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operaattori";
+
+/* Masternode keys */
+"Operator keys" = "Operaattoriavaimet";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operaattorin julkinen avain (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "tai";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Muut lopputulokset";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Tuloste %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Tulosteet (%d)";
+
+/* Masternodes */
+"Owner" = "Omistaja";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Omistajan osoite";
+
+/* Masternodes */
+"Owner key hash" = "Omistaja-avaimen tiiviste";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Maksetaan identiteettisi krediittisaldosta.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Liitä saamasi kutsulinkki tai skannaa sen QR-koodi. Se maksaa käyttäjätunnuksesi rekisteröinnin.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "maksaa suoraan käyttäjätunnukselle";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Maksa ihmisille, älä osoitteille";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Hyötykuorma (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Maksut ovat yksityisiä: yhteystiedon kanssa vaihtamasi osoitteet kulkevat salatussa hyötykuormassa, jonka vain te kaksi voitte lukea, eikä niitä koskaan julkaista — joten maksujasi ei voi helposti yhdistää käyttäjätunnukseesi. Ne ovat silti tavallisia maksuja läpinäkyvässä ketjussa: kehittynyt ketjuanalyysi saattaa vuotaa tietoa. Shielded DashPay (tulossa pian) paikkaa tuon aukon. Itse yhteyspyynnöt EIVÄT ole tällä hetkellä yksityisiä: kuka tahansa näkee, että kaksi identiteettiä on yhdistetty. Yksityiset yhteyspyynnöt ovat pian tuleva ominaisuus. Käyttäjätunnuksesi ja profiilisi ovat myös julkisia Dash Platformissa.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Maksut vahvistuvat sekunneissa InstantSendin avulla";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Suoraan osoitteisiin tehtyjä maksuja ei säilytetä toiminnassa.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Kunkin yhteystiedon kanssa tehdyt maksut on koottu yhteen paikkaan, nimineen ja profiileineen raakatapahtumien sijaan.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Maksuosoite";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-osoite";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-solmu";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-solmun tunnus";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-maksut eivät yksilöi lähettäjää. Tämä maksu kirjattiin, kun lompakko havaitsi saldomuutoksen — se on saattanut saapua aiemmin.";
+
+"Platform SDK not ready" = "Platform-SDK ei ole valmis";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform-synkronointi ei ole käynnissä. Avaa Synkronointitiedot → Platform-synkronoinnin tila käynnistääksesi sen.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Suojattu";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Aiemmin käytetty: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Yksityinen jo suunnittelultaan";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Yksityiset yhteyspyynnöt (jotta se, keneen olet yhteydessä, pysyy yksityisenä), Shielded DashPay — maksut yhteystiedoille yksityisestä suojatusta saldostasi — ja maksaminen käyttäjille, jotka eivät vielä ole yhteystiedoissasi, ovat kaikki tulossa pian.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Yksityiset yhteyspyynnöt ovat kehitteillä ja niitä odotetaan noin syys–lokakuussa 2026. Nyt itse pyyntö on julkinen — kuka tahansa näkee, että kaksi identiteettiä on yhdistetty, vaikka sen sisällä olevat maksutiedot ovat salattuja. Kun yksityiset yhteyspyynnöt julkaistaan, voit valita, onko ystävyytesi julkinen vai yksityinen.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Yksityiset yhteyspyynnöt, Shielded DashPay ja maksaminen ihmisille, jotka eivät vielä ole yhteystietoja.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Yksityiset maksuosoitteet vaihdetaan sinun ja yhteystietojesi välillä. Vain sinä ja yhteystietosi tiedätte, kuka on välillänne kulkevien maksujen saaja ja lähettäjä.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Yksityiset maksut";
+
+/* Usernames */
+"Private registration" = "Yksityinen rekisteröinti";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Käsittelyaika";
+
+/* Balance info sheet section */
+"Pros" = "Edut";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Palveluntarjoajan tapahtumat";
+
+/* Masternode keys */
+"Public key" = "Julkinen avain";
+
+/* Masternode keys */
+"Public key (legacy)" = "Julkinen avain (vanha)";
+
+/* Identities */
+"Public keys" = "Julkiset avaimet";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Käyttötarkoitus";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Raakatapahtuma";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Raakatapahtuma ei ole käytettävissä";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Tarkistaa tiiviit lohkosuodattimet uudelleen valitusta korkeudesta tämän lompakon tapahtumien varalta lataamalla ja täsmäyttämällä ne uudelleen. Uudelleenskannauksen alarajana ovat lompakon luontikorkeus ja paikallisesti tallennetut ketjutiedot — palauttaaksesi sitä vanhempaa historiaa laske sen sijaan lompakon aloituskorkeutta.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Vain luku";
+
+/* Usernames */
+"Ready around %@" = "Valmis noin %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Syy";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Vastaanotettu käyttäjältä %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Kirjaa masternodesi äänestäneiksi ottamatta kantaa.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Päivitä";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Rekisteröity";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Yksityinen rekisteröinti vaatii vähintään %@ Dashia suojatussa saldossasi sekä muutaman tunnin lepoajan — seuraavat näytöt opastavat sinut läpi.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Rekisteröinti";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Pyytää tätä nimeä";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Palautetut lompakot eivät aina pysty selvittämään toiminnon tyyppiä. Tämä merkintä on koottu ketjussa olevista muistiinpanotiedoista.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Uudelleensynkronointi valmisteltu korkeudesta %u — sulje sovellus ja avaa se uudelleen aloittaaksesi.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "säilyttää yhteisen tapahtumahistorian";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Poistettu käytöstä";
 
 /* No comment provided by engineer. */
 "Retry" = "Yritä uudelleen";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Peruutus";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skripti";
+
+/* Raw transaction inspector */
+"Script signature" = "Skriptin allekirjoitus";
+
+/* Raw transaction inspector */
+"Script type" = "Skriptin tyyppi";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Etsi yhteystietoa";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Etsi yhteyspyyntöä";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Etsi käyttäjää Dash-verkosta";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Etsi käyttäjätunnusta";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Hakutulokset haulle \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Hae käyttäjätunnuksia";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Haetaan käyttäjätunnusta %@ Dash-verkosta";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Turvallisuustaso";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Valitse kaikki";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Valitse vähintään yksi masternode, jolla äänestät.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Mitä vähemmän solmuja valitset, sitä vähemmän paljastuu siitä, mitä masternodeja ylläpidät.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Lähetä yhteystiedolle";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Lähetä käyttäjätunnukselle, jonka todella muistat ja voit varmistaa.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Lähetä ensimmäinen yhteyspyyntösi";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Lähetetään yhteyspyyntöä";
+
+/* No comment provided by engineer. */
+"Sending to" = "Lähetetään";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Lähetetty käyttäjälle %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Palvelu";
+
+/* Identities */
+"Set as Main" = "Aseta pääasialliseksi";
+
+/* Identities */
+"Set as Main Identity" = "Aseta pääidentiteetiksi";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Jaettu yksityisyysallas on vähimmäiskoossa";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Suojattu osoite";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Suojattu maksu";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Käynnistetään suojattua lompakkoa…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Suojattu → Platform";
+
+"Shielded → Transparent" = "Suojattu → Läpinäkyvä";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Koko";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Osa masternodeistasi saattaa puuttua tästä luettelosta — lompakko ei pystynyt lukemaan koko äänestysavainjoukkoasi. Viimeistele synkronointi ja avaa tämä näyttö uudelleen.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Järjestä yhteystiedot";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Erityinen hyötykuorma";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Alkaa, kun lisäät varoja";
+
+/* Transaction details */
+"Status" = "Tila";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Tallennettu muodossa";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Synkronointitiedot";
+
+/* SPV sync */
+"Sync too slow?" = "Onko synkronointi liian hidasta?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Älä asetu kummankaan puolelle";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Kopioi napauttamalla";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-solmuavain (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash saapuu vastaanottajan osoitteeseen sen jälkeen, kun verkko on käsitellyt noston — tämä voi kestää jopa 10 minuuttia.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash saapuu vastaanottajan osoitteeseen heti, kun verkko käsittelee noston.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash saapuu läpinäkyvään saldoosi heti, kun verkko käsittelee noston.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Pääidentiteetin voi valita vain aktiivisesta lompakosta";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Yksityisin paikka Dashiesi säilytykseen";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Tallennetulla lompakkorivillä ei ole verkkoa — uudelleensynkronointia ei voi valmistella.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Rekisteröinti lähetettiin, mutta sen tulosta ei voitu vahvistaa. Odota minuutti, että lompakko synkronoituu, ja yritä sitten uudelleen — älä lähetä heti uudelleen.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Jaettu yksityisyysallas kasvaa vielä (%1$ld/%2$ld talletusta). Yksityinen rekisteröinti avautuu, kun se saavuttaa vähimmäismäärän.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Jaettu yksityisyysallas kasvaa vielä (%1$ld/%2$ld talletusta). Yritä uudelleen, kun se saavuttaa vähimmäismäärän.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Lompakon luontikorkeus — alaraja suodatinskannauksille ja ”Lompakon luonnista” -uudelleenskannauksille. Aseta se lompakon ensimmäisen rahoituksen tasolle tai sen alle; tuonnit käyttävät oletuksena arvoa 200000 mainnetissä ja 0 testnetissä. Jos tallennat nykyistä pienemmän tai yhtä suuren korkeuden, tämän verkon ketjutiedot tyhjennetään seuraavalla käynnistyksellä ja skannataan uudelleen siitä alkaen.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "hänet (haetaan tietoja)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Ei uusia ilmoituksia";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nimeä %@ vastaavia käyttäjiä ei ole";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Yhteystiedoissasi ei ole nimeä %@ vastaavia käyttäjiä";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Nämä varat siirtyvät Platform-saldoosi ja ovat käytettävissä heti, kun siirto on valmis.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Tätä osoitetta ei voi maksaa %@-saldostasi";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Tämä lisää identiteettiisi kaksi avainta, jotta muut käyttäjät voivat lähettää sinulle yhteyspyyntöjä ja jotta sinä voit hyväksyä heidän pyyntönsä. Tämä tapahtuu vain kerran.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Tämä soveltaa yhtä valintaa kaikkiin %d valittuun käyttäjätunnukseen.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Tämä kutsulinkki ei ole kelvollinen.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Tämä ei ole kelvollinen Dash-osoite tässä verkossa";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Tämä ei ole kelvollinen kutsulinkki";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Tämä on pääidentiteettisi";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Tällä masternodella ei ole vielä Platform-identiteettiä.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Tämä lasketaan silti siksi, että masternodesi ovat äänestäneet tässä kiistassa.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Tämän tapahtuman raakatavuja ei ole tallennettu tähän laitteeseen.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Tämä käyttäjätunnus meni jollekin toiselle";
+
+"This wallet could not derive the voting key for this node." = "Tämä lompakko ei pystynyt johtamaan äänestysavainta tälle solmulle.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Tässä lompakossa ei ole aktiivisia masternodejen äänestysavaimia, joten se ei voi äänestää. Rekisteröidyt solmut näkyvät kohdassa Työkalut → Masternodet.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Tämä nostaa koko Platform-saldosi yhdellä siirrolla. Dash saapuu vastaanottajan osoitteeseen heti, kun verkko käsittelee noston.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Tämä nostaa koko Platform-saldosi yhdellä siirrolla. Dash saapuu läpinäkyvään saldoosi heti, kun verkko käsittelee noston.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Tapahtumahistoria ei ole käytettävissä";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Tapahtumatunnus";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Siirto sisään";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Siirto ulos";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Siirrot kestävät kauemmin — yksityisyystodisteiden rakentaminen vie aikaa";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Siirrot muihin Platform-osoitteisiin ja suojattuihin osoitteisiin ovat välittömiä ja lopullisia";
+
+/* Balance breakdown */
+"Transparent" = "Läpinäkyvä";
+
+/* Send screen destination type */
+"Transparent address" = "Läpinäkyvä osoite";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Läpinäkyvä saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Läpinäkyvä rahoitus yhdistää käyttäjätunnuksesi julkisesti näihin varoihin.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Läpinäkyvä → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Läpinäkyvä → Suojattu";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Ehdotuksia ei voi antaa";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tuntematon erikoistyyppi %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Suojaamaton";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Päivitä Evolutioniin";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Käytä sen sijaan läpinäkyvää saldoa";
+
+/* Masternode keys */
+"Used" = "Käytetty";
+
+/* Masternode keys */
+"Used at: " = "Käytetty: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Käyttäjä (haetaan tietoja)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Käyttäjätunnukset";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Käyttäjätunnukset tallennetaan normalisoidussa muodossa samannäköisten nimien estämiseksi, joten tämä voi poiketa siitä, mitä kukin on kirjoittanut.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Käyttäjätunnuksia, ei osoitteita";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Käyttäjät, jotka vastaavat hakua %@ ja jotka eivät tällä hetkellä ole yhteystiedoissasi";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Käyttää yhtä eniten auditoiduista ja testatuista nollatietokirjastoista (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Kelvollinen kutsu";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Vahvistettu rekisteröinnin yhteydessä";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versio";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Erittäin tehokas ja matalat maksut";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Näytä kaikki";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Näytä tapahtuma";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Äänestä";
+
+"Vote cast" = "Ääni annettu";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Äänestä kiistanalaisista käyttäjätunnuksista";
+
+"Vote on several" = "Äänestä useista";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Äänestä käyttäen";
+
+"Votes that nobody should receive these usernames." = "Äänestää sen puolesta, ettei kukaan saisi näitä käyttäjätunnuksia.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Äänestysosoite";
+
+"Voting ended with no winner" = "Äänestys päättyi ilman voittajaa";
+
+"Voting ends" = "Äänestys päättyy";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Äänestys käynnissä";
+
+"Voting in progress — lock votes are ahead" = "Äänestys käynnissä — lukitusäänet johtavat";
+
+"Voting in progress — you are ahead" = "Äänestys käynnissä — sinä johdat";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Äänestysavaimen tiiviste";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Äänestys tästä käyttäjätunnuksesta on suljettu. Alla olevat luvut ovat viimeksi luetut.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Äänestys kohteesta ”%@” on jo suljettu. Päivitä nähdäksesi tuloksen.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Odotetaan Dash Platformia";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Lompakon aloituskorkeus";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Entä Unstoppable Domains ja vastaavat nimipalvelut?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Paljonko se maksaa?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Mikä DashPay on?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Mitä on tulossa seuraavaksi?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Milloin yhteyspyynnöistä tulee yksityisiä?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kuka pyytää tätä nimeä";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Miksi minun täytyy ottaa se käyttöön?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Nostaa koko saldon";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Toimii kaikkien Dash-lompakoiden, pörssien ja kauppiaiden kanssa";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Sinä";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Hyväksyit yhteyspyynnön käyttäjältä %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Sinulla ei ole tällä hetkellä yhtään yhteystietoa";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Sinulla on toistaiseksi %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Lähetit yhteyspyynnön käyttäjälle %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Voitit tämän käyttäjätunnuksen";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Kaikki valmista. Muut käyttäjät voivat nyt lähettää sinulle yhteyspyyntöjä — ja sinä voit lähettää omasi.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Dash Platform -identiteettisi näkyy tässä, kun rekisteröit käyttäjätunnuksen.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Historiasi, järjestyksessä";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identiteettisi tarvitsee kaksi lisäavainta, jotta yhteyspyynnöt voidaan salata sinun ja muiden käyttäjien välillä. Käyttöönotto lisää ne yhdellä verkkotapahtumalla. Tämä tapahtuu vain kerran.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Kutsusi maksaa tämän käyttäjätunnuksen rekisteröintimaksun.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Pääasiallinen Dash-saldosi Core-lohkoketjussa — se, mitä lähetät ja vastaanotat muiden lompakoiden, pörssien ja kauppiaiden kanssa.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Sekoitetut kolikkosi siirrettiin Dash-lompakkosi saldoon.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Sekoitetut kolikkosi siirrettiin suojattuun saldoosi. Parhaan yksityisyyden vuoksi odota vähintään 2 tuntia ennen näiden varojen käyttöä.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Platform-saldosi";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Yksityinen saldosi. Summat ja osoitteet on salattu ketjussa, joten omistuksesi ja historiasi pysyvät luottamuksellisina.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Suojattu saldosi";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Suojattu saldosi on melkein valmis — voit rekisteröityä yksityisesti noin %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Suojattu saldosi on valmis — rekisteröi käyttäjätunnuksesi yksityisesti nyt";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Suojattu saldosi lepää — voit rekisteröityä yksityisesti noin %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Suojattu saldosi kypsyy vielä. Se on valmis noin %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Läpinäkyvä saldosi";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Käyttäjätunnuksesi näkyy kaikille. Kun rahoitat sen suojatusta saldostasi — annettuasi varojen levätä muutaman tunnin — kukaan ei voi yhdistää käyttäjätunnustasi muihin Dasheihisi.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Käyttäjätunnuksesi, profiilisi ja yhteystietosi seuraavat tätä identiteettiä.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Käyttäjätunnuksesi, profiilisi ja yhteystietosi seuraavat tätä identiteettiä.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Äänesi";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Lompakkosi synkronoituu vielä Dash-verkon kanssa. Lähettäminen on mahdollista, kun synkronointi on valmis.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Lompakkosi synkronoituu vielä. Lähettäminen läpinäkyvästä saldostasi on mahdollista, kun synkronointi on valmis.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Merkkijonoa ”%@” ei voitu lukea Dash-käyttäjätunnuksena.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "”%@” on rekisteröity. Lähetetäänkö yhteyspyyntö sinut kutsuneelle henkilölle?";

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Kaikki solmut kerralla";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kaikki masternodesi ovat äänestäneet tästä käyttäjätunnuksesta. Muuttaaksesi ääntä äänestä uudelleen siltä hakijalta, jota nyt suosit.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Kaikki masternodesi ovat äänestäneet tästä käyttäjätunnuksesta. Muuttaaksesi ääntä äänestä uudelleen sitä hakijaa, jota nyt suosit.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -469,7 +469,7 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
-"Balance after" = "Saldo jälkeenpäin";
+"Balance after" = "Saldo maksun jälkeen";
 
 /* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
@@ -1014,7 +1014,7 @@
 
 "Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ei ole vielä indeksoinut tätä kiistaa. Äänimäärät näkyvät tässä, kun se on tehty.";
 
-"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platformiin ei ole vielä yhdistetty. Odota, että synkronointi valmistuu, ja yritä uudelleen.";
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Yhteyttä Dash Platformiin ei ole vielä muodostettu. Odota, että synkronointi valmistuu, ja yritä uudelleen.";
 
 /* Send confirm sheet */
 "Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Väärään osoitteeseen lähetettyä Dashia ei voi saada takaisin. Varmista, että osoite on täsmälleen se, jolle aiot maksaa.";
@@ -1106,7 +1106,7 @@
 "Deposit sent" = "Deposit sent";
 
 /* Identities: BIP-32 style derivation path of this key */
-"Derivation path" = "Johtamispolku";
+"Derivation path" = "Johdannaispolku";
 
 /* No comment provided by engineer. */
 "Destination" = "Destination";
@@ -3954,7 +3954,7 @@
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
 
 /* Send sheet source/destination mismatch */
-"This address can't be paid from your %@ balance" = "Tätä osoitetta ei voi maksaa %@-saldostasi";
+"This address can't be paid from your %@ balance" = "Tästä %@-saldosta ei voi maksaa tähän osoitteeseen";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -4412,7 +4412,7 @@
 "Version" = "Versio";
 
 /* Balance info sheet */
-"Very efficient with low fees" = "Erittäin tehokas ja matalat maksut";
+"Very efficient with low fees" = "Erittäin tehokas, ja maksut ovat matalat";
 
 /* adjective, security level */
 "Very High" = "Very High";

--- a/DashWallet/fi.lproj/Localizable.stringsdict
+++ b/DashWallet/fi.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ laskettu kohteelle ”%2$@”</string>
+		<string>%#@votes@ kohteelle ”%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u ääni</string>
+			<string>%1$u laskettu ääni</string>
 			<key>other</key>
-			<string>%1$u ääntä</string>
+			<string>%1$u laskettua ääntä</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d / %#@nodes@ on äänestänyt</string>
+		<string>Äänestäneitä: %1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d / %#@nodes@ on äänestänyt</string>
+		<string>Äänestäneitä: %1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/fi.lproj/Localizable.stringsdict
+++ b/DashWallet/fi.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ laskettu kohteelle ”%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u ääni</string>
+			<key>other</key>
+			<string>%1$u ääntä</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Äänestetty %1$d / %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d käyttäjätunnus</string>
+			<key>other</key>
+			<string>%2$d käyttäjätunnusta</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Anna %u ääni</string>
+			<key>other</key>
+			<string>Anna %u ääntä</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d / %#@nodes@ on äänestänyt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodea</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d / %#@nodes@ on äänestänyt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d solmu</string>
+			<key>other</key>
+			<string>%2$d solmua</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodea</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ääni yhteensä</string>
+			<key>other</key>
+			<string>%u ääntä yhteensä</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodea</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d valittu</string>
+			<key>other</key>
+			<string>%d valittu</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d solmuistasi on jo äänestänyt täällä eikä näy luettelossa.</string>
+			<key>other</key>
+			<string>%d solmuasi on jo äänestänyt täällä eivätkä ne näy luettelossa.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ääni kiistaa kohden — evonodet lasketaan neljäksi, masternodet yhdeksi</string>
+			<key>other</key>
+			<string>%u ääntä kiistaa kohden — evonodet lasketaan neljäksi, masternodet yhdeksi</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Äänestä %d käyttäjätunnuksesta</string>
+			<key>other</key>
+			<string>Äänestä %d käyttäjätunnuksesta</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u ääni</string>
+			<key>other</key>
+			<string>%u ääntä</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Äänestä ×%d</string>
+			<key>other</key>
+			<string>Äänestä ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d pyyntö</string>
+			<key>other</key>
+			<string>%d pyyntöä</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Lahat ng node nang sabay";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Bumoto na ang lahat ng iyong masternode sa username na ito. Para baguhin ang boto, bumoto muli mula sa kalahok na mas gusto mo ngayon.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Bumoto na ang lahat ng iyong masternode sa username na ito. Para baguhin ang boto, bumoto muli para sa kalahok na mas gusto mo ngayon.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " o ";
+
 /* CrowdNode */
 " Privacy Policy " = "Patakaran sa Pagkapribado";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Hindi mahanap si %@ sa Dash network para makapagpadala ng kahilingan sa pakikipag-ugnay.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash ang available";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "Tinanggap ni %@ ang iyong kahilingan sa pakikipag-ugnay";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu mga contact / %3$lu mga update sa profile";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "ipapalabas ang mga %d boto dahil marami kang voting key na nakaimbak sa wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicate";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld sa %ld deposito";
 
 /* Voting */
 "%ld requests" = "%ld mga kahilingan";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" ay hindi isang recovery phrase. Nais mo bang subukang mabawi ang tamang salita na dapat ay nasa lugar nito?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Balanse ng kredito sa Dash Platform na ginagamit para sa mabilisang bayad sa pagitan ng mga Platform address at para sa mga tampok gaya ng username.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Kailangan ng device passcode para pangalagaan ang iyong pitaka. Pumunta sa settings at i-on ang passcode para magpatuloy,";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Tungkol sa";
 
+/* DashPay FAQ title */
+"About DashPay" = "Tungkol sa DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Tungkol sa Akin";
+
+"Abstain" = "Umabstain";
+
+"Abstain on “%@”" = "Umabstain sa “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Tanggapin";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Pagbawi ng Account";
 
+/* Masternode status */
+"Active" = "Aktibo";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktibidad";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Pampubliko ang aktibidad pero hindi madaling matunton";
+
 /* No comment provided by engineer. */
 "Add" = "Dagdagan";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Idagdag si %@ bilang kontak";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Idagdag si %@ bilang kontak para makabayad nang direkta sa username at mapanatili ang magkabilaang kasaysayan ng transaksyon";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Magdagdag ng %@ Dash sa iyong protektadong balanse at hayaang magpahinga ito nang ilang oras para makapagparehistro nang hindi iniuugnay ang iyong username sa iba mong pondo.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Magdagdag ng Bagong Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Magdagdag ng hindi bababa sa %@ Dash sa iyong protektadong balanse";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Magdagdag ng pondo sa protektadong balanse ngayon at iparehistro ang iyong username nang pribado makalipas ang ilang oras";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Lahat";
 
+"All nodes at once" = "Lahat ng node nang sabay";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Bumoto na ang lahat ng iyong masternode sa username na ito. Para baguhin ang boto, bumoto muli mula sa kalahok na mas gusto mo ngayon.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Payagan ang pagpapadala ng lahat ng mga transaksyon mula sa Dash Wallet sa Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Halos agad ang pag-sync ng mga balanse";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Pampubliko sa blockchain ang mga halaga at address";
+
 /* No comment provided by engineer. */
 "An error occurred" = "May naganap na error";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ang Ethereum account ay iisang address na paulit-ulit na ginagamit: nakalantad doon ang buong balanse at kasaysayan ng bayad mo, at ang isang pangalan (gaya ng ENS domain) ay karaniwang tumuturo mismo sa address na iyon para matunton ninuman. Kabaligtaran ang DashPay — ang pangalan ay tumutungo sa isang pagkakakilanlan, hindi sa address ng bayad, at nananatili sa loob ng naka-encrypt na palitan ng kontak ang tunay na mga address ng bayad, bago para sa bawat kontak.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Ang sapantaha at pamilyar na karanasan sa lahat ng iyong aparato";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Awtomatikong maaaprubahan ang anumang username na mayroong numero 2-9, higit sa 20 character o may gitling.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Makikita ninuman ang kasaysayan ng isang address kung alam niya ito";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Mag-apply";
 
+"Approve" = "Aprubahan";
+
+"Approving a specific request can only be done one username at a time." = "Isang username lang sa bawat pagkakataon ang maaaprubahan para sa isang tiyak na kahilingan.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Sigurado ka bang gusto mong kanselahin ang order na ito?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Bilang teksto";
 
 /* DashSpend */
 "at" = "sa";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Kinansela ang pagpapatunay. Hindi naihulog ang iyong boto.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Nabigo ang pagpapatunay. Hindi naihulog ang iyong boto.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Hindi magagamit ang pagpapatunay";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Igawad ang “%@” sa kalahok na ito";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balanse";
 
 /* CrowdNode */
+"Balance after" = "Balanse pagkatapos";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balanse sa CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balanse:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Hindi pampublikong nakikita ang mga balanse at paglilipat";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Kinakailangan maaccess ang Biometrics ";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Naitala ang panimulang taas — ilalapat ang itinaas na sahig ng pag-scan simula sa susunod na pagbukas.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Naka-block '%@' na username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Nakatali sa kontrata";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Nakatali sa kontrata, uri ng dokumentong “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Panonood lamang";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Tinitipon ang kamakailang diagnostic log sa isang zip para i-AirDrop, i-email, o i-save sa Files";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Ihulog ang boto";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Palitan ang mga peer";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Baguhin ang PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Sinusuri…";
+
+"Choice" = "Pagpipilian";
+
 /* Choose your Dash username */
 "Choose your" = "Pumili ng iyong";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Piliin ang Iyong Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Kunin ang iyong imbitasyon";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Balanseng maaaring angkinin";
+
 /* No comment provided by engineer. */
 "Claimed" = "Inangkin";
+
+/* SPV diagnostics */
+"Clear & resync" = "Burahin at i-resync";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Burahin ang chain data at mag-resync?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Isara ang app";
 
+"Closing" = "Isasara na";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (bagong barya)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "Hindi na sinusuportahan ang CoinJoin — piliin kung saan ililipat ang iyong pinaghalong barya.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolateral";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Malapit nang dumating";
+
+/* Shielded transfer status */
+"Completed" = "Tapos na";
 
 /* No comment provided by engineer. */
 "Confirm" = "Kumpirmahin";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Nakumpirma";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Kapag kinumpirma, itatala ang panimulang taas na %u at buburahin ang chain data ng network na ito sa susunod na pagbukas ng app, ida-download itong muli at ise-scan muli ang mga filter mula sa taas na iyon. Pananatilihin ng kasalukuyang session ang dating sahig ng pag-scan — isara at buksang muli ang app para magsimula.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Ikonekta ang iyong mga crypto wallet sa platform ng ZenLedger. Matuto pa at magsimula sa iyong mga transaksyon sa Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Nakakonektang Dash address";
 
+/* SPV sync */
+"Connected peers" = "Mga nakakonektang peer";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Mga Disbentahe";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Nabigo ang kahilingan sa pakikipag-ugnay";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Naipadala ang kahilingan sa pakikipag-ugnay kay %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Mga Kahilingan sa Pakikipag-ugnay";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Mga Contact";
 
+"Contender %@" = "Kalahok %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Ipagpatuloy";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Magpatuloy para piliin ang iyong username. Babayaran ng imbitasyon ang bayarin sa pagpaparehistro.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Kopyahin ang Link ng Imbitasyon";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopyahin ang raw na transaksyon";
+
 /* No comment provided by engineer. */
 "Copy text" = "Kopyahin ang text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Hindi awtomatikong mababawi ang mga nawawala o hindi tamang salita";
 
+/* Log export */
+"Could not create the log archive: %@" = "Hindi malikha ang archive ng log: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Hindi makita ang halaga ng palitan";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Hindi ma-refresh ang %d pagkakakilanlan";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Hindi makuha ang balanse (error sa network). Subukang mag-refresh.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Hindi makagawa ng ipambabayad";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Gumawa ng iyong username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Likhain ang iyong Username, hanapin ang pamilya't kaibigan sa pamamagitan ng kanilang username, at idagdag sila sa iyong mga kontak";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Mga Kredito";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Ang pagbabayad ng Dash ay hindi dapat bababa sa %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Hindi pa na-index ng Dash Platform ang paligsahang ito. Lilitaw dito ang bilang ng boto kapag nagawa na nito.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Hindi pa nakakonekta ang Dash Platform. Hintaying matapos ang pag-sync at subukang muli.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Hindi na mababawi ang Dash na naipadala sa maling address. Tiyaking eksaktong tama ang address na balak mong bayaran.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Iniimbak ng Dash ang mga username sa anyong ligtas sa magkakahawig, kaya maaaring iba ang nakaimbak na pangalan sa tinipa ng bawat tao.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Balanse ng Dash Wallet";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet sa device na ito";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "Naka-enable na ang DashPay";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Imbitasyon sa DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "Ang DashPay ang panlipunang karanasan sa pagbabayad ng Dash, nakabatay sa Dash Platform. Magrerehistro ka ng username, magdadagdag ng ibang user bilang kontak, at magbabayad sa kanila sa pangalan — wala nang kopyahang address.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "Pinapalitan ng DashPay ang mahahaba't magulong address ng username. Idagdag ang mga kaibigan bilang kontak, magpadala ng pera sa isang pangalan, at panatilihing nakaayos ayon sa tao ang bawat bayad.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Bayad sa Pag-upgrade ng DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Petsa: Luma sa bago";
+
+"Deadline unknown" = "Hindi alam ang deadline";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Ipinadala ang deposito";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Derivation path";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAnumang 'jailbreak' app ay maaaring maka-access ng app's keychain data (at nakawin ang iyong Dash). I-wipe kaagad itong pitaka at i-restore sa ligtas na device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Naka-disable";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Idiskonekta ang Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Tapos";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Tapos na — sapat na katagal nang nagpahinga ang iyong balanse";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Suriing mabuti ang address";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Ang bawat imbitasyon ay popondohan ng halagang ito upang mabilis na magawa ng tatanggap ang kanilang username sa Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "May isang buhay na boto ang bawat masternode sa bawat paligsahan. Mababago mo ito mamaya, pero 5 boto lang sa kabuuan ang pinapayagan ng Dash Platform sa bawat masternode sa bawat paligsahan.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Sa bawat tap, isa pang node ang bumoboto, kaya ikaw ang pumipili kung ilan ang iuugnay nang magkakasama.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Mas maaga";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Madaling i-stake ang Dash at kumita ng passive income sa ilang simpleng pag-click.";
+
+/* SPV diagnostics */
+"Edit birth height" = "I-edit ang panimulang taas";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "I-edit ang profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "I-enable";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "I-enable ang DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Paganahin ang Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Paganahin ang Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "May maliit at isang beses lang na bayarin sa network ang pag-enable ng DashPay, kinukuha mula sa balanse ng kredito ng iyong pagkakakilanlan. Ipapakita ang tumpak na tantiya bago ka kumpirmahin. Karaniwang bayarin sa network naman ang pagpapadala ng kahilingan sa pakikipag-ugnay at ng bayad.";
+
+"Ending soonest" = "Pinakamaagang matatapos";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error sa pag-update ng iyong profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Tinatayang bayarin sa network";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Sabay-sabay bumoboto ang bawat node. Mas mabilis, pero pampublikong iniuugnay nito ang iyong mga masternode sa isa't isa.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Mga operator key ng Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "I-export ang CSV";
 
+/* Log export */
+"Export Logs" = "I-export ang mga Log";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Panlabas na address";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Nabigo";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Nabigong i-load ang barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Kinukuha ang mga rate...";
 
+/* Masternodes */
+"Fetching…" = "Kinukuha…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Salain";
+
+/* SPV sync phase */
+"Filter headers" = "Mga filter header";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "I-filter ang mga transaksyon";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Maghanap ng user sa Dash Network";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Maghanap ng mga ATM kung saan maaari kang bumili o magbenta ng Dash.";
+
+/* Identities */
+"Find identities" = "Maghanap ng mga pagkakakilanlan";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Nakalimutan ang PIN?";
 
+/* Identities */
+"Found %d new identities" = "May nahanap na %d bagong pagkakakilanlan";
+
+/* Identities */
+"Found 1 new identity" = "May nahanap na 1 bagong pagkakakilanlan";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Natagpuan ang nawawalang salita:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Pondohan ang iyong username mula sa protektadong balanse. Magdagdag ng pondo ilang oras nang mas maaga — pinananatili ng maikling pahinga na hindi maiuugnay ang username mo sa iba mong Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Pinondohan mula sa iyong protektadong balanse — hindi maiuugnay ang iyong username sa iba mong Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Naka-lock ang pondo — tinatapos ang paglilipat";
+
+/* CoinJoin */
+"Funds moved" = "Nailipat ang pondo";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Makakuha ng mga reward mula sa mga deposito sa Dash Masternodes na may kasing liit na 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Kumuha ng Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Maghanda nang sumali sa DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Makakuha kaagad ng Mga Gantimpala";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Nakuha ko";
+
+/* Governance */
+"Governance" = "Pamamahala";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Magbigay ng mga pahintulot sa GPS upang maipakita namin sa iyo ang mga lokasyong malapit sa iyo.";
 
 /* Voting */
 "Has blocked votes" = "May mga naka-block na boto";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ay humiling na maging kaibigan mo";
+
+/* DashPay Invitations */
+"Have an invitation?" = "May imbitasyon ka ba?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Magkaroon ng kumpletong kontrol at pinasadyang pitaka base sa iyong nais";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d ng %2$d";
+
+/* SPV sync phase */
+"Headers" = "Mga header";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Taas %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Narito ang isang Dash address na itinalaga para sa iyong CrowdNode account sa Dash Wallet sa device na ito.";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Mataas hanggang mababa";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Mas mataas na bayarin, mga 7 sentimo (mas mababa pa rin kaysa sa ibang blockchain na may katulad na privacy)";
+
 /* No comment provided by engineer. */
 "History" = "Kasaysayan";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Paano ako makakakuha ng Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Paano ito ikinukumpara sa Bitcoin pagdating sa privacy?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Paano ito ikinukumpara sa mga Ethereum account pagdating sa privacy?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Gaano kapribado ang DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Paano kumpirmahin ang iyong API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Naisulat ko na ito";
 
+/* Identities */
+"Identities" = "Mga Pagkakakilanlan";
+
 /* Voting */
 "Identity" = "Pagkakakilanlan";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Mga kredito ng pagkakakilanlan";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Index ng pagkakakilanlan";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Pagpaparehistro ng pagkakakilanlan";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Pag-top-up ng pagkakakilanlan";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Sa seksyon ng pagbabayad ng iyong pag-checkout, piliin ang \"gift card\" at ilagay ang numero ng iyong card at pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Hindi aktibo";
+
+/* No comment provided by engineer. */
 "Income" = "Kita";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Nagsisimula";
+
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Mga input (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Hindi sapat na pondo";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Bayad sa Imbitasyon";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Imbitasyon mula kay %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Imbitasyon na ginamit ni";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Mag-imbita";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Mag-imbita ng Sinuman na sumali sa Dash Network";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Imbitahin ang iyong pamilya, hanapin ang iyong mga kaibigan sa pamamagitan ng paghahanap sa kanilang mga username";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Imbitahin ang iyong mga kaibigan at pamilya na sumali sa Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Imbitahan ang iyong pamilya't kaibigan sa Dash Network";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Naiulat na isyu";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Sumasali sa pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Panatilihing pribado ang mga baryang ito. May bayarin sa network at sa privacy.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Panatilihing ligtas ang iyong passphrase";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Key #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Datos ng key";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Pagmamay-ari ng key";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Mga Key";
 
 /* Explore Dash */
 "Last device sync" = "Huling pag-sync ng device";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Nangunguna";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Matuto Pa";
 
 /* Info Screen */
 "Learn More..." = "Matuto pa...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Ikinakarga ang mga transaksyon";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Lokal na pananalapi";
 
+/* Identities */
+"Local Only" = "Lokal Lamang";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Lokal na hiniling na halaga: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Lokasyon";
 
+"Lock" = "I-lock";
+
+"Lock the name" = "I-lock ang pangalan";
+
+"Lock “%@” so nobody gets it" = "I-lock ang “%@” para walang makakuha nito";
+
 /* No comment provided by engineer. */
 "Locked" = "Naka-lock";
 
+"Locked — nobody receives this username" = "Naka-lock — walang makakakuha ng username na ito";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "mag-log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Mababa";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Mababang bayarin para sa pang-araw-araw na gastos";
+
 /* Voting */
 "Low to high" = "Mababa hanggang mataas";
+
+/* Identities — the wallet's main identity */
+"Main" = "Pangunahin";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Masternode IP address";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode Keychain";
+
+/* Masternode keys */
 "Masternode keys" = "Mga Masternode Key";
+
+/* SPV sync phase */
+"Masternode list" = "Listahan ng masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "listahan ng masternode #%1$d ng %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Pag-update ng Masternode";
 
+"Masternode votes" = "Mga boto ng masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Mga Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Lilitaw dito ang mga masternode at evonode na nakarehistro sa mga key ng wallet na ito matapos mag-sync ang wallet.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Mga masternode at evonode na gumagamit ng mga key ng wallet na ito";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Bumoboto ang mga masternode sa mga pangalang higit sa isang tao ang humiling. Aabisuhan ka kapag natapos na ang pagboto.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Naabot ang minimum";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Mas marami pang kontrol";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Higit Pang Mungkahi";
+
+"Most lock votes" = "Pinakamaraming lock vote";
+
+"Most votes" = "Pinakamaraming boto";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Ilipat at I-zoom ang iyong larawan upang mahanap ang perpektong akma";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Ilipat sa iyong karaniwang magagamit na balanse.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Ilipat sa address";
+
+/* CoinJoin */
+"Moving funds" = "Inililipat ang pondo";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Pangalan";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Ang mga serbisyo ng pangalan gaya ng Unstoppable Domains ay nag-uugnay ng nababasang pangalan sa isang nakapirming pampublikong address sa chain. Matutunton ninuman ang pangalan at makikita ang bawat bayad na naipadala doon. Ang username sa DashPay ay hindi kailanman pampublikong tumuturo sa address ng bayad — inilalantad lang ang mga address sa loob ng naka-encrypt na palitan sa bawat kontak, kaya nananatiling hindi magkaugnay ang pangalan at pera mo sa paningin ng mga tagalabas.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Kailangan ng tulong ?";
+
+"Needs attention" = "Kailangan ng atensyon";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Walang nahanap na diagnostic log sa device na ito. Isusulat ang mga log simula sa susunod na pagbukas.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Walang Pagkakakilanlan";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Wala pang masternode";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Walang tumutugmang paligsahan";
+
+/* Identities */
+"No new identities were found for this wallet" = "Walang nahanap na bagong pagkakakilanlan para sa wallet na ito";
+
+"No open contest matches that search." = "Walang bukas na paligsahang tumutugma sa paghahanap na iyon.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Walang bukas na paligsahang tumutugma sa paghahanap na iyon. Nakaimbak sa normalisadong anyo ang mga pangalan, kaya nakalista ang “alice” bilang “a11ce”.";
+
+"No open contests" = "Walang bukas na paligsahan";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Walang paraan ng pagbabayad";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Walang nahanap na naka-save na wallet record para sa nakatalinang wallet.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Wala pang available na Platform address para sa pang-alternatibong protektadong pagpaparehistro. Subukang muli matapos mag-sync ang wallet.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Walang nahanap na resulta";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Walang username na pinag-aagawan sa ngayon. Nabubuksan ang paligsahan kapag dalawa o higit pang tao ang humiling ng parehong pangalan.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Walang natitirang boto";
+
+"No votes were cast" = "Walang naihulog na boto";
+
+"Nobody gets it" = "Walang makakakuha nito";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Hindi pamantayan";
 
 /* adjective, security level */
 "None" = "Wala";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Hindi available";
 
+"Not available yet" = "Hindi pa available";
+
+"Not cast" = "Hindi naihulog";
+
+/* Masternodes */
+"Not checked yet" = "Hindi pa nasusuri";
+
 /* Location Service Status */
 "Not Determined" = "Hindi determinado";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Kulang ang protektadong balanse para magparehistro ng pagkakakilanlan";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Wala sa kasaysayan ng wallet";
+
+"Not now" = "Hindi ngayon";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Hindi malawakang tinatanggap ng mga merchant";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Hindi pa malawakang tinatanggap ng mga merchant";
+
+/* Masternode keys */
+"Not yet used" = "Hindi pa nagagamit";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Luma sa bago";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Walang layer ng pangalan sa Bitcoin, kaya hayagang ibinabahagi at inuulit ng mga tao ang paggamit ng mga address — kapag nalaman na ang isang address, maiuugnay na sa may-ari nito ang lahat ng natanggap nito. Sa DashPay, pampubliko ang iyong username pero hindi ito kailanman tumuturo sa address ng bayad: pribadong ipinapalitan ang mga address sa bawat kontak at nagpapalit-palit ito, kaya hindi inilalantad ng pagbabayad sa pangalan kung saan napupunta ang pera mo. Parehong transparent na chain ang dalawa, kaya nananatiling nakaaapekto sa mismong barya ang chain analysis.";
+
+/* Identities */
+"On Network" = "Nasa Network";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kapag tinanggap na ni %@ ang iyong kahilingan, makakabayad ka nang direkta sa username";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Isang node sa bawat pagkakataon";
 
 /* Voting */
 "One vote left" = "Isang boto ang natitira";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Mga duplicate lang";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Mga masternode at evonode lang ang makakaboto sa mga username. Walang aktibong masternode voting key ang wallet na ito.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Mga kahilingan lamang na may mga link";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Lamang na may mga link";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Mga operator key";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Pampublikong key ng operator (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "o";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Preview ng Order";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Iba pang kalalabasan";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Mga output (%d)";
+
+/* Masternodes */
+"Owner" = "May-ari";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Address ng may-ari";
+
+/* Masternodes */
+"Owner address" = "Address ng may-ari";
+
+/* Masternodes */
+"Owner key hash" = "Hash ng key ng may-ari";
 
 /* Owner keys */
 "Owner keys" = "Mga susi ng may-ari";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Binayaran mula sa balanse ng kredito ng iyong pagkakakilanlan.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Idikit ang link dito";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "I-paste ang link ng imbitasyong natanggap mo, o i-scan ang QR code nito. Pinopondohan nito ang pagpaparehistro ng iyong username.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "I-paste ang URL ng iyong larawan";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Magbayad at mabayaran agad dahil sa madaling paraan ng pagbabayad.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "Magbayad nang Direkta sa Username";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Magbayad sa tao, hindi sa address";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Magbayad sa mga username. Wala nang mga alphanumeric na address";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Nagbabayad...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Paraan ng Pagbayad";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Pribado ang mga bayad: ang mga address na ipinapalitan mo sa isang kontak ay dumadaan sa loob ng naka-encrypt na payload na kayong dalawa lang ang makakabasa, at hindi ito kailanman inilalathala — kaya hindi basta-basta maiuugnay sa username mo ang mga bayad mo. Gayunpaman, karaniwang bayad pa rin ito sa transparent na chain: maaaring makapaglabas ng impormasyon ang masinsinang chain analysis. Isasara ng Shielded DashPay (malapit nang dumating) ang puwang na iyon. Ang mismong mga kahilingan sa pakikipag-ugnay ay HINDI pribado sa ngayon: makikita ninuman na magkaugnay ang dalawang pagkakakilanlan. Malapit nang dumating na tampok ang pribadong kahilingan sa pakikipag-ugnay. Pampubliko rin sa Dash Platform ang iyong username at profile.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Nakukumpirma ang mga bayad sa loob ng ilang segundo gamit ang InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Hindi mananatili sa aktibidad ang mga bayad na direktang ipinadala sa mga address.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Nakagrupo sa isang lugar ang mga bayad sa bawat kontak, may pangalan at profile sa halip na raw na transaksyon.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Address ng bayad";
 
 /* CrowdNode */
 "Payout Options" = "Mga Pagpipilian sa Pagbabayad";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform address";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Balanse sa Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform node";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform Node ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Hindi tinutukoy ng mga bayad sa Platform kung sino ang nagpadala. Naitala ang bayad na ito noong napansin ng wallet ang pagbabago sa balanse — maaaring mas maaga itong dumating.";
+
+"Platform SDK not ready" = "Hindi pa handa ang Platform SDK";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Hindi tumatakbo ang Platform sync. Buksan ang Sync Info → Platform Sync Status para simulan ito.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Protektado";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Mangyaring magdagdag ng paraan ng pagbabayad sa Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "I-preview ang Imbitasyon";
 
+/* Masternode keys */
+"Previously used at: " = "Dating ginamit noong: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Ang mga presyo ay hindi bababa sa 30 minutong gulang. Maaaring mali ang mga halaga ng Fiat.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Pribado sa disenyo";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Malapit nang dumating ang lahat ng ito: mga pribadong kahilingan sa pakikipag-ugnay (para manatiling pribado kung sino ang kinakaugnay mo), Shielded DashPay — mga bayad sa kontak mula sa iyong pribadong protektadong balanse — at pagbabayad sa mga user na wala pa sa iyong mga kontak.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Ginagawa pa ang pribadong kahilingan sa pakikipag-ugnay at inaasahang darating sa mga buwan ng Setyembre–Oktubre 2026. Sa ngayon, pampubliko ang mismong kahilingan — makikita ninuman na magkaugnay ang dalawang pagkakakilanlan, kahit naka-encrypt ang detalye ng bayad sa loob nito. Kapag dumating na ang pribadong kahilingan, mapipili mo kung pampubliko o pribado ang iyong pagkakaibigan.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Mga pribadong kahilingan sa pakikipag-ugnay, Shielded DashPay, at pagbabayad sa mga taong hindi pa kontak.";
+
 /* No comment provided by engineer. */
 "Private key" = "Pribadong susi";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Ipinapalitan ang mga pribadong address ng bayad sa pagitan mo at ng iyong mga kontak. Ikaw at ang kontak mo lang ang nakakaalam ng tatanggap at nagpadala sa mga bayad sa pagitan ninyo.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Mga pribadong bayad";
+
+/* Usernames */
+"Private registration" = "Pribadong pagpaparehistro";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Oras ng pagproseso";
+
+/* Balance info sheet section */
+"Pros" = "Mga Bentahe";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protektahan ang iyong mga ipon";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Address ng tagapagbigay ng serbisyo";
 
+/* Masternodes */
+"Provider transactions" = "Mga transaksyon ng provider";
+
+/* Masternode keys */
+"Public key" = "Pampublikong key";
+
+/* Masternode keys */
+"Public key (legacy)" = "Pampublikong key (luma)";
+
+/* Identities */
+"Public keys" = "Mga pampublikong key";
+
 /* No comment provided by engineer. */
 "Public URL" = "Pampublikong URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Nabigo ang Pagbili";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Layunin";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Palitan: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Raw na transaksyon";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Walang available na raw na transaksyon";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Sinusuri muli ang mga compact block filter mula sa piniling taas para sa mga transaksyon ng wallet na ito, ida-download at itutugma itong muli. Ang sahig ng muling pag-scan ay ang taas ng paglikha ng wallet at ang lokal na nakaimbak na chain data — para mabawi ang kasaysayang mas mababa pa roon, ibaba na lang ang panimulang taas ng wallet.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Basahin ang Patakaran sa Pag-withdraw";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Basahin lamang";
+
+/* Usernames */
+"Ready around %@" = "Handa nang mga %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Dahilan";
 
 /* No comment provided by engineer. */
 "Receive" = "Tumanggap";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Natanggap mula";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Natanggap mula kay %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Pagtanggap ng mga gantimpala";
+
+"Records your masternodes as having voted, without taking a side." = "Itinatala ang iyong mga masternode bilang bumoto na, nang hindi pumapanig.";
 
 /* No comment provided by engineer. */
 "Recover" = "Bawiin";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = " Ang recovery phrase ay kailangang mayroong 12, 15, 18, 21 o 24 na salita";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "I-refresh";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Magparehistro?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Nairehistro noong";
+
+/* No comment provided by engineer. */
 "Registered from" = "Nagrehistro mula";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Nakarehistrong Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Kailangan ng pribadong pagpaparehistro ng hindi bababa sa %@ Dash sa iyong protektadong balanse at ilang oras ng pahinga — gagabayan ka ng mga susunod na screen.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Pagpaparehistro";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Humihiling ng pangalang ito";
+
 /* An action */
 "Rescan" = "I-scan muli";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Hindi laging nababawi ng mga naibalik na wallet ang uri ng operasyon. Muling binuo ang entry na ito mula sa on-chain na datos ng tala.";
+
+/* Location Service Status */
 "Restricted" = "Pinaghihigpitan";
 
 /* Usernames */
 "Results" = "Mga resulta";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Nakahanda ang resync mula sa taas na %u — isara at buksang muli ang app para magsimula.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "Panatilihin ang Magkabilaang Kasaysayan ng Transaksyon";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retirado";
 
 /* No comment provided by engineer. */
 "Retry" = "Subukang muli";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Suriin ang pag-post sa ibaba upang i-verify ang pagmamay-ari ng username na ito";
+
+/* Masternodes */
+"Revocation" = "Pagbawi";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Ang mga screenshot ay kita sa ibang apps o device. Lumikha ng bagong recovery phrase at panatilihin itong sikreto.                                  ";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Lagda ng script";
+
+/* Raw transaction inspector */
+"Script type" = "Uri ng script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Maghanap ng kontak";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Maghanap ng kahilingan sa pakikipag-ugnay";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Maghanap ng User sa Dash Network";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Maghanap ng username";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Mga resulta ng paghahanap para sa \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Maghanap ng mga teritoryo";
+
+"Search usernames" = "Maghanap ng username";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Hinahanap ang username na %@ sa Dash Network";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "I-secure ang Iyong Wallet";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Lebel ng seguridad";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Antas ng seguridad";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Pumili ng serbisyong bibilhin, ibebenta, iko-convert at ililipat ang Dash";
 
+"Select all" = "Piliin lahat";
+
 /* DashSpend denomination selection */
 "Select amount" = "Pumili ng halaga";
+
+"Select at least one masternode to vote with." = "Pumili ng hindi bababa sa isang masternode na ipangboboto.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Piliin ang barya";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Kapag mas kaunting node ang pinili, mas kaunti ang naibubunyag tungkol sa kung anong masternode ang pinapatakbo mo.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Pinadala kay";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Magpadala sa Kontak";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Magpadala sa username na talagang matatandaan at mabeberipika mo.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Ipadala sa address";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Ipadala ang iyong unang kahilingan sa pakikipag-ugnay";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Ipinapadala";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Nagpapadala ng Kahilingan sa Pakikipag-ugnay";
+
+/* No comment provided by engineer. */
+"Sending to" = "Ipinapadala kay";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Ipinapadala sa CrowdNode account";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Ipadala kay";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Ipinadala kay %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Nagkaroon ng error sa server. Pakisubukang muli mamaya.";
+
+/* Masternodes */
+"Service" = "Serbisyo";
+
+/* Identities */
+"Set as Main" = "Itakda bilang Pangunahin";
+
+/* Identities */
+"Set as Main Identity" = "Itakda bilang Pangunahing Pagkakakilanlan";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Mag-set ng PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Ibahagi ang susi";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Nasa minimum na laki ang ibinahaging privacy pool";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Protektadong address";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Protektadong paggastos";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Sinisimulan ang protektadong wallet…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Protektado → Platform";
+
+"Shielded → Transparent" = "Protektado → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Ipakita ang lahat ng Lokasyon";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Laki";
+
 /* No comment provided by engineer. */
 "Skip" = "Laktawan";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Maaaring may ilan sa iyong mga masternode na wala sa listahang ito — hindi nabasa ng wallet ang buo mong pool ng voting key. Tapusin ang pag-sync at buksang muli ang screen na ito.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Maaaring i-block ang ilang mga username";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Pag-uri-uriin ayon";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ayusin ang mga Kontak";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Pinagbukud-bukod ayon sa diskwento";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Inayos ayon sa pangalan";
+
+/* Raw transaction inspector */
+"Special payload" = "Espesyal na payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Tukuyin ang halaga";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Magsisimula kapag nagdagdag ka ng pondo";
+
+/* Transaction details */
+"Status" = "Katayuan";
+
 /* Step 1 */
 "Step %ld" = "Hakbang %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Nakaimbak bilang";
 
 /* Voting */
 "Submit" = "Isumite";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Kasalukuyang isinasagawa ang pag-sync... Maaaring hindi kumpleto ang resulta.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Sync Info";
+
+/* SPV sync */
+"Sync too slow?" = "Masyadong mabagal ang pag-sync?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Kumuha ng Larawan mula sa Camera";
 
+"Take no side" = "Huwag pumanig";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "I-tap ang address mula sa clipboard para i-paste ito";
+
+/* Raw transaction inspector */
+"Tap to copy" = "I-tap para kopyahin";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Pindutin upang itago ang balanse";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Pansamantalang hindi magagamit";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash node key (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Mga tuntunin at kundisyon";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Mali ang code. Pakisuri at subukang muli!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dumarating ang Dash sa address ng tatanggap matapos iproseso ng network ang withdrawal — maaari itong tumagal nang hanggang 10 minuto.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dumarating ang Dash sa address ng tatanggap sa oras na maiproseso ng network ang withdrawal.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dumarating ang Dash sa iyong transparent na balanse sa oras na maiproseso ng network ang withdrawal.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Ang network ng Dash ay kailangang bumoto upang aprubahan ang ilang mga username bago sila malikha";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Ang link na iyong ipapadala ay makikita lamang ng mga may-ari ng network";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Mapipili lang ang pangunahing pagkakakilanlan mula sa aktibong wallet";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Ang pinakamababang halaga na maaari mong ipadala ay %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Ang pinakapribadong lugar para itago ang iyong Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Walang network ang naka-save na wallet record — hindi maihahanda ang resync.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Naisumite ang pagpaparehistro pero hindi makumpirma ang resulta nito. Maghintay ng isang minuto para makapag-sync ang wallet, saka subukang muli — huwag agad isumiteng muli.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Lumalaki pa ang ibinahaging privacy pool (%1$ld sa %2$ld deposito). Bubuksan ang pribadong pagpaparehistro kapag naabot na nito ang minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Lumalaki pa ang ibinahaging privacy pool (%1$ld sa %2$ld deposito). Subukang muli kapag naabot na nito ang minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Ang username '%@' ay hinarangan ng Dash Network. Pakisubukang muli sa pamamagitan ng paghiling ng isa pang username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Ang taas ng paglikha ng wallet — ang sahig para sa mga filter scan at sa mga “Mula sa paglikha ng wallet” na muling pag-scan. Itakda ito sa o mas mababa pa sa unang pagpopondo ng wallet; 200000 ang default ng mga import sa mainnet at 0 sa testnet. Kapag nag-save ng taas na katumbas o mas mababa sa kasalukuyan, buburahin ang chain data ng network na ito sa susunod na pagbukas at ise-scan muli mula roon.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "siya (Kinukuha ang Impormasyon)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Walang bagong abiso";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Walang transaksyon na maipapakita";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Walang user na tumutugma sa pangalang %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Walang user sa iyong mga kontak na tumutugma sa pangalang %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Nagkaroon ng error noong ine-export ang iyong history ng transaksyon sa ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Nagkaroon ng error, pakisubukang muli sa ibang pagkakataon";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Napupunta ang pondong ito sa iyong balanse sa Platform at handa nang gastusin sa oras na matapos ang paglilipat.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Hindi mababayaran ang address na ito mula sa iyong %@ na balanse";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Nagdaragdag ito ng dalawang key sa iyong pagkakakilanlan para makapagpadala sa iyo ng kahilingan sa pakikipag-ugnay ang ibang user, at para matanggap mo ang sa kanila. Isang beses lang ito nangyayari.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Inilalapat nito ang iisang pagpipilian sa lahat ng %d napiling username.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Ipinapakita ng karagdagang hakbang na ito na ikaw talaga ang sumusubok na gumawa ng transaksyon.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Hindi wasto ang link ng imbitasyong ito.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Hindi ito wastong Dash address para sa network na ito";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Hindi ito wastong link ng imbitasyon";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ito ang iyong pangunahing pagkakakilanlan";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Wala pang Platform na pagkakakilanlan ang masternode na ito.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Kasalukuyang hindi available ang merchant na ito.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Kinakatawan nito ang kasalukuyang Annual Percentage Yield ng isang buong Masternode na mas mababa sa 15% na bayad sa CrowdNode. Ito ay hindi isang garantisadong rate ng pagbabalik at maaaring tumaas o bumaba batay sa laki ng mga pool ng CrowdNode at ang presyo ng Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Nabibilang pa rin itong bumoto ang iyong mga masternode sa paligsahang ito.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Hindi nakaimbak sa device na ito ang raw na bytes ng transaksyong ito.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Napunta sa iba ang username na ito";
+
+"This wallet could not derive the voting key for this node." = "Hindi nailabas ng wallet na ito ang voting key para sa node na ito.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Walang aktibong masternode voting key ang wallet na ito, kaya hindi ito makakaboto. Lilitaw sa Tools → Masternodes ang mga nakarehistrong node.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Iniuurong nito ang buo mong balanse sa Platform sa isang paglilipat. Dumarating ang Dash sa address ng tatanggap sa oras na maiproseso ng network ang withdrawal.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Iniuurong nito ang buo mong balanse sa Platform sa isang paglilipat. Dumarating ang Dash sa iyong transparent na balanse sa oras na maiproseso ng network ang withdrawal.";
 
 /* Send Screen: to address */
 "to" = "para kay:";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Kasaysayan ng Transaksyon";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Hindi available ang kasaysayan ng transaksyon";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaction ID";
 
 /* A verb, button title. */
 "Transfer" = "Ilipat";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Maglipat sa";
 
+/* Balance breakdown */
+"Transfer in" = "Papasok na paglilipat";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Ilipat sa";
+
+/* Balance breakdown */
+"Transfer out" = "Palabas na paglilipat";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Mas matagal ang mga paglilipat — kailangan ng oras para makabuo ng mga patunay ng privacy";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Agad at pinal ang mga paglilipat sa ibang Platform address at sa protektadong address";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Transparent na address";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparent na balanse";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Pampublikong iniuugnay ng transparent na pagpopondo ang iyong username sa pondong ito.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Protektado";
 
 /* An action */
 "Try again" = "Subukan muli";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Hindi makapagbigay ng mungkahi";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Hindi alam ang Balanse";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Hindi kilalang espesyal na uri %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Hindi protektado";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Hindi suportadong URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Mag-upgrade sa DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Mag-upgrade sa Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Gamitin na lang ang transparent na balanse";
+
+/* Masternode keys */
+"Used" = "Nagamit";
+
+/* Masternode keys */
+"Used at: " = "Nagamit noong: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "User (Kinukuha ang Impormasyon)";
 
 /* Voting */
 "Username" = "Username";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Matagumpay na hiniling ang username";
 
+/* Identities */
+"Usernames" = "Mga Username";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Nakaimbak sa normalisadong anyo ang mga username para maiwasan ang magkakahawig na pangalan, kaya maaaring iba ito sa tinipa ng bawat tao.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Username, hindi address";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Mga user na tumutugma kay %@ na kasalukuyang wala sa iyong mga kontak";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Gumagamit ng isa sa pinakasuring at pinakasubok na zero-knowledge library (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Wastong imbitasyon";
+
 /* CrowdNode Portal */
 "Validating address…" = "Pinapatunayan ang address...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Kailangan ng beripikasyon";
 
+/* Usernames */
+"Verified during registration" = "Naberipika habang nagpaparehistro";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Matagumpay na na-beripika";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "I-verify ang iyong pagkakakilanlan";
 
+/* Raw transaction inspector */
+"Version" = "Bersyon";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Napakahusay at mababa ang bayarin";
+
 /* adjective, security level */
 "Very High" = "Napakataas";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Ang napakaliit na halaga ng Dash ay ipapadala sa at mula sa CrowdNode upang i-verify na ikaw ang may-ari ng address ng wallet na ito.";
+
+/* No comment provided by engineer. */
+"View All" = "Tingnan Lahat";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Tingnan sa Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Ipakita ang recovery phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Tingnan ang Transaksyon";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Tingnan ang mga detalye ng transaksyon";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Bumoto";
+
+"Vote cast" = "Naihulog ang boto";
+
 /* Voting */
 "Vote for All" = "Bumoto para sa Lahat";
 
 /* Voting */
+"Vote on contested usernames" = "Bumoto sa mga pinag-aagawang username";
+
+"Vote on several" = "Bumoto sa marami";
+
+/* Voting */
 "Vote to Approve" = "Bumoto para Aprubahan";
+
+"Vote with" = "Bumoto gamit ang";
+
+"Votes that nobody should receive these usernames." = "Bumoboto na walang dapat makakuha ng mga username na ito.";
 
 /* Voting */
 "Votes: High to low" = "Mga Boto: Mataas hanggang mababa";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Address ng pagboto";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Address ng pagboto";
+
+"Voting ended with no winner" = "Natapos ang pagboto nang walang nanalo";
+
+"Voting ends" = "Magtatapos ang pagboto";
+
 /* Voting */
 "Voting ends in %dd" = "Nagtatapos ang pagboto %dd";
+
+"Voting in progress" = "Isinasagawa ang pagboto";
+
+"Voting in progress — lock votes are ahead" = "Isinasagawa ang pagboto — nangunguna ang mga lock vote";
+
+"Voting in progress — you are ahead" = "Isinasagawa ang pagboto — ikaw ang nangunguna";
 
 /* Usernames */
 "Voting is only required in some cases" = "Ang pagboto ay kinakailangan lamang sa ilang mga kaso";
 
+/* Masternodes */
+"Voting key hash" = "Hash ng key ng pagboto";
+
 /* Voting keys */
 "Voting keys" = "Mga susi ng pagboto";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Sarado na ang pagboto sa username na ito. Ang mga bilang sa ibaba ang huling nabasa.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Sarado na ang pagboto sa “%@”. Mag-refresh para makita ang resulta.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Maghintay hanggang ma-sync ang wallet upang makumpleto ang transaksyon";
 
+"Waiting for Dash Platform" = "Naghihintay sa Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "address ng pitaka";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Panimulang taas ng wallet";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Naka-disabled ang iyong pitaka";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Maligayang pagdating sa DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Paano naman ang Unstoppable Domains at katulad na serbisyo ng pangalan?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Magkano ang halaga nito?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Ano ang DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Ano ang pagboto ng username?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Ano ang susunod?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kailan magiging pribado ang mga kahilingan sa pakikipag-ugnay?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Saan Gagastos";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Saan Gagastos?";
+
+"Who is requesting this name" = "Sino ang humihiling ng pangalang ito";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Bakit ko kailangang i-enable ito?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Bakit ko nakikita ang lahat ng mga transaksyong ito?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Hiniling ang withdrawal";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Iniuurong ang buong balanse";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Gumagana sa bawat Dash wallet, exchange, at merchant";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Gusto mo bang tanggapin ang imbitasyon?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Kahapon";
+
+"You" = "Ikaw";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Tinanggap mo ang kahilingan sa pakikipag-ugnay mula kay %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Pinili mo ang “%@” bilang iyong username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Wala kang anumang kontak sa ngayon";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Wala ka nang sapat na pondo para makompleto ang transaksyong ito";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Lumampas ka sa limitasyon ng awtorisasyon sa Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "May %@ Dash ka na sa ngayon";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Mayroon kang %1$@ Dash.\nAng ilang mga username ay nagkakahalaga ng hanggang %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Ipinadala mo ang kahilingan sa pakikipag-ugnay kay %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Dapat ay mayroon kang positibong balanse sa Dash Wallet";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Napanalunan mo ang username na ito";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Handa na ang lahat. Makakapagpadala na ngayon sa iyo ng kahilingan sa pakikipag-ugnay ang ibang user — at makakapagpadala ka na rin ng sa iyo.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Lilitaw dito ang iyong Dash Platform na pagkakakilanlan kapag nagparehistro ka ng username.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Ang iyong email ay ginagamit lamang upang magpadala ng isang beses na password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Ang iyong kasaysayan, nakaayos";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Kailangan ng iyong pagkakakilanlan ng dalawang dagdag na key para ma-encrypt ang mga kahilingan sa pakikipag-ugnay sa pagitan mo at ng ibang user. Idinaragdag ito ng pag-enable sa iisang transaksyon sa network. Isang beses lang ito nangyayari.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Na-claim na ang iyong imbitasyon mula sa %@ ";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Ang iyong imbitasyon mula sa %@ ay hindi wasto";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Babayaran ng iyong imbitasyon ang bayarin sa pagpaparehistro ng username na ito.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Ginagamit ang iyong lokasyon upang ipakita ang iyong posisyon sa mapa, mga ATM sa napiling radius at pinabubuti ang mga resulta ng paghahanap.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Ginagamit ang iyong lokasyon upang ipakita ang iyong posisyon sa mapa, mga mangangalakal sa napiling redius at pagbutihin ang mga resulta ng paghahanap.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Ang iyong pangunahing balanse ng Dash sa Core blockchain — ang ipinapadala at natatanggap mo sa ibang wallet, exchange, at merchant.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Nailipat sa balanse ng iyong Dash Wallet ang pinaghalo mong barya.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Nailipat sa iyong protektadong balanse ang pinaghalo mong barya. Para sa pinakamahusay na privacy, maghintay nang hindi bababa sa 2 oras bago gamitin ang pondong ito.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Ang iyong balanse sa Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Ang iyong pangunahing Dash address na kasalukuyan mong ginagamit para sa iyong CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Ang iyong pribadong balanse. Naka-encrypt on-chain ang mga halaga at address, kaya nananatiling kumpidensyal ang hawak at kasaysayan mo.";
+
 /* Usernames */
 "Your request was cancelled" = "Kinansela ang iyong kahilingan";
 
 /* DashSpend */
 "Your session expired" = "Nag-expire ang iyong session";
+
+/* Usernames */
+"Your Shielded balance" = "Ang iyong protektadong balanse";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Malapit nang maging handa ang iyong protektadong balanse — makakapagparehistro ka nang pribado nang mga %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Handa na ang iyong protektadong balanse — iparehistro na ang iyong username nang pribado";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Nagpapahinga ang iyong protektadong balanse — makakapagparehistro ka nang pribado nang mga %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Naghihinog pa ang iyong protektadong balanse. Magiging handa ito nang mga %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Ang iyong transparent na balanse";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Ang iyong username %@ ay matagumpay na nilikha sa Network ng Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Ang iyong username ay matagumpay na nalikha";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Nakikita ng lahat ang iyong username. Kapag pinondohan mo ito mula sa protektadong balanse — matapos hayaang magpahinga ang pondo nang ilang oras — walang makakapag-ugnay ng username mo sa iba mong Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Sumusunod sa pagkakakilanlang ito ang iyong username, profile, at mga kontak.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Susunod sa pagkakakilanlang ito ang iyong username, profile, at mga kontak.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Kinansela ang iyong boto";
 
 /* Voting */
 "Your vote was submitted" = "Naisumite ang iyong boto";
 
+"Your votes" = "Ang iyong mga boto";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Ang iyong pitaka ay ligtas na. Maari mong magamit ang recovery phrase kahit kailan upanh marekober ang account sa ibang device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Nagsi-sync pa ang iyong wallet sa Dash network. Magiging available ang pagpapadala kapag natapos na ang pag-sync.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Nagsi-sync pa ang iyong wallet. Magiging available ang pagpapadala mula sa iyong transparent na balanse kapag natapos na ang pag-sync.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Hindi mabasa ang “%@” bilang Dash username.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "Nairehistro na ang “%@”. Magpadala ng kahilingan sa pakikipag-ugnay sa taong nag-imbita sa iyo?";

--- a/DashWallet/fil.lproj/Localizable.stringsdict
+++ b/DashWallet/fil.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d mga susi</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ ang nabilang para sa “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u boto</string>
+			<key>other</key>
+			<string>%1$u na boto</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Naboto ang %1$d sa %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d username</string>
+			<key>other</key>
+			<string>%2$d na username</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Ihulog ang %u boto</string>
+			<key>other</key>
+			<string>Ihulog ang %u na boto</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d sa %#@nodes@ ang bumoto</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d na masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d sa %#@nodes@ ang bumoto</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d node</string>
+			<key>other</key>
+			<string>%2$d na node</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d na evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u boto sa kabuuan</string>
+			<key>other</key>
+			<string>%u na boto sa kabuuan</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d na masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ang napili</string>
+			<key>other</key>
+			<string>%d ang napili</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d sa mga node mo ang bumoto na rito kaya hindi ito nakalista.</string>
+			<key>other</key>
+			<string>%d sa mga node mo ang bumoto na rito kaya hindi sila nakalista.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u boto bawat paligsahan — ang evonode ay bilang 4, ang masternode ay 1</string>
+			<key>other</key>
+			<string>%u na boto bawat paligsahan — ang evonode ay bilang 4, ang masternode ay 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Bumoto sa %d username</string>
+			<key>other</key>
+			<string>Bumoto sa %d na username</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u boto</string>
+			<key>other</key>
+			<string>%u na boto</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Bumoto ×%d</string>
+			<key>other</key>
+			<string>Bumoto ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d kahilingan</string>
+			<key>other</key>
+			<string>%d na kahilingan</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ou ";
+
 /* CrowdNode */
 " Privacy Policy " = "Politique de confidentialité";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ est introuvable sur le réseau Dash pour lui envoyer une demande de contact.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponibles";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ a accepté votre demande de contact";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu mises à jour de profil";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d octets";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes seront enregistrés car votre portefeuille possède plusieurs clés de vote";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld doublons";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld dépôts sur %ld";
 
 /* Voting */
 "%ld requests" = "%ld requêtes";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" n'est pas un mot de phrase de récupération. Voulez-vous tenter de retrouver le bon mot qui devrait être à la même place ?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Un solde de crédits sur Dash Platform utilisé pour les paiements instantanés entre adresses Platform et pour des fonctionnalités comme les noms d'utilisateur.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "\nUn code d'accès est nécessaire pour sécuriser votre portefeuille. Allez dans les paramètres et activez le code d'accès pour continuer.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "À propos";
 
+/* DashPay FAQ title */
+"About DashPay" = "À propos de DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "À propos de moi";
+
+"Abstain" = "S'abstenir";
+
+"Abstain on “%@”" = "S'abstenir sur « %@ »";
 
 /* No comment provided by engineer. */
 "Accept" = "Accepter";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Restauration de compte";
 
+/* Masternode status */
+"Active" = "Actif";
+
+/* No comment provided by engineer. */
+"Activity" = "Activité";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "L'activité est publique, mais difficile à tracer";
+
 /* No comment provided by engineer. */
 "Add" = "Ajouter";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Ajouter %@ comme contact";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Ajoutez %@ comme contact pour payer directement au nom d'utilisateur et conserver l'historique mutuel des transactions";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Ajoutez %@ Dash à votre solde blindé et laissez-le reposer quelques heures afin de vous enregistrer sans lier votre nom d'utilisateur à vos autres fonds.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Ajouter un nouveau contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Ajoutez au moins %@ Dash à votre solde blindé";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Ajoutez des fonds à votre solde blindé maintenant et enregistrez votre nom d'utilisateur en privé quelques heures plus tard";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Tous";
 
+"All nodes at once" = "Tous les nœuds en même temps";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tous vos masternodes ont voté sur ce nom d'utilisateur. Pour modifier un vote, votez de nouveau depuis le candidat que vous préférez désormais.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Autoriser l'envoi de toutes les transactions depuis Dash Wallet vers ZenLedger ?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Synchronisation des soldes quasi instantanée";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Les montants et les adresses sont publics sur la blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Une erreur s'est produite";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un compte Ethereum est une seule adresse réutilisable : l'intégralité de votre solde et de votre historique de paiements y figure publiquement, et un nom (comme un domaine ENS) pointe généralement directement vers cette adresse, que n'importe qui peut résoudre. DashPay a la forme inverse : le nom résout vers une identité, pas vers une adresse de paiement, et les véritables adresses de paiement restent à l'intérieur d'échanges de contact chiffrés, renouvelées pour chaque contact.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Une utilisation familière et intuitive sur tous vos appareils";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Tout nom d'utilisateur sera automatiquement approuvé s'il contient au moins un chiffre entre 2 et 9, ou s'il a plus de 20 caractères, ou s'il contient un trait d'union.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Quiconque connaît une adresse peut consulter son historique";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Appliquer";
 
+"Approve" = "Approuver";
+
+"Approving a specific request can only be done one username at a time." = "L'approbation d'une demande précise ne peut se faire que pour un nom d'utilisateur à la fois.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Êtes-vous sûr(e) de vouloir annuler cet ordre ?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "En texte";
 
 /* DashSpend */
 "at" = "à";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Authentification annulée. Votre vote n'a pas été soumis.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Échec de l'authentification. Votre vote n'a pas été soumis.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "L'authentification n'est pas disponible";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Attribuer « %@ » à ce candidat";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Solde";
 
 /* CrowdNode */
+"Balance after" = "Solde après";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Solde sur CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Solde :";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Les soldes et les transferts ne sont pas visibles publiquement";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Compte bancaire";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Accès à la reconnaissance biométrique";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Hauteur d'origine enregistrée — le plancher de scan relevé s'applique à partir du prochain démarrage.";
+
 /* Voting */
 "Block" = "Bloc";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Nom d'utilisateur '%@' bloqué";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Liée à un contrat";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Liée à un contrat, type de document « %@ »";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Consultation seule";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Regrouper les journaux de diagnostic récents dans un zip pour les envoyer par AirDrop, par e-mail ou les enregistrer dans Fichiers";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Soumettre le vote";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Changer de pairs";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Modifier le code PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Vérification…";
+
+"Choice" = "Choix";
+
 /* Choose your Dash username */
 "Choose your" = "Choisissez votre";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choisir votre nom d'utilisateur";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Réclamez votre invitation";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Solde réclamable";
+
 /* No comment provided by engineer. */
 "Claimed" = "Demandé";
+
+/* SPV diagnostics */
+"Clear & resync" = "Effacer et resynchroniser";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Effacer les données de la chaîne et resynchroniser ?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Fermer l'application";
 
+"Closing" = "Clôture en cours";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nouvelles pièces)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Code 2FA Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin n'est plus pris en charge — choisissez où déplacer vos pièces mélangées.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Garantie";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Bientôt disponible";
+
+/* Shielded transfer status */
+"Completed" = "Terminé";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirmer";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confirmée";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Confirmer enregistre la hauteur d'origine %u et efface les données de chaîne de ce réseau au prochain démarrage de l'application, puis les retélécharge et rescanne les filtres à partir de cette hauteur. La session en cours conserve son ancien plancher de scan — quittez et rouvrez l'application pour démarrer.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connectez vos portefeuilles crypto à la plateforme ZenLedger. En savoir plus et se lancer avec vos transactions Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Adresse Dash connectée";
 
+/* SPV sync */
+"Connected peers" = "Pairs connectés";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Inconvénients";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Échec de la demande de contact";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Demande de contact envoyée à %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Demandes de contact";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Candidat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continuer";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continuez pour choisir votre nom d'utilisateur. L'invitation paie les frais d'enregistrement.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copier le lien d'invitation";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copier la transaction brute";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copier le texte";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Les mots incorrects ou manquants n'ont pas pu être retrouvés automatiquement";
 
+/* Log export */
+"Could not create the log archive: %@" = "Impossible de créer l'archive des journaux : %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Taux de change introuvables.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Impossible d'actualiser %d identités";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Impossible de récupérer le solde (erreur réseau). Essayez d'actualiser.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Impossible d'effectuer le paiement";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Créez votre nom d'utilisateur";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Créez votre nom d'utilisateur, retrouvez vos amis et votre famille grâce à leur nom d'utilisateur et ajoutez-les à vos contacts";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Carte bancaire";
+
+/* Masternodes */
+"Credits" = "Crédits";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Les paiements Dash ne peuvent pas être inférieurs à %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform n'a pas encore indexé ce litige. Les décomptes de votes apparaîtront ici une fois que ce sera fait.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform n'est pas encore connecté. Attendez la fin de la synchronisation et réessayez.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Les Dash envoyés à une mauvaise adresse ne peuvent pas être récupérés. Assurez-vous que l'adresse est exactement celle que vous souhaitez payer.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash stocke les noms d'utilisateur sous une forme protégée contre les sosies : le nom stocké peut donc différer de ce que chaque personne a saisi.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nom d'utilisateur Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Portefeuille Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Solde du portefeuille Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Portefeuille Dash sur cet appareil";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay activé";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Invitation DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay est l'expérience de paiement social de Dash, construite sur Dash Platform. Vous enregistrez un nom d'utilisateur, ajoutez d'autres utilisateurs comme contacts et les payez par leur nom — fini le copier-coller d'adresses.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay remplace les longues adresses cryptiques par des noms d'utilisateur. Ajoutez vos amis comme contacts, envoyez de l'argent à un nom et gardez chaque paiement organisé par personne.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Frais de mise à jour DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date : ancienne à récente";
+
+"Deadline unknown" = "Échéance inconnue";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Transfert envoyé";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Chemin de dérivation";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "SÉCURITÉ DE L'APPAREIL COMPROMISE\nN'importe quelle application débridée peut accéder aux données du trousseau des autres applications (et voler vos dashs). Effacez immédiatement ce portefeuille et restaurez-le sur un appareil sécurisé.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Désactivée";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Se déconnecter du compte Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Terminé";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Terminé — votre solde a reposé assez longtemps";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Vérifiez bien l'adresse";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Chaque invitation percevra ce montant, et le bénéficiaire peut créer rapidement son nom d'utilisateur sur le réseau Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Chaque masternode dispose d'un vote actif par litige. Vous pouvez le modifier plus tard, mais Dash Platform n'autorise que 5 votes au total par masternode et par litige.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Chaque appui fait voter un nœud de plus : vous choisissez donc combien en relier ensemble.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Plus tôt";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Percevez facilement des gains Dash et gagnez un revenu passif après quelques simples clics.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Modifier la hauteur d'origine";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Éditer le profil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-mail";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Activer";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Activer DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Activer Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Activer Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "L'activation de DashPay coûte de petits frais de réseau uniques, prélevés sur le solde de crédits de votre identité. L'estimation exacte s'affiche avant votre confirmation. L'envoi de demandes de contact et de paiements coûte les frais de réseau habituels.";
+
+"Ending soonest" = "Se termine le plus tôt";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Erreur en modifiant votre profil";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Frais de réseau estimés";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Tous les nœuds votent ensemble. Plus rapide, mais cela relie publiquement vos masternodes entre eux.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Clés d'opérateur d'evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Exporter les journaux";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Clé publique étendue (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Adresse externe";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Limite pour Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Échec";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Échec de chargement du code-barres";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Récupération des cours…";
 
+/* Masternodes */
+"Fetching…" = "Récupération…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Compte fiduciaire";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtre";
+
+/* SPV sync phase */
+"Filter headers" = "En-têtes de filtres";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtrer les transactions";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Trouver un utilisateur sur le réseau Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Trouver des distributeurs pour acheter ou vendre des dashs";
+
+/* Identities */
+"Find identities" = "Rechercher des identités";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Code PIN oublié ?";
 
+/* Identities */
+"Found %d new identities" = "%d nouvelles identités trouvées";
+
+/* Identities */
+"Found 1 new identity" = "1 nouvelle identité trouvée";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Trouvé le mot manquant :\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financez votre nom d'utilisateur depuis votre solde blindé. Ajoutez les fonds quelques heures à l'avance — ce court repos empêche de relier votre nom d'utilisateur à vos autres Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financé depuis votre solde blindé — votre nom d'utilisateur ne peut pas être relié à vos autres Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fonds verrouillés — finalisation du transfert";
+
+/* CoinJoin */
+"Funds moved" = "Fonds déplacés";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Percevez des récompenses grâce à vos transferts sur des masternodes Dash, dès la petite somme de 0,5 dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Obtenir un devis";
+
+/* Usernames */
+"Get ready to join DashPay" = "Préparez-vous à rejoindre DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Percevez des récompenses instantanément";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Compris";
+
+/* Governance */
+"Governance" = "Gouvernance";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Autorisez les permissions GPS pour que nous puissions vous afficher les endroits proches.";
 
 /* Voting */
 "Has blocked votes" = "A des votes de blocage";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "a demandé à devenir votre ami";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Vous avez une invitation ?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Gardez un contrôle complet et personnalisez votre portefeuille selon vos besoins";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "en-tête #%1$d sur %2$d";
+
+/* SPV sync phase */
+"Headers" = "En-têtes";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Hauteur %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Voici une adresse Dash attribuée à votre compte CrowdNode dans Dash Wallet sur cet appareil";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "De haut à bas";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Frais plus élevés, autour de 7 centimes (toujours plus bas que d'autres blockchains offrant une confidentialité similaire)";
+
 /* No comment provided by engineer. */
 "History" = "Historique";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Comment puis-je obtenir des dashs de test ?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Comment cela se compare-t-il à Bitcoin en matière de confidentialité ?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Comment cela se compare-t-il aux comptes Ethereum en matière de confidentialité ?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Quel est le niveau de confidentialité de DashPay ?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Comment confirmer votre adresse API Dash";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Je l'ai écrite sur papier";
 
+/* Identities */
+"Identities" = "Identités";
+
 /* Voting */
 "Identity" = "Identité";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Crédits d'identité";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Index d'identité";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Enregistrement d'identité";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Recharge d'identité";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Dans la section paiement de votre achat, choisissez \"carte-cadeau\" puis tapez son numéro et son code.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactif";
+
+/* No comment provided by engineer. */
 "Income" = "Revenu";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initialisation";
+
+/* Raw transaction inspector */
+"Input %d" = "Entrée %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Entrée %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Entrées (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Fonds insuffisants";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Frais d'invitation";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitation de %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation utilisée par";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Inviter";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invitez quelqu'un à rejoindre le réseau Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Inviter votre famille, trouver vos amis en recherchant leurs noms d'utilisateur";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Inviter vos amis et votre famille à rejoindre le réseau Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invitez vos amis et votre famille sur le réseau Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "Dash Wallet iOS : %@ Problème signalé";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Rejoindre une équipe";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Gardez ces pièces privées. Des frais de réseau et de confidentialité s'appliquent.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Gardez secrète votre phrase de passe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Clé n° %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Données de la clé";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Propriété de la clé";
+
 /* No comment provided by engineer. */
 "Keypair" = "Paire de clés";
+
+/* Masternodes */
+"Keys" = "Clés";
 
 /* Explore Dash */
 "Last device sync" = "Dernière synchro de l'appareil";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "En tête";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "En savoir plus";
 
 /* Info Screen */
 "Learn More..." = "En savoir plus…";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Chargement des transactions";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Monnaie locale";
 
+/* Identities */
+"Local Only" = "Local uniquement";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Montant local demandé : %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Localisation";
 
+"Lock" = "Verrouiller";
+
+"Lock the name" = "Verrouiller le nom";
+
+"Lock “%@” so nobody gets it" = "Verrouiller « %@ » pour que personne ne l'obtienne";
+
 /* No comment provided by engineer. */
 "Locked" = "Verrouillé";
 
+"Locked — nobody receives this username" = "Verrouillé — personne ne reçoit ce nom d'utilisateur";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Se connecter";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Bas";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Frais réduits pour les dépenses du quotidien";
+
 /* Voting */
 "Low to high" = "De bas à haut";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principale";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Réseau principal";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Adresse IP de masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Trousseau de masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Clés de masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Liste des masternodes";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "liste de masternodes #%1$d sur %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Mettre à jour un masternode";
 
+"Masternode votes" = "Votes des masternodes";
+
 /* Voting */
 "Masternode Voting Key" = "Clé de vote de masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Les masternodes et evonodes enregistrés avec les clés de ce portefeuille apparaîtront ici une fois le portefeuille synchronisé.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes et evonodes utilisant les clés de ce portefeuille";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Les masternodes votent sur les noms demandés par plus d'une personne. Vous serez notifié à la fin du vote.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min. : %@";
 
+/* Usernames */
+"Minimum met" = "Minimum atteint";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Plus de contrôle";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Plus de suggestions";
+
+"Most lock votes" = "Le plus de votes de verrouillage";
+
+"Most votes" = "Le plus de votes";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Déplacez et zoomez votre photo pour trouver la meilleure apparence";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Déplacer vers votre solde dépensable habituel.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Déplacé vers l'adresse";
+
+/* CoinJoin */
+"Moving funds" = "Déplacement des fonds";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Nom";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Les services de noms comme Unstoppable Domains associent un nom lisible à une adresse publique fixe sur la chaîne. N'importe qui peut résoudre le nom et voir chaque paiement qui lui a été fait. Un nom d'utilisateur DashPay ne résout jamais publiquement vers une adresse de paiement — les adresses ne sont révélées qu'au sein de l'échange chiffré avec chaque contact, de sorte que votre nom et votre argent restent dissociés pour les observateurs extérieurs.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Besoin d'aide ?";
+
+"Needs attention" = "Nécessite votre attention";
 
 /* No comment provided by engineer. */
 "Network" = "Réseau";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Aucun journal de diagnostic n'a été trouvé sur cet appareil. Les journaux sont écrits à partir du prochain démarrage.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Aucune identité";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Pas encore de masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Aucun litige correspondant";
+
+/* Identities */
+"No new identities were found for this wallet" = "Aucune nouvelle identité n'a été trouvée pour ce portefeuille";
+
+"No open contest matches that search." = "Aucun litige en cours ne correspond à cette recherche.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Aucun litige en cours ne correspond à cette recherche. Les noms sont stockés sous une forme normalisée : « alice » est donc listé comme « a11ce ».";
+
+"No open contests" = "Aucun litige en cours";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Aucun mode de paiement";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Aucune entrée de portefeuille enregistrée n'a été trouvée pour le portefeuille lié.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Aucune adresse Platform n'est encore disponible pour l'enregistrement blindé de secours. Réessayez une fois que le portefeuille aura terminé sa synchronisation.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Aucun résultat trouvé";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Aucun nom d'utilisateur n'est contesté pour l'instant. Un litige s'ouvre lorsque deux personnes ou plus demandent le même nom.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Plus de vote possible";
+
+"No votes were cast" = "Aucun vote n'a été soumis";
+
+"Nobody gets it" = "Personne ne l'obtient";
+
+/* SPV sync peer type */
+"Node" = "Nœud";
+
+/* Raw transaction inspector */
+"Non-standard" = "Non standard";
 
 /* adjective, security level */
 "None" = "Aucun";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Non disponible";
 
+"Not available yet" = "Pas encore disponible";
+
+"Not cast" = "Non soumis";
+
+/* Masternodes */
+"Not checked yet" = "Pas encore vérifié";
+
 /* Location Service Status */
 "Not Determined" = "Indéterminé";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Solde blindé insuffisant pour enregistrer une identité";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Absent de l'historique du portefeuille";
+
+"Not now" = "Pas maintenant";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Peu accepté par les commerçants";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Pas encore largement accepté par les commerçants";
+
+/* Masternode keys */
+"Not yet used" = "Pas encore utilisée";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "D'ancien vers récent";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Sur Bitcoin, il n'y a pas de couche de noms : les gens partagent et réutilisent donc des adresses au grand jour — une fois qu'une adresse est connue, tout ce qu'elle a jamais reçu peut être relié à son propriétaire. Avec DashPay, votre nom d'utilisateur est public, mais il ne pointe jamais vers une adresse de paiement : les adresses sont échangées en privé avec chaque contact et changent régulièrement, si bien que payer par nom ne publie pas la destination de votre argent. Les deux sont des chaînes transparentes, l'analyse de chaîne s'applique donc toujours aux pièces elles-mêmes.";
+
+/* Identities */
+"On Network" = "Sur le réseau";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Une fois que %@ aura accepté votre demande, vous pourrez payer directement au nom d'utilisateur";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Un nœud à la fois";
 
 /* Voting */
 "One vote left" = "Plus qu'un vote";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Doublons seulement";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Seuls les masternodes et les evonodes peuvent voter sur les noms d'utilisateur. Ce portefeuille ne détient aucune clé de vote de masternode active.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Requêtes avec liens seulement";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Avec liens seulement";
+
+/* Masternodes */
+"Operator" = "Opérateur";
+
+/* Masternode keys */
+"Operator keys" = "Clés d'opérateur";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Clé publique de l'opérateur (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ou";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Prévisualisation de la commande";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Autres issues";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Sortie %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Sorties (%d)";
+
+/* Masternodes */
+"Owner" = "Propriétaire";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Adresse du propriétaire";
+
+/* Masternodes */
+"Owner address" = "Adresse du propriétaire";
+
+/* Masternodes */
+"Owner key hash" = "Hachage de la clé du propriétaire";
 
 /* Owner keys */
 "Owner keys" = "Clés de propriétaire";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Payé depuis le solde de crédits de votre identité.";
 
 /* DashSpend */
 "Password" = "Mot de passe";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Coller ici le lien";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Collez le lien d'invitation que vous avez reçu, ou scannez son code QR. Il finance l'enregistrement de votre nom d'utilisateur.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Coller l'URL de votre image";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Payez et soyez payé instantanément avec des flux de paiement simples à utiliser";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "payer directement au nom d'utilisateur";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Payez des personnes, pas des adresses";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Payer à des noms d'utilisateur. Il n'y a plus d'adresses alphanumériques";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paiement en cours...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Charge utile (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Méthode de paiement";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Les paiements sont privés : les adresses que vous échangez avec un contact circulent dans une charge chiffrée que vous seuls pouvez lire, et ne sont jamais publiées — vos paiements ne sont donc pas facilement reliables à votre nom d'utilisateur. Il s'agit toutefois de paiements ordinaires sur une chaîne transparente : une analyse de chaîne poussée pourrait divulguer des informations. Shielded DashPay (bientôt disponible) comblera cette lacune. Les demandes de contact elles-mêmes ne sont PAS privées actuellement : n'importe qui peut voir que deux identités sont connectées. Les demandes de contact privées sont une fonctionnalité à venir. Votre nom d'utilisateur et votre profil sont également publics sur Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Les paiements se confirment en quelques secondes avec InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Les paiements effectués directement vers des adresses ne seront pas conservés dans l'activité.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Les paiements avec chaque contact sont regroupés au même endroit, avec des noms et des profils au lieu de transactions brutes.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adresse de paiement";
 
 /* CrowdNode */
 "Payout Options" = "Options de paiement";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adresse Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Solde Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nœud Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID du nœud Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Les paiements Platform n'identifient pas l'expéditeur. Ce paiement a été enregistré lorsque le portefeuille a constaté le changement de solde — il a pu arriver plus tôt.";
+
+"Platform SDK not ready" = "SDK Platform pas prêt";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "La synchronisation Platform n'est pas en cours. Ouvrez Infos de synchronisation → État de synchronisation Platform pour la démarrer.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Blindé";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Veuillez ajouter un mode de paiement sur Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Prévisualiser l'invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Précédemment utilisée le : ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Les cours ont au minimum 30 minutes d'âge. Les valeurs fiduciaires peuvent être incorrectes.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privé par conception";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Les demandes de contact privées (pour que vos relations restent privées), Shielded DashPay — les paiements aux contacts depuis votre solde blindé privé — et le paiement d'utilisateurs qui ne figurent pas encore dans vos contacts arrivent bientôt.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Les demandes de contact privées sont en développement et attendues aux alentours de septembre-octobre 2026. Aujourd'hui, la demande elle-même est publique — n'importe qui peut voir que deux identités sont connectées, même si les détails de paiement qu'elle contient sont chiffrés. Une fois les demandes de contact privées disponibles, vous pourrez choisir de rendre votre relation publique ou privée.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Les demandes de contact privées, Shielded DashPay et le paiement de personnes qui ne sont pas encore vos contacts.";
+
 /* No comment provided by engineer. */
 "Private key" = "Clé privée";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Des adresses de paiement privées sont échangées entre vous et vos contacts. Vous et votre contact êtes les seuls à connaître le destinataire et l'expéditeur des paiements entre vous.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Paiements privés";
+
+/* Usernames */
+"Private registration" = "Enregistrement privé";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Délai de traitement";
+
+/* Balance info sheet section */
+"Pros" = "Avantages";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protéger vos fonds";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Adresse du fournisseur";
 
+/* Masternodes */
+"Provider transactions" = "Transactions de fournisseur";
+
+/* Masternode keys */
+"Public key" = "Clé publique";
+
+/* Masternode keys */
+"Public key (legacy)" = "Clé publique (ancienne)";
+
+/* Identities */
+"Public keys" = "Clés publiques";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL publique";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Échec de l'achat";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Utilisation";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Taux : %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transaction brute";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transaction brute indisponible";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Revérifie les filtres de blocs compacts à partir de la hauteur choisie pour les transactions de ce portefeuille, en les retéléchargeant et en les recomparant. Les rescans sont limités à la hauteur de création du portefeuille et aux données de chaîne stockées localement — pour récupérer l'historique en deçà, abaissez plutôt la hauteur d'origine du portefeuille.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Lire les conditions de retrait";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Lecture seule";
+
+/* Usernames */
+"Ready around %@" = "Prêt vers %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motif";
 
 /* No comment provided by engineer. */
 "Receive" = "Recevoir";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Reçu de";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Reçu de %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Recevoir les paiements";
+
+"Records your masternodes as having voted, without taking a side." = "Enregistre vos masternodes comme ayant voté, sans prendre parti.";
 
 /* No comment provided by engineer. */
 "Recover" = "Récupération";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "La phrase de récupération doit avoir 12, 15, 18, 21 ou 24 mots";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Actualiser";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Enregistrer ?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Enregistré le";
+
+/* No comment provided by engineer. */
 "Registered from" = "Enregistré depuis";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternode enregistré";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "L'enregistrement privé nécessite au moins %@ Dash sur votre solde blindé, plus quelques heures de repos — les écrans suivants vous guident.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Enregistrement";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Demande ce nom";
+
 /* An action */
 "Rescan" = "Réanalyser";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Les portefeuilles restaurés ne peuvent pas toujours récupérer le type d'opération. Cette entrée a été reconstruite à partir des données de note on-chain.";
+
+/* Location Service Status */
 "Restricted" = "Restreint";
 
 /* Usernames */
 "Results" = "Résultats";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Resynchronisation programmée depuis la hauteur %u — quittez et rouvrez l'application pour démarrer.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "conserver l'historique mutuel des transactions";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retiré";
 
 /* No comment provided by engineer. */
 "Retry" = "Réessayer";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Relisez les données ci-dessous pour vérifier la propriété de ce nom d'utilisateur";
+
+/* Masternodes */
+"Revocation" = "Révocation";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Les captures d'écran sont visibles aux autres applis et appareils. Générez une nouvelle phrase de récupération et gardez-la secrète.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Signature du script";
+
+/* Raw transaction inspector */
+"Script type" = "Type de script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Rechercher un contact";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Rechercher une demande de contact";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Rechercher un utilisateur sur le réseau Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Rechercher un nom d'utilisateur";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Résultats de recherche pour \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Chercher des régions";
+
+"Search usernames" = "Rechercher des noms d'utilisateur";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Recherche du nom d'utilisateur %@ sur le réseau Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Sécuriser votre portefeuille";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Niveau de sécurité";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Niveau de sécurité";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Choisissez un service pour acheter, vendre, convertir et transférer des dashs";
 
+"Select all" = "Tout sélectionner";
+
 /* DashSpend denomination selection */
 "Select amount" = "Choisir le montant";
+
+"Select at least one masternode to vote with." = "Sélectionnez au moins un masternode avec lequel voter.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Choisir les pièces";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Sélectionner moins de nœuds révèle moins d'informations sur les masternodes que vous exploitez.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Paiement automatique";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Envoyer à";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Envoyer à un contact";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Envoyez à un nom d'utilisateur que vous pouvez vraiment retenir et vérifier.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Envoyer à l'adresse";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Envoyez votre première demande de contact";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Envoi en cours";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Envoi de la demande de contact";
+
+/* No comment provided by engineer. */
+"Sending to" = "Envoi à";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Envoi au compte CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Envoyé à";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Envoyé à %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Erreur du serveur. Veuillez réessayer plus tard.";
+
+/* Masternodes */
+"Service" = "Service";
+
+/* Identities */
+"Set as Main" = "Définir comme principale";
+
+/* Identities */
+"Set as Main Identity" = "Définir comme identité principale";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Choisir un code PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Partager la clé";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Pool de confidentialité partagé à sa taille minimale";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Adresse blindée";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Dépense blindée";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Démarrage du portefeuille blindé…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Blindé → Platform";
+
+"Shielded → Transparent" = "Blindé → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Voir tous les endroits";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Taille";
+
 /* No comment provided by engineer. */
 "Skip" = "Ignorer";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Certains de vos masternodes sont peut-être absents de cette liste — le portefeuille n'a pas pu lire l'ensemble de vos clés de vote. Terminez la synchronisation et rouvrez cet écran.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Certains noms d'utilisateur peuvent être bloqués";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Trier par";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Trier les contacts";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Trié par réductions";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Trié par nom";
+
+/* Raw transaction inspector */
+"Special payload" = "Charge utile spéciale";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Indiquez le montant";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Récompenses";
 
+/* Usernames */
+"Starts after you add funds" = "Démarre après l'ajout de fonds";
+
+/* Transaction details */
+"Status" = "Statut";
+
 /* Step 1 */
 "Step %ld" = "Étape %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Stocké sous";
 
 /* Voting */
 "Submit" = "Valider";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Synchronisation en cours… Les résultats peuvent être encore incomplets.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Infos de synchronisation";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronisation trop lente ?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Prendre une photo";
 
+"Take no side" = "Ne prendre aucun parti";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Touchez l'adresse du presse-papiers pour la coller";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Touchez pour copier";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Touchez pour masquer le solde";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Provisoirement indisponible";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Clé de nœud Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Termes & conditions";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Réseau de test";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Ce code est incorrect. Veuillez vérifier et réessayer !";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Les Dash arrivent à l'adresse du destinataire une fois que le réseau a traité le retrait — cela peut prendre jusqu'à 10 minutes.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Les Dash arrivent à l'adresse du destinataire dès que le réseau traite le retrait.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Les Dash arrivent sur votre solde transparent dès que le réseau traite le retrait.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Le réseau Dash doit voter pour approuver certains noms d'utilisateur avant leur création";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Le lien que vous envoyez sera visible seulement par les propriétaires du réseau";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "L'identité principale ne peut être choisie que dans le portefeuille actif";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Le montant minimal que vous pouvez envoyer est %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "L'endroit le plus privé où conserver vos Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "L'entrée de portefeuille enregistrée n'a pas de réseau — impossible de programmer une resynchronisation.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "L'enregistrement a été soumis, mais son résultat n'a pas pu être confirmé. Attendez une minute que le portefeuille se synchronise, puis réessayez — ne le resoumettez pas immédiatement.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Le pool de confidentialité partagé est encore en croissance (%1$ld dépôts sur %2$ld). L'enregistrement privé se débloque une fois le minimum atteint.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Le pool de confidentialité partagé est encore en croissance (%1$ld dépôts sur %2$ld). Réessayez une fois le minimum atteint.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Le nom d'utilisateur '%@' a été bloqué par le réseau Dash. Veuillez réessayer en demandant un autre nom d'utilisateur.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "La hauteur de création du portefeuille — le plancher des scans de filtres et des rescans « Depuis la création du portefeuille ». Réglez-la au niveau ou en dessous du premier financement du portefeuille ; les imports utilisent 200000 par défaut sur mainnet et 0 sur testnet. Enregistrer une hauteur égale ou inférieure à l'actuelle efface les données de chaîne de ce réseau au prochain démarrage et relance le scan à partir de là.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "lui (récupération des infos)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Il n'y a aucune nouvelle notification";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Il n'y a pas de transactions à afficher";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Aucun utilisateur ne correspond au nom %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Aucun utilisateur ne correspond au nom %@ dans vos contacts";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Il y a eu une erreur lors de l'exportation de votre historique de transactions vers ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Il y a eu une erreur, veuillez réessayer ultérieurement";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ces fonds sont transférés vers votre solde Platform et seront dépensables dès que le transfert sera terminé.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Cette adresse ne peut pas être payée depuis votre solde %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Cela ajoute deux clés à votre identité pour que d'autres utilisateurs puissent vous envoyer des demandes de contact et que vous puissiez accepter les leurs. Cela n'arrive qu'une seule fois.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Cela applique un seul choix aux %d noms d'utilisateur sélectionnés.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Cette étape supplémentaire montre que c'est vraiment vous qui essaie de faire une transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ce lien d'invitation n'est pas valide.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ceci n'est pas une adresse Dash valide pour ce réseau";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ceci n'est pas un lien d'invitation valide";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ceci est votre identité principale";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ce masternode n'a pas encore d'identité Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Le vendeur n'est pas disponible actuellement.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Cela représente le pourcentage annuel de rendement d'un masternode entier, moins les 15% des frais de CrowdNode. Cela n'est pas un taux garanti de retour, et peut augmenter ou diminuer en fonction des tailles des serveurs CrowdNode et du cours de Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Cela compte tout de même comme un vote de vos masternodes dans ce litige.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Les octets bruts de cette transaction ne sont pas stockés sur cet appareil.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ce nom d'utilisateur est allé à quelqu'un d'autre";
+
+"This wallet could not derive the voting key for this node." = "Ce portefeuille n'a pas pu dériver la clé de vote de ce nœud.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ce portefeuille ne détient aucune clé de vote de masternode active, il ne peut donc pas voter. Les nœuds enregistrés apparaissent dans Outils → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Cela retire l'intégralité de votre solde Platform en un seul transfert. Les Dash arrivent à l'adresse du destinataire dès que le réseau traite le retrait.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Cela retire l'intégralité de votre solde Platform en un seul transfert. Les Dash arrivent sur votre solde transparent dès que le réseau traite le retrait.";
 
 /* Send Screen: to address */
 "to" = "vers";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Historique des transactions";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "L'historique des transactions n'est pas disponible";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Identifiant de transaction";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID de transaction";
 
 /* A verb, button title. */
 "Transfer" = "Transférer";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Virement entrant";
 
+/* Balance breakdown */
+"Transfer in" = "Transfert entrant";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Virement sortant";
+
+/* Balance breakdown */
+"Transfer out" = "Transfert sortant";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Les transferts prennent plus de temps — la construction des preuves de confidentialité demande du temps";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Les transferts vers d'autres adresses Platform et adresses blindées sont instantanés et définitifs";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Adresse transparente";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Solde transparent";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Un financement transparent relie publiquement votre nom d'utilisateur à ces fonds.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Blindé";
 
 /* An action */
 "Try again" = "Veuillez réessayer";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Impossible de fournir des suggestions";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Solde inconnu";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Type spécial inconnu %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Non blindé";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "URL non compatible";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Faites la mise à jour vers DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Passer à Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Utiliser plutôt le solde transparent";
+
+/* Masternode keys */
+"Used" = "Utilisée";
+
+/* Masternode keys */
+"Used at: " = "Utilisée le : ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Utilisateur (récupération des infos)";
 
 /* Voting */
 "Username" = "Nom d'utilisateur";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "La demande de nom d'utilisateur a bien été envoyée";
 
+/* Identities */
+"Usernames" = "Noms d'utilisateur";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Les noms d'utilisateur sont stockés sous une forme normalisée afin d'éviter les noms sosies : cela peut donc différer de ce que chaque personne a saisi.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Des noms d'utilisateur, pas des adresses";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Utilisateurs correspondant à %@ qui ne figurent pas actuellement dans vos contacts";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Utilise l'une des bibliothèques à divulgation nulle de connaissance les plus auditées et testées (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Invitation valide";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validation de l'adresse...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Vérification demandée";
 
+/* Usernames */
+"Verified during registration" = "Vérifié lors de l'enregistrement";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Vérifié avec succès";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Vérifier votre identité";
 
+/* Raw transaction inspector */
+"Version" = "Version";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Très efficace avec des frais réduits";
+
 /* adjective, security level */
 "Very High" = "Très élevé";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "De très petits montants en dashs seront envoyés vers et depuis CrowdNode, pour vérifier que vous êtes le propriétaire de cette adresse de portefeuille.";
+
+/* No comment provided by engineer. */
+"View All" = "Tout afficher";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Voir dans l'explorateur";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Voir la phrase de récupération";
 
+/* Raw transaction inspector */
+"View Transaction" = "Voir la transaction";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Voir les détails de la transaction";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Voter";
+
+"Vote cast" = "Vote soumis";
+
 /* Voting */
 "Vote for All" = "Voter pour tous";
 
 /* Voting */
+"Vote on contested usernames" = "Voter sur les noms d'utilisateur contestés";
+
+"Vote on several" = "Voter sur plusieurs";
+
+/* Voting */
 "Vote to Approve" = "Voter pour approuver";
+
+"Vote with" = "Voter avec";
+
+"Votes that nobody should receive these usernames." = "Vote pour que personne ne reçoive ces noms d'utilisateur.";
 
 /* Voting */
 "Votes: High to low" = "Votes : de haut à bas";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Adresse de vote";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresse de vote";
+
+"Voting ended with no winner" = "Le vote s'est terminé sans gagnant";
+
+"Voting ends" = "Fin du vote";
+
 /* Voting */
 "Voting ends in %dd" = "Le vote se termine dans %d jours";
+
+"Voting in progress" = "Vote en cours";
+
+"Voting in progress — lock votes are ahead" = "Vote en cours — les votes de verrouillage sont en tête";
+
+"Voting in progress — you are ahead" = "Vote en cours — vous êtes en tête";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voter est requis seulement dans certains cas";
 
+/* Masternodes */
+"Voting key hash" = "Hachage de la clé de vote";
+
 /* Voting keys */
 "Voting keys" = "Clés de vote";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Le vote sur ce nom d'utilisateur est clos. Les décomptes ci-dessous sont les derniers relevés.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Le vote sur « %@ » est déjà clos. Actualisez pour voir le résultat.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Veuillez attendre que le portefeuille soit synchronisé avant de terminer la transaction";
 
+"Waiting for Dash Platform" = "En attente de Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Adresse du portefeuille";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Hauteur d'origine du portefeuille";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Portefeuille désactivé";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Bienvenue sur DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Qu'en est-il d'Unstoppable Domains et des services de noms similaires ?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Combien cela coûte-t-il ?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Qu'est-ce que DashPay ?";
+
 /* Usernames */
 "What is username voting?" = "Qu'est-ce que le vote des noms d'utilisateur ?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Quelle est la suite ?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Quand les demandes de contact deviendront-elles privées ?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Où dépenser";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Où dépenser ?";
+
+"Who is requesting this name" = "Qui demande ce nom";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Pourquoi dois-je l'activer ?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Pourquoi vois-je toutes ces transactions ?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Retrait demandé";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Retire l'intégralité du solde";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Fonctionne avec tous les portefeuilles, plateformes d'échange et commerçants Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Souhaitez-vous accepter l'invitation ?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Hier";
+
+"You" = "Vous";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Vous avez accepté la demande de contact de %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Vous avez choisi “%@” comme nom d'utilisateur.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Vous n'avez aucun contact pour le moment";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Vous n'avez pas assez de fonds pour terminer cette transaction";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Vous avez dépassé la limite d'autorisation sur Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Vous avez %@ Dash jusqu'à présent";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Vous avez %1$@ dashs.\nCertains noms d'utilisateur coûtent jusqu'à %2$@ dashs.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Vous avez envoyé la demande de contact à %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Vous devriez avoir un solde positif sur votre Dash Wallet";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Vous avez remporté ce nom d'utilisateur";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Tout est prêt. D'autres utilisateurs peuvent désormais vous envoyer des demandes de contact — et vous pouvez envoyer les vôtres.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Votre identité Dash Platform apparaîtra ici une fois que vous aurez enregistré un nom d'utilisateur.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Votre adresse e-mail n'est utilisée que pour vous envoyer un mot de passe temporaire.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Votre historique, organisé";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Votre identité a besoin de deux clés supplémentaires pour que les demandes de contact puissent être chiffrées entre vous et les autres utilisateurs. L'activation les ajoute au moyen d'une seule transaction réseau. Cela n'arrive qu'une seule fois.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Votre invitation par %@ a déjà été réclamée";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Votre invitation par %@ n'est pas valide";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Votre invitation paie les frais d'enregistrement de ce nom d'utilisateur.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Votre localisation est utilisée pour afficher votre position sur la carte, les distributeurs dans le rayon choisi et pour améliorer les résultats de recherche.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Votre lieu est utilisé pour montrer votre position sur la carte et les vendeurs dans les environs choisis, et pour améliorer les résultats de recherche.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Votre solde Dash principal sur la blockchain Core — ce que vous envoyez et recevez avec les autres portefeuilles, plateformes d'échange et commerçants.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vos pièces mélangées ont été déplacées vers le solde de votre portefeuille Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vos pièces mélangées ont été déplacées vers votre solde blindé. Pour une meilleure confidentialité, attendez au moins 2 heures avant d'utiliser ces fonds.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Votre solde Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Votre adresse Dash principale, actuellement utilisée par votre compte CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Votre solde privé. Les montants et les adresses sont chiffrés on-chain, vos avoirs et votre historique restent donc confidentiels.";
+
 /* Usernames */
 "Your request was cancelled" = "Votre demande a été annulée";
 
 /* DashSpend */
 "Your session expired" = "Votre session a expiré";
+
+/* Usernames */
+"Your Shielded balance" = "Votre solde blindé";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Votre solde blindé est presque prêt — vous pourrez vous enregistrer en privé vers %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Votre solde blindé est prêt — enregistrez votre nom d'utilisateur en privé maintenant";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Votre solde blindé est en repos — vous pourrez vous enregistrer en privé vers %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Votre solde blindé est encore en maturation. Il sera prêt vers %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Votre solde transparent";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Votre nom d'utilisateur %@ a bien été créé sur le réseau Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Votre nom d'utilisateur a été créé avec succès";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Votre nom d'utilisateur est visible de tous. Le financer depuis votre solde blindé — après avoir laissé les fonds reposer quelques heures — fait que personne ne peut relier votre nom d'utilisateur à vos autres Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Votre nom d'utilisateur, votre profil et vos contacts suivent cette identité.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Votre nom d'utilisateur, votre profil et vos contacts suivront cette identité.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Votre vote a été annulé";
 
 /* Voting */
 "Your vote was submitted" = "Votre vote a été soumis";
 
+"Your votes" = "Vos votes";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Votre portefeuille est désormais sécurisé. Vous pouvez utiliser cette phrase de récupération à tout moment pour récupérer votre compte sur un autre appareil.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Votre portefeuille est encore en cours de synchronisation avec le réseau Dash. L'envoi sera disponible une fois la synchronisation terminée.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Votre portefeuille est encore en cours de synchronisation. L'envoi depuis votre solde transparent sera disponible une fois la synchronisation terminée.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "« %@ » n'a pas pu être lu comme un nom d'utilisateur Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "« %@ » a été enregistré. Envoyer une demande de contact à la personne qui vous a invité ?";

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Tous les nœuds en même temps";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tous vos masternodes ont voté sur ce nom d'utilisateur. Pour modifier un vote, votez de nouveau depuis le candidat que vous préférez désormais.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tous vos masternodes ont voté sur ce nom d'utilisateur. Pour modifier un vote, votez de nouveau pour le candidat que vous préférez désormais.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/fr.lproj/Localizable.stringsdict
+++ b/DashWallet/fr.lproj/Localizable.stringsdict
@@ -92,5 +92,245 @@
 			<string>%d clés</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ comptabilisées pour « %2$@ »</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u voix</string>
+			<key>other</key>
+			<string>%1$u voix</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d sur %#@names@ votés</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nom d'utilisateur</string>
+			<key>other</key>
+			<string>%2$d noms d'utilisateur</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Soumettre %u voix</string>
+			<key>other</key>
+			<string>Soumettre %u voix</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d sur %#@nodes@ ont voté</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d sur %#@nodes@ ont voté</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nœud</string>
+			<key>other</key>
+			<string>%2$d nœuds</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voix au total</string>
+			<key>other</key>
+			<string>%u voix au total</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d sélectionné</string>
+			<key>other</key>
+			<string>%d sélectionnés</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d de vos nœuds a déjà voté ici et n'est pas répertorié.</string>
+			<key>other</key>
+			<string>%d de vos nœuds ont déjà voté ici et ne sont pas répertoriés.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voix par litige — les evonodes comptent pour 4, les masternodes pour 1</string>
+			<key>other</key>
+			<string>%u voix par litige — les evonodes comptent pour 4, les masternodes pour 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voter sur %d nom d'utilisateur</string>
+			<key>other</key>
+			<string>Voter sur %d noms d'utilisateur</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voix</string>
+			<key>other</key>
+			<string>%u voix</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voter ×%d</string>
+			<key>other</key>
+			<string>Voter ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d demande</string>
+			<key>other</key>
+			<string>%d demandes</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/fr.lproj/Localizable.stringsdict
+++ b/DashWallet/fr.lproj/Localizable.stringsdict
@@ -95,7 +95,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ comptabilisées pour « %2$@ »</string>
+		<string>%#@votes@ pour « %2$@ »</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -103,15 +103,15 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u voix</string>
+			<string>%1$u voix comptabilisée</string>
 			<key>other</key>
-			<string>%1$u voix</string>
+			<string>%1$u voix comptabilisées</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d sur %#@names@ votés</string>
+		<string>Voté : %1$d sur %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -143,7 +143,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d sur %#@nodes@ ont voté</string>
+		<string>Voté : %1$d sur %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -159,7 +159,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d sur %#@nodes@ ont voté</string>
+		<string>Voté : %1$d sur %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ili ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ nije pronađen na Dash mreži pa mu se ne može poslati zahtjev za kontakt.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash dostupno";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ je prihvatio vaš zahtjev za kontakt";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtova";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld od %ld uplata";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditno stanje na Dash Platform koje se koristi za trenutna plaćanja između Platform adresa i za značajke poput korisničkih imena.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "O nama";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPayu";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Suzdrži se";
+
+"Abstain on “%@”" = "Suzdrži se povodom „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktivan";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivnost";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivnost je javna, ali ju nije lako pratiti";
+
 /* No comment provided by engineer. */
 "Add" = "Dodaj";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Dodaj %@ kao kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Dodajte %@ kao kontakt kako biste plaćali izravno na korisničko ime i zadržali zajedničku povijest transakcija";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Dodajte %@ Dash u svoje zaštićeno stanje i pustite ga da odstoji nekoliko sati kako biste se registrirali bez povezivanja korisničkog imena s ostalim sredstvima.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Dodajte najmanje %@ Dash u svoje zaštićeno stanje";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Napunite zaštićeno stanje sada i registrirajte korisničko ime privatno nekoliko sati poslije";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Svi čvorovi odjednom";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodeovi glasali su o ovom korisničkom imenu. Da biste promijenili glas, glasajte ponovno od kandidata kojeg sada preferirate.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Gotovo trenutna sinkronizacija stanja";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Iznosi i adrese javni su na blockchainu";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum račun je jedna adresa koja se ponovno koristi: cijelo vaše stanje i povijest plaćanja javno stoje pod njom, a ime (primjerice ENS domena) obično pokazuje ravno na tu adresu pa ju svatko može razriješiti. DashPay je postavljen obrnuto — ime vodi do identiteta, a ne do adrese za plaćanje, dok stvarne adrese za plaćanje ostaju unutar šifriranih razmjena s kontaktima, nove za svaki kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Svatko tko zna adresu može pogledati njezinu povijest";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Odobri";
+
+"Approving a specific request can only be done one username at a time." = "Odobravanje konkretnog zahtjeva moguće je samo za jedno korisničko ime odjednom.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Kao tekst";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Provjera identiteta je otkazana. Vaš glas nije predan.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Provjera identiteta nije uspjela. Vaš glas nije predan.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Dodijeli „%@“ ovom kandidatu";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Stanje nakon toga";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Stanja i prijenosi nisu javno vidljivi";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Početna visina je spremljena — povišeni prag skeniranja vrijedi od sljedećeg pokretanja.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vezan uz ugovor";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vezan uz ugovor, vrsta dokumenta „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Samo pregled";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Pakira nedavne dijagnostičke zapise u zip kako biste ih poslali AirDropom, e-poštom ili spremili u Datoteke";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Predaj glas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Promijeni čvorove";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Provjera…";
+
+"Choice" = "Odabir";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Preuzmite svoju pozivnicu";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Stanje koje se može preuzeti";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Obriši i ponovno sinkroniziraj";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Obrisati podatke lanca i ponovno sinkronizirati?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Zatvara se";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (novi novčići)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin više nije podržan — odaberite kamo premjestiti svoje pomiješane novčiće.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolateral";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Uskoro";
+
+/* Shielded transfer status */
+"Completed" = "Dovršeno";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potvrđena";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potvrda sprema početnu visinu %u i briše podatke lanca ove mreže pri sljedećem pokretanju aplikacije, ponovno ih preuzima i skenira filtre od te visine. Trenutna sesija zadržava stari prag skeniranja — zatvorite i ponovno otvorite aplikaciju da biste počeli.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Povezani čvorovi";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nedostaci";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Zahtjev za kontakt nije uspio";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Zahtjev za kontakt poslan korisniku %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Zahtjevi za kontakt";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Nastavite kako biste odabrali svoje korisničko ime. Pozivnica plaća naknadu za registraciju.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiraj sirovu transakciju";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Nije moguće izraditi arhivu zapisa: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Konverzijska stopa nije pronađena.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nije moguće osvježiti %d identiteta";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Nije moguće dohvatiti stanje (mrežna pogreška). Pokušajte osvježiti.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Izradite svoje korisničko ime, pronađite prijatelje i obitelj po njihovim korisničkim imenima i dodajte ih u kontakte";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediti";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform još nije indeksirao ovaj spor. Broj glasova pojavit će se ovdje kada to učini.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform još nije povezan. Pričekajte da se sinkronizacija dovrši i pokušajte ponovno.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash poslan na pogrešnu adresu ne može se povratiti. Provjerite je li adresa točno ona kojoj želite platiti.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash čuva korisnička imena u obliku otpornom na slične zapise, pa se spremljeno ime može razlikovati od onoga što je svatko upisao.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Stanje Dash novčanika";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay je omogućen";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je Dashov društveni doživljaj plaćanja, izgrađen na Dash Platform. Registrirate korisničko ime, dodajete druge korisnike kao kontakte i plaćate im po imenu — nema više kopiranja adresa.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay zamjenjuje duge i nerazumljive adrese korisničkim imenima. Dodajte prijatelje kao kontakte, pošaljite novac na ime i držite svako plaćanje uredno posloženo po osobi.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Rok nepoznat";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Putanja izvođenja";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Onemogućen";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Gotovo — vaše stanje odstajalo je dovoljno dugo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Provjerite adresu još jednom";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Svaki masternode ima jedan važeći glas po sporu. Možete ga poslije promijeniti, ali Dash Platform dopušta ukupno samo 5 glasova po masternodeu po sporu.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Svaki dodir dodaje još jedan čvor u glasanje, pa vi birate koliko će ih biti povezano.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Uredi početnu visinu";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Omogući";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Omogući DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Omogućavanje DashPaya stoji malu jednokratnu mrežnu naknadu, plaćenu iz kreditnog stanja vašeg identiteta. Točna procjena prikazuje se prije nego što potvrdite. Slanje zahtjeva za kontakt i plaćanja stoji uobičajene mrežne naknade.";
+
+"Ending soonest" = "Najranije završava";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Procijenjena mrežna naknada";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Svi čvorovi glasaju zajedno. Brže je, ali javno povezuje vaše masternodeove međusobno.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operaterski ključevi Evonodea";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Izvezi zapise";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Vanjska adresa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Neuspješno";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Dohvaćanje…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Zaglavlja filtara";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Pronađite korisnika na Dash mreži";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Pronađi identitete";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Pronađeno je %d novih identiteta";
+
+/* Identities */
+"Found 1 new identity" = "Pronađen je 1 novi identitet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financirajte svoje korisničko ime iz zaštićenog stanja. Dodajte sredstva nekoliko sati unaprijed — kratko odstajavanje čini da se vaše korisničko ime ne može povezati s ostalim vašim Dashem.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financirano iz vašeg zaštićenog stanja — vaše korisničko ime ne može se povezati s ostalim vašim Dashem.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Sredstva zaključana — prijenos se dovršava";
+
+/* CoinJoin */
+"Funds moved" = "Sredstva premještena";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pripremite se za pridruživanje DashPayu";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Razumijem";
+
+/* Governance */
+"Governance" = "Upravljanje";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "zatražio je da vam bude prijatelj";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Imate pozivnicu?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Zaglavlja";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Visina %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Više naknade, oko 7 centi (i dalje niže nego kod drugih blockchaina sa sličnom privatnošću)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kako se to uspoređuje s Bitcoinom po pitanju privatnosti?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kako se to uspoređuje s Ethereum računima po pitanju privatnosti?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Koliko je DashPay privatan?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identiteti";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Krediti identiteta";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identiteta";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registracija identiteta";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Nadopuna identiteta";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktivan";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Ulaz %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Ulaz %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Ulazi (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Pozivnica od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Pozovite nekoga da se pridruži Dash mreži";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Pozovite prijatelje i obitelj na Dash mrežu";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Zadržite ove novčiće privatnima. Primjenjuju se mrežne naknade i naknade za privatnost.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ključ br. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Podaci ključa";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Vlasništvo nad ključem";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ključevi";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vodi";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Saznaj više";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Učitavanje transakcija";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Samo lokalno";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Zaključaj";
+
+"Lock the name" = "Zaključaj ime";
+
+"Lock “%@” so nobody gets it" = "Zaključaj „%@“ da ga nitko ne dobije";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Zaključano — nitko ne dobiva ovo korisničko ime";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Niske naknade za svakodnevnu potrošnju";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Glavni";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Privjesak ključeva masternodea";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Popis masternodeova";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Glasovi masternodeova";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodeovi";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodeovi i evonodeovi registrirani ključevima ovog novčanika pojavit će se ovdje nakon što se novčanik sinkronizira.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodeovi i evonodeovi koji koriste ključeve ovog novčanika";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodeovi glasaju o imenima koja je zatražila više od jedne osobe. Bit ćete obaviješteni kada glasanje završi.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum je dosegnut";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Više prijedloga";
+
+"Most lock votes" = "Najviše glasova za zaključavanje";
+
+"Most votes" = "Najviše glasova";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Premjestite u svoje uobičajeno raspoloživo stanje.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Premještanje sredstava";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Usluge imena poput Unstoppable Domains povezuju čitljivo ime s fiksnom javnom adresom na lancu. Svatko može razriješiti to ime i vidjeti svako plaćanje koje mu je ikada poslano. DashPay korisničko ime nikada se javno ne razrješava u adresu za plaćanje — adrese se otkrivaju samo unutar šifrirane razmjene sa svakim kontaktom, pa vaše ime i vaš novac za vanjske promatrače ostaju nepovezani.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Zahtijeva pozornost";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Na ovom uređaju nisu pronađeni dijagnostički zapisi. Zapisi se bilježe od sljedećeg pokretanja.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nema identiteta";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Još nema masternodeova";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nema odgovarajućih sporova";
+
+/* Identities */
+"No new identities were found for this wallet" = "Za ovaj novčanik nisu pronađeni novi identiteti";
+
+"No open contest matches that search." = "Nijedan otvoren spor ne odgovara toj pretrazi.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nijedan otvoren spor ne odgovara toj pretrazi. Imena se čuvaju u normaliziranom obliku pa se „alice“ navodi kao „a11ce“.";
+
+"No open contests" = "Nema otvorenih sporova";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Za povezani novčanik nije pronađen spremljeni zapis.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Još nema dostupne Platform adrese za rezervnu zaštićenu registraciju. Pokušajte ponovno nakon što se novčanik sinkronizira.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Trenutačno nijedno korisničko ime nije sporno. Spor se otvara kada dvije ili više osoba zatraže isto ime.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nijedan glas nije predan";
+
+"Nobody gets it" = "Nitko ga ne dobiva";
+
+/* SPV sync peer type */
+"Node" = "Čvor";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandardan";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Još nije dostupno";
+
+"Not cast" = "Nije predan";
+
+/* Masternodes */
+"Not checked yet" = "Još nije provjereno";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nedovoljno zaštićenog stanja za registraciju identiteta";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nije u povijesti novčanika";
+
+"Not now" = "Ne sada";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Trgovci ga ne prihvaćaju široko";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Trgovci ga još ne prihvaćaju široko";
+
+/* Masternode keys */
+"Not yet used" = "Još nije korišten";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Na Bitcoinu ne postoji sloj imena, pa ljudi otvoreno dijele i ponovno koriste adrese — čim je adresa poznata, sve što je ikada primila može se povezati s njezinim vlasnikom. Uz DashPay vaše korisničko ime je javno, ali nikada ne pokazuje na adresu za plaćanje: adrese se privatno razmjenjuju sa svakim kontaktom i izmjenjuju se, pa plaćanje po imenu ne objavljuje kamo vaš novac ide. Oba su transparentni lanci, pa se analiza lanca i dalje odnosi na same novčiće.";
+
+/* Identities */
+"On Network" = "Na mreži";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kada %@ prihvati vaš zahtjev, moći ćete plaćati izravno na korisničko ime";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Jedan po jedan čvor";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Samo masternodeovi i evonodeovi mogu glasati o korisničkim imenima. Ovaj novčanik ne sadrži aktivne ključeve za glasanje masternodeova.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operater";
+
+/* Masternode keys */
+"Operator keys" = "Operaterski ključevi";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Javni ključ operatera (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ili";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Drugi ishodi";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Izlaz %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Izlazi (%d)";
+
+/* Masternodes */
+"Owner" = "Vlasnik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adresa vlasnika";
+
+/* Masternodes */
+"Owner key hash" = "Hash ključa vlasnika";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Plaćeno iz kreditnog stanja vašeg identiteta.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Zalijepite poveznicu pozivnice koju ste dobili ili skenirajte njezin QR kod. Ona financira registraciju vašeg korisničkog imena.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "plaćali izravno na korisničko ime";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plaćajte ljudima, a ne adresama";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload heks";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Plaćanja su privatna: adrese koje razmjenjujete s kontaktom putuju unutar šifriranog sadržaja koji možete pročitati samo vas dvoje i nikada se ne objavljuju — pa se vaša plaćanja ne mogu lako povezati s vašim korisničkim imenom. Ipak, i dalje su to obična plaćanja na transparentnom lancu: napredna analiza lanca može otkriti informacije. Shielded DashPay (uskoro) zatvorit će taj procjep. Sami zahtjevi za kontakt trenutačno NISU privatni: svatko može vidjeti da su dva identiteta povezana. Privatni zahtjevi za kontakt značajka su koja stiže uskoro. Vaše korisničko ime i profil također su javni na Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Plaćanja se potvrđuju u nekoliko sekundi uz InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Plaćanja izvršena izravno na adrese neće se čuvati u aktivnosti.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Plaćanja sa svakim kontaktom grupirana su na jednom mjestu, s imenima i profilima umjesto sirovih transakcija.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adresa isplate";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform adresa";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform stanje";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform čvor";
+
+/* Masternode keys */
+"Platform Node ID" = "ID Platform čvora";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform plaćanja ne identificiraju pošiljatelja. Ovo plaćanje zabilježeno je kada je novčanik primijetio promjenu stanja — možda je stiglo i ranije.";
+
+"Platform SDK not ready" = "Platform SDK nije spreman";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform sinkronizacija nije pokrenuta. Otvorite Informacije o sinkronizaciji → Status Platform sinkronizacije da biste ju pokrenuli.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Zaštićeno";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Prethodno korišten: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privatan po dizajnu";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privatni zahtjevi za kontakt (da ostane privatno s kim se povezujete), Shielded DashPay — plaćanja kontaktima iz vašeg privatnog zaštićenog stanja — i plaćanja korisnicima koji još nisu u vašim kontaktima, sve to stiže uskoro.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privatni zahtjevi za kontakt u izradi su i očekuju se oko rujna–listopada 2026. Danas je sam zahtjev javan — svatko može vidjeti da su dva identiteta povezana, iako su podaci o plaćanju u njemu šifrirani. Kada privatni zahtjevi za kontakt budu dostupni, moći ćete birati hoće li vaše prijateljstvo biti javno ili privatno.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privatni zahtjevi za kontakt, Shielded DashPay i plaćanje ljudima koji još nisu kontakti.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privatne adrese za plaćanje razmjenjuju se između vas i vaših kontakata. Samo vi i vaš kontakt znate primatelja i pošiljatelja plaćanja između vas.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privatna plaćanja";
+
+/* Usernames */
+"Private registration" = "Privatna registracija";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Vrijeme obrade";
+
+/* Balance info sheet section */
+"Pros" = "Prednosti";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transakcije pružatelja";
+
+/* Masternode keys */
+"Public key" = "Javni ključ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Javni ključ (stari)";
+
+/* Identities */
+"Public keys" = "Javni ključevi";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Svrha";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Sirova transakcija";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Sirova transakcija nije dostupna";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ponovno provjerava kompaktne blok filtre od odabrane visine radi transakcija ovog novčanika, tako da ih ponovno preuzima i uspoređuje. Ponovna skeniranja odozdo su ograničena visinom stvaranja novčanika i lokalno spremljenim podacima lanca — za povrat starije povijesti umjesto toga smanjite početnu visinu novčanika.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Samo za čitanje";
+
+/* Usernames */
+"Ready around %@" = "Spremno oko %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Razlog";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Primljeno od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Bilježi vaše masternodeove kao da su glasali, bez staja na nečiju stranu.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Osvježi";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registriran";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privatna registracija zahtijeva najmanje %@ Dash u zaštićenom stanju i nekoliko sati odstajavanja — sljedeći zasloni vodit će vas kroz postupak.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registracija";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Traži ovo ime";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovljeni novčanici ne mogu uvijek povratiti vrstu operacije. Ovaj unos rekonstruiran je iz podataka bilješke na lancu.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ponovna sinkronizacija pripremljena od visine %u — zatvorite i ponovno otvorite aplikaciju da biste počeli.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "zadržali zajedničku povijest transakcija";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Povučen";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Opoziv";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skripta";
+
+/* Raw transaction inspector */
+"Script signature" = "Potpis skripte";
+
+/* Raw transaction inspector */
+"Script type" = "Vrsta skripte";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Pretraži kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Pretraži zahtjev za kontakt";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Pretraži korisnika na Dash mreži";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Pretraži korisničko ime";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultati pretrage za \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Pretraži korisnička imena";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Traženje korisničkog imena %@ na Dash mreži";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Razina sigurnosti";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Odaberi sve";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Odaberite barem jedan masternode s kojim ćete glasati.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Odabir manjeg broja čvorova otkriva manje o tome koje masternodeove držite.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Pošalji kontaktu";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Pošaljite na korisničko ime kojeg se doista možete sjetiti i koje možete provjeriti.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Pošaljite svoj prvi zahtjev za kontakt";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Slanje zahtjeva za kontakt";
+
+/* No comment provided by engineer. */
+"Sending to" = "Slanje na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Poslano korisniku %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Usluga";
+
+/* Identities */
+"Set as Main" = "Postavi kao glavni";
+
+/* Identities */
+"Set as Main Identity" = "Postavi kao glavni identitet";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Zajednički skup privatnosti na minimalnoj veličini";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Zaštićena adresa";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Zaštićena potrošnja";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Pokretanje zaštićenog novčanika…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Zaštićeno → Platform";
+
+"Shielded → Transparent" = "Zaštićeno → Transparentno";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Veličina";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Neki od vaših masternodeova možda nedostaju na ovom popisu — novčanik nije mogao pročitati cijeli vaš skup ključeva za glasanje. Dovršite sinkronizaciju i ponovno otvorite ovaj zaslon.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortiraj kontakte";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Poseban payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Počinje nakon što dodate sredstva";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Spremljeno kao";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacije o sinkronizaciji";
+
+/* SPV sync */
+"Sync too slow?" = "Sinkronizacija je prespora?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne staj ni na čiju stranu";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Dodirnite za kopiranje";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ključ Tenderdash čvora (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash stiže na adresu primatelja nakon što mreža obradi isplatu — to može potrajati do 10 minuta.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash stiže na adresu primatelja čim mreža obradi isplatu.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash stiže na vaše transparentno stanje čim mreža obradi isplatu.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Glavni identitet može se odabrati samo iz aktivnog novčanika";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najprivatnije mjesto za čuvanje vašeg Dasha";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Spremljeni zapis novčanika nema mrežu — nije moguće pripremiti ponovnu sinkronizaciju.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registracija je poslana, ali njezin ishod nije bilo moguće potvrditi. Pričekajte minutu da se novčanik sinkronizira pa pokušajte ponovno — nemojte odmah ponovno slati.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Zajednički skup privatnosti još raste (%1$ld od %2$ld uplata). Privatna registracija otključava se kada dosegne minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Zajednički skup privatnosti još raste (%1$ld od %2$ld uplata). Pokušajte ponovno kada dosegne minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Visina stvaranja novčanika — donja granica za skeniranja filtara i za ponovna skeniranja „Od stvaranja novčanika“. Postavite ju na razinu prvog priljeva u novčanik ili ispod nje; uvozi po zadanom koriste 200000 na mainnetu i 0 na testnetu. Spremanje visine jednake trenutnoj ili niže briše podatke lanca ove mreže pri sljedećem pokretanju i ponovno skenira od nje.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "njega (Dohvaćanje informacija)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nema novih obavijesti";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nema korisnika koji odgovaraju imenu %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "U vašim kontaktima nema korisnika koji odgovaraju imenu %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ta sredstva prelaze na vaše Platform stanje i spremna su za trošenje čim se prijenos dovrši.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Ova adresa ne može se platiti iz vašeg stanja %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ovo dodaje dva ključa vašem identitetu kako bi vam drugi korisnici mogli slati zahtjeve za kontakt i kako biste vi mogli prihvatiti njihove. To se događa samo jednom.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ovo primjenjuje jedan odabir na svih %d odabranih korisničkih imena.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ova poveznica pozivnice nije važeća.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ovo nije važeća Dash adresa za ovu mrežu";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ovo nije važeća poveznica pozivnice";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ovo je vaš glavni identitet";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ovaj masternode još nema Platform identitet.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "To se i dalje računa kao da su vaši masternodeovi glasali u ovom sporu.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Sirovi bajtovi ove transakcije nisu spremljeni na ovom uređaju.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ovo korisničko ime pripalo je nekom drugom";
+
+"This wallet could not derive the voting key for this node." = "Ovaj novčanik nije mogao izvesti ključ za glasanje za ovaj čvor.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ovaj novčanik ne sadrži aktivne ključeve za glasanje masternodeova pa ne može glasati. Registrirani čvorovi prikazuju se u Alati → Masternodeovi.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ovo isplaćuje cjelokupno vaše Platform stanje u jednom prijenosu. Dash stiže na adresu primatelja čim mreža obradi isplatu.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ovo isplaćuje cjelokupno vaše Platform stanje u jednom prijenosu. Dash stiže na vaše transparentno stanje čim mreža obradi isplatu.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Povijest transakcija nije dostupna";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcije";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Prijenos u";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Prijenos iz";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Prijenosi traju dulje — izgradnja dokaza privatnosti zahtijeva vrijeme";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Prijenosi na druge Platform adrese i na zaštićene adrese trenutni su i konačni";
+
+/* Balance breakdown */
+"Transparent" = "Transparentno";
+
+/* Send screen destination type */
+"Transparent address" = "Transparentna adresa";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentno stanje";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentno financiranje javno povezuje vaše korisničko ime s tim sredstvima.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentno → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentno → Zaštićeno";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nije moguće ponuditi prijedloge";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Nepoznata posebna vrsta %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nezaštićeno";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Nadogradi na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Umjesto toga koristi transparentno stanje";
+
+/* Masternode keys */
+"Used" = "Korišten";
+
+/* Masternode keys */
+"Used at: " = "Korišten: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Korisnik (Dohvaćanje informacija)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Korisnička imena";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Korisnička imena čuvaju se u normaliziranom obliku kako bi se spriječila slična imena, pa se to može razlikovati od onoga što je svatko upisao.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Korisnička imena, a ne adrese";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Korisnici koji odgovaraju %@, a trenutačno nisu u vašim kontaktima";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Koristi jednu od najrevidiranijih i najtestiranijih biblioteka s nultim znanjem (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Važeća pozivnica";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Provjereno tijekom registracije";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Verzija";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Vrlo učinkovito uz niske naknade";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Prikaži sve";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Prikaži transakciju";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Glasaj";
+
+"Vote cast" = "Glas je predan";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Glasajte o spornim korisničkim imenima";
+
+"Vote on several" = "Glasaj o više njih";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Glasaj s";
+
+"Votes that nobody should receive these usernames." = "Glasa da nitko ne bi trebao dobiti ta korisnička imena.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresa za glasanje";
+
+"Voting ended with no winner" = "Glasanje je završilo bez pobjednika";
+
+"Voting ends" = "Glasanje završava";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Glasanje je u tijeku";
+
+"Voting in progress — lock votes are ahead" = "Glasanje je u tijeku — glasovi za zaključavanje vode";
+
+"Voting in progress — you are ahead" = "Glasanje je u tijeku — vi vodite";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash ključa za glasanje";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Glasanje o ovom korisničkom imenu je zatvoreno. Brojevi ispod posljednji su očitani.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Glasanje o „%@“ već je zatvoreno. Osvježite da biste vidjeli rezultat.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Čeka se Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Početna visina novčanika";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Što je s Unstoppable Domains i sličnim uslugama imena?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Koliko košta?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Što je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Što slijedi?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kada će zahtjevi za kontakt postati privatni?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Tko traži ovo ime";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Zašto ga moram omogućiti?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Isplaćuje cjelokupno stanje";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Radi sa svakim Dash novčanikom, mjenjačnicom i trgovcem";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vi";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Prihvatili ste zahtjev za kontakt od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Trenutačno nemate nijedan kontakt";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Do sada imate %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Poslali ste zahtjev za kontakt korisniku %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Osvojili ste ovo korisničko ime";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Sve je spremno. Drugi korisnici sada vam mogu slati zahtjeve za kontakt — a i vi možete slati svoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaš Dash Platform identitet pojavit će se ovdje kada registrirate korisničko ime.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaša povijest, posložena";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vašem identitetu potrebna su dva dodatna ključa kako bi se zahtjevi za kontakt mogli šifrirati između vas i drugih korisnika. Omogućavanje ih dodaje jednom jedinom mrežnom transakcijom. To se događa samo jednom.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaša pozivnica plaća naknadu za registraciju ovog korisničkog imena.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Vaše glavno Dash stanje na Core blockchainu — ono što šaljete i primate s drugim novčanicima, mjenjačnicama i trgovcima.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaši pomiješani novčići premješteni su u stanje vašeg Dash novčanika.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaši pomiješani novčići premješteni su u zaštićeno stanje. Radi najbolje privatnosti pričekajte najmanje 2 sata prije nego što upotrijebite ta sredstva.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Vaše Platform stanje";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Vaše privatno stanje. Iznosi i adrese šifrirani su na lancu, pa vaša sredstva i povijest ostaju povjerljivi.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Vaše zaštićeno stanje";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Vaše zaštićeno stanje gotovo je spremno — moći ćete se registrirati privatno oko %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Vaše zaštićeno stanje je spremno — registrirajte svoje korisničko ime privatno sada";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Vaše zaštićeno stanje odstoji — moći ćete se registrirati privatno oko %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Vaše zaštićeno stanje još sazrijeva. Bit će spremno oko %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Vaše transparentno stanje";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše korisničko ime vide svi. Ako ga financirate iz zaštićenog stanja — nakon što sredstva odstoje nekoliko sati — nitko neće moći povezati vaše korisničko ime s ostalim vašim Dashem.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše korisničko ime, profil i kontakti prate ovaj identitet.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše korisničko ime, profil i kontakti pratit će ovaj identitet.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Vaši glasovi";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaš novčanik još se sinkronizira s Dash mrežom. Slanje će biti dostupno kada se sinkronizacija dovrši.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaš novčanik još se sinkronizira. Slanje iz transparentnog stanja bit će dostupno kada se sinkronizacija dovrši.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ nije bilo moguće pročitati kao Dash korisničko ime.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ je registrirano. Poslati zahtjev za kontakt osobi koja vas je pozvala?";

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Svi čvorovi odjednom";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodeovi glasali su o ovom korisničkom imenu. Da biste promijenili glas, glasajte ponovno od kandidata kojeg sada preferirate.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodeovi glasali su o ovom korisničkom imenu. Da biste promijenili glas, glasajte ponovno za kandidata kojeg sada preferirate.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
@@ -3069,7 +3069,7 @@
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
 
-"Records your masternodes as having voted, without taking a side." = "Bilježi vaše masternodeove kao da su glasali, bez staja na nečiju stranu.";
+"Records your masternodes as having voted, without taking a side." = "Bilježi vaše masternodeove kao da su glasali, bez zauzimanja strane.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";

--- a/DashWallet/hr.lproj/Localizable.stringsdict
+++ b/DashWallet/hr.lproj/Localizable.stringsdict
@@ -111,7 +111,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d korisničko ime</string>
+			<string>%2$d korisničkog imena</string>
 			<key>few</key>
 			<string>%2$d korisnička imena</string>
 			<key>other</key>
@@ -147,7 +147,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d masternode</string>
+			<string>%2$d masternodea</string>
 			<key>few</key>
 			<string>%2$d masternodea</string>
 			<key>other</key>
@@ -165,7 +165,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d čvor</string>
+			<string>%2$d čvora</string>
 			<key>few</key>
 			<string>%2$d čvora</string>
 			<key>other</key>

--- a/DashWallet/hr.lproj/Localizable.stringsdict
+++ b/DashWallet/hr.lproj/Localizable.stringsdict
@@ -82,5 +82,275 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ izbrojeno za „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u glas</string>
+			<key>few</key>
+			<string>%1$u glasa</string>
+			<key>other</key>
+			<string>%1$u glasova</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Glasano o %1$d od %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d korisničko ime</string>
+			<key>few</key>
+			<string>%2$d korisnička imena</string>
+			<key>other</key>
+			<string>%2$d korisničkih imena</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Predaj %u glas</string>
+			<key>few</key>
+			<string>Predaj %u glasa</string>
+			<key>other</key>
+			<string>Predaj %u glasova</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>few</key>
+			<string>%2$d masternodea</string>
+			<key>other</key>
+			<string>%2$d masternodeova</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d čvor</string>
+			<key>few</key>
+			<string>%2$d čvora</string>
+			<key>other</key>
+			<string>%2$d čvorova</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonodea</string>
+			<key>other</key>
+			<string>%d evonodeova</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>ukupno %u glas</string>
+			<key>few</key>
+			<string>ukupno %u glasa</string>
+			<key>other</key>
+			<string>ukupno %u glasova</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>few</key>
+			<string>%d masternodea</string>
+			<key>other</key>
+			<string>%d masternodeova</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d odabran</string>
+			<key>few</key>
+			<string>%d odabrana</string>
+			<key>other</key>
+			<string>%d odabranih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vaš čvor već je glasao ovdje i nije naveden.</string>
+			<key>few</key>
+			<string>%d vaša čvora već su glasala ovdje i nisu navedena.</string>
+			<key>other</key>
+			<string>%d vaših čvorova već je glasalo ovdje i nisu navedeni.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas po sporu — evonodeovi se broje kao 4, masternodeovi kao 1</string>
+			<key>few</key>
+			<string>%u glasa po sporu — evonodeovi se broje kao 4, masternodeovi kao 1</string>
+			<key>other</key>
+			<string>%u glasova po sporu — evonodeovi se broje kao 4, masternodeovi kao 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasaj o %d korisničkom imenu</string>
+			<key>few</key>
+			<string>Glasaj o %d korisnička imena</string>
+			<key>other</key>
+			<string>Glasaj o %d korisničkih imena</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas</string>
+			<key>few</key>
+			<string>%u glasa</string>
+			<key>other</key>
+			<string>%u glasova</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasaj ×%d</string>
+			<key>few</key>
+			<string>Glasaj ×%d</string>
+			<key>other</key>
+			<string>Glasaj ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d zahtjev</string>
+			<key>few</key>
+			<string>%d zahtjeva</string>
+			<key>other</key>
+			<string>%d zahtjeva</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/hr.lproj/Localizable.stringsdict
+++ b/DashWallet/hr.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ izbrojeno za „%2$@“</string>
+		<string>%#@votes@ za „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,11 +93,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u glas</string>
+			<string>%1$u izbrojen glas</string>
 			<key>few</key>
-			<string>%1$u glasa</string>
+			<string>%1$u izbrojena glasa</string>
 			<key>other</key>
-			<string>%1$u glasova</string>
+			<string>%1$u izbrojenih glasova</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -139,7 +139,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Az összes csomópont egyszerre";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Az összes masternode-od szavazott erről a felhasználónévről. A szavazat módosításához szavazz újra attól a pályázótól, akit most előnyben részesítesz.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Az összes masternode-od szavazott erről a felhasználónévről. A szavazat módosításához szavazz újra arra a pályázóra, akit most előnyben részesítesz.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " vagy ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ nem található a Dash hálózaton, így nem küldhető neki kapcsolatkérés.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash érhető el";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ elfogadta a kapcsolatkérésedet";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bájt";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duff";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld befizetés";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditegyenleg a Dash Platformon, amelyet a Platform-címek közötti azonnali fizetésekhez és olyan funkciókhoz használnak, mint a felhasználónevek.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Névjegy";
 
+/* DashPay FAQ title */
+"About DashPay" = "A DashPay névjegye";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Tartózkodás";
+
+"Abstain on “%@”" = "Tartózkodás ennél: „%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktív";
+
+/* No comment provided by engineer. */
+"Activity" = "Tevékenység";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "A tevékenység nyilvános, de nem könnyű nyomon követni";
+
 /* No comment provided by engineer. */
 "Add" = "Hozzáadás";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ hozzáadása névjegyként";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Add hozzá %@ felhasználót névjegyként, hogy közvetlenül a felhasználónévre fizethess, és megőrizd a közös tranzakciós előzményeket";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Adj %@ Dash összeget az árnyékolt egyenlegedhez, és hagyd pár órán át pihenni, hogy úgy regisztrálhass, hogy a felhasználóneved nem kapcsolódik a többi pénzedhez.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Adj legalább %@ Dash összeget az árnyékolt egyenlegedhez";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Töltsd fel most az árnyékolt egyenlegedet, és pár óra múlva regisztráld a felhasználónevedet privát módon";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Az összes csomópont egyszerre";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Az összes masternode-od szavazott erről a felhasználónévről. A szavazat módosításához szavazz újra attól a pályázótól, akit most előnyben részesítesz.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Az egyenlegek szinkronizálása szinte azonnali";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Az összegek és a címek nyilvánosak a blokkláncon";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Egy Ethereum-fiók egyetlen, újra és újra használt cím: a teljes egyenleged és a fizetési előzményeid nyilvánosan alatta állnak, egy név (például egy ENS-domain) pedig általában egyenesen erre a címre mutat, így bárki feloldhatja. A DashPay ennek az ellenkezője — a név egy identitásra mutat, nem fizetési címre, a valódi fizetési címek pedig titkosított névjegycserékben maradnak, minden névjegyhez újként.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Bárki, aki ismer egy címet, megnézheti annak előzményeit";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Jóváhagyás";
+
+"Approving a specific request can only be done one username at a time." = "Egy konkrét kérés jóváhagyása egyszerre csak egy felhasználónévre végezhető el.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Szövegként";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "A hitelesítés megszakítva. A szavazatod nem lett leadva.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "A hitelesítés sikertelen. A szavazatod nem lett leadva.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "A(z) „%@” odaítélése ennek a pályázónak";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Egyenleg";
 
 /* CrowdNode */
+"Balance after" = "Egyenleg utána";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Az egyenlegek és az átutalások nem nyilvánosan láthatók";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Kezdőmagasság elmentve — a megemelt vizsgálati küszöb a következő indítástól érvényes.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Szerződéshez kötve";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Szerződéshez kötve, dokumentumtípus: „%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Csak böngészés";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "A legutóbbi diagnosztikai naplókat zip-fájlba gyűjti, hogy AirDroppal vagy e-mailben elküldhesd, illetve a Fájlokba menthesd";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Szavazat leadása";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Partnerek cseréje";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Ellenőrzés…";
+
+"Choice" = "Választás";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Váltsd be a meghívódat";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Igényelhető egyenleg";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Törlés és újraszinkronizálás";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Törlöd a láncadatokat és újraszinkronizálsz?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Záródik";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (új érmék)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "A CoinJoin már nem támogatott — válaszd ki, hová kerüljenek a kevert érméid.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Fedezet";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Hamarosan";
+
+/* Shielded transfer status */
+"Completed" = "Befejezve";
 
 /* No comment provided by engineer. */
 "Confirm" = "Megerősítés";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Megerősítve";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "A megerősítés elmenti a(z) %u kezdőmagasságot, és az alkalmazás következő indításakor törli e hálózat láncadatait, majd újra letölti azokat, és attól a magasságtól újra átvizsgálja a szűrőket. A futó munkamenet megtartja a régi vizsgálati küszöbét — lépj ki az alkalmazásból, és nyisd meg újra az indításhoz.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Csatlakozott partnerek";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Hátrányok";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "A kapcsolatkérés sikertelen";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kapcsolatkérés elküldve neki: %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kapcsolatkérések";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Pályázó: %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Folytasd a felhasználóneved kiválasztásához. A meghívó fedezi a regisztrációs díjat.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Nyers tranzakció másolása";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "A naplóarchívum létrehozása nem sikerült: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Árfolyam nem található.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d identitást nem sikerült frissíteni";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Az egyenleget nem sikerült lekérni (hálózati hiba). Próbáld meg frissíteni.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Hozd létre a felhasználónevedet, találd meg barátaidat és családtagjaidat a felhasználónevük alapján, és add hozzá őket a névjegyeidhez";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kreditek";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "A Dash Platform még nem indexelte ezt a versengést. A szavazatszámok akkor jelennek meg itt.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "A Dash Platform még nincs csatlakoztatva. Várd meg a szinkronizálás végét, és próbáld újra.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "A rossz címre küldött Dash nem szerezhető vissza. Győződj meg róla, hogy a cím pontosan az, amelynek fizetni szeretnél.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "A Dash a felhasználóneveket megtévesztésbiztos formában tárolja, így a tárolt név eltérhet attól, amit az egyes emberek beírtak.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash-tárca egyenlege";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "A DashPay engedélyezve";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "A DashPay a Dash közösségi fizetési élménye, a Dash Platformra építve. Regisztrálsz egy felhasználónevet, más felhasználókat névjegyként adsz hozzá, és név alapján fizetsz nekik — nincs több címmásolás.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "A DashPay a hosszú, rejtélyes címeket felhasználónevekre cseréli. Add hozzá barátaidat névjegyként, küldj pénzt egy névre, és tartsd minden fizetésedet személyenként rendezve.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "A határidő ismeretlen";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Származtatási útvonal";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Letiltva";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Kész";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Kész — az egyenleged elég hosszan pihent";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Ellenőrizd kétszer a címet";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Versengésenként minden masternode-nak egy élő szavazata van. Később módosíthatod, de a Dash Platform versengésenként és masternode-onként összesen csak 5 szavazatot engedélyez.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Minden koppintással egy újabb csomópont szavaz, így te döntöd el, hányat kapcsolsz össze.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Kezdőmagasság szerkesztése";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Engedélyezés";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay engedélyezése";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "A DashPay engedélyezése egy kis, egyszeri hálózati díjba kerül, amelyet az identitásod kreditegyenlegéből fizetsz. A pontos becslést a megerősítés előtt láthatod. A kapcsolatkérések és fizetések küldése a szokásos hálózati díjakba kerül.";
+
+"Ending soonest" = "A leghamarabb ér véget";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Becsült hálózati díj";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Minden csomópont együtt szavaz. Gyorsabb, de nyilvánosan összekapcsolja egymással a masternode-jaidat.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode üzemeltetői kulcsok";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Naplók exportálása";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Külső cím";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID összehatár";
+
+/* No comment provided by engineer. */
+"Failed" = "Sikertelen";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Lekérés…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Szűrő";
+
+/* SPV sync phase */
+"Filter headers" = "Szűrőfejlécek";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Keress felhasználót a Dash hálózaton";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Identitások keresése";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "%d új identitás található";
+
+/* Identities */
+"Found 1 new identity" = "1 új identitás található";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "A felhasználónevedet az árnyékolt egyenlegedből finanszírozd. Pár órával korábban töltsd fel — a rövid pihenés miatt a felhasználóneved nem köthető a többi Dashodhoz.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Az árnyékolt egyenlegedből finanszírozva — a felhasználóneved nem köthető a többi Dashodhoz.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Az összeg zárolva — az átutalás befejeződik";
+
+/* CoinJoin */
+"Funds moved" = "A pénz áthelyezve";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Készülj fel a DashPayhez való csatlakozásra";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Értem";
+
+/* Governance */
+"Governance" = "Irányítás";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "kérte, hogy a barátod legyen";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Van meghívód?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Fejlécek";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Magasság: %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Magasabb díjak, nagyjából 7 cent (még mindig alacsonyabb, mint más, hasonló adatvédelmet kínáló blokkláncoknál)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Adatvédelem szempontjából hogyan viszonyul ez a Bitcoinhoz?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Adatvédelem szempontjából hogyan viszonyul ez az Ethereum-fiókokhoz?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Mennyire privát a DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identitások";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identitáskreditek";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identitásindex";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identitásregisztráció";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Identitás feltöltése";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inaktív";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Bemenet %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Bemenet %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Bemenetek (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Meghívó tőle: %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Hívj meg valakit a Dash hálózatra";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Hívd meg barátaidat és családodat a Dash hálózatra";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Tartsd privátban ezeket az érméket. Hálózati és adatvédelmi díjak érvényesek.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "%d. kulcs";
+
+/* Identities: the public key bytes */
+"Key data" = "Kulcsadatok";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Kulcs tulajdonjoga";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Kulcsok";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vezet";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Tudj meg többet";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Tranzakciók betöltése";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Csak helyi";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Zárolás";
+
+"Lock the name" = "A név zárolása";
+
+"Lock “%@” so nobody gets it" = "A(z) „%@” zárolása, hogy senki ne kapja meg";
+
 /* No comment provided by engineer. */
 "Locked" = "Zárolva";
 
+"Locked — nobody receives this username" = "Zárolva — ezt a felhasználónevet senki nem kapja meg";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Alacsony díjak a mindennapi költésre";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Fő";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode-kulcstartó";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternode-lista";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternode-szavazatok";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode-ok";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Az ennek a tárcának a kulcsaival regisztrált masternode-ok és evonode-ok itt jelennek meg, miután a tárca szinkronizált.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Az ennek a tárcának a kulcsait használó masternode-ok és evonode-ok";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "A masternode-ok olyan nevekről szavaznak, amelyeket több ember is kért. Értesítünk, amikor a szavazás véget ér.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "A minimum teljesült";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "További javaslatok";
+
+"Most lock votes" = "Legtöbb zárolási szavazat";
+
+"Most votes" = "Legtöbb szavazat";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Áthelyezés a szokásos, elkölthető egyenlegedre.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Pénz áthelyezése";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Az olyan névszolgáltatások, mint az Unstoppable Domains, egy olvasható nevet egy rögzített, nyilvános lánci címhez rendelnek. Bárki feloldhatja a nevet, és láthatja az összes valaha ráküldött fizetést. A DashPay-felhasználónév soha nem oldódik fel nyilvánosan fizetési címmé — a címek csak az egyes névjegyekkel folytatott titkosított cserén belül kerülnek elő, így a neved és a pénzed a külső megfigyelők számára összekapcsolatlan marad.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Figyelmet igényel";
 
 /* No comment provided by engineer. */
 "Network" = "Hálózat";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Ezen az eszközön nem található diagnosztikai napló. A naplók a következő indítástól kezdve íródnak.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nincs identitás";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Még nincs masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nincs illeszkedő versengés";
+
+/* Identities */
+"No new identities were found for this wallet" = "Ehhez a tárcához nem található új identitás";
+
+"No open contest matches that search." = "Egyetlen nyitott versengés sem illeszkedik erre a keresésre.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Egyetlen nyitott versengés sem illeszkedik erre a keresésre. A neveket normalizált formában tároljuk, így az „alice” „a11ce” néven szerepel.";
+
+"No open contests" = "Nincs nyitott versengés";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "A kötött tárcához nem található mentett tárcabejegyzés.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Az árnyékolt regisztráció tartalékához még nem érhető el Platform-cím. Próbáld újra, miután a tárca befejezte a szinkronizálást.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Jelenleg egyetlen felhasználónév sem vitatott. Versengés akkor indul, ha két vagy több ember kéri ugyanazt a nevet.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nem adtak le szavazatot";
+
+"Nobody gets it" = "Senki nem kapja meg";
+
+/* SPV sync peer type */
+"Node" = "Csomópont";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nem szabványos";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Még nem érhető el";
+
+"Not cast" = "Nincs leadva";
+
+/* Masternodes */
+"Not checked yet" = "Még nincs ellenőrizve";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nincs elég árnyékolt egyenleg egy identitás regisztrálásához";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nincs a tárca előzményeiben";
+
+"Not now" = "Most nem";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "A kereskedők nem fogadják el széles körben";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "A kereskedők még nem fogadják el széles körben";
+
+/* Masternode keys */
+"Not yet used" = "Még nincs használatban";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "A Bitcoinon nincs névréteg, ezért az emberek nyíltan osztják meg és használják újra a címeket — ha egy cím ismertté válik, minden, amit valaha kapott, összekapcsolható a tulajdonosával. A DashPaynél a felhasználóneved nyilvános, de soha nem mutat fizetési címre: a címeket névjegyenként privát módon cserélitek, és váltakoznak, így a névre fizetés nem hozza nyilvánosságra, hová megy a pénzed. Mindkettő átlátszó lánc, így a láncelemzés magukra az érmékre továbbra is vonatkozik.";
+
+/* Identities */
+"On Network" = "A hálózaton";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Amint %@ elfogadja a kérésedet, közvetlenül a felhasználónévre fizethetsz";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Egyszerre egy csomópont";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Felhasználónevekről csak masternode-ok és evonode-ok szavazhatnak. Ez a tárca nem tartalmaz aktív masternode-szavazókulcsot.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Üzemeltető";
+
+/* Masternode keys */
+"Operator keys" = "Üzemeltetői kulcsok";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Üzemeltetői nyilvános kulcs (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "vagy";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Egyéb kimenetelek";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Kimenet %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Kimenetek (%d)";
+
+/* Masternodes */
+"Owner" = "Tulajdonos";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Tulajdonos címe";
+
+/* Masternodes */
+"Owner key hash" = "Tulajdonosi kulcs hash-e";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Tulajdonosi Kulcsok";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Az identitásod kreditegyenlegéből fizetve.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Illeszd be a kapott meghívólinket, vagy olvasd be a QR-kódját. Ez fedezi a felhasználóneved regisztrációját.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "közvetlenül a felhasználónévre fizethess";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Embereknek fizess, ne címeknek";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "A fizetések privátak: a névjeggyel cserélt címek titkosított tartalomban utaznak, amelyet csak ti ketten tudtok elolvasni, és soha nem kerülnek nyilvánosságra — így a fizetéseidet nem lehet könnyen a felhasználónevedhez kötni. Ettől még átlátszó láncon zajló, hagyományos fizetésekről van szó: a kifinomult láncelemzés információt szivárogtathat. A Shielded DashPay (hamarosan) betölti ezt a rést. Maguk a kapcsolatkérések jelenleg NEM privátak: bárki láthatja, hogy két identitás összekapcsolódik. A privát kapcsolatkérések hamarosan érkező funkció. A felhasználóneved és a profilod szintén nyilvános a Dash Platformon.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "A fizetések másodpercek alatt megerősödnek az InstantSenddel";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "A közvetlenül címekre küldött fizetések nem őrződnek meg a tevékenységben.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Az egyes névjegyekkel folytatott fizetések egy helyen csoportosulnak, nyers tranzakciók helyett nevekkel és profilokkal.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Kifizetési cím";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-cím";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-egyenleg";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-csomópont";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-csomópont azonosítója";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "A Platform-fizetések nem azonosítják a küldőt. Ezt a fizetést akkor rögzítettük, amikor a tárca észlelte az egyenlegváltozást — lehet, hogy korábban érkezett.";
+
+"Platform SDK not ready" = "A Platform SDK nem áll készen";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "A Platform szinkronizálása nem fut. Nyisd meg a Szinkronizálási információk → Platform szinkronizálási állapot menüpontot az indításához.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Árnyékolt";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Korábban használva ekkor: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Tervezésétől fogva privát";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Hamarosan érkezik mind: a privát kapcsolatkérések (hogy privát maradjon, kivel kapcsolódsz), a Shielded DashPay — névjegyeknek küldött fizetések a privát árnyékolt egyenlegedből —, és a fizetés olyan felhasználóknak, akik még nincsenek a névjegyeid között.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "A privát kapcsolatkérések fejlesztés alatt állnak, és nagyjából 2026 szeptemberére–októberére várhatók. Ma maga a kérés nyilvános — bárki láthatja, hogy két identitás összekapcsolódik, még ha a benne lévő fizetési adatok titkosítottak is. Ha megérkeznek a privát kapcsolatkérések, választhatsz, hogy a barátságod nyilvános vagy privát legyen.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privát kapcsolatkérések, Shielded DashPay, és fizetés olyanoknak, akik még nem névjegyek.";
+
 /* No comment provided by engineer. */
 "Private key" = "Privát kulcs";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "A privát fizetési címeket te és a névjegyeid cserélitek egymással. Csak te és a névjegyed tudja, ki a köztetek zajló fizetések címzettje és küldője.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privát fizetések";
+
+/* Usernames */
+"Private registration" = "Privát regisztráció";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Feldolgozási idő";
+
+/* Balance info sheet section */
+"Pros" = "Előnyök";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Szolgáltatói tranzakciók";
+
+/* Masternode keys */
+"Public key" = "Nyilvános kulcs";
+
+/* Masternode keys */
+"Public key (legacy)" = "Nyilvános kulcs (régi)";
+
+/* Identities */
+"Public keys" = "Nyilvános kulcsok";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Cél";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Nyers tranzakció";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "A nyers tranzakció nem érhető el";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "A kiválasztott magasságtól újra ellenőrzi a tömör blokkszűrőket e tárca tranzakcióira, újra letöltve és újra megfeleltetve azokat. Az újravizsgálat alsó határa a tárca létrehozási magassága és a helyben tárolt láncadat — az ez alatti előzmények visszaállításához inkább csökkentsd a tárca kezdőmagasságát.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Csak olvasható";
+
+/* Usernames */
+"Ready around %@" = "Kb. ekkor lesz kész: %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Ok";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Kapott tőle: %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Rögzíti, hogy a masternode-jaid szavaztak, anélkül hogy oldalra állnának.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Frissítés";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Regisztrálva ekkor";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "A privát regisztrációhoz legalább %@ Dash kell az árnyékolt egyenlegeden, plusz néhány óra pihenőidő — a következő képernyők végigvezetnek rajta.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Regisztráció";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Ezt a nevet kéri";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "A visszaállított tárcák nem mindig tudják visszanyerni a művelet típusát. Ez a bejegyzés a láncon lévő megjegyzésadatokból lett rekonstruálva.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Újraszinkronizálás előkészítve a(z) %u magasságtól — lépj ki az alkalmazásból, és nyisd meg újra az indításhoz.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "megőrizd a közös tranzakciós előzményeket";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Kivonva";
 
 /* No comment provided by engineer. */
 "Retry" = "Újra";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Visszavonás";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "A képernyőmentések láthatóak más alkalmazások és eszközök számára. Generálj egy új helyreállítási kódmondatot és tartsd titokban.";
 
+/* Raw transaction inspector */
+"Script" = "Szkript";
+
+/* Raw transaction inspector */
+"Script signature" = "Szkript aláírása";
+
+/* Raw transaction inspector */
+"Script type" = "Szkript típusa";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Névjegy keresése";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Kapcsolatkérés keresése";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Felhasználó keresése a Dash hálózaton";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Felhasználónév keresése";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Találatok erre: \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Felhasználónevek keresése";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "%@ felhasználónév keresése a Dash hálózaton";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Biztonsági szint";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Összes kijelölése";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Válassz legalább egy masternode-ot, amellyel szavazol.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Kevesebb csomópont kiválasztása kevesebbet árul el arról, mely masternode-okat üzemelteted.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Küldés névjegynek";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Olyan felhasználónévre küldj, amelyre tényleg emlékszel, és amelyet ellenőrizni tudsz.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Küldd el az első kapcsolatkérésedet";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Kapcsolatkérés küldése";
+
+/* No comment provided by engineer. */
+"Sending to" = "Küldés ide";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Elküldve neki: %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Szolgáltatás";
+
+/* Identities */
+"Set as Main" = "Beállítás főként";
+
+/* Identities */
+"Set as Main Identity" = "Beállítás fő identitásként";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "A megosztott adatvédelmi készlet minimális méretű";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Árnyékolt cím";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Árnyékolt költés";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Árnyékolt tárca indítása…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Árnyékolt → Platform";
+
+"Shielded → Transparent" = "Árnyékolt → Átlátszó";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Méret";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Néhány masternode-od hiányozhat erről a listáról — a tárca nem tudta beolvasni a teljes szavazókulcs-készletedet. Fejezd be a szinkronizálást, és nyisd meg újra ezt a képernyőt.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Névjegyek rendezése";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Speciális payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Akkor indul, amikor pénzt adsz hozzá";
+
+/* Transaction details */
+"Status" = "Állapot";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Tárolva így";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Szinkronizálási információk";
+
+/* SPV sync */
+"Sync too slow?" = "Túl lassú a szinkronizálás?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne állj egyik oldalra sem";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Koppints a másoláshoz";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash csomópontkulcs (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "A Dash azután érkezik meg a címzett címére, hogy a hálózat feldolgozta a kifizetést — ez akár 10 percig is tarthat.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "A Dash megérkezik a címzett címére, amint a hálózat feldolgozza a kifizetést.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "A Dash megérkezik az átlátszó egyenlegedre, amint a hálózat feldolgozza a kifizetést.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "A fő identitás csak az aktív tárcából választható";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "A legprivátabb hely a Dashod tárolására";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "A mentett tárcabejegyzéshez nem tartozik hálózat — az újraszinkronizálás nem készíthető elő.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "A regisztrációt elküldtük, de az eredményét nem sikerült megerősíteni. Várj egy percet, amíg a tárca szinkronizál, majd próbáld újra — ne küldd be azonnal ismét.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "A megosztott adatvédelmi készlet még növekszik (%1$ld / %2$ld befizetés). A privát regisztráció akkor nyílik meg, amikor eléri a minimumot.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "A megosztott adatvédelmi készlet még növekszik (%1$ld / %2$ld befizetés). Próbáld újra, amikor eléri a minimumot.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "A tárca létrehozási magassága — a szűrővizsgálatok és a „Tárca létrehozásától” kezdődő újravizsgálatok alsó határa. Állítsd a tárca első feltöltésére vagy az alá; az importálások alapértelmezése mainneten 200000, testneten 0. Ha a jelenlegivel egyező vagy annál alacsonyabb magasságot mentesz, az a következő indításkor törli e hálózat láncadatait, és onnantól újra átvizsgál.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "őt (információk lekérése)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nincsenek új értesítések";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nincs a(z) %@ névre illeszkedő felhasználó";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "A névjegyeid között nincs a(z) %@ névre illeszkedő felhasználó";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ez a pénz átkerül a Platform-egyenlegedre, és az átutalás befejeztével azonnal elkölthető.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Ez a cím nem fizethető a(z) %@ egyenlegedből";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ez két kulcsot ad az identitásodhoz, hogy más felhasználók kapcsolatkérést küldhessenek neked, és hogy te elfogadhasd az övéket. Ez csak egyszer történik meg.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ez egyetlen választást alkalmaz mind a(z) %d kijelölt felhasználónévre.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ez a meghívólink nem érvényes.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ez nem érvényes Dash-cím ehhez a hálózathoz";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ez nem érvényes meghívólink";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ez a fő identitásod";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ennek a masternode-nak még nincs Platform-identitása.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Ez akkor is úgy számít, hogy a masternode-jaid szavaztak ebben a versengésben.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Ennek a tranzakciónak a nyers bájtjai nincsenek eltárolva ezen az eszközön.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ez a felhasználónév máshoz került";
+
+"This wallet could not derive the voting key for this node." = "Ez a tárca nem tudta származtatni a szavazókulcsot ehhez a csomóponthoz.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ez a tárca nem tartalmaz aktív masternode-szavazókulcsot, ezért nem tud szavazni. A regisztrált csomópontok az Eszközök → Masternode-ok alatt jelennek meg.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ez egyetlen átutalással kiveszi a teljes Platform-egyenlegedet. A Dash megérkezik a címzett címére, amint a hálózat feldolgozza a kifizetést.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ez egyetlen átutalással kiveszi a teljes Platform-egyenlegedet. A Dash megérkezik az átlátszó egyenlegedre, amint a hálózat feldolgozza a kifizetést.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "A tranzakciós előzmények nem érhetők el";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Tranzakció azonosító";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Tranzakcióazonosító";
 
 /* A verb, button title. */
 "Transfer" = "Átutalás";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Bejövő átutalás";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Kimenő átutalás";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Az átutalások tovább tartanak — az adatvédelmi bizonyítékok felépítése időbe telik";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "A más Platform-címekre és árnyékolt címekre történő átutalások azonnaliak és véglegesek";
+
+/* Balance breakdown */
+"Transparent" = "Átlátszó";
+
+/* Send screen destination type */
+"Transparent address" = "Átlátszó cím";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Átlátszó egyenleg";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Az átlátszó finanszírozás nyilvánosan összekapcsolja a felhasználónevedet ezzel a pénzzel.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Átlátszó → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Átlátszó → Árnyékolt";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nem lehet javaslatokat adni";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Ismeretlen speciális típus: %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nem árnyékolt";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Frissítés Evolutionre";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Használd inkább az átlátszó egyenleget";
+
+/* Masternode keys */
+"Used" = "Használva";
+
+/* Masternode keys */
+"Used at: " = "Használva ekkor: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Felhasználó (információk lekérése)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Felhasználónevek";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "A felhasználóneveket normalizált formában tároljuk a megtévesztően hasonló nevek elkerülése érdekében, így ez eltérhet attól, amit az egyes emberek beírtak.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Felhasználónevek, nem címek";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "A(z) %@ névre illeszkedő felhasználók, akik jelenleg nincsenek a névjegyeid között";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Az egyik legtöbbet auditált és tesztelt zéró tudású könyvtárat használja (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Érvényes meghívó";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Ellenőrizve a regisztráció során";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Verzió";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Nagyon hatékony, alacsony díjakkal";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Összes megtekintése";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Tranzakció megtekintése";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Szavazás";
+
+"Vote cast" = "Szavazat leadva";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Szavazz a vitatott felhasználónevekről";
+
+"Vote on several" = "Szavazás többre";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Szavazás ezzel";
+
+"Votes that nobody should receive these usernames." = "Arra szavaz, hogy ezeket a felhasználóneveket senki ne kapja meg.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Szavazási cím";
+
+"Voting ended with no winner" = "A szavazás győztes nélkül ért véget";
+
+"Voting ends" = "A szavazás vége";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "A szavazás folyamatban";
+
+"Voting in progress — lock votes are ahead" = "A szavazás folyamatban — a zárolási szavazatok vezetnek";
+
+"Voting in progress — you are ahead" = "A szavazás folyamatban — te vezetsz";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Szavazókulcs hash-e";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Szavazati Kulcsok";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Ennek a felhasználónévnek a szavazása lezárult. Az alábbi számok a legutóbb beolvasottak.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "A(z) „%@” szavazása már lezárult. Frissíts az eredmény megtekintéséhez.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Várakozás a Dash Platformra";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Tárca kezdőmagassága";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Mi a helyzet az Unstoppable Domainsszel és a hasonló névszolgáltatásokkal?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Mennyibe kerül?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Mi az a DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Mi jön ezután?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Mikor válnak privátra a kapcsolatkérések?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Ki kéri ezt a nevet";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Miért kell engedélyeznem?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "A teljes egyenleget kiveszi";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Minden Dash-tárcával, tőzsdével és kereskedővel működik";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Te";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Elfogadtad %@ kapcsolatkérését";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Jelenleg nincs egyetlen névjegyed sem";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Eddig %@ Dashod van";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Elküldted a kapcsolatkérést neki: %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Megnyerted ezt a felhasználónevet";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Minden készen áll. Más felhasználók mostantól kapcsolatkérést küldhetnek neked — és te is elküldheted a sajátodat.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "A Dash Platform-identitásod itt jelenik meg, amint regisztrálsz egy felhasználónevet.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Az előzményeid, rendezve";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Az identitásodnak két további kulcsra van szüksége, hogy a kapcsolatkérések titkosíthatók legyenek közted és más felhasználók között. Az engedélyezés egyetlen hálózati tranzakcióval hozzáadja ezeket. Ez csak egyszer történik meg.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "A meghívód fedezi ennek a felhasználónévnek a regisztrációs díját.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "A fő Dash-egyenleged a Core blokkláncon — ezt küldöd és fogadod más tárcákkal, tőzsdékkel és kereskedőkkel.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "A kevert érméidet a Dash-tárcád egyenlegére helyeztük.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "A kevert érméidet az árnyékolt egyenlegedre helyeztük. A legjobb adatvédelem érdekében várj legalább 2 órát, mielőtt felhasználod ezt a pénzt.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "A Platform-egyenleged";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "A privát egyenleged. Az összegek és a címek titkosítva vannak a láncon, így a vagyonod és az előzményeid bizalmasak maradnak.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Az árnyékolt egyenleged";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Az árnyékolt egyenleged már majdnem kész — kb. ekkor regisztrálhatsz privát módon: %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Az árnyékolt egyenleged kész — regisztráld most privát módon a felhasználónevedet";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Az árnyékolt egyenleged pihen — kb. ekkor regisztrálhatsz privát módon: %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Az árnyékolt egyenleged még érik. Kb. ekkor lesz kész: %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Az átlátszó egyenleged";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "A felhasználónevedet mindenki látja. Ha az árnyékolt egyenlegedből finanszírozod — miután a pénz pár órát pihent —, senki nem tudja összekapcsolni a felhasználónevedet a többi Dashoddal.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "A felhasználóneved, a profilod és a névjegyeid ehhez az identitáshoz tartoznak.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "A felhasználóneved, a profilod és a névjegyeid ehhez az identitáshoz fognak tartozni.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "A szavazataid";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "A tárcád még szinkronizál a Dash hálózattal. A küldés a szinkronizálás befejeztével lesz elérhető.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "A tárcád még szinkronizál. Az átlátszó egyenlegedről történő küldés a szinkronizálás befejeztével lesz elérhető.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "A(z) „%@” nem olvasható Dash-felhasználónévként.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "A(z) „%@” regisztrálva. Küldesz kapcsolatkérést annak, aki meghívott?";

--- a/DashWallet/hu.lproj/Localizable.stringsdict
+++ b/DashWallet/hu.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ számolva ehhez: „%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u szavazat</string>
+			<key>other</key>
+			<string>%1$u szavazat</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@ közül %1$d megszavazva</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d felhasználónév</string>
+			<key>other</key>
+			<string>%2$d felhasználónév</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u szavazat leadása</string>
+			<key>other</key>
+			<string>%u szavazat leadása</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ közül %1$d szavazott</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ közül %1$d szavazott</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d csomópont</string>
+			<key>other</key>
+			<string>%2$d csomópont</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>összesen %u szavazat</string>
+			<key>other</key>
+			<string>összesen %u szavazat</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d kijelölve</string>
+			<key>other</key>
+			<string>%d kijelölve</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>A csomópontjaid közül %d már szavazott itt, ezért nem szerepel a listában.</string>
+			<key>other</key>
+			<string>A csomópontjaid közül %d már szavazott itt, ezért nem szerepel a listában.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u szavazat versengésenként — az evonode-ok 4-nek, a masternode-ok 1-nek számítanak</string>
+			<key>other</key>
+			<string>%u szavazat versengésenként — az evonode-ok 4-nek, a masternode-ok 1-nek számítanak</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Szavazás %d felhasználónévről</string>
+			<key>other</key>
+			<string>Szavazás %d felhasználónévről</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u szavazat</string>
+			<key>other</key>
+			<string>%u szavazat</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Szavazás ×%d</string>
+			<key>other</key>
+			<string>Szavazás ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d kérés</string>
+			<key>other</key>
+			<string>%d kérés</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Semua node sekaligus";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode Anda telah memberi suara untuk nama pengguna ini. Untuk mengubah suara, beri suara lagi dari penawar yang kini Anda pilih.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode Anda telah memberi suara untuk nama pengguna ini. Untuk mengubah suara, beri suara lagi untuk penawar yang kini Anda pilih.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " atau ";
+
 /* CrowdNode */
 " Privacy Policy " = "Kebijakan pribadi";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ tidak dapat ditemukan di jaringan Dash untuk dikirimi permintaan kontak.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash tersedia";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ telah menerima permintaan kontak Anda";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu kontak / %3$lu pembaruan profil";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duff";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d suara akan diberikan karena Anda memiliki beberapa kunci pemungutan suara yang disimpan di dompet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplikat";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld dari %ld setoran";
 
 /* Voting */
 "%ld requests" = "%ld permintaan";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" bukanlah kata frasa pemulihan. Apakah Anda ingin mencoba mendapatkan kembali kata yang benar yang seharusnya ada pada tempatnya?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Saldo kredit di Dash Platform yang digunakan untuk pembayaran instan antar alamat Platform dan untuk fitur seperti nama pengguna.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Kode akses perangkat diperlukan untuk melindungi dompet Anda. Buka pengaturan dan aktifkan kode akses untuk melanjutkan.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Tentang";
 
+/* DashPay FAQ title */
+"About DashPay" = "Tentang DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Tentang saya";
+
+"Abstain" = "Abstain";
+
+"Abstain on “%@”" = "Abstain pada “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Terima";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Pemulihan Akun";
 
+/* Masternode status */
+"Active" = "Aktif";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivitas";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivitas bersifat publik tetapi tidak mudah dilacak";
+
 /* No comment provided by engineer. */
 "Add" = "Tambahkan";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Tambahkan %@ sebagai kontak";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Tambahkan %@ sebagai kontak Anda untuk membayar langsung ke nama pengguna dan menyimpan riwayat transaksi bersama";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Tambahkan %@ Dash ke saldo terlindungi Anda dan biarkan mengendap beberapa jam agar pendaftaran tidak mengaitkan nama pengguna Anda dengan dana lainnya.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Tambahkan Kontak Baru";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Tambahkan setidaknya %@ Dash ke saldo terlindungi Anda";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Tambahkan dana ke saldo terlindungi sekarang dan daftarkan nama pengguna Anda secara privat beberapa jam kemudian";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Semua";
 
+"All nodes at once" = "Semua node sekaligus";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode Anda telah memberi suara untuk nama pengguna ini. Untuk mengubah suara, beri suara lagi dari penawar yang kini Anda pilih.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Izinkan mengirim semua transaksi dari dompet Dash ke Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sinkronisasi saldo hampir seketika";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Jumlah dan alamat bersifat publik di blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Terjadi kesalahan";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Akun Ethereum adalah satu alamat yang dipakai berulang: seluruh saldo dan riwayat pembayaran Anda tercatat publik di bawahnya, dan sebuah nama (misalnya domain ENS) biasanya langsung menunjuk ke alamat itu sehingga siapa pun dapat menelusurinya. DashPay justru sebaliknya — nama tertuju pada identitas, bukan alamat pembayaran, dan alamat pembayaran sesungguhnya tetap berada di dalam pertukaran kontak terenkripsi, baru untuk setiap kontak.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Pengalaman intuitif dan akrab di semua perangkat Anda";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Nama pengguna apa pun yang memiliki angka 2-9, lebih dari 20 karakter atau yang memiliki tanda hubung akan disetujui secara otomatis";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Siapa pun yang mengetahui suatu alamat dapat melihat riwayatnya";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Terapkan";
 
+"Approve" = "Setujui";
+
+"Approving a specific request can only be done one username at a time." = "Menyetujui permintaan tertentu hanya dapat dilakukan satu nama pengguna dalam satu waktu.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Anda yakin ingin membatalkan pesanan ini?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Sebagai teks";
 
 /* DashSpend */
 "at" = "pada";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autentikasi dibatalkan. Suara Anda tidak diberikan.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autentikasi gagal. Suara Anda tidak diberikan.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Otentikasi tidak tersedia";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Berikan “%@” kepada penawar ini";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo setelahnya";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Saldo Di CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Saldo:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldo dan transfer tidak terlihat secara publik";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Akun Bank";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Akses Biometrik Diperlukan";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Tinggi awal tersimpan — batas bawah pemindaian yang dinaikkan berlaku mulai peluncuran berikutnya.";
+
 /* Voting */
 "Block" = "Blok";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Nama pengguna '%@' diblokir";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Terikat pada kontrak";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Terikat pada kontrak, jenis dokumen “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Hanya menelusuri";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Kumpulkan log diagnostik terbaru menjadi zip untuk dikirim lewat AirDrop, email, atau disimpan ke Files";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Berikan suara";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Ganti peer";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Ubah PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Memeriksa…";
+
+"Choice" = "Pilihan";
+
 /* Choose your Dash username */
 "Choose your" = "Pilih Anda";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Pilih Nama pengguna";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Klaim undangan Anda";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo yang dapat diklaim";
+
 /* No comment provided by engineer. */
 "Claimed" = "Diklaim";
+
+/* SPV diagnostics */
+"Clear & resync" = "Hapus & sinkronkan ulang";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Hapus data rantai dan sinkronkan ulang?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Tutup aplikasi";
 
+"Closing" = "Menutup";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (koin baru)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Kode 2FA Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin tidak lagi didukung — pilih ke mana koin campuran Anda akan dipindahkan.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Jaminan";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Segera hadir";
+
+/* Shielded transfer status */
+"Completed" = "Selesai";
 
 /* No comment provided by engineer. */
 "Confirm" = "Memastikan";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Terkonfirmasi";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Mengonfirmasi akan menyimpan tinggi awal %u dan menghapus data rantai jaringan ini pada peluncuran aplikasi berikutnya, mengunduhnya kembali serta memindai ulang filter dari tinggi tersebut. Sesi yang sedang berjalan tetap memakai batas bawah pemindaian lamanya — tutup dan buka kembali aplikasi untuk memulai.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Hubungkan dompet crypto anda ke platform Zenledger. Pelajari lebih lanjut dan mulai dengan transaksi Domept Dash.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Alamat Dash terhubung";
 
+/* SPV sync */
+"Connected peers" = "Peer terhubung";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Kekurangan";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Permintaan kontak gagal";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Permintaan kontak dikirim ke %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Permintaan Kontak";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kontak";
 
+"Contender %@" = "Penawar %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Teruskan";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Lanjutkan untuk memilih nama pengguna Anda. Undangan membayar biaya pendaftaran.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Salin Tautan Undangan";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Salin transaksi mentah";
+
 /* No comment provided by engineer. */
 "Copy text" = "Salin teks";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Tidak dapat secara otomatis memulihkan kata yang hilang atau salah";
 
+/* Log export */
+"Could not create the log archive: %@" = "Tidak dapat membuat arsip log: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Tidak dapat menemukan nilai tukar. ";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Tidak dapat menyegarkan %d identitas";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Tidak dapat mengambil saldo (kesalahan jaringan). Coba segarkan.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Tidak dapat melakukan pembayaran";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Buat Nama Pengguna anda";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Buat Nama Pengguna Anda, temukan teman & keluarga lewat nama pengguna mereka, lalu tambahkan ke kontak Anda";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Kartu Kredit";
+
+/* Masternodes */
+"Credits" = "Kredit";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "pembayaran dash tidak boleh kurang dari %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform belum mengindeks sengketa ini. Jumlah suara muncul di sini setelah terindeks.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform belum terhubung. Tunggu sinkronisasi selesai lalu coba lagi.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash yang dikirim ke alamat yang salah tidak dapat dipulihkan. Pastikan alamatnya persis seperti yang Anda tuju.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash menyimpan nama pengguna dalam bentuk yang aman dari kemiripan, jadi nama tersimpan bisa berbeda dari yang diketik masing-masing orang.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nama pengguna Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dompet Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo Dompet Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dompet Dash di perangkat ini";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay diaktifkan";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Undangan DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay adalah pengalaman pembayaran sosial dari Dash, dibangun di atas Dash Platform. Anda mendaftarkan nama pengguna, menambahkan pengguna lain sebagai kontak, dan membayar mereka lewat nama — tidak perlu lagi menyalin alamat.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay mengganti alamat panjang yang membingungkan dengan nama pengguna. Tambahkan teman sebagai kontak, kirim uang ke sebuah nama, dan simpan setiap pembayaran secara rapi per orang.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Biaya Peningkatan DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Tanggal: Lama ke baru";
+
+"Deadline unknown" = "Tenggat tidak diketahui";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Setoran terkirim";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Jalur derivasi";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "KEAMANAN PERANGKAT MEMBAHAYAKAN\nAplikasi 'jailbreak' apa pun dapat mengakses data keychain aplikasi lain (dan mencuri Dash Anda). Bersihkan dompet ini segera dan kembalikan pada perangkat yang aman.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Dinonaktifkan";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Putuskan Sambungan Akun Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Selesai";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Selesai — saldo Anda sudah cukup lama mengendap";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Periksa ulang alamatnya";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Setiap undangan akan didanai dengan jumlah ini sehingga penerima dapat dengan cepat membuat nama pengguna mereka di Jaringan Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Setiap masternode punya satu suara aktif per sengketa. Anda dapat mengubahnya nanti, tetapi Dash Platform hanya mengizinkan total 5 suara per masternode per sengketa.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Setiap ketukan memberi suara dengan satu node tambahan, jadi Anda memilih berapa banyak yang dikaitkan bersama.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Sebelumnya";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Stake Dash dengan mudah dan dapatkan penghasilan pasif dengan beberapa klik yang mudah.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Ubah tinggi awal";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Sunting profil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktifkan";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Aktifkan DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Aktifkan Pengenal Wajah";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Aktifkan Pengenal sentuh";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Mengaktifkan DashPay memerlukan satu biaya jaringan kecil sekali bayar, diambil dari saldo kredit identitas Anda. Perkiraan tepatnya ditampilkan sebelum Anda mengonfirmasi. Mengirim permintaan kontak dan pembayaran dikenakan biaya jaringan seperti biasa.";
+
+"Ending soonest" = "Berakhir paling cepat";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Terjadi kesalahan saat memperbarui profil Anda";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Perkiraan biaya jaringan";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Setiap node memberi suara bersama. Lebih cepat, tetapi mengaitkan masternode Anda satu sama lain secara publik.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Kunci operator Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Ekspor CSV";
 
+/* Log export */
+"Export Logs" = "Ekspor Log";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Kunci Publik Diperpanjang (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Alamat eksternal";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Identitas wajah terbatas";
+
+/* No comment provided by engineer. */
+"Failed" = "Gagal";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Gagal memuat kode batang";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Mengambil tarif…";
 
+/* Masternodes */
+"Fetching…" = "Mengambil…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Akun Fiat";
 
 /* No comment provided by engineer. */
 "Filter" = "Menyaring";
+
+/* SPV sync phase */
+"Filter headers" = "Header filter";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Saring transaksi";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Temukan pengguna di Jaringan Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Temukan ATM dimana anda dapat membeli atau menjual Dash.";
+
+/* Identities */
+"Find identities" = "Cari identitas";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Lupa PIN?";
 
+/* Identities */
+"Found %d new identities" = "Ditemukan %d identitas baru";
+
+/* Identities */
+"Found 1 new identity" = "Ditemukan 1 identitas baru";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Menemukan kata yang hilang:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Danai nama pengguna Anda dari saldo terlindungi. Tambahkan dana beberapa jam sebelumnya — jeda singkat itu membuat nama pengguna Anda tidak dapat dikaitkan dengan Dash Anda yang lain.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Didanai dari saldo terlindungi Anda — nama pengguna Anda tidak dapat dikaitkan dengan Dash Anda yang lain.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Dana terkunci — menyelesaikan transfer";
+
+/* CoinJoin */
+"Funds moved" = "Dana dipindahkan";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Dapatkan hadiah dari deposit di Dash Masternodes hanya dengan 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Dapatkan Penawaran";
+
+/* Usernames */
+"Get ready to join DashPay" = "Bersiaplah bergabung dengan DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Dapatkan Hadiah Instan";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Mengerti";
+
+/* Governance */
+"Governance" = "Tata Kelola";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Berikan izin GPS sehingga kami dapat menunjukkan lokasi di dekat Anda.";
 
 /* Voting */
 "Has blocked votes" = "Telah memblokir suara";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "telah meminta untuk menjadi teman Anda";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Punya undangan?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Memiliki kendali penuh dan sesuaikan dompet Anda berdasarkan kebutuhan Anda";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d dari %2$d";
+
+/* SPV sync phase */
+"Headers" = "Header";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Tinggi %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Berikut adalah alamat Dash yang ditujukan untuk akun CrowdNode Anda di Dash Wallet pada perangkat ini";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Tinggi ke rendah";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Biaya lebih tinggi sekitar 7 sen (tetap lebih rendah daripada blockchain lain dengan privasi serupa)";
+
 /* No comment provided by engineer. */
 "History" = "Riwayat";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Bagaimana saya mendapatkan tes Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Bagaimana perbandingannya dengan Bitcoin dari sisi privasi?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Bagaimana perbandingannya dengan akun Ethereum dari sisi privasi?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Seberapa privat DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Bagaimana cara mengonfirmasi API alamat Dash Anda";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Saya telah mencatat";
 
+/* Identities */
+"Identities" = "Identitas";
+
 /* Voting */
 "Identity" = "Identitas";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kredit identitas";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identitas";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Pendaftaran identitas";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Isi ulang identitas";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Di bagian pembayaran pada kasir Anda, pilih \"kartu hadiah\" dan masukkan nomor kartu dan pin Anda.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Tidak aktif";
+
+/* No comment provided by engineer. */
 "Income" = "Pemasukan";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Menginisialisasi";
+
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Input (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Dana tidak mencukupi";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Biaya Undangan";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Undangan dari %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Undangan telah digunakan oleh";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Undang";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Undang Seseorang untuk bergabung dengan Jaringan Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Undang keluarga Anda, temukan teman Anda dengan mencari nama pengguna mereka";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Undang teman dan keluarga Anda untuk bergabung dengan Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Undang teman dan keluarga Anda ke Jaringan Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ masalah yang dilaporkan";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Bergabung ke pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Jaga koin ini tetap privat. Berlaku biaya jaringan dan privasi.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Simpan frasa sandi Anda dengan aman";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Kunci #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Data kunci";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Kepemilikan kunci";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Kunci";
 
 /* Explore Dash */
 "Last device sync" = "Sinkronisasi perangkat terakhir";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Memimpin";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Pelajari Lebih Lanjut";
 
 /* Info Screen */
 "Learn More..." = "Pelajari lebih lanjut...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Memuat transaksi";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Mata uang lokal";
 
+/* Identities */
+"Local Only" = "Hanya Lokal";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Jumlah lokal yang diminta: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Lokasi";
 
+"Lock" = "Kunci";
+
+"Lock the name" = "Kunci namanya";
+
+"Lock “%@” so nobody gets it" = "Kunci “%@” agar tidak ada yang mendapatkannya";
+
 /* No comment provided by engineer. */
 "Locked" = "Terkunci";
 
+"Locked — nobody receives this username" = "Terkunci — tidak ada yang menerima nama pengguna ini";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Masuk";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Rendah";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Biaya rendah untuk belanja sehari-hari";
+
 /* Voting */
 "Low to high" = "Rendah ke tinggi";
+
+/* Identities — the wallet's main identity */
+"Main" = "Utama";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Alamat IP masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Gantungan Kunci Masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Kunci Masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Daftar masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "daftar masternode #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Pembaruan Masternode";
 
+"Masternode votes" = "Suara masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Kunci Voting Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode dan evonode yang terdaftar dengan kunci dompet ini akan muncul di sini setelah dompet tersinkronkan.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode dan evonode yang menggunakan kunci dompet ini";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode memberi suara untuk nama yang diminta lebih dari satu orang. Anda akan diberi tahu ketika pemungutan suara berakhir.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum terpenuhi";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Kontrol lebih lanjut";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Saran Lainnya";
+
+"Most lock votes" = "Suara kunci terbanyak";
+
+"Most votes" = "Suara terbanyak";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Pindahkan dan Perbesar foto Anda untuk menemukan yang pas";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Pindahkan ke saldo biasa yang dapat dibelanjakan.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Terpindah ke Alamat";
+
+/* CoinJoin */
+"Moving funds" = "Memindahkan dana";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Nama";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Layanan nama seperti Unstoppable Domains memetakan nama yang mudah dibaca ke satu alamat publik tetap di rantai. Siapa pun dapat menelusuri nama itu dan melihat setiap pembayaran yang pernah dilakukan ke sana. Nama pengguna DashPay tidak pernah tertuju secara publik ke alamat pembayaran — alamat hanya diungkapkan di dalam pertukaran terenkripsi dengan setiap kontak, sehingga nama dan uang Anda tetap tidak terkait bagi pengamat luar.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Butuh bantuan?";
+
+"Needs attention" = "Perlu perhatian";
 
 /* No comment provided by engineer. */
 "Network" = "Jaringan";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Tidak ada log diagnostik yang ditemukan di perangkat ini. Log ditulis mulai peluncuran berikutnya.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Tidak Ada Identitas";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Belum ada masternode";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Tidak ada sengketa yang cocok";
+
+/* Identities */
+"No new identities were found for this wallet" = "Tidak ada identitas baru yang ditemukan untuk dompet ini";
+
+"No open contest matches that search." = "Tidak ada sengketa terbuka yang cocok dengan pencarian itu.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Tidak ada sengketa terbuka yang cocok dengan pencarian itu. Nama disimpan dalam bentuk yang dinormalisasi, jadi “alice” terdaftar sebagai “a11ce”.";
+
+"No open contests" = "Tidak ada sengketa terbuka";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Tidak ada metode pembayaran";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Tidak ditemukan baris dompet tersimpan untuk dompet yang terikat.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Belum ada alamat Platform yang tersedia untuk cadangan pendaftaran terlindungi. Coba lagi setelah dompet selesai bersinkronisasi.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Tidak ada hasil yang ditemukan";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Saat ini tidak ada nama pengguna yang disengketakan. Sengketa terbuka ketika dua orang atau lebih meminta nama yang sama.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Tidak ada suara tersisa";
+
+"No votes were cast" = "Tidak ada suara yang diberikan";
+
+"Nobody gets it" = "Tidak ada yang mendapatkannya";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nonstandar";
 
 /* adjective, security level */
 "None" = "Tidak ada";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Tak tersedia";
 
+"Not available yet" = "Belum tersedia";
+
+"Not cast" = "Belum diberikan";
+
+/* Masternodes */
+"Not checked yet" = "Belum diperiksa";
+
 /* Location Service Status */
 "Not Determined" = "Tidak ditentukan";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Saldo terlindungi tidak cukup untuk mendaftarkan identitas";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Tidak ada dalam riwayat dompet";
+
+"Not now" = "Nanti saja";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Belum diterima luas oleh pedagang";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Belum diterima luas oleh pedagang";
+
+/* Masternode keys */
+"Not yet used" = "Belum digunakan";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Lama ke Baru";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Di Bitcoin tidak ada lapisan nama, jadi orang membagikan dan memakai ulang alamat secara terbuka — begitu sebuah alamat diketahui, semua yang pernah diterimanya dapat dikaitkan dengan pemiliknya. Dengan DashPay nama pengguna Anda bersifat publik, tetapi tidak pernah menunjuk ke alamat pembayaran: alamat dipertukarkan secara privat per kontak dan berganti-ganti, jadi membayar lewat nama tidak mengumumkan ke mana uang Anda pergi. Keduanya adalah rantai transparan, jadi analisis rantai tetap berlaku pada koinnya sendiri.";
+
+/* Identities */
+"On Network" = "Di Jaringan";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Setelah %@ menerima permintaan Anda, Anda dapat membayar langsung ke nama pengguna";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Satu node dalam satu waktu";
 
 /* Voting */
 "One vote left" = "Satu suara tersisa";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Hanya duplikat";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Hanya masternode dan evonode yang dapat memberi suara untuk nama pengguna. Dompet ini tidak memiliki kunci pemungutan suara masternode yang aktif.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Hanya permintaan dengan tautan";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Hanya dengan tautan";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Kunci operator";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Kunci publik operator (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "atau";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Pratinjau Pesanan";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Hasil lainnya";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Output (%d)";
+
+/* Masternodes */
+"Owner" = "Pemilik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Alamat pemilik";
+
+/* Masternodes */
+"Owner address" = "Alamat pemilik";
+
+/* Masternodes */
+"Owner key hash" = "Hash kunci pemilik";
 
 /* Owner keys */
 "Owner keys" = "Kunci Pemilik";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Dibayar dari saldo kredit identitas Anda.";
 
 /* DashSpend */
 "Password" = "Kata sandi";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Tempel tautan disini";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Tempel tautan undangan yang Anda terima, atau pindai kode QR-nya. Undangan itu mendanai pendaftaran nama pengguna Anda.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Tempel URL gambar Anda";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Bayar dan dapatkan bayaran instan dengan aliran pembayaran yang mudah digunakan";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "Membayar Langsung ke Nama Pengguna";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Bayar orang, bukan alamat";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Bayar ke nama pengguna. Tidak ada lagi alamat alfanumerik";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Membayar...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload heks";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Metode pembayaran";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Pembayaran bersifat privat: alamat yang Anda pertukarkan dengan sebuah kontak dikirim di dalam muatan terenkripsi yang hanya bisa dibaca oleh Anda berdua, dan tidak pernah dipublikasikan — jadi pembayaran Anda tidak mudah dikaitkan dengan nama pengguna Anda. Meski begitu, ini tetap pembayaran biasa di rantai transparan: analisis rantai yang canggih masih bisa membocorkan informasi. Shielded DashPay (segera hadir) akan menutup celah tersebut. Permintaan kontak itu sendiri saat ini TIDAK privat: siapa pun dapat melihat bahwa dua identitas terhubung. Permintaan kontak privat adalah fitur yang segera hadir. Nama pengguna dan profil Anda juga bersifat publik di Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Pembayaran terkonfirmasi dalam hitungan detik dengan InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Pembayaran yang dilakukan langsung ke alamat tidak akan disimpan dalam aktivitas.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Pembayaran dengan setiap kontak dikelompokkan di satu tempat, dengan nama dan profil alih-alih transaksi mentah.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Alamat pembayaran";
 
 /* CrowdNode */
 "Payout Options" = "Opsi Pembayaran";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Alamat Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Node Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID Node Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Pembayaran Platform tidak mengidentifikasi pengirim. Pembayaran ini dicatat saat dompet menyadari perubahan saldo — bisa jadi sudah tiba lebih awal.";
+
+"Platform SDK not ready" = "SDK Platform belum siap";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Sinkronisasi Platform tidak berjalan. Buka Info Sinkronisasi → Status Sinkronisasi Platform untuk memulainya.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Terlindungi";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Silakan tambahkan metode pembayaran di Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Pratinjau Undangan";
 
+/* Masternode keys */
+"Previously used at: " = "Sebelumnya digunakan pada: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Harga setidaknya berumur 30 menit. Nilai Fiat mungkin salah.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat sejak dirancang";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Permintaan kontak privat (agar dengan siapa Anda terhubung tetap privat), Shielded DashPay — pembayaran ke kontak dari saldo terlindungi privat Anda — dan membayar pengguna yang belum ada di kontak Anda, semuanya segera hadir.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Permintaan kontak privat sedang dikembangkan dan diperkirakan hadir sekitar September–Oktober 2026. Saat ini permintaannya sendiri bersifat publik — siapa pun dapat melihat bahwa dua identitas terhubung, meski detail pembayaran di dalamnya terenkripsi. Setelah permintaan kontak privat tersedia, Anda dapat memilih apakah pertemanan Anda bersifat publik atau privat.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Permintaan kontak privat, Shielded DashPay, dan membayar orang yang belum menjadi kontak.";
+
 /* No comment provided by engineer. */
 "Private key" = "Kunci pribadi";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Alamat pembayaran privat dipertukarkan antara Anda dan kontak Anda. Hanya Anda dan kontak Anda yang mengetahui penerima dan pengirim pembayaran di antara kalian.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pembayaran privat";
+
+/* Usernames */
+"Private registration" = "Pendaftaran privat";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Waktu pemrosesan";
+
+/* Balance info sheet section */
+"Pros" = "Kelebihan";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Lindungi tabungan Anda";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Alamat Penyedia";
 
+/* Masternodes */
+"Provider transactions" = "Transaksi penyedia";
+
+/* Masternode keys */
+"Public key" = "Kunci publik";
+
+/* Masternode keys */
+"Public key (legacy)" = "Kunci publik (lama)";
+
+/* Identities */
+"Public keys" = "Kunci publik";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL publik";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Pembelian gagal";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Tujuan";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Nilai: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transaksi mentah";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transaksi mentah tidak tersedia";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Memeriksa ulang filter blok ringkas mulai dari tinggi yang dipilih untuk mencari transaksi dompet ini, dengan mengunduh dan mencocokkannya kembali. Pemindaian ulang dibatasi pada tinggi pembuatan dompet dan data rantai yang tersimpan lokal — untuk memulihkan riwayat di bawah itu, turunkan tinggi awal dompet.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Baca Kebijakan Penarikan";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Hanya-baca";
+
+/* Usernames */
+"Ready around %@" = "Siap sekitar %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Alasan";
 
 /* No comment provided by engineer. */
 "Receive" = "Terima";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Diterima dari";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Diterima dari %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Menerima imbalan";
+
+"Records your masternodes as having voted, without taking a side." = "Mencatat masternode Anda sebagai telah memberi suara, tanpa memihak.";
 
 /* No comment provided by engineer. */
 "Recover" = "Pemulihan";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Frasa pemulihan harus memiliki 12, 15, 18, 21, atau 24 kata";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Segarkan";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Daftar?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Terdaftar pada";
+
+/* No comment provided by engineer. */
 "Registered from" = "Terdaftar dari";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternode Terdaftar";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Pendaftaran privat memerlukan setidaknya %@ Dash di saldo terlindungi Anda ditambah beberapa jam waktu mengendap — layar berikutnya akan memandu Anda.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Pendaftaran";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Meminta nama ini";
+
 /* An action */
 "Rescan" = "Pindai ulang";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Dompet yang dipulihkan tidak selalu dapat memulihkan jenis operasinya. Entri ini direkonstruksi dari data catatan on-chain.";
+
+/* Location Service Status */
 "Restricted" = "Terbatas";
 
 /* Usernames */
 "Results" = "Hasil";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Sinkronisasi ulang disiapkan dari tinggi %u — tutup dan buka kembali aplikasi untuk memulai.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "Menyimpan Riwayat Transaksi Bersama";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Pensiun";
 
 /* No comment provided by engineer. */
 "Retry" = "Coba lagi";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Tinjau postingan di bawah untuk memverifikasi kepemilikan nama pengguna ini";
+
+/* Masternodes */
+"Revocation" = "Pencabutan";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Tangkapan layar terlihat oleh aplikasi dan perangkat lain. Hasilkan frasa pemulihan baru dan jaga kerahasiaannya.";
 
+/* Raw transaction inspector */
+"Script" = "Skrip";
+
+/* Raw transaction inspector */
+"Script signature" = "Tanda tangan skrip";
+
+/* Raw transaction inspector */
+"Script type" = "Jenis skrip";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Cari kontak";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Cari permintaan kontak";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Cari Pengguna di Jaringan Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Cari nama pengguna";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Hasil pencarian untuk \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Wilayah pencarian";
+
+"Search usernames" = "Cari nama pengguna";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Mencari nama pengguna %@ di Jaringan Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Amankan Dompet Anda";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Tingkat keamanan";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Tingkat keamanan";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Pilih layanan untuk membeli, menjual, menukar dan mentransfer Dash";
 
+"Select all" = "Pilih semua";
+
 /* DashSpend denomination selection */
 "Select amount" = "Pilih jumlah";
+
+"Select at least one masternode to vote with." = "Pilih setidaknya satu masternode untuk memberi suara.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Pilih koin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Memilih lebih sedikit node lebih sedikit mengungkap masternode mana yang Anda jalankan.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Pembayaran mandiri";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Kirim ke";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Kirim ke Kontak";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Kirim ke nama pengguna yang benar-benar bisa Anda ingat dan verifikasi.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Kirim ke alamat";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Kirim permintaan kontak pertama Anda";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Mengirim";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Mengirim Permintaan Kontak";
+
+/* No comment provided by engineer. */
+"Sending to" = "Mengirim ke";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Mengirim ke akun CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Terkirim ke";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Dikirim ke %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Terjadi kesalahan server. Silakan coba lagi nanti.";
+
+/* Masternodes */
+"Service" = "Layanan";
+
+/* Identities */
+"Set as Main" = "Jadikan Utama";
+
+/* Identities */
+"Set as Main Identity" = "Jadikan Identitas Utama";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Tetapkan PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Bagikan kunci";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Kolam privasi bersama pada ukuran minimum";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Alamat terlindungi";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Pengeluaran terlindungi";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Memulai dompet terlindungi…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Terlindungi → Platform";
+
+"Shielded → Transparent" = "Terlindungi → Transparan";
 
 /* Explore Dash */
 "Show all locations" = "Tampilkan Semua Lokasi";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Ukuran";
+
 /* No comment provided by engineer. */
 "Skip" = "Lewati";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Sebagian masternode Anda mungkin tidak ada dalam daftar ini — dompet tidak dapat membaca seluruh kumpulan kunci pemungutan suara Anda. Selesaikan sinkronisasi lalu buka kembali layar ini.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Beberapa nama pengguna dapat diblokir";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Urutkan dengan";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Urutkan Kontak";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Diurutkan berdasarkan diskon";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Diurutkan berdasarkan nama";
+
+/* Raw transaction inspector */
+"Special payload" = "Payload khusus";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Tentukan Jumlah";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Dimulai setelah Anda menambahkan dana";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Langkah %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Disimpan sebagai";
 
 /* Voting */
 "Submit" = "Kirim";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sinkronisasi sedang berlangsung... Hasil mungkin tidak lengkap.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Info Sinkronisasi";
+
+/* SPV sync */
+"Sync too slow?" = "Sinkronisasi terlalu lambat?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Ambil Foto dari Kamera";
 
+"Take no side" = "Tidak memihak";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Ketuk alamat dari clipboard untuk menempelkannya";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Ketuk untuk menyalin";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Ketuk untuk menyembunyikan saldo";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Tidak tersedia untuk sementara";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Kunci node Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Syarat dan kondisi";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Kode tidak benar. Silakan periksa dan coba lagi!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash tiba di alamat penerima setelah jaringan memproses penarikan — ini bisa memakan waktu hingga 10 menit.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash tiba di alamat penerima begitu jaringan memproses penarikan.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash tiba di saldo transparan Anda begitu jaringan memproses penarikan.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Jaringan Dash harus memberikan suara untuk menyetujui beberapa nama pengguna sebelum dibuat";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Tautan yang Anda kirimkan hanya akan terlihat oleh pemilik jaringan";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Identitas utama hanya dapat dipilih dari dompet yang aktif";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Jumlah minimum yang dapat Anda kirim adalah %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Tempat paling privat untuk menyimpan Dash Anda";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Baris dompet tersimpan tidak memiliki jaringan — tidak dapat menyiapkan sinkronisasi ulang.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Pendaftaran telah dikirim tetapi hasilnya tidak dapat dikonfirmasi. Tunggu satu menit hingga dompet bersinkronisasi, lalu coba lagi — jangan kirim ulang seketika.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Kolam privasi bersama masih bertumbuh (%1$ld dari %2$ld setoran). Pendaftaran privat terbuka setelah mencapai batas minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Kolam privasi bersama masih bertumbuh (%1$ld dari %2$ld setoran). Coba lagi setelah mencapai batas minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Nama pengguna '%@' telah diblokir oleh jaringan Dash. Silahkan mencoba kembali dengan meminta nama pengguna lain.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Tinggi pembuatan dompet — batas bawah untuk pemindaian filter dan pemindaian ulang “Dari pembuatan dompet”. Atur pada atau di bawah pendanaan pertama dompet; impor menggunakan 200000 secara bawaan di mainnet dan 0 di testnet. Menyimpan tinggi yang sama atau lebih rendah dari saat ini akan menghapus data rantai jaringan ini pada peluncuran berikutnya dan memindai ulang dari sana.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "dia (Mengambil Info)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Tidak ada pemberitahuan baru";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Tidak ada transaksi untuk ditampilkan";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Tidak ada pengguna yang cocok dengan nama %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Tidak ada pengguna yang cocok dengan nama %@ di kontak Anda";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Terjadi kesalahan saat mengekspor riwayat transaksi Anda ke ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Terjadi kesalahan, coba lagi nanti";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Dana ini berpindah ke saldo Platform Anda dan siap dibelanjakan begitu transfer selesai.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Alamat ini tidak dapat dibayar dari saldo %@ Anda";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ini menambahkan dua kunci ke identitas Anda agar pengguna lain dapat mengirimi Anda permintaan kontak, dan agar Anda dapat menerima permintaan mereka. Ini hanya terjadi sekali.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ini menerapkan satu pilihan ke semua %d nama pengguna yang dipilih.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Langkah ekstra ini menunjukkan bahwa Anda benar-benar mencoba melakukan transaksi.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Tautan undangan ini tidak valid.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ini bukan alamat Dash yang valid untuk jaringan ini";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ini bukan tautan undangan yang valid";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ini adalah identitas utama Anda";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Masternode ini belum memiliki identitas Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Pedagang saat ini tidak tersedia.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Ini mewakili Persentase Hasil Tahunan saat ini dari Masternode penuh dikurangi biaya CrowdNode 15%. Ini bukan tingkat pengembalian yang dijamin dan dapat naik atau turun berdasarkan ukuran  CrowdNode pool dan harga Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Ini tetap dihitung sebagai masternode Anda telah memberi suara dalam sengketa ini.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Byte mentah transaksi ini tidak disimpan di perangkat ini.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Nama pengguna ini jatuh ke orang lain";
+
+"This wallet could not derive the voting key for this node." = "Dompet ini tidak dapat menurunkan kunci pemungutan suara untuk node ini.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Dompet ini tidak memiliki kunci pemungutan suara masternode yang aktif, sehingga tidak dapat memberi suara. Node terdaftar muncul di Alat → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ini menarik seluruh saldo Platform Anda dalam satu transfer. Dash tiba di alamat penerima begitu jaringan memproses penarikan.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ini menarik seluruh saldo Platform Anda dalam satu transfer. Dash tiba di saldo transparan Anda begitu jaringan memproses penarikan.";
 
 /* Send Screen: to address */
 "to" = "ke";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Riwayat Transaksi";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Riwayat transaksi tidak tersedia";
+
 /* No comment provided by engineer. */
 "Transaction id" = "ID transaksi";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID Transaksi";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer Masuk";
 
+/* Balance breakdown */
+"Transfer in" = "Transfer masuk";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Keluar";
+
+/* Balance breakdown */
+"Transfer out" = "Transfer keluar";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transfer memakan waktu lebih lama — membangun bukti privasi butuh waktu";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transfer ke alamat Platform lain dan alamat terlindungi bersifat instan dan final";
+
+/* Balance breakdown */
+"Transparent" = "Transparan";
+
+/* Send screen destination type */
+"Transparent address" = "Alamat transparan";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo transparan";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Pendanaan transparan mengaitkan nama pengguna Anda dengan dana ini secara publik.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparan → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparan → Terlindungi";
 
 /* An action */
 "Try again" = "Coba lagi";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Tidak dapat memberikan saran";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Saldo Tidak diketahui";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Jenis khusus tidak dikenal %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Tidak terlindungi";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "URL tidak didukung";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Tingkatkan ke DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Tingkatkan ke Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Gunakan saldo transparan saja";
+
+/* Masternode keys */
+"Used" = "Digunakan";
+
+/* Masternode keys */
+"Used at: " = "Digunakan pada: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Pengguna (Mengambil Info)";
 
 /* Voting */
 "Username" = "Nama pengguna";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Nama pengguna berhasil diminta";
 
+/* Identities */
+"Usernames" = "Nama Pengguna";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Nama pengguna disimpan dalam bentuk yang dinormalisasi untuk mencegah nama yang mirip, jadi ini bisa berbeda dari yang diketik masing-masing orang.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nama pengguna, bukan alamat";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Pengguna yang cocok dengan %@ yang saat ini tidak ada di kontak Anda";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Menggunakan salah satu pustaka zero-knowledge yang paling banyak diaudit dan diuji (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Undangan valid";
+
 /* CrowdNode Portal */
 "Validating address…" = "Memvalidasi alamat…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verifikasi Diperlukan";
 
+/* Usernames */
+"Verified during registration" = "Diverifikasi saat pendaftaran";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Berhasil Diverifikasi";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verifikasi identitas Anda";
 
+/* Raw transaction inspector */
+"Version" = "Versi";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Sangat efisien dengan biaya rendah";
+
 /* adjective, security level */
 "Very High" = "Sangat tinggi";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Jumlah Dash yang sangat kecil akan dikirim ke dan dari CrowdNode untuk memverifikasi bahwa Anda adalah pemilik alamat dompet ini.";
+
+/* No comment provided by engineer. */
+"View All" = "Lihat Semua";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Lihat di Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Lihat frasa pemulihan";
 
+/* Raw transaction inspector */
+"View Transaction" = "Lihat Transaksi";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Lihat Detail Transaksi";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Beri suara";
+
+"Vote cast" = "Suara diberikan";
+
 /* Voting */
 "Vote for All" = "Pilih untuk semua";
 
 /* Voting */
+"Vote on contested usernames" = "Beri suara untuk nama pengguna yang diperebutkan";
+
+"Vote on several" = "Beri suara untuk beberapa";
+
+/* Voting */
 "Vote to Approve" = "Pilih untuk Setujui";
+
+"Vote with" = "Beri suara dengan";
+
+"Votes that nobody should receive these usernames." = "Memberi suara agar tidak ada yang menerima nama pengguna ini.";
 
 /* Voting */
 "Votes: High to low" = "Votes: Tinggi ke rendah";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Alamat pemungutan suara";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Alamat pemungutan suara";
+
+"Voting ended with no winner" = "Pemungutan suara berakhir tanpa pemenang";
+
+"Voting ends" = "Pemungutan suara berakhir";
+
 /* Voting */
 "Voting ends in %dd" = "Pemungutan suara berakhir dalam %dh";
+
+"Voting in progress" = "Pemungutan suara berlangsung";
+
+"Voting in progress — lock votes are ahead" = "Pemungutan suara berlangsung — suara kunci unggul";
+
+"Voting in progress — you are ahead" = "Pemungutan suara berlangsung — Anda unggul";
 
 /* Usernames */
 "Voting is only required in some cases" = "Pemungutan suara hanya diperlukan dalam beberapa kasus";
 
+/* Masternodes */
+"Voting key hash" = "Hash kunci pemungutan suara";
+
 /* Voting keys */
 "Voting keys" = "Kunci pemungutan suara";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Pemungutan suara untuk nama pengguna ini telah ditutup. Jumlah di bawah adalah yang terakhir terbaca.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Pemungutan suara untuk “%@” sudah ditutup. Segarkan untuk melihat hasilnya.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Tunggu hingga dompet disinkronkan untuk menyelesaikan transaksi";
 
+"Waiting for Dash Platform" = "Menunggu Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Alamat Dompet";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Tinggi awal dompet";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Dompet dinonaktifkan";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Selamat datang di DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Bagaimana dengan Unstoppable Domains dan layanan nama sejenis?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Berapa biayanya?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Apa itu DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Apa itu voting nama pengguna?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Apa yang akan datang berikutnya?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kapan permintaan kontak menjadi privat?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Dimana harus Belanja";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Dimana harus Belanja?";
+
+"Who is requesting this name" = "Siapa yang meminta nama ini";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Mengapa saya perlu mengaktifkannya?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Mengapa saya melihat semua transaksi ini?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Penarikan diminta";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Menarik seluruh saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Bekerja dengan setiap dompet, bursa, dan pedagang Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Apakah Anda ingin menerima undangan?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Kemarin";
+
+"You" = "Anda";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Anda menerima permintaan kontak dari %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Anda memilih \"%@\" sebagai nama pengguna anda.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Anda belum memiliki kontak saat ini";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Anda tidak memiliki dana yang cukup umtuk memyelesaikan pembayaran ini";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Anda melampaui batas otorisasi di Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Anda memiliki %@ Dash sejauh ini";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Anda mempunyai %1$@ Dash.\nBeberapa nama pengguna berharga hingga %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Anda mengirim permintaan kontak ke %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Anda harus memiliki saldo positif di Dash Wallet";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Anda memenangkan nama pengguna ini";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Semua siap. Pengguna lain kini dapat mengirimi Anda permintaan kontak — dan Anda dapat mengirim milik Anda.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Identitas Dash Platform Anda muncul di sini setelah Anda mendaftarkan nama pengguna.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Email anda hanya digunakan untuk mengirim one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Riwayat Anda, tertata";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identitas Anda memerlukan dua kunci tambahan agar permintaan kontak dapat dienkripsi antara Anda dan pengguna lain. Mengaktifkannya menambahkan kunci tersebut lewat satu transaksi jaringan. Ini hanya terjadi sekali.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Undangan Anda dari %@ telah diklaim";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Undangan Anda dari %@ tidak valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Undangan Anda membayar biaya pendaftaran untuk nama pengguna ini.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Lokasi Anda digunakan untuk menunjukkan posisi Anda di peta, ATM di redius yang dipilih, dan meningkatkan hasil pencarian.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Lokasi Anda digunakan untuk menunjukkan posisi Anda di peta, pedagang di radius yang dipilih, dan meningkatkan hasil pencarian.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Saldo Dash utama Anda di blockchain Core — yang Anda kirim dan terima dengan dompet, bursa, dan pedagang lain.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Koin campuran Anda telah dipindahkan ke saldo Dompet Dash Anda.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Koin campuran Anda telah dipindahkan ke saldo terlindungi. Demi privasi terbaik, tunggu setidaknya 2 jam sebelum menggunakan dana ini.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Saldo Platform Anda";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Alamat Dash utama Anda yang saat ini  digunakan untuk akun CrowdNode Anda";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Saldo privat Anda. Jumlah dan alamat dienkripsi on-chain, sehingga kepemilikan dan riwayat Anda tetap rahasia.";
+
 /* Usernames */
 "Your request was cancelled" = "Permintaan anda telah dibatalkan";
 
 /* DashSpend */
 "Your session expired" = "Sesi anda telah kedaluwarsa";
+
+/* Usernames */
+"Your Shielded balance" = "Saldo terlindungi Anda";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Saldo terlindungi Anda hampir siap — Anda dapat mendaftar secara privat sekitar %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Saldo terlindungi Anda siap — daftarkan nama pengguna Anda secara privat sekarang";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Saldo terlindungi Anda sedang mengendap — Anda dapat mendaftar secara privat sekitar %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Saldo terlindungi Anda masih matang. Akan siap sekitar %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Saldo transparan Anda";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Nama pengguna anda %@ telah sukses dibuat di jaringan Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Nama pengguna Anda telah berhasil dibuat";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Nama pengguna Anda terlihat oleh semua orang. Mendanainya dari saldo terlindungi — setelah membiarkan dananya mengendap beberapa jam — berarti tidak ada yang dapat mengaitkan nama pengguna Anda dengan Dash Anda yang lain.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Nama pengguna, profil, dan kontak Anda mengikuti identitas ini.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Nama pengguna, profil, dan kontak Anda akan mengikuti identitas ini.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Pilihan anda telah dibatalkan";
 
 /* Voting */
 "Your vote was submitted" = "Pilihan anda telah diserahkan";
 
+"Your votes" = "Suara Anda";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Dompet Anda aman sekarang. Anda dapat menggunakan frasa pemulihan kapan saja untuk memulihkan akun di perangkat lain.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Dompet Anda masih bersinkronisasi dengan jaringan Dash. Pengiriman tersedia setelah sinkronisasi selesai.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Dompet Anda masih bersinkronisasi. Pengiriman dari saldo transparan tersedia setelah sinkronisasi selesai.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@” tidak dapat dibaca sebagai nama pengguna Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” telah terdaftar. Kirim permintaan kontak ke orang yang mengundang Anda?";

--- a/DashWallet/id.lproj/Localizable.stringsdict
+++ b/DashWallet/id.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d kunci</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ dihitung untuk “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u suara</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d dari %#@names@ telah dipilih</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d nama pengguna</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>Berikan %u suara</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d dari %#@nodes@ telah memilih</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d dari %#@nodes@ telah memilih</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d node</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u suara secara keseluruhan</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d dipilih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d node Anda sudah memilih di sini dan tidak ditampilkan.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u suara per sengketa — evonode dihitung 4, masternode 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Beri suara untuk %d nama pengguna</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u suara</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Beri suara ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d permintaan</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " o ";
+
 /* CrowdNode */
 " Privacy Policy " = "Politica sulla Riservatezza";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Non è stato possibile trovare %@ sulla rete Dash per inviargli una richiesta di contatto.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponibili";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ ha accettato la tua richiesta di contatto";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contatti / %3$lu aggiornamenti del profilo";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d i voti verranno espressi poiché nel portafoglio sono memorizzate più chiavi di voto";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicati";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld di %ld depositi";
 
 /* Voting */
 "%ld requests" = "%ld richieste";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\"  non è una parola della frase di recupero. Vorresti provare a recuperare la parola corretta che dovrebbe stare in questa posizione?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Un saldo di credito su Dash Platform usato per pagamenti istantanei tra indirizzi Platform e per funzioni come i nomi utente.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Un codice di accesso è necessario per proteggere il tuo portafoglio. Vai nelle impostazioni e attiva il codice per continuare.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "A proposito di";
 
+/* DashPay FAQ title */
+"About DashPay" = "Informazioni su DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Informazioni su di me";
+
+"Abstain" = "Astieniti";
+
+"Abstain on “%@”" = "Astieniti su «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Accetta";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Recupero dell'account";
 
+/* Masternode status */
+"Active" = "Attivo";
+
+/* No comment provided by engineer. */
+"Activity" = "Attività";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "L'attività è pubblica ma non facile da tracciare";
+
 /* No comment provided by engineer. */
 "Add" = "Aggiungi";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Aggiungi %@ come contatto";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Aggiungi %@ come contatto per pagare direttamente al nome utente e conservare la cronologia reciproca delle transazioni";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Aggiungi %@ Dash al tuo saldo schermato e lascialo riposare qualche ora per registrarti senza collegare il tuo nome utente agli altri tuoi fondi.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Aggiungi un nuovo contatto";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Aggiungi almeno %@ Dash al tuo saldo schermato";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Aggiungi fondi al tuo saldo schermato adesso e registra il tuo nome utente in privato qualche ora dopo";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Tutte";
 
+"All nodes at once" = "Tutti i nodi insieme";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tutti i tuoi masternode hanno votato su questo nome utente. Per cambiare un voto, vota di nuovo dal candidato che ora preferisci.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Consentire l'invio di tutte le transazioni dal Portafoglio Dash a Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sincronizzazione dei saldi quasi istantanea";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Importi e indirizzi sono pubblici sulla blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Si è verificato un errore";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un account Ethereum è un unico indirizzo riutilizzabile: l'intero saldo e la cronologia dei pagamenti sono pubblicamente sotto di esso, e un nome (come un dominio ENS) di solito punta direttamente a quell'indirizzo, che chiunque può risolvere. DashPay ha la forma opposta: il nome risolve a un'identità, non a un indirizzo di pagamento, e gli indirizzi di pagamento reali restano dentro scambi di contatto cifrati, nuovi per ogni contatto.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Un'esperienza intuitiva e familiare su tutti i tuoi dispositivi";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Qualsiasi nome utente che contenga un numero compreso tra 2 e 9, che abbia più di 20 caratteri o che contenga un trattino verrà automaticamente approvato";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Chiunque conosca un indirizzo può vederne la cronologia";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Applica";
 
+"Approve" = "Approva";
+
+"Approving a specific request can only be done one username at a time." = "L'approvazione di una richiesta specifica può essere fatta solo per un nome utente alla volta.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Sei sicuro di voler annullare questo ordine?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Come testo";
 
 /* DashSpend */
 "at" = "a";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autenticazione annullata. Il tuo voto non è stato espresso.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autenticazione non riuscita. Il tuo voto non è stato espresso.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "L'autenticazione non è disponibile";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Assegna «%@» a questo candidato";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo dopo";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Saldo su CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Bilancio:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldi e trasferimenti non sono visibili pubblicamente";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Conto bancario";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Accesso biometrico richiesto";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Altezza di origine salvata: il limite di scansione più alto si applica dal prossimo avvio.";
+
 /* Voting */
 "Block" = "Blocchi";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Nome utente '%@' bloccato";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vincolata a un contratto";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vincolata a un contratto, tipo di documento «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Sola consultazione";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Raccoglie i log diagnostici recenti in uno zip da inviare con AirDrop, via e-mail o da salvare in File";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Esprimi il voto";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Cambia peer";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Modificare PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Verifica in corso…";
+
+"Choice" = "Scelta";
+
 /* Choose your Dash username */
 "Choose your" = "Scegli il tuo";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Scegli il tuo Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Riscatta il tuo invito";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo riscattabile";
+
 /* No comment provided by engineer. */
 "Claimed" = "Rivendicato";
+
+/* SPV diagnostics */
+"Clear & resync" = "Cancella e risincronizza";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Cancellare i dati della catena e risincronizzare?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Chiudi app";
 
+"Closing" = "In chiusura";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nuove monete)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Codice Coinbase 2FA";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin non è più supportato: scegli dove spostare le tue monete miscelate.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Collaterale";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Prossimamente";
+
+/* Shielded transfer status */
+"Completed" = "Completato";
 
 /* No comment provided by engineer. */
 "Confirm" = "Conferma";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confermata";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "La conferma salva l'altezza di origine %u e cancella i dati della catena di questa rete al prossimo avvio dell'app, riscaricandoli e riscansionando i filtri da quell'altezza. La sessione in corso mantiene il suo vecchio limite di scansione: chiudi e riapri l'app per iniziare.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Collega i tuoi portafogli crypto alla piattaforma ZenLedger. Scopri di più e inizia con le transazioni del tuo Portafoglio Dash.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Indirizzo Dash connesso";
 
+/* SPV sync */
+"Connected peers" = "Peer connessi";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Contro";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Richiesta di contatto non riuscita";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Richiesta di contatto inviata a %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Richieste di contatto";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contatti";
 
+"Contender %@" = "Candidato %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continua";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continua per scegliere il tuo nome utente. L'invito paga la commissione di registrazione.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copia il Link dell'Invito";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copia la transazione grezza";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copia il testo";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Non è stato possibile recuperare automaticamente le parole mancanti od errate.";
 
+/* Log export */
+"Could not create the log archive: %@" = "Impossibile creare l'archivio dei log: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Impossibile trovare il tasso di cambio.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Impossibile aggiornare %d identità";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Impossibile recuperare il saldo (errore di rete). Prova ad aggiornare.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Impossibile effettuare il pagamento";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Crea il tuo nome utente";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Crea il tuo nome utente, trova amici e familiari tramite i loro nomi utente e aggiungili ai tuoi contatti";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Carta di Credito";
+
+/* Masternodes */
+"Credits" = "Crediti";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "I pagamneti in Dash non possono essere inferiori a %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform non ha ancora indicizzato questa contesa. I conteggi dei voti compariranno qui quando lo farà.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform non è ancora connesso. Attendi il termine della sincronizzazione e riprova.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "I Dash inviati a un indirizzo sbagliato non possono essere recuperati. Assicurati che l'indirizzo sia esattamente quello a cui intendi pagare.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash memorizza i nomi utente in una forma a prova di somiglianza, quindi il nome memorizzato può differire da quanto digitato da ciascuna persona.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nome utente Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Portafoglio Dash ";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo del portafoglio Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Portafoglio Dash su questo dispositivo";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay attivato";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Invito DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay è l'esperienza di pagamenti sociali di Dash, costruita su Dash Platform. Registri un nome utente, aggiungi altri utenti come contatti e li paghi per nome: niente più copia degli indirizzi.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay sostituisce i lunghi indirizzi criptici con i nomi utente. Aggiungi amici come contatti, invia denaro a un nome e mantieni ogni pagamento organizzato per persona.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Commissione di aggiornamento DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Data: dal Vecchio al nuovo";
+
+"Deadline unknown" = "Scadenza sconosciuta";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposito inviato";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Percorso di derivazione";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "SICUREZZA DEL DISPOSITIVO COMPROMESSA\nQualunque app \"jailbreak\" può accedere ai dati di altre app (e rubare i tuoi Dash). Elimina subito questo portafoglio e ripristina su un dispositivo sicuro.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Disabilitata";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnetti l'account Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Fatto";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Fatto: il tuo saldo ha riposato abbastanza a lungo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Ricontrolla l'indirizzo";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Ogni invito sarà finanziato con questo importo in modo che il destinatario possa creare rapidamente il proprio Username Nella Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Ogni masternode ha un voto valido per contesa. Puoi cambiarlo in seguito, ma Dash Platform consente in tutto solo 5 voti per masternode per contesa.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Ogni tocco fa votare un nodo in più, così scegli quanti collegarne tra loro.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Prima";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Vincola facilmente Dash e guadagna entrate passive con pochi semplici clic.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Modifica l'altezza di origine";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Modifica Profilo";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-mail";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Attiva";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Attiva DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Abilita Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Abilita Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Attivare DashPay costa una piccola commissione di rete una tantum, pagata dal saldo di credito della tua identità. La stima esatta viene mostrata prima della conferma. Inviare richieste di contatto e pagamenti costa le normali commissioni di rete.";
+
+"Ending soonest" = "In scadenza prima";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Errore durante l'aggiornamento del tuo profilo ";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Commissione di rete stimata";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Tutti i nodi votano insieme. Più veloce, ma collega pubblicamente i tuoi masternode tra loro.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Chiavi operatore Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Exporta CSV";
 
+/* Log export */
+"Export Logs" = "Esporta i log";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Chiavi pubbliche estese (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Indirizzo esterno";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Limite \"Face ID\"";
+
+/* No comment provided by engineer. */
+"Failed" = "Non riuscito";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Impossibile caricare il codice a barre";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Ricerca tariffe…";
 
+/* Masternodes */
+"Fetching…" = "Recupero…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Conto Fiat";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtro";
+
+/* SPV sync phase */
+"Filter headers" = "Header dei filtri";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtra le transazioni";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Trova un utente sulla rete Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Trova gli ATM dove puoi acquistare o vendere Dash.";
+
+/* Identities */
+"Find identities" = "Trova identità";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Hai dimenticato il PIN?";
 
+/* Identities */
+"Found %d new identities" = "Trovate %d nuove identità";
+
+/* Identities */
+"Found 1 new identity" = "Trovata 1 nuova identità";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Parola mancante trovata:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finanzia il tuo nome utente dal tuo saldo schermato. Aggiungi i fondi con qualche ora di anticipo: il breve riposo rende il tuo nome utente non collegabile agli altri tuoi Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finanziato dal tuo saldo schermato: il tuo nome utente non può essere collegato agli altri tuoi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fondi bloccati: trasferimento in fase di completamento";
+
+/* CoinJoin */
+"Funds moved" = "Fondi spostati";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Ottieni ricompense dai depositi in Dash Masternodes con un minimo di 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Ottieni preventivo";
+
+/* Usernames */
+"Get ready to join DashPay" = "Preparati a entrare in DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Ottieni premi all'istante";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Ho capito";
+
+/* Governance */
+"Governance" = "Governance";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Concedi le autorizzazioni GPS in modo che possiamo mostrarti le posizioni vicino a te.";
 
 /* Voting */
 "Has blocked votes" = "Ha bloccato i voti";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ha chiesto di essere tuo amico";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Hai un invito?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Assumi il completo controllo e personalizza il tuo portafoglio in base alle tue esigenze";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "intestazione #%1$d di %2$d";
+
+/* SPV sync phase */
+"Headers" = "Header";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Altezza %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Ecco un indirizzo Dash designato per il tuo account CrowdNode nel Portafoglio Dash su questo dispositivo";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Dall'alto al basso";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Commissioni più alte, intorno a 7 centesimi (comunque più basse di altre blockchain che offrono una privacy simile)";
+
 /* No comment provided by engineer. */
 "History" = "Storia";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Come posso ottenere Dash di Test?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Come si confronta con Bitcoin in termini di privacy?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Come si confronta con gli account Ethereum in termini di privacy?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Quanto è privato DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Come confermare il tuo indirizzo API Dash";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "L'ho scritto";
 
+/* Identities */
+"Identities" = "Identità";
+
 /* Voting */
 "Identity" = "Identità";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Crediti dell'identità";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indice dell'identità";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registrazione dell'identità";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Ricarica dell'identità";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Nella sezione pagamenti del tuo checkout, seleziona \"carta regalo\" e inserisci il numero della tua carta e il PIN.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inattivo";
+
+/* No comment provided by engineer. */
 "Income" = "Reddito";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Inizializzazione";
+
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Input (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Fondi insufficenti";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Commissione di invito";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invito da %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invito utilizzato da";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invita";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invita qualcuno a entrare nella rete Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invita la tua famiglia, trova i tuoi amici cercando i loro Usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invita i tuoi amici e la tua famiglia ad unirsi alla Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invita amici e familiari nella rete Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "Portafoglio Dash iOS: %@ Problema segnalato";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Unisciti alla pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Mantieni private queste monete. Si applicano commissioni di rete e di privacy.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Mantieni la tua passphrase al sicuro";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Chiave n. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Dati della chiave";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Proprietà della chiave";
+
 /* No comment provided by engineer. */
 "Keypair" = "Coppia di chiavi";
+
+/* Masternodes */
+"Keys" = "Chiavi";
 
 /* Explore Dash */
 "Last device sync" = "Ultima sincronizzazione del dispositivo";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "In testa";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Scopri di più";
 
 /* Info Screen */
 "Learn More..." = "Per saperne di più...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Caricamento delle transazioni";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Moneta Locale";
 
+/* Identities */
+"Local Only" = "Solo locale";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Quantità locale richiesta: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Località";
 
+"Lock" = "Blocca";
+
+"Lock the name" = "Blocca il nome";
+
+"Lock “%@” so nobody gets it" = "Blocca «%@» così nessuno lo ottiene";
+
 /* No comment provided by engineer. */
 "Locked" = "Bloccato";
 
+"Locked — nobody receives this username" = "Bloccato: nessuno riceve questo nome utente";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Basso";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Commissioni basse per le spese quotidiane";
+
 /* Voting */
 "Low to high" = "Dal basso all'alto";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principale";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Indirizzo IP del Masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Portachiavi Masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Chiavi Masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Elenco dei masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "lista masternode #%1$d di %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Aggiornamento Masternode";
 
+"Masternode votes" = "Voti dei masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Chiave di voto Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "I masternode e gli evonode registrati con le chiavi di questo portafoglio compariranno qui dopo la sincronizzazione del portafoglio.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode ed evonode che usano le chiavi di questo portafoglio";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "I masternode votano sui nomi richiesti da più di una persona. Riceverai una notifica al termine del voto.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimo raggiunto";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Più Controllo";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Altri suggerimenti";
+
+"Most lock votes" = "Più voti di blocco";
+
+"Most votes" = "Più voti";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Sposta e ingrandisci la tua foto per trovare l'adattamento perfetto";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Sposta nel tuo saldo spendibile normale.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Spostato in Indirizzo";
+
+/* CoinJoin */
+"Moving funds" = "Spostamento dei fondi";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Nome";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "I servizi di nomi come Unstoppable Domains associano un nome leggibile a un indirizzo pubblico fisso sulla catena. Chiunque può risolvere il nome e vedere ogni pagamento mai effettuato verso di esso. Un nome utente DashPay non risolve mai pubblicamente a un indirizzo di pagamento: gli indirizzi vengono rivelati solo all'interno dello scambio cifrato con ciascun contatto, così il tuo nome e il tuo denaro restano scollegati per gli osservatori esterni.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Ho bisogno di aiuto?";
+
+"Needs attention" = "Richiede attenzione";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Su questo dispositivo non è stato trovato alcun log diagnostico. I log vengono scritti a partire dal prossimo avvio.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nessuna identità";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ancora nessun masternode";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nessuna contesa corrispondente";
+
+/* Identities */
+"No new identities were found for this wallet" = "Non sono state trovate nuove identità per questo portafoglio";
+
+"No open contest matches that search." = "Nessuna contesa aperta corrisponde a questa ricerca.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nessuna contesa aperta corrisponde a questa ricerca. I nomi sono memorizzati in forma normalizzata, quindi «alice» è elencato come «a11ce».";
+
+"No open contests" = "Nessuna contesa aperta";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Nessun metodo di pagamento";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Nessuna riga di portafoglio salvata trovata per il portafoglio collegato.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Non è ancora disponibile alcun indirizzo Platform per la registrazione schermata di riserva. Riprova dopo che il portafoglio avrà terminato la sincronizzazione.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Nessun risultato trovato";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Al momento nessun nome utente è conteso. Le contese si aprono quando due o più persone richiedono lo stesso nome.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Nessun voto rimasto";
+
+"No votes were cast" = "Non è stato espresso alcun voto";
+
+"Nobody gets it" = "Nessuno lo ottiene";
+
+/* SPV sync peer type */
+"Node" = "Nodo";
+
+/* Raw transaction inspector */
+"Non-standard" = "Non standard";
 
 /* adjective, security level */
 "None" = "Nessuno";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Non disponibile";
 
+"Not available yet" = "Non ancora disponibile";
+
+"Not cast" = "Non espresso";
+
+/* Masternodes */
+"Not checked yet" = "Non ancora verificato";
+
 /* Location Service Status */
 "Not Determined" = "Non determinato";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Saldo schermato insufficiente per registrare un'identità";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Non presente nella cronologia del portafoglio";
+
+"Not now" = "Non ora";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Non ampiamente accettato dai commercianti";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Non ancora ampiamente accettato dai commercianti";
+
+/* Masternode keys */
+"Not yet used" = "Non ancora usata";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Dal vecchio al nuovo";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Su Bitcoin non esiste un livello dei nomi, perciò le persone condividono e riutilizzano gli indirizzi allo scoperto: una volta che un indirizzo è noto, tutto ciò che ha ricevuto è collegabile al suo proprietario. Con DashPay il tuo nome utente è pubblico, ma non punta mai a un indirizzo di pagamento: gli indirizzi vengono scambiati privatamente con ogni contatto e ruotano, così pagare per nome non rende pubblico dove va il tuo denaro. Entrambe sono catene trasparenti, quindi l'analisi della catena si applica ancora alle monete stesse.";
+
+/* Identities */
+"On Network" = "In rete";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Una volta che %@ avrà accettato la tua richiesta potrai pagare direttamente al nome utente";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Un nodo alla volta";
 
 /* Voting */
 "One vote left" = "Ti rimane un voto";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Solo duplicati";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Solo masternode ed evonode possono votare sui nomi utente. Questo portafoglio non contiene chiavi di voto masternode attive.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Solo richieste con link";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Solo con link";
+
+/* Masternodes */
+"Operator" = "Operatore";
+
+/* Masternode keys */
+"Operator keys" = "Chiavi operatore";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Chiave pubblica dell'operatore (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "o";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Anteprima dell'ordine";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Altri esiti";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Output (%d)";
+
+/* Masternodes */
+"Owner" = "Proprietario";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Indirizzo del proprietario";
+
+/* Masternodes */
+"Owner address" = "Indirizzo del proprietario";
+
+/* Masternodes */
+"Owner key hash" = "Hash della chiave del proprietario";
 
 /* Owner keys */
 "Owner keys" = "Chiavi proprietario";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Pagato dal saldo di credito della tua identità.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Incolla il link qui";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Incolla il link d'invito che hai ricevuto, oppure scansiona il suo codice QR. Finanzia la registrazione del tuo nome utente.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Incolla l'URL dell'immagine";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Paga e ricevi pagamenti istantaneamente in modo semplice e facile da usare";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "pagare direttamente al nome utente";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Paga le persone, non gli indirizzi";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Paga allo Username. Niente più indirizzi alfanumerici";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Pagamento in corso...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload esadecimale";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Metodo di pagamento";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "I pagamenti sono privati: gli indirizzi che scambi con un contatto viaggiano dentro un payload cifrato che solo voi due potete leggere e non vengono mai pubblicati, quindi i tuoi pagamenti non sono facilmente collegabili al tuo nome utente. Restano comunque normali pagamenti su una catena trasparente: un'analisi della catena sofisticata potrebbe rivelare informazioni. Shielded DashPay (prossimamente) colmerà questa lacuna. Le richieste di contatto in sé al momento NON sono private: chiunque può vedere che due identità sono collegate. Le richieste di contatto private sono una funzione in arrivo. Anche il tuo nome utente e il tuo profilo sono pubblici su Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "I pagamenti si confermano in pochi secondi con InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "I pagamenti effettuati direttamente verso indirizzi non verranno conservati nell'attività.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "I pagamenti con ogni contatto sono raggruppati in un unico posto, con nomi e profili al posto di transazioni grezze.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Indirizzo di pagamento";
 
 /* CrowdNode */
 "Payout Options" = "Opzioni di pagamento";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Indirizzo Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nodo Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID del nodo Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "I pagamenti Platform non identificano il mittente. Questo pagamento è stato registrato quando il portafoglio ha rilevato la variazione del saldo: potrebbe essere arrivato prima.";
+
+"Platform SDK not ready" = "SDK Platform non pronto";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "La sincronizzazione di Platform non è in esecuzione. Apri Info sincronizzazione → Stato sincronizzazione Platform per avviarla.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Schermato";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Aggiungi un metodo di pagamento su Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Anteprima dell'invito";
 
+/* Masternode keys */
+"Previously used at: " = "Usata in precedenza il: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "I prezzi risalgono ad almeno 30 minuti. I valori Fiat potrebbero essere errati.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privato per progettazione";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Le richieste di contatto private (così resta privato con chi ti colleghi), Shielded DashPay — pagamenti ai contatti dal tuo saldo schermato privato — e i pagamenti a utenti non ancora presenti tra i tuoi contatti arriveranno presto.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Le richieste di contatto private sono in sviluppo e sono attese intorno a settembre-ottobre 2026. Oggi la richiesta stessa è pubblica: chiunque può vedere che due identità sono collegate, anche se i dettagli di pagamento al suo interno sono cifrati. Quando arriveranno le richieste di contatto private, potrai scegliere se rendere la tua amicizia pubblica o privata.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Richieste di contatto private, Shielded DashPay e pagamenti a persone che non sono ancora tuoi contatti.";
+
 /* No comment provided by engineer. */
 "Private key" = "Chiave privata";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Gli indirizzi di pagamento privati vengono scambiati tra te e i tuoi contatti. Solo tu e il tuo contatto conoscete destinatario e mittente dei pagamenti tra di voi.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pagamenti privati";
+
+/* Usernames */
+"Private registration" = "Registrazione privata";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Tempo di elaborazione";
+
+/* Balance info sheet section */
+"Pros" = "Pro";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Proteggi i tuoi risparmi";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Indirizzo del Provider";
 
+/* Masternodes */
+"Provider transactions" = "Transazioni del provider";
+
+/* Masternode keys */
+"Public key" = "Chiave pubblica";
+
+/* Masternode keys */
+"Public key (legacy)" = "Chiave pubblica (legacy)";
+
+/* Identities */
+"Public keys" = "Chiavi pubbliche";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL pubblico";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Acquisto fallito";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Scopo";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Tasso: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transazione grezza";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transazione grezza non disponibile";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ricontrolla i filtri di blocco compatti a partire dall'altezza scelta per cercare le transazioni di questo portafoglio, riscaricandoli e riconfrontandoli. Le riscansioni hanno come limite l'altezza di creazione del portafoglio e i dati della catena memorizzati localmente: per recuperare la cronologia al di sotto, abbassa invece l'altezza di origine del portafoglio.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Leggi la Policy di prelievo";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Sola lettura";
+
+/* Usernames */
+"Ready around %@" = "Pronto verso le %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motivo";
 
 /* No comment provided by engineer. */
 "Receive" = "Ricevi";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Ricevuto da";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Ricevuto da %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Ricevi le ricompense";
+
+"Records your masternodes as having voted, without taking a side." = "Registra i tuoi masternode come votanti, senza prendere posizione.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recupera";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "La frase di recupero deve avere 12, 15, 18, 21 o 24 parole";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Aggiorna";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registrato?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrato il";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registrato da";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternode registrato";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "La registrazione privata richiede almeno %@ Dash nel tuo saldo schermato più qualche ora di riposo: le schermate successive ti guideranno.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrazione";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Richiede questo nome";
+
 /* An action */
 "Rescan" = "Riscansiona";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "I portafogli ripristinati non sempre riescono a recuperare il tipo di operazione. Questa voce è stata ricostruita dai dati delle note on-chain.";
+
+/* Location Service Status */
 "Restricted" = "Limitato";
 
 /* Usernames */
 "Results" = "Risultati";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Risincronizzazione programmata dall'altezza %u: chiudi e riapri l'app per iniziare.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "conservare la cronologia reciproca delle transazioni";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Ritirato";
 
 /* No comment provided by engineer. */
 "Retry" = "Riprova";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Esamina il messaggio riportato di seguito per verificare la proprietà di questo nome utente";
+
+/* Masternodes */
+"Revocation" = "Revoca";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Gli screenshot sono visibili ad altri dispositivi e applicazioni. Genera una nuova frase di recupero e tienila segreta.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Firma dello script";
+
+/* Raw transaction inspector */
+"Script type" = "Tipo di script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Cerca un contatto";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Cerca una richiesta di contatto";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Cerca un utente sulla rete Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Cerca un nome utente";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Risultati della ricerca per \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Cerca territori";
+
+"Search usernames" = "Cerca nomi utente";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Ricerca del nome utente %@ sulla rete Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Proteggi il tuo Portafoglio";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Livello di sicurezza";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Livello di sicurezza";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Seleziona un servizio per acquistare, vendere, convertire e trasferire Dash";
 
+"Select all" = "Seleziona tutto";
+
 /* DashSpend denomination selection */
 "Select amount" = "Seleziona l'importo";
+
+"Select at least one masternode to vote with." = "Seleziona almeno un masternode con cui votare.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Seleziona una coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Selezionare meno nodi rivela meno su quali masternode gestisci.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Pagamento automatico";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Manda a";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Invia a un contatto";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Invia a un nome utente che puoi davvero ricordare e verificare.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Invia all'indirizzo";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Invia la tua prima richiesta di contatto";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Invio in corso";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Invio della richiesta di contatto";
+
+/* No comment provided by engineer. */
+"Sending to" = "Invio a";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Invio all'account CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Inviato a";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Inviato a %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Si è verificato un errore del server. Riprova più tardi.";
+
+/* Masternodes */
+"Service" = "Servizio";
+
+/* Identities */
+"Set as Main" = "Imposta come principale";
+
+/* Identities */
+"Set as Main Identity" = "Imposta come identità principale";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Imposta PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Condividi la chiave";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Pool di privacy condiviso alla dimensione minima";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Indirizzo schermato";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Spesa schermata";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Avvio del portafoglio schermato…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Schermato → Platform";
+
+"Shielded → Transparent" = "Schermato → Trasparente";
 
 /* Explore Dash */
 "Show all locations" = "Mostra tutte le posizioni";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Dimensione";
+
 /* No comment provided by engineer. */
 "Skip" = "Salta";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Alcuni dei tuoi masternode potrebbero mancare da questo elenco: il portafoglio non è riuscito a leggere l'insieme completo delle tue chiavi di voto. Completa la sincronizzazione e riapri questa schermata.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Alcuni nomi utente possono essere bloccati";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Ordina per";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ordina i contatti";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Ordinati per sconto";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Ordinati per nome";
+
+/* Raw transaction inspector */
+"Special payload" = "Payload speciale";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specifica Importo";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Inizia dopo che avrai aggiunto i fondi";
+
+/* Transaction details */
+"Status" = "Stato";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Memorizzato come";
 
 /* Voting */
 "Submit" = "Invia";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sincronizzazione in corso... I risultati potrebbero non essere completi.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Info sincronizzazione";
+
+/* SPV sync */
+"Sync too slow?" = "Sincronizzazione troppo lenta?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Scatta una foto dalla Fotocamera";
 
+"Take no side" = "Non prendere posizione";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tocca l'indirizzo dagli appunti per incollarlo";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tocca per copiare";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tocca per nascondere il saldo";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporaneamente non disponibile";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Chiave del nodo Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Termini & condizioni";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Il codice non è corretto. Si prega di verificare e riprovare!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "I Dash arrivano all'indirizzo del destinatario dopo che la rete ha elaborato il prelievo: può richiedere fino a 10 minuti.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "I Dash arrivano all'indirizzo del destinatario non appena la rete elabora il prelievo.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "I Dash arrivano nel tuo saldo trasparente non appena la rete elabora il prelievo.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "La rete Dash deve votare per approvare alcuni nomi utente prima che vengano creati";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Il collegamento inviato sarà visibile solo ai proprietari della rete";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "L'identità principale può essere scelta solo dal portafoglio attivo";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "L'importo minimo che puoi inviare è%@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Il posto più privato dove tenere i tuoi Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "La riga di portafoglio salvata non ha una rete: impossibile programmare una risincronizzazione.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "La registrazione è stata inviata, ma non è stato possibile confermarne l'esito. Attendi un minuto che il portafoglio si sincronizzi, poi riprova: non reinviarla subito.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Il pool di privacy condiviso sta ancora crescendo (%1$ld di %2$ld depositi). La registrazione privata si sblocca quando raggiunge il minimo.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Il pool di privacy condiviso sta ancora crescendo (%1$ld di %2$ld depositi). Riprova quando raggiunge il minimo.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Il nome utente '%@' è stato bloccato dalla Rete Dash. Riprova richiedendo un altro nome utente.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "L'altezza di creazione del portafoglio: il limite inferiore per le scansioni dei filtri e per le riscansioni «Dalla creazione del portafoglio». Impostala pari o inferiore al primo finanziamento del portafoglio; le importazioni usano 200000 come predefinito su mainnet e 0 su testnet. Salvare un'altezza pari o inferiore a quella attuale cancella i dati della catena di questa rete al prossimo avvio e riscansiona da lì.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "lui (recupero informazioni)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Non ci sono nuove notifiche";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Non ci sono transazioni da visualizzare";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Non ci sono utenti che corrispondono al nome %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Non ci sono utenti che corrispondono al nome %@ nei tuoi contatti";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Si è verificato un errore durante l'esportazione della cronologia delle transazioni su ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Si è verificato un errore, riprova più tardi";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Questi fondi si spostano nel tuo saldo Platform e sono pronti da spendere non appena il trasferimento è completato.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Questo indirizzo non può essere pagato dal tuo saldo %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Questo aggiunge due chiavi alla tua identità, così altri utenti possono inviarti richieste di contatto e tu puoi accettare le loro. Avviene una sola volta.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Questo applica una sola scelta a tutti i %d nomi utente selezionati.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Questo passaggio aggiuntivo mostra che stai davvero cercando di effettuare una transazione.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Questo link d'invito non è valido.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Questo non è un indirizzo Dash valido per questa rete";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Questo non è un link d'invito valido";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Questa è la tua identità principale";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Questo masternode non ha ancora un'identità Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Questo commerciante non è al momento disponibile.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Questo rappresenta l'attuale rendimento percentuale annuo di un Masternode completo meno la commissione CrowdNode del 15%. Non è un tasso di rendimento garantito e può aumentare o diminuire in base alle dimensioni delle pool  di CrowdNode e al prezzo di Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Questo conta comunque come voto espresso dai tuoi masternode in questa contesa.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "I byte grezzi di questa transazione non sono memorizzati su questo dispositivo.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Questo nome utente è andato a qualcun altro";
+
+"This wallet could not derive the voting key for this node." = "Questo portafoglio non è riuscito a derivare la chiave di voto per questo nodo.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Questo portafoglio non contiene chiavi di voto masternode attive, quindi non può votare. I nodi registrati compaiono in Strumenti → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Questo preleva l'intero saldo Platform in un unico trasferimento. I Dash arrivano all'indirizzo del destinatario non appena la rete elabora il prelievo.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Questo preleva l'intero saldo Platform in un unico trasferimento. I Dash arrivano nel tuo saldo trasparente non appena la rete elabora il prelievo.";
 
 /* Send Screen: to address */
 "to" = "a";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Cronologia delle transazioni";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "La cronologia delle transazioni non è disponibile";
+
 /* No comment provided by engineer. */
 "Transaction id" = "id Transazione";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transazione";
 
 /* A verb, button title. */
 "Transfer" = "Trasferimento";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Trasferimento in entrata";
 
+/* Balance breakdown */
+"Transfer in" = "Trasferimento in entrata";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Trasferimento in uscita";
+
+/* Balance breakdown */
+"Transfer out" = "Trasferimento in uscita";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "I trasferimenti richiedono più tempo: costruire le prove di privacy richiede tempo";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "I trasferimenti verso altri indirizzi Platform e indirizzi schermati sono istantanei e definitivi";
+
+/* Balance breakdown */
+"Transparent" = "Trasparente";
+
+/* Send screen destination type */
+"Transparent address" = "Indirizzo trasparente";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo trasparente";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Il finanziamento trasparente collega pubblicamente il tuo nome utente a questi fondi.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Trasparente → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Trasparente → Schermato";
 
 /* An action */
 "Try again" = "Riprova";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Impossibile fornire suggerimenti";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Bilancio Sconosciuto";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tipo speciale sconosciuto %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Non schermato";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "URL non supportato";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Aggiorna a DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Passa a Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Usa invece il saldo trasparente";
+
+/* Masternode keys */
+"Used" = "Usata";
+
+/* Masternode keys */
+"Used at: " = "Usata il: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Utente (recupero informazioni)";
 
 /* Voting */
 "Username" = "Carica la tua foto, personalizza la tua identità.\n ";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Il nome utente è stato richiesto con successo";
 
+/* Identities */
+"Usernames" = "Nomi utente";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "I nomi utente sono memorizzati in forma normalizzata per evitare nomi somiglianti, quindi questo può differire da quanto digitato da ciascuna persona.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nomi utente, non indirizzi";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Utenti che corrispondono a %@ e che attualmente non sono nei tuoi contatti";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Usa una delle librerie a conoscenza zero più verificate e testate (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Invito valido";
+
 /* CrowdNode Portal */
 "Validating address…" = "Indirizzo di convalida...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verifica richiesta";
 
+/* Usernames */
+"Verified during registration" = "Verificato durante la registrazione";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verifica effettuata con Successo";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verifica la tua identità";
 
+/* Raw transaction inspector */
+"Version" = "Versione";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Molto efficiente con commissioni basse";
+
 /* adjective, security level */
 "Very High" = "Molto Alto";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Piccole quantità di Dash verranno inviate da e verso CrowdNode per verificare che tu sia il proprietario di questo indirizzo di portafoglio.";
+
+/* No comment provided by engineer. */
+"View All" = "Mostra tutto";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Visualizza su Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Visualizza la frase di recupero";
 
+/* Raw transaction inspector */
+"View Transaction" = "Visualizza la transazione";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Visualizza i dettagli della transazione";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Vota";
+
+"Vote cast" = "Voto espresso";
+
 /* Voting */
 "Vote for All" = "Vota per tutti";
 
 /* Voting */
+"Vote on contested usernames" = "Vota sui nomi utente contesi";
+
+"Vote on several" = "Vota su più nomi";
+
+/* Voting */
 "Vote to Approve" = "Vota per approvare\n ";
+
+"Vote with" = "Vota con";
+
+"Votes that nobody should receive these usernames." = "Vota affinché nessuno riceva questi nomi utente.";
 
 /* Voting */
 "Votes: High to low" = "Voti: da alto a basso";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Indirizzo di voto";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Indirizzo di voto";
+
+"Voting ended with no winner" = "Il voto si è concluso senza vincitore";
+
+"Voting ends" = "Il voto termina";
+
 /* Voting */
 "Voting ends in %dd" = "Le votazioni si concludono tra %d giorni";
+
+"Voting in progress" = "Voto in corso";
+
+"Voting in progress — lock votes are ahead" = "Voto in corso: i voti di blocco sono in vantaggio";
+
+"Voting in progress — you are ahead" = "Voto in corso: sei in vantaggio";
 
 /* Usernames */
 "Voting is only required in some cases" = "La votazione è necessaria solo in alcuni casi";
 
+/* Masternodes */
+"Voting key hash" = "Hash della chiave di voto";
+
 /* Voting keys */
 "Voting keys" = "Chiavi di Voto";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Il voto su questo nome utente è chiuso. I conteggi qui sotto sono gli ultimi letti.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Il voto su «%@» è già chiuso. Aggiorna per vedere il risultato.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Attendi fino a quando il portafoglio non viene sincronizzato per completare la transazione";
 
+"Waiting for Dash Platform" = "In attesa di Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Indirizzo del portafoglio";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Altezza di origine del portafoglio";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Portafoglio disabilitato";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Benvenuto su DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "E Unstoppable Domains e servizi di nomi simili?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Quanto costa?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Cos'è DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Cos'è la votazione del nome utente?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Cosa arriverà dopo?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Quando le richieste di contatto diventeranno private?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Dove spendere";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Dove Spendere?";
+
+"Who is requesting this name" = "Chi richiede questo nome";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Perché devo attivarlo?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Perché vedo tutte queste transazioni?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Ritiro richiesto";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Preleva l'intero saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funziona con ogni portafoglio, exchange e commerciante Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Vuoi accettare l'invito?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Ieri";
+
+"You" = "Tu";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Hai accettato la richiesta di contatto di %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Hai scelto “%@” come tuo nome utente.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Al momento non hai contatti";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Non hai fondi sufficienti per completare questa transazione";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Hai superato il limite di autorizzazione su Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Finora hai %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Hai %1$@ Dash.\nAlcuni nomi utente costano fino a %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Hai inviato la richiesta di contatto a %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Dovresti avere un saldo positivo sul Portafoglio Dash";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Hai vinto questo nome utente";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "È tutto pronto. Ora altri utenti possono inviarti richieste di contatto, e tu puoi inviare le tue.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "La tua identità Dash Platform comparirà qui una volta registrato un nome utente.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "La tua email viene utilizzata solo per inviare una password monouso.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "La tua cronologia, organizzata";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "La tua identità ha bisogno di due chiavi aggiuntive perché le richieste di contatto possano essere cifrate tra te e gli altri utenti. L'attivazione le aggiunge con un'unica transazione di rete. Avviene una sola volta.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Il tuo invito da %@ è già stato rivendicato";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Il tuo invito da %@ non è valido";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Il tuo invito paga la commissione di registrazione di questo nome utente.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "La tua posizione viene utilizzata per mostrare la tua posizione sulla mappa, e gli ATM nel redius selezionato e migliorare cosi i risultati della ricerca.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "La tua posizione viene utilizzata per mostrare la tua posizione sulla mappa, i commercianti nel redius selezionato e per migliorare i risultati di ricerca.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Il tuo saldo Dash principale sulla blockchain Core: quello che invii e ricevi con altri portafogli, exchange e commercianti.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Le tue monete miscelate sono state spostate nel saldo del tuo portafoglio Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Le tue monete miscelate sono state spostate nel tuo saldo schermato. Per una privacy migliore, attendi almeno 2 ore prima di usare questi fondi.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Il tuo saldo Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Il tuo indirizzo Dash principale che utilizzi attualmente per il tuo account CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Il tuo saldo privato. Importi e indirizzi sono cifrati on-chain, così le tue disponibilità e la tua cronologia restano riservate.";
+
 /* Usernames */
 "Your request was cancelled" = "La tua richiesta è stata annullata";
 
 /* DashSpend */
 "Your session expired" = "La tua sessione è scaduta";
+
+/* Usernames */
+"Your Shielded balance" = "Il tuo saldo schermato";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Il tuo saldo schermato è quasi pronto: potrai registrarti in privato verso le %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Il tuo saldo schermato è pronto: registra ora il tuo nome utente in privato";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Il tuo saldo schermato sta riposando: potrai registrarti in privato verso le %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Il tuo saldo schermato sta ancora maturando. Sarà pronto verso le %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Il tuo saldo trasparente";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Il tuo nome utente %@ è stato creato con successo sulla rete Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Il tuo nome utente è stato creato con successo";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Il tuo nome utente è visibile a tutti. Finanziarlo dal tuo saldo schermato — dopo aver lasciato riposare i fondi per qualche ora — fa sì che nessuno possa collegare il tuo nome utente agli altri tuoi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Il tuo nome utente, il tuo profilo e i tuoi contatti seguono questa identità.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Il tuo nome utente, il tuo profilo e i tuoi contatti seguiranno questa identità.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Il tuo voto è stato annullato";
 
 /* Voting */
 "Your vote was submitted" = "Il tuo voto è stato inviato";
 
+"Your votes" = "I tuoi voti";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Il tuo portafoglio ora è protetto. Puoi utilizzare la frase di recupero in qualsiasi momento per ripristinare il tuo account su un altro dispositivo.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Il tuo portafoglio si sta ancora sincronizzando con la rete Dash. L'invio sarà disponibile al termine della sincronizzazione.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Il tuo portafoglio si sta ancora sincronizzando. L'invio dal tuo saldo trasparente sarà disponibile al termine della sincronizzazione.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Non è stato possibile leggere «%@» come nome utente Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» è stato registrato. Vuoi inviare una richiesta di contatto alla persona che ti ha invitato?";

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Tutti i nodi insieme";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tutti i tuoi masternode hanno votato su questo nome utente. Per cambiare un voto, vota di nuovo dal candidato che ora preferisci.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tutti i tuoi masternode hanno votato su questo nome utente. Per cambiare un voto, vota di nuovo per il candidato che ora preferisci.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/it.lproj/Localizable.stringsdict
+++ b/DashWallet/it.lproj/Localizable.stringsdict
@@ -95,7 +95,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ conteggiati per «%2$@»</string>
+		<string>%#@votes@ per «%2$@»</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -103,15 +103,15 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u voto</string>
+			<string>%1$u voto conteggiato</string>
 			<key>other</key>
-			<string>%1$u voti</string>
+			<string>%1$u voti conteggiati</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>Votato su %1$d di %#@names@</string>
+		<string>Votato: %1$d di %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -143,7 +143,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d di %#@nodes@ hanno votato</string>
+		<string>Votato: %1$d di %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -159,7 +159,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d di %#@nodes@ hanno votato</string>
+		<string>Votato: %1$d di %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/it.lproj/Localizable.stringsdict
+++ b/DashWallet/it.lproj/Localizable.stringsdict
@@ -92,5 +92,245 @@
 			<string>%d chiavi  </string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ conteggiati per «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u voto</string>
+			<key>other</key>
+			<string>%1$u voti</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Votato su %1$d di %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nome utente</string>
+			<key>other</key>
+			<string>%2$d nomi utente</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Esprimi %u voto</string>
+			<key>other</key>
+			<string>Esprimi %u voti</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d di %#@nodes@ hanno votato</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d di %#@nodes@ hanno votato</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nodo</string>
+			<key>other</key>
+			<string>%2$d nodi</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto in totale</string>
+			<key>other</key>
+			<string>%u voti in totale</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d selezionato</string>
+			<key>other</key>
+			<string>%d selezionati</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d dei tuoi nodi ha già votato qui e non è elencato.</string>
+			<key>other</key>
+			<string>%d dei tuoi nodi hanno già votato qui e non sono elencati.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto per contesa — gli evonode contano 4, i masternode 1</string>
+			<key>other</key>
+			<string>%u voti per contesa — gli evonode contano 4, i masternode 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Vota su %d nome utente</string>
+			<key>other</key>
+			<string>Vota su %d nomi utente</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto</string>
+			<key>other</key>
+			<string>%u voti</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Vota ×%d</string>
+			<key>other</key>
+			<string>Vota ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d richiesta</string>
+			<key>other</key>
+			<string>%d richieste</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " または ";
+
 /* CrowdNode */
 " Privacy Policy " = "プライバシーポリシー";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "連絡先リクエストを送るための %@ さんが Dash ネットワーク上で見つかりませんでした。";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 利用可能";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ さんがあなたの連絡先リクエストを承認しました";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu の連絡先 / %3$lu のプロフィール更新";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d バイト";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "ウォレットに複数の投票キーが保管されているため、%d票の投票が行われます";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld件の重複";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld 件の入金";
 
 /* Voting */
 "%ld requests" = "%ld件の請求";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = " 「%@」はリカバリーフレーズではありません。その箇所にあるはずの正しい語句をリカバリーしますか。";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platform 上のクレジット残高です。Platform アドレス間の即時支払いや、ユーザー名などの機能に使われます。";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "端末のパスコードを設定しないとウォレットを守ることができません。端末設定にてパスコードを有効にしてから次に進んでください。";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "このアプリについて";
 
+/* DashPay FAQ title */
+"About DashPay" = "DashPay について";
+
 /* No comment provided by engineer. */
 "About me" = "プロフィール";
+
+"Abstain" = "棄権する";
+
+"Abstain on “%@”" = "「%@」で棄権する";
 
 /* No comment provided by engineer. */
 "Accept" = "承認";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "アカウントの復旧";
 
+/* Masternode status */
+"Active" = "有効";
+
+/* No comment provided by engineer. */
+"Activity" = "アクティビティ";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "アクティビティは公開されますが、追跡は簡単ではありません";
+
 /* No comment provided by engineer. */
 "Add" = "追加";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ さんを連絡先に追加";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "%@ さんを連絡先に追加して、ユーザー名に直接支払い、相互の取引履歴を保持しましょう";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "シールド残高に %@ Dash を追加し、数時間ねかせてから登録すると、ユーザー名が他の資金と結び付けられません。";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "新しい連絡先を追加";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "シールド残高に少なくとも %@ Dash を追加してください";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "今すぐシールド残高に資金を追加し、数時間後にプライベートにユーザー名を登録しましょう";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "全て";
 
+"All nodes at once" = "すべてのノードを一度に";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "すべてのマスターノードがこのユーザー名に投票済みです。票を変更するには、今支持する候補者からもう一度投票してください。";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "DashウォレットからZenledgerに全ての取引の送信を許可しますか。";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "残高の同期はほぼ即時です";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "金額とアドレスはブロックチェーン上で公開されます";
+
 /* No comment provided by engineer. */
 "An error occurred" = "エラーが発生しました";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum のアカウントは再利用される 1 つのアドレスです。残高と支払い履歴のすべてがその下に公開され、名前（ENS ドメインなど）は通常そのアドレスを直接指すため、誰でも解決できます。DashPay はその逆の形です。名前は支払いアドレスではなくアイデンティティに解決され、実際の支払いアドレスは暗号化された連絡先のやり取りの中に留まり、連絡先ごとに新しくなります。";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "全てのデバイスで直感的かつ使いやすい使用感";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "ユーザー名は2〜9の数字を含み、20文字を超えるもので、ハイフンを含むものが自動的に承認されます。";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "アドレスを知っている人は誰でもその履歴を閲覧できます";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "申し込み";
 
+"Approve" = "承認";
+
+"Approving a specific request can only be done one username at a time." = "特定のリクエストの承認は、一度に 1 つのユーザー名でのみ行えます。";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "この注文のキャンセルをしてもよろしいですか。";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "テキストとして";
 
 /* DashSpend */
 "at" = "で";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "認証をキャンセルしました。票は投じられていません。";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "認証に失敗しました。票は投じられていません。";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "認証はご利用できません";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "「%@」をこの候補者に与える";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "残高";
 
 /* CrowdNode */
+"Balance after" = "後の残高";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "CrowdNodeの残高";
 
 /* CrowdNode */
 "Balance: " = "残高:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "残高と送金は公開されません";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "銀行口座";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "生体認証の利用が必要です";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "開始ブロック高を保存しました。引き上げられたスキャン下限は次回の起動から適用されます。";
+
 /* Voting */
 "Block" = "ブロック";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "「%@」というユーザー名をブロックしました";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "コントラクトに紐付け";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "コントラクトに紐付け、ドキュメントタイプ「%@」";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "閲覧のみ";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "最近の診断ログを zip にまとめて、AirDrop・メール送信、または「ファイル」に保存します";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "投票する";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "ピアを変更";
 
 /* No comment provided by engineer. */
 "Change PIN" = "PINを変更する";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "確認中…";
+
+"Choice" = "選択";
+
 /* Choose your Dash username */
 "Choose your" = "あなたのを選択する";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "ユーザー名を選択する";
 
+/* DashPay Invitations */
+"Claim your invitation" = "招待状を受け取る";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "受取可能な残高";
+
 /* No comment provided by engineer. */
 "Claimed" = "請求しました";
+
+/* SPV diagnostics */
+"Clear & resync" = "消去して再同期";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "チェーンデータを消去して再同期しますか？";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "アプリを閉じる";
 
+"Closing" = "まもなく終了";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "コインベース（新規コイン）";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbaseの2FAコード";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin はサポートされなくなりました。ミキシングしたコインの移動先を選んでください。";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "担保";
+
+/* DashPay intro: feature title */
+"Coming soon" = "近日公開";
+
+/* Shielded transfer status */
+"Completed" = "完了";
 
 /* No comment provided by engineer. */
 "Confirm" = "確認する";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "承認済み";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "確定すると開始ブロック高 %u が保存され、次回のアプリ起動時にこのネットワークのチェーンデータが消去されて再ダウンロードされ、そのブロック高からフィルターが再スキャンされます。実行中のセッションは以前のスキャン下限を保持します。アプリを終了して開き直すと開始されます。";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "お手持ちのクリプトウォレットをZenLedgerのプラットフォームと紐づけましょう。詳細をご確認の上、Dashウォレットの取引を始めましょう。";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "連結されたDashアドレス";
 
+/* SPV sync */
+"Connected peers" = "接続中のピア";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "デメリット";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "連絡先リクエストに失敗しました";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "%@ さんに連絡先リクエストを送信しました";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "連絡先リクエスト";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "連絡先";
 
+"Contender %@" = "候補者 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "続ける";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "続けてユーザー名を選んでください。招待状が登録手数料を負担します。";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "招待リンクをコピーする";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "生の取引データをコピー";
+
 /* No comment provided by engineer. */
 "Copy text" = "テキストをコピーする";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "見落としまたは間違った言葉を自動回復できませんでした";
 
+/* Log export */
+"Could not create the log archive: %@" = "ログのアーカイブを作成できませんでした: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "為替レートが見つかりません。";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d 件のアイデンティティを更新できませんでした";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "残高を取得できませんでした（ネットワークエラー）。更新をお試しください。";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "支払いを完了できませんでした";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "ユーザー名の作成";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "ユーザー名を作成し、友人や家族をユーザー名で探して連絡先に追加しましょう";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "クレジットカード";
+
+/* Masternodes */
+"Credits" = "クレジット";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dashの送金は %@ 以上でないと送れません";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform はまだこの争奪をインデックスしていません。インデックスされると得票数がここに表示されます。";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform にまだ接続されていません。同期の完了を待ってからもう一度お試しください。";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "誤ったアドレスに送金された Dash は取り戻せません。支払い先として意図したアドレスと完全に一致しているか確認してください。";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash はユーザー名を紛らわしい表記に強い形で保存するため、保存名は各人が入力した内容と異なる場合があります。";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dashのユーザー名";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dashウォレット";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash ウォレットの残高";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "この端末のDashウォレット";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay を有効にしました";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPayの招待";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay は、Dash Platform 上に構築された Dash のソーシャル決済です。ユーザー名を登録し、他のユーザーを連絡先に追加して、名前で支払えます。アドレスをコピーする必要はもうありません。";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay は長くて分かりにくいアドレスをユーザー名に置き換えます。友人を連絡先に追加し、名前宛てに送金して、すべての支払いを相手ごとに整理できます。";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPayのアップグレード料金";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "日付：古い順";
+
+"Deadline unknown" = "期限は不明";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "入金額が送金されました";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "導出パス";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "端末が危険な状態です！！！\nどの脱獄アプリからでも、他のあらゆるアプリのキーチェーンのデータへアクセスが可能です（そしてあなたのDashを簡単に盗めます）。直ちにこのウォレットを完全削除して、安全な端末にて復元して下さい。";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "無効";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Coinbaseのアカウントを切断する";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "完了";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "完了しました。残高は十分な時間ねかされました";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "アドレスを再確認してください";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "招待状はこの金額で提供され、受取人はDashネットワーク上で速やかにユーザー名を作成できます。";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "各マスターノードは 1 つの争奪につき有効な票を 1 票持ちます。後から変更できますが、Dash Platform では 1 つの争奪につきマスターノードあたり合計 5 票までしか認められません。";
+
+"Each tap votes with one more node, so you choose how many to link together." = "タップするたびにノードが 1 つずつ投票に加わるので、結び付ける数を選べます。";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "以前";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "簡単にDashをステークし、数回のクリックでパッシブ収入を得ます。";
+
+/* SPV diagnostics */
+"Edit birth height" = "開始ブロック高を編集";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "プロフィールを編集";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Eメール";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "有効にする";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay を有効にする";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "顔認証を有効にする";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Touch IDを有効にする";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPay の有効化には、一度きりの少額のネットワーク手数料がかかり、アイデンティティのクレジット残高から支払われます。正確な見積もりは確定前に表示されます。連絡先リクエストや支払いの送信には通常のネットワーク手数料がかかります。";
+
+"Ending soonest" = "終了が最も早い";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "プロフィールの更新エラー";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "推定ネットワーク手数料";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "すべてのノードがまとめて投票します。速いですが、マスターノード同士が公開の形で結び付けられます。";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode オペレーターキー";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "CSVをエクスポートする";
 
+/* Log export */
+"Export Logs" = "ログを書き出す";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "拡張したパブリックキー(BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "外部アドレス";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "顔認証の送金可能額";
+
+/* No comment provided by engineer. */
+"Failed" = "失敗";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "バーコードのロードに失敗しました";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "レートの取得中...";
 
+/* Masternodes */
+"Fetching…" = "取得中…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "フィアットアカウント";
 
 /* No comment provided by engineer. */
 "Filter" = "絞り込む";
+
+/* SPV sync phase */
+"Filter headers" = "フィルターヘッダー";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "取引を絞り込む";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Dash ネットワークでユーザーを探す";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Dashを売買できるATMを探す。";
+
+/* Identities */
+"Find identities" = "アイデンティティを検索";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "PINを忘れましたか?";
 
+/* Identities */
+"Found %d new identities" = "%d 件の新しいアイデンティティが見つかりました";
+
+/* Identities */
+"Found 1 new identity" = "1 件の新しいアイデンティティが見つかりました";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "不足している語句を発見しました:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "シールド残高からユーザー名の費用をまかないます。数時間前に資金を追加してください。短い待機によって、ユーザー名が他の Dash と結び付けられなくなります。";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "シールド残高からまかなわれました。ユーザー名を他の Dash と結び付けることはできません。";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "資金をロック中 — 送金を完了しています";
+
+/* CoinJoin */
+"Funds moved" = "資金を移動しました";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "0.5DashからDashのマスターノードに入金して報酬を得ることができます。";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "見積もりを得る";
+
+/* Usernames */
+"Get ready to join DashPay" = "DashPay に参加する準備をしましょう";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "すぐに報酬を獲得する";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "了解";
+
+/* Governance */
+"Governance" = "ガバナンス";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "GPSの許可を得ると、近くにある店舗を表示できます。";
 
 /* Voting */
 "Has blocked votes" = "投票をブロックしました";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "さんが友達になりたいとリクエストしています";
+
+/* DashPay Invitations */
+"Have an invitation?" = "招待状をお持ちですか？";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "自分のウォレットを完全に制御し、自在にカスタマイズする";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "%2$dのヘッダー#%1$d";
+
+/* SPV sync phase */
+"Headers" = "ヘッダー";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "ブロック高 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "こちらが、この端末のDashウォレットでCrowdNodeアカウントに指定されたDashアドレスです。";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "高から低";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "手数料は約 7 セントと高めです（それでも同等のプライバシーを提供する他のブロックチェーンより低額です）";
+
 /* No comment provided by engineer. */
 "History" = "履歴";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "テストDashを取得するには";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "プライバシーの点で Bitcoin と比べてどうですか？";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "プライバシーの点で Ethereum のアカウントと比べてどうですか？";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay のプライバシーはどの程度ですか？";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "APIのDashアドレスの確認方法";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "紙に書き留めました";
 
+/* Identities */
+"Identities" = "アイデンティティ";
+
 /* Voting */
 "Identity" = "アイデンティティ";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "アイデンティティのクレジット";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "アイデンティティのインデックス";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "アイデンティティの登録";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "アイデンティティのチャージ";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "決済画面で支払い方法を選択する際に、「ギフトカード」を選択し、カード番号とPINを入力してください。";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "無効";
+
+/* No comment provided by engineer. */
 "Income" = "収入";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "初期化中";
+
+/* Raw transaction inspector */
+"Input %d" = "入力 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "入力 %d — アウトポイント";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "入力 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "資金不足";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "招待料";
 
+/* DashPay Invitations */
+"Invitation from %@" = "%@ さんからの招待状";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "使用された招待状";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "招待する";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "誰かを Dash ネットワークに招待する";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "家族を招待したり、ユーザー名を検索して友人を見つけることができます。";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "友達や家族をDashネットワークに招待してみましょう。";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "友人や家族を Dash ネットワークに招待しましょう";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOSのDashウォレット: %@件の報告済みの問題";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "プールの参加";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "これらのコインをプライベートに保ちます。ネットワーク手数料とプライバシー手数料がかかります。";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "パスフレーズを安全に保つ";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "キー #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "キーのデータ";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "キーの所有";
+
 /* No comment provided by engineer. */
 "Keypair" = "キーペア";
+
+/* Masternodes */
+"Keys" = "キー";
 
 /* Explore Dash */
 "Last device sync" = "前回のデバイス同期";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "リード中";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "詳細はこちら";
 
 /* Info Screen */
 "Learn More..." = "詳細はこちら...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "取引を読み込み中";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "通貨表示";
 
+/* Identities */
+"Local Only" = "ローカルのみ";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "現地通貨の請求金額: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "位置";
 
+"Lock" = "ロック";
+
+"Lock the name" = "名前をロックする";
+
+"Lock “%@” so nobody gets it" = "「%@」をロックして誰も取得できないようにする";
+
 /* No comment provided by engineer. */
 "Locked" = "ロック済み";
 
+"Locked — nobody receives this username" = "ロック済み — 誰もこのユーザー名を取得できません";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "ロックタイム";
 
 /* Log in */
 "Log in" = "ログイン";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "低";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "日常の支払いに適した低い手数料";
+
 /* Voting */
 "Low to high" = "低から高";
+
+/* Identities — the wallet's main identity */
+"Main" = "メイン";
 
 /* No comment provided by engineer. */
 "Mainnet" = "メインネット";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "マスターノードのIPアドレス";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "マスターノードのキーチェーン";
+
+/* Masternode keys */
 "Masternode keys" = "マスターノードキー";
+
+/* SPV sync phase */
+"Masternode list" = "マスターノードリスト";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "%2$dのマスターノードリスト#%1$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "マスターノードのアップデート";
 
+"Masternode votes" = "マスターノードの票";
+
 /* Voting */
 "Masternode Voting Key" = "マスターノードの投票キー";
+
+/* Tools menu */
+"Masternodes" = "マスターノード";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "このウォレットのキーで登録されたマスターノードと Evonode は、ウォレットの同期後にここに表示されます。";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "このウォレットのキーを使用しているマスターノードと Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "マスターノードは 2 人以上がリクエストした名前について投票します。投票が終了するとお知らせします。";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "最大";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "最低: %@";
 
+/* Usernames */
+"Minimum met" = "最低額に到達";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "コントロールの追加";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "その他の候補";
+
+"Most lock votes" = "ロック票が最多";
+
+"Most votes" = "得票数が最多";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "写真を移動・拡大し、最適なサイズに調整できます";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "通常の利用可能な残高へ移動します。";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "アドレスへ移動した";
+
+/* CoinJoin */
+"Moving funds" = "資金を移動中";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "名前";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains のようなネームサービスは、人が読める名前をチェーン上の固定された公開アドレスに対応付けます。誰でもその名前を解決し、そこへの支払いをすべて見ることができます。DashPay のユーザー名は支払いアドレスに公開解決されることがありません。アドレスは各連絡先との暗号化されたやり取りの中でのみ明かされるため、あなたの名前とお金は外部の観察者には結び付けられません。";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "お困りですか。";
+
+"Needs attention" = "要対応";
 
 /* No comment provided by engineer. */
 "Network" = "ネットワーク";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "この端末に診断ログは見つかりませんでした。ログは次回の起動から記録されます。";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "アイデンティティなし";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "マスターノードはまだありません";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "一致する争奪はありません";
+
+/* Identities */
+"No new identities were found for this wallet" = "このウォレットの新しいアイデンティティは見つかりませんでした";
+
+"No open contest matches that search." = "その検索に一致する進行中の争奪はありません。";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "その検索に一致する進行中の争奪はありません。名前は正規化された形で保存されるため、「alice」は「a11ce」として掲載されます。";
+
+"No open contests" = "進行中の争奪はありません";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "支払い方法がありません";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "紐付けられたウォレットの保存済みレコードが見つかりません。";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "シールド登録のフォールバックに使える Platform アドレスがまだありません。ウォレットの同期が完了してからもう一度お試しください。";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "検索結果が見つかりませんでした";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "現在、争奪中のユーザー名はありません。2 人以上が同じ名前をリクエストすると争奪が始まります。";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "あと0票";
+
+"No votes were cast" = "票は投じられませんでした";
+
+"Nobody gets it" = "誰も取得しない";
+
+/* SPV sync peer type */
+"Node" = "ノード";
+
+/* Raw transaction inspector */
+"Non-standard" = "非標準";
 
 /* adjective, security level */
 "None" = "無し";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "ご利用できません";
 
+"Not available yet" = "まだ利用できません";
+
+"Not cast" = "未投票";
+
+/* Masternodes */
+"Not checked yet" = "未確認";
+
 /* Location Service Status */
 "Not Determined" = "未定";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "アイデンティティを登録するにはシールド残高が足りません";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "ウォレットの履歴にありません";
+
+"Not now" = "後で";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "加盟店での利用は広がっていません";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "加盟店での利用はまだ広がっていません";
+
+/* Masternode keys */
+"Not yet used" = "未使用";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "古い順";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoin には名前のレイヤーがないため、人々はアドレスを公然と共有し使い回します。いったんアドレスが知られると、そのアドレスが受け取ったものすべてが所有者に結び付けられます。DashPay ではユーザー名は公開されますが、支払いアドレスを指すことはありません。アドレスは連絡先ごとに非公開でやり取りされ、更新されるため、名前で支払ってもお金の行き先は公開されません。どちらも透明なチェーンなので、コイン自体にはチェーン分析が依然として当てはまります。";
+
+/* Identities */
+"On Network" = "ネットワーク上";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "%@ さんがリクエストを承認すると、ユーザー名に直接支払えるようになります";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "1 ノードずつ";
 
 /* Voting */
 "One vote left" = "あと1票";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "重複分のみ";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "ユーザー名に投票できるのはマスターノードと Evonode のみです。このウォレットには有効なマスターノードの投票キーがありません。";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "リンク付きの請求のみ";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "リンク付きのみ";
+
+/* Masternodes */
+"Operator" = "オペレーター";
+
+/* Masternode keys */
+"Operator keys" = "オペレーターキー";
+
+/* Masternodes */
+"Operator public key (BLS)" = "オペレーター公開鍵 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "または";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "注文プレビュー";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "その他の結果";
+
+/* Masternodes */
+"Outpoint" = "アウトポイント";
+
+/* Raw transaction inspector */
+"Output %d" = "出力 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "出力 (%d)";
+
+/* Masternodes */
+"Owner" = "所有者";
+
 /* No comment provided by engineer. */
 "Owner Address" = "所有者のアドレス";
+
+/* Masternodes */
+"Owner address" = "所有者のアドレス";
+
+/* Masternodes */
+"Owner key hash" = "所有者キーのハッシュ";
 
 /* Owner keys */
 "Owner keys" = "所有者のキー";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "アイデンティティのクレジット残高から支払われます。";
 
 /* DashSpend */
 "Password" = "パスワード";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "ここにリンクを貼り付ける";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "受け取った招待リンクを貼り付けるか、その QR コードをスキャンしてください。ユーザー名の登録費用がまかなわれます。";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "画像のURLを貼り付ける";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "簡単なお支払い手順で速やかに送金と入金";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "ユーザー名に直接支払い";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "アドレスではなく、人に支払う";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "ユーザー名に支払います。英数字のアドレスはもう必要ありません";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "支払い中…";
 
+/* Raw transaction inspector */
+"Payload hex" = "ペイロード (16 進)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "支払い方法";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "支払いはプライベートです。連絡先とやり取りするアドレスは、二人だけが読める暗号化されたペイロードの中を通り、公開されることはありません。そのため、支払いを簡単にユーザー名と結び付けることはできません。ただし、これらは依然として通常の透明チェーン上の支払いであり、高度なチェーン分析によって情報が漏れる可能性があります。Shielded DashPay（近日公開）がこのギャップを埋めます。連絡先リクエスト自体は現在プライベートではありません。2 つのアイデンティティがつながっていることは誰でも確認できます。プライベートな連絡先リクエストは近日公開予定の機能です。ユーザー名とプロフィールも Dash Platform 上で公開されます。";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "InstantSend により支払いは数秒で承認されます";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "アドレスに直接行われた支払いは、アクティビティに保持されません。";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "各連絡先との支払いが 1 か所にまとまり、生の取引ではなく名前とプロフィールで表示されます。";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "支払い先アドレス";
 
 /* CrowdNode */
 "Payout Options" = "支払い方法";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform アドレス";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 残高";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform ノード";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform ノード ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform の支払いでは送信者は特定されません。この支払いは、ウォレットが残高の変化に気づいた時点で記録されました。実際にはそれより早く届いていた可能性があります。";
+
+"Platform SDK not ready" = "Platform SDK の準備ができていません";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform の同期が実行されていません。同期情報 → Platform 同期ステータスを開いて開始してください。";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → シールド";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Coinbaseで支払い方法を追加してください";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "招待状プレビュー";
 
+/* Masternode keys */
+"Previously used at: " = "以前の使用日: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "価格は30分以上前のものです。フィアットの値が正しくない可能性があります。";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "設計段階からプライベート";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "プライベートな連絡先リクエスト（誰とつながっているかを非公開に保てます）、Shielded DashPay（プライベートなシールド残高からの連絡先への支払い）、そしてまだ連絡先にいないユーザーへの支払いは、いずれも近日公開予定です。";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "プライベートな連絡先リクエストは開発中で、2026 年 9 月〜10 月ごろを予定しています。現在はリクエスト自体が公開されており、中の支払い情報が暗号化されていても、2 つのアイデンティティがつながっていることは誰でも確認できます。プライベートな連絡先リクエストが提供されれば、つながりを公開するか非公開にするかを選べるようになります。";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "プライベートな連絡先リクエスト、Shielded DashPay、まだ連絡先でない相手への支払い。";
+
 /* No comment provided by engineer. */
 "Private key" = "プライベートキー";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "プライベートな支払いアドレスは、あなたと連絡先の間でやり取りされます。二人の間の支払いの受取人と送信者を知っているのは、あなたとその連絡先だけです。";
+
+/* DashPay intro: feature title */
+"Private payments" = "プライベートな支払い";
+
+/* Usernames */
+"Private registration" = "プライベート登録";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "処理時間";
+
+/* Balance info sheet section */
+"Pros" = "メリット";
 
 /* CrowdNode Portal */
 "Protect your savings" = "貯蓄の保護";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "プロバイダーアドレス";
 
+/* Masternodes */
+"Provider transactions" = "プロバイダー取引";
+
+/* Masternode keys */
+"Public key" = "公開鍵";
+
+/* Masternode keys */
+"Public key (legacy)" = "公開鍵（レガシー）";
+
+/* Identities */
+"Public keys" = "公開鍵";
+
 /* No comment provided by engineer. */
 "Public URL" = "パブリックURL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "購入に失敗しました";
+
+/* Identities: what a public key is used for */
+"Purpose" = "用途";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "レート: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "生の取引データ";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "生の取引データは利用できません";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "選択したブロック高から、このウォレットの取引についてコンパクトブロックフィルターを再確認し、再ダウンロードして再照合します。再スキャンの下限はウォレットの作成ブロック高とローカルに保存されたチェーンデータです。それより前の履歴を復元するには、代わりにウォレットの開始ブロック高を下げてください。";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "出金ポリシーを読む";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "読み取り専用";
+
+/* Usernames */
+"Ready around %@" = "%@ ごろに準備完了";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "理由";
 
 /* No comment provided by engineer. */
 "Receive" = "入金";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "から入金済み";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "%@ さんから受け取りました";
+
 /* CrowdNode */
 "Receiving rewards" = "報酬の受取";
+
+"Records your masternodes as having voted, without taking a side." = "どちらにもつかずに、あなたのマスターノードが投票したものとして記録します。";
 
 /* No comment provided by engineer. */
 "Recover" = "リカバー";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "リカバリーフレーズは12、15、18、21、24単語あります。";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "更新";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "登録しますか。";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "登録日";
+
+/* No comment provided by engineer. */
 "Registered from" = "から登録済み";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "登録済みのマスターノード";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "プライベート登録には、シールド残高に少なくとも %@ Dash と数時間の待機が必要です。次の画面で手順をご案内します。";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "登録";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "この名前をリクエスト中";
+
 /* An action */
 "Rescan" = "再スキャン";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "復元したウォレットでは操作の種類を復元できない場合があります。この項目はオンチェーンのメモデータから再構成されました。";
+
+/* Location Service Status */
 "Restricted" = "制限中";
 
 /* Usernames */
 "Results" = "結果";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "ブロック高 %u からの再同期を準備しました。アプリを終了して開き直すと開始されます。";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "相互の取引履歴を保持";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "運用終了";
 
 /* No comment provided by engineer. */
 "Retry" = "リトライ";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "下記の投稿を確認し、このユーザー名の所有権を確認してください";
+
+/* Masternodes */
+"Revocation" = "失効";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "スクリーンショットは、他のアプリやデバイスで閲覧することができます。新しい復元フレーズを作り大事に守って下さい。";
 
+/* Raw transaction inspector */
+"Script" = "スクリプト";
+
+/* Raw transaction inspector */
+"Script signature" = "スクリプト署名";
+
+/* Raw transaction inspector */
+"Script type" = "スクリプトの種類";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "連絡先を検索";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "連絡先リクエストを検索";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Dash ネットワークでユーザーを検索";
+
+/* No comment provided by engineer. */
+"Search for a username" = "ユーザー名を検索";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "次の検索結果: \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "テリトリーを検索";
+
+"Search usernames" = "ユーザー名を検索";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Dash ネットワークでユーザー名 %@ を検索中";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "ウォレットを保護する";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "セキュリティレベル";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "セキュリティレベル";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Dashの購入、売却、交換、送金などサービスを選択します";
 
+"Select all" = "すべて選択";
+
 /* DashSpend denomination selection */
 "Select amount" = "金額を選択する";
+
+"Select at least one masternode to vote with." = "投票に使うマスターノードを少なくとも 1 つ選んでください。";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "通貨を選択する";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "選ぶノードが少ないほど、どのマスターノードを運用しているかが分かりにくくなります。";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "セルフレジの場合";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "に送信する";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "連絡先に送金";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "本当に覚えて確認できるユーザー名に送金しましょう。";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "アドレスに送金する";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "最初の連絡先リクエストを送る";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "送金中";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "連絡先リクエストを送信中";
+
+/* No comment provided by engineer. */
+"Sending to" = "送金先";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "CrowdNodeアカウントへの送金";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "へ送金済み";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "%@ さんに送金しました";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "シーケンス";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "サーバーエラーが発生しました。しばらく経ってからもう一度お試しください。";
+
+/* Masternodes */
+"Service" = "サービス";
+
+/* Identities */
+"Set as Main" = "メインに設定";
+
+/* Identities */
+"Set as Main Identity" = "メインのアイデンティティに設定";
 
 /* No comment provided by engineer. */
 "Set PIN" = "PINを設定する";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "シェアキー";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "共有プライバシープールが最小サイズに到達";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "シールドアドレス";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "シールド送金";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "シールドウォレットを起動中…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "シールド → Platform";
+
+"Shielded → Transparent" = "シールド → 透明";
 
 /* Explore Dash */
 "Show all locations" = "全ての場所を表示する";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "サイズ";
+
 /* No comment provided by engineer. */
 "Skip" = "スキップする";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "一部のマスターノードがこのリストに表示されていない可能性があります。ウォレットが投票キーのすべてを読み取れませんでした。同期を完了してからこの画面を開き直してください。";
 
 /* Usernames */
 "Some usernames can be blocked" = "一部のユーザー名をブロックできます";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "並べ替え方法";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "連絡先を並べ替え";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "割引で並べ替え";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "名前順で並べ替え";
+
+/* Raw transaction inspector */
+"Special payload" = "特別ペイロード";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "金額を指定する";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "ステーキング";
 
+/* Usernames */
+"Starts after you add funds" = "資金を追加すると開始します";
+
+/* Transaction details */
+"Status" = "ステータス";
+
 /* Step 1 */
 "Step %ld" = "ステップ %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "保存名";
 
 /* Voting */
 "Submit" = "提出する";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "同期中... 入力結果が完了していない可能性があります。";
 
+/* No comment provided by engineer. */
+"Sync Info" = "同期情報";
+
+/* SPV sync */
+"Sync too slow?" = "同期が遅すぎますか？";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "カメラで撮影する";
 
+"Take no side" = "どちらにもつかない";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "クリップボードからアドレスをタップしてペーストする";
+
+/* Raw transaction inspector */
+"Tap to copy" = "タップしてコピー";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "タップして残高を非表示にする";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "現在はご利用いただけません";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash ノードキー (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "利用規約";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "テストネット";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "コードが正しくありません。ご確認の上、再度ご入力ください。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "ネットワークが出金を処理した後、Dash が受取人のアドレスに届きます。最大 10 分ほどかかる場合があります。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "ネットワークが出金を処理すると、Dash が受取人のアドレスに届きます。";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "ネットワークが出金を処理すると、Dash が透明残高に届きます。";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Dashネットワークでは、ユーザー名が作成される前に、そのユーザー名に対して投票で承認する必要があります";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "送信したリンクは、ネットワークの所有者にのみ表示されます";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "メインのアイデンティティはアクティブなウォレットからのみ選択できます";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "送金可能な最小金額は、%@です";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Dash を保管する最もプライベートな場所";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "保存済みのウォレットレコードにネットワークがありません。再同期を準備できません。";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "登録は送信されましたが、その結果を確認できませんでした。ウォレットが同期するまで 1 分ほど待ってから、もう一度お試しください。すぐに再送信しないでください。";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "共有プライバシープールはまだ拡大中です（%1$ld / %2$ld 件の入金）。最低額に達するとプライベート登録が利用できるようになります。";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "共有プライバシープールはまだ拡大中です（%1$ld / %2$ld 件の入金）。最低額に達してからもう一度お試しください。";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "「%@」というユーザー名は、Dashネットワークによってブロックされました。別のユーザー名をリクエストして再度お試しください。";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "ウォレットの作成ブロック高です。フィルタースキャンと「ウォレット作成時から」の再スキャンの下限になります。ウォレットへの最初の入金と同じかそれ以下に設定してください。インポート時の既定値はメインネットで 200000、テストネットで 0 です。現在の値と同じかそれ以下のブロック高を保存すると、次回の起動時にこのネットワークのチェーンデータが消去され、そこから再スキャンされます。";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "その人（情報を取得中）";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "新しい通知はありません";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "表示する取引はありません";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "名前 %@ に一致するユーザーはいません";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "連絡先の中に名前 %@ に一致するユーザーはいません";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "取引履歴をZenLedgerにエクスポートする際に、エラーが発生しました";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "エラーが発生しました。後でもう一度お試しください。";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "この資金は Platform 残高へ移り、送金が完了するとすぐに使えるようになります。";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "このアドレスには %@ 残高から支払えません";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "これにより、他のユーザーがあなたに連絡先リクエストを送れるように、またあなたが相手のリクエストを承認できるように、アイデンティティに 2 つのキーが追加されます。これは一度きりです。";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "選択した %d 件のユーザー名すべてに 1 つの選択を適用します。";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "この追加ステップは、お客様が本当に取引を行おうとしていることを証明するために行われます。";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "この招待リンクは有効ではありません。";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "これはこのネットワークで有効な Dash アドレスではありません";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "これは有効な招待リンクではありません";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "これはあなたのメインのアイデンティティです";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "このマスターノードにはまだ Platform アイデンティティがありません。";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "この加盟店は現在利用できません。";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "これは、現在のフル・マスターノードの年間利回りから15%のCrowdNode手数料を差し引いたものです。これは保証された還元率ではなく、CrowdNodeプールの規模やDashの価格によって上下する可能性があります。";
 
+"This still counts as your masternodes having voted in this contest." = "これでもこの争奪であなたのマスターノードが投票したものとして扱われます。";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "この取引の生のバイトデータはこの端末に保存されていません。";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "このユーザー名は他の人のものになりました";
+
+"This wallet could not derive the voting key for this node." = "このウォレットはこのノードの投票キーを導出できませんでした。";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "このウォレットには有効なマスターノードの投票キーがないため、投票できません。登録済みのノードはツール → マスターノードに表示されます。";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Platform 残高の全額を 1 回の送金で出金します。ネットワークが出金を処理すると、Dash が受取人のアドレスに届きます。";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Platform 残高の全額を 1 回の送金で出金します。ネットワークが出金を処理すると、Dash が透明残高に届きます。";
 
 /* Send Screen: to address */
 "to" = "へ";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "取引履歴";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "取引履歴は利用できません";
+
 /* No comment provided by engineer. */
 "Transaction id" = "取引のid";
+
+/* Raw transaction inspector */
+"Transaction ID" = "取引 ID";
 
 /* A verb, button title. */
 "Transfer" = "送金";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "入金";
 
+/* Balance breakdown */
+"Transfer in" = "入金";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "出金";
+
+/* Balance breakdown */
+"Transfer out" = "出金";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "送金には時間がかかります。プライバシー証明の生成に時間が必要です";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "他の Platform アドレスやシールドアドレスへの送金は即時かつ最終的です";
+
+/* Balance breakdown */
+"Transparent" = "透明";
+
+/* Send screen destination type */
+"Transparent address" = "透明アドレス";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "透明残高";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "透明残高からまかなうと、ユーザー名がその資金と公開の形で結び付けられます。";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "透明 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "透明 → シールド";
 
 /* An action */
 "Try again" = "もう一度お試しください";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "候補を提示できません";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "不明な残高";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "不明な特別タイプ %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "シールドなし";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "サポートされていないURL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "DashPayにアップグレードする";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Evolution にアップグレード";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "代わりに透明残高を使う";
+
+/* Masternode keys */
+"Used" = "使用済み";
+
+/* Masternode keys */
+"Used at: " = "使用日: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "ユーザー（情報を取得中）";
 
 /* Voting */
 "Username" = "ユーザー名";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "ユーザー名を正常に申請できました";
 
+/* Identities */
+"Usernames" = "ユーザー名";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "ユーザー名は紛らわしい名前を防ぐため正規化された形で保存されるため、各人が入力した内容と異なる場合があります。";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "アドレスではなくユーザー名";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "%@ に一致し、現在連絡先にいないユーザー";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "最も監査とテストが行われているゼロ知識ライブラリの 1 つ (Orchard) を使用しています";
+
+/* DashPay Invitations */
+"Valid invitation" = "有効な招待状";
+
 /* CrowdNode Portal */
 "Validating address…" = "アドレスを有効化中";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "認証が必要です";
 
+/* Usernames */
+"Verified during registration" = "登録時に確認済み";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "無事に認証されました";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "本人確認を行う";
 
+/* Raw transaction inspector */
+"Version" = "バージョン";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "非常に効率的で手数料も低額";
+
 /* adjective, security level */
 "Very High" = " 非常に高い";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "このウォレットのアドレスの所有者であることを認証するために、極めて少額のDashがCrowdNodeで行き来することになります。";
+
+/* No comment provided by engineer. */
+"View All" = "すべて表示";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "エクスプローラーで表示";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "復元フレーズを表示する";
 
+/* Raw transaction inspector */
+"View Transaction" = "取引を表示";
+
 /* No comment provided by engineer. */
 "View transaction details" = "取引詳細を表示する";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "投票";
+
+"Vote cast" = "投票済み";
+
 /* Voting */
 "Vote for All" = "全てに投票";
 
 /* Voting */
+"Vote on contested usernames" = "競合しているユーザー名に投票する";
+
+"Vote on several" = "複数に投票";
+
+/* Voting */
 "Vote to Approve" = "承認に投票";
+
+"Vote with" = "投票に使うノード";
+
+"Votes that nobody should receive these usernames." = "これらのユーザー名を誰も取得しないよう投票します。";
 
 /* Voting */
 "Votes: High to low" = "投票数：高から低";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = " 投票のアドレス";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "投票アドレス";
+
+"Voting ended with no winner" = "投票は勝者なしで終了しました";
+
+"Voting ends" = "投票終了";
+
 /* Voting */
 "Voting ends in %dd" = "%dに投票を終了します";
+
+"Voting in progress" = "投票進行中";
+
+"Voting in progress — lock votes are ahead" = "投票進行中 — ロック票がリードしています";
+
+"Voting in progress — you are ahead" = "投票進行中 — あなたがリードしています";
 
 /* Usernames */
 "Voting is only required in some cases" = "投票が必要な場合もあります";
 
+/* Masternodes */
+"Voting key hash" = "投票キーのハッシュ";
+
 /* Voting keys */
 "Voting keys" = "投票キー";
+
+"Voting on this username has closed. The counts below are the last ones read." = "このユーザー名の投票は終了しました。以下の集計は最後に読み取られた値です。";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "「%@」の投票はすでに終了しています。更新して結果をご確認ください。";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "ウォレットが同期されるまで待ち、取引を完了させます。";
 
+"Waiting for Dash Platform" = "Dash Platform を待機中";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "ウォレットのアドレス";
+
+/* SPV diagnostics */
+"Wallet birth height" = "ウォレットの開始ブロック高";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "ウォレットは機能停止しています";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "DashPayにようこそ";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains などのネームサービスはどうですか？";
+
+/* DashPay FAQ */
+"What does it cost?" = "費用はいくらですか？";
+
+/* DashPay FAQ */
+"What is DashPay?" = "DashPay とは何ですか？";
+
 /* Usernames */
 "What is username voting?" = "ユーザー名投票とは？";
+
+/* DashPay FAQ */
+"What's coming next?" = "次に来る機能は？";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "連絡先リクエストはいつプライベートになりますか？";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "使用できる場所";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "どこで使えますか。";
+
+"Who is requesting this name" = "この名前をリクエストしている人";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "なぜ有効にする必要があるのですか？";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "なぜこのような取引があるのですか。";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "出金がリクエストされました";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "残高の全額を出金します";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "あらゆる Dash ウォレット、取引所、加盟店で利用できます";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "招待状を受け取りますか。";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "昨日";
+
+"You" = "あなた";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "%@ さんからの連絡先リクエストを承認しました";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "「%@」をユーザー名に選択しました";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "現在、連絡先はありません";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "この取引を完了するのに十分な資金がありません";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Coinbaseの認証制限を超えてしまいました。";
+
+/* Usernames */
+"You have %@ Dash so far" = "現在 %@ Dash あります";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "お客様は%1$@Dashをお持ちです。\n一部のユーザー名は最大で%2$@Dashかかります。";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "%@ さんに連絡先リクエストを送信しました";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Dash Walletに残高が残っている状態にする必要があります。";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "このユーザー名を獲得しました";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "準備が整いました。他のユーザーがあなたに連絡先リクエストを送れるようになり、あなたも自分のリクエストを送れます。";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "ユーザー名を登録すると、Dash Platform のアイデンティティがここに表示されます。";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "お客様のメールはワンタイムパスワードを送る時にのみ使用されます。";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "整理された履歴";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "あなたと他のユーザーとの間で連絡先リクエストを暗号化できるように、アイデンティティには 2 つの追加キーが必要です。有効にすると、1 回のネットワーク取引でそれらが追加されます。これは一度きりです。";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "%@からの招待状はすでに請求済みです";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "%@からの招待状は無効です";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "招待状がこのユーザー名の登録手数料を負担します。";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "お客様の位置情報は、地図上のお客様の位置、選択した圏内にあるATMの表示、検索結果の改善に使用されます。";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "お客様の位置情報は、地図上でお客様の位置を表示したり、選択された距離内の加盟店を表示したり、検索結果を向上するために使用されます。";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Core ブロックチェーン上のメインの Dash 残高です。他のウォレット、取引所、加盟店とやり取りする際に使います。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "ミキシングしたコインを Dash ウォレットの残高に移動しました。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "ミキシングしたコインをシールド残高に移動しました。プライバシーを最大限に高めるため、この資金を使う前に少なくとも 2 時間お待ちください。";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "あなたの Platform 残高";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "お客様のCrowdNodeアカウントで使用中のメインのDashアドレス";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "プライベートな残高です。金額とアドレスはオンチェーンで暗号化されるため、保有額と履歴は非公開のままです。";
+
 /* Usernames */
 "Your request was cancelled" = "申請がキャンセルされました";
 
 /* DashSpend */
 "Your session expired" = "セッションの有効時間が切れました";
+
+/* Usernames */
+"Your Shielded balance" = "あなたのシールド残高";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "シールド残高の準備がまもなく整います。%@ ごろにプライベートに登録できます。";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "シールド残高の準備が整いました。今すぐプライベートにユーザー名を登録しましょう";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "シールド残高をねかせています。%@ ごろにプライベートに登録できます";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "シールド残高はまだ成熟中です。%@ ごろに準備が整います。";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "あなたの透明残高";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "あなたのユーザー名%@はDashネットワークに無事作成されました。";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "ユーザー名が正常に作成されました";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "ユーザー名は誰にでも見えます。数時間ねかせたうえでシールド残高からまかなえば、ユーザー名を他の Dash と結び付けられることはありません。";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "ユーザー名、プロフィール、連絡先はこのアイデンティティに紐付いています。";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "ユーザー名、プロフィール、連絡先はこのアイデンティティに紐付きます。";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "投票がキャンセルされました";
 
 /* Voting */
 "Your vote was submitted" = "投票が提出されました";
 
+"Your votes" = "あなたの票";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "現在あなたのウォレットは安全です。復元フレーズを使えばいつでも\n他の端末であなたのアカウントを復元できます。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "ウォレットはまだ Dash ネットワークと同期中です。同期が完了すると送金できるようになります。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "ウォレットはまだ同期中です。同期が完了すると透明残高から送金できるようになります。";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "「%@」を Dash のユーザー名として読み取れませんでした。";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "「%@」が登録されました。招待してくれた相手に連絡先リクエストを送りますか？";

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "すべてのノードを一度に";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "すべてのマスターノードがこのユーザー名に投票済みです。票を変更するには、今支持する候補者からもう一度投票してください。";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "すべてのマスターノードがこのユーザー名に投票済みです。票を変更するには、今支持する候補者にもう一度投票してください。";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ja.lproj/Localizable.stringsdict
+++ b/DashWallet/ja.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d キー</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>「%2$@」に%#@votes@を集計</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@中 %1$d 件に投票済み</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d ユーザー名</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票を投じる</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中 %1$d 件が投票済み</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d マスターノード</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中 %1$d 件が投票済み</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d ノード</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 件の Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>合計 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 件のマスターノード</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 件選択中</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>あなたのノードのうち %d 件はすでにここで投票済みのため表示されていません。</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>1 つの争奪につき %u 票 — Evonode は 4、マスターノードは 1 として数えます</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 件のユーザー名に投票</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>投票 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 件のリクエスト</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ja.lproj/Localizable.stringsdict
+++ b/DashWallet/ja.lproj/Localizable.stringsdict
@@ -97,7 +97,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%2$d ユーザー名</string>
+			<string>%2$d 件のユーザー名</string>
 		</dict>
 	</dict>
 	<key>Cast %u votes</key>
@@ -125,7 +125,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%2$d マスターノード</string>
+			<string>%2$d 件のマスターノード</string>
 		</dict>
 	</dict>
 	<key>%d of %d nodes voted</key>
@@ -139,7 +139,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%2$d ノード</string>
+			<string>%2$d 件のノード</string>
 		</dict>
 	</dict>
 	<key>%d evonodes</key>

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "모든 노드를 한 번에";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "모든 마스터노드가 이 사용자 이름에 투표했습니다. 투표를 바꾸려면 지금 선호하는 후보에서 다시 투표하세요.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "모든 마스터노드가 이 사용자 이름에 투표했습니다. 투표를 바꾸려면 지금 선호하는 후보에게 다시 투표하세요.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " 또는 ";
+
 /* CrowdNode */
 " Privacy Policy " = "개인정보 보호정책";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "연락처 요청을 보낼 %@ 님을 Dash 네트워크에서 찾을 수 없습니다.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 사용 가능";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ 님이 회원님의 연락처 요청을 수락했습니다";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu 연락처 / %3$lu 프로필 업데이트";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d바이트";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "이 지갑에 수 개의 투표 키가 저장되어 있으므로 %d 표가 던져지게 됩니다 ";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%Id 복사";
+
+/* Usernames */
+"%ld of %ld deposits" = "입금 %ld/%ld건";
 
 /* Voting */
 "%ld requests" = "%Id 요청";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\"는 복구 문구 단어가 아닙니다. 해당 위치에 입력해야 할 올바른 단어를 복구하시겠습니까?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Platform 주소 간 즉시 결제와 사용자 이름 같은 기능에 사용되는 Dash Platform의 크레딧 잔액입니다.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "지갑을 보호하기 위해 비밀번호가 필요합니다. 설정에서 비밀번호를 활성화해주세요.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "정보";
 
+/* DashPay FAQ title */
+"About DashPay" = "DashPay 소개";
+
 /* No comment provided by engineer. */
 "About me" = "나에 관하여";
+
+"Abstain" = "기권";
+
+"Abstain on “%@”" = "“%@”에 기권";
 
 /* No comment provided by engineer. */
 "Accept" = "수락";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "계정 복구";
 
+/* Masternode status */
+"Active" = "활성";
+
+/* No comment provided by engineer. */
+"Activity" = "활동";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "활동은 공개되지만 추적하기는 쉽지 않습니다";
+
 /* No comment provided by engineer. */
 "Add" = "추가";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ 님을 연락처에 추가";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "%@ 님을 연락처에 추가해 사용자 이름으로 바로 결제하고 상호 거래 내역을 보관하세요";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "보호 잔액에 %@ Dash를 추가하고 몇 시간 두어, 사용자 이름이 다른 자금과 연결되지 않은 채로 등록하세요.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "새로운 연락처 추가하기";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "보호 잔액에 최소 %@ Dash를 추가하세요";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "지금 보호 잔액에 자금을 추가하고 몇 시간 뒤에 사용자 이름을 비공개로 등록하세요";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "모두";
 
+"All nodes at once" = "모든 노드를 한 번에";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "모든 마스터노드가 이 사용자 이름에 투표했습니다. 투표를 바꾸려면 지금 선호하는 후보에서 다시 투표하세요.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "대시 지갑의 모든 거래를 Zenledger로 보내시겠습니까?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "잔액 동기화가 거의 즉시 이루어집니다";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "금액과 주소가 블록체인에 공개됩니다";
+
 /* No comment provided by engineer. */
 "An error occurred" = "오류 발생";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum 계정은 재사용되는 하나의 주소입니다. 전체 잔액과 결제 내역이 그 아래에 공개되고, 이름(예: ENS 도메인)은 보통 그 주소를 바로 가리켜 누구나 조회할 수 있습니다. DashPay는 정반대 구조입니다. 이름은 결제 주소가 아니라 아이덴티티로 연결되고, 실제 결제 주소는 암호화된 연락처 교환 안에 남아 연락처마다 새로 만들어집니다.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "당신의 모든 기기에 걸친 직관적이고 친근한 경험";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "2-9사이의 숫자가 포함되고, 20글자 이상이거나 하이픈 기호를 포함한 사용자 이름은 자동으로 승인됩니다";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "주소를 아는 사람은 누구나 그 내역을 볼 수 있습니다";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "적용";
 
+"Approve" = "승인";
+
+"Approving a specific request can only be done one username at a time." = "특정 요청 승인은 한 번에 사용자 이름 하나씩만 가능합니다.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "이 주문을 정말 취소하시겠습니까?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "텍스트로";
 
 /* DashSpend */
 "at" = "이곳에서";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "인증이 취소되었습니다. 투표가 처리되지 않았습니다.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "인증에 실패했습니다. 투표가 처리되지 않았습니다.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "인증할 수 없습니다";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "“%@”을(를) 이 후보에게 부여";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "잔액";
 
 /* CrowdNode */
+"Balance after" = "이후 잔액";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "크라우드노드 잔고";
 
 /* CrowdNode */
 "Balance: " = "잔고:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "잔액과 전송은 공개되지 않습니다";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "은행 계좌";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "생체 인증 접근이 필요합니다";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "시작 블록 높이를 저장했습니다. 상향된 스캔 하한은 다음 실행부터 적용됩니다.";
+
 /* Voting */
 "Block" = "블록";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "사용자 이름 '%@' 차단 됨";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "컨트랙트에 연결됨";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "컨트랙트에 연결됨, 문서 유형 “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "보기 전용";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "최근 진단 로그를 zip으로 묶어 AirDrop, 메일로 보내거나 파일에 저장합니다";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "투표하기";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "피어 변경";
 
 /* No comment provided by engineer. */
 "Change PIN" = "PIN 변경";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "확인 중…";
+
+"Choice" = "선택";
+
 /* Choose your Dash username */
 "Choose your" = "다음을 선택하세요";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "사용자 이름을 선택하세요";
 
+/* DashPay Invitations */
+"Claim your invitation" = "초대장 받기";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "수령 가능한 잔액";
+
 /* No comment provided by engineer. */
 "Claimed" = "사용중입니다";
+
+/* SPV diagnostics */
+"Clear & resync" = "지우고 다시 동기화";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "체인 데이터를 지우고 다시 동기화할까요?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "앱 닫기";
 
+"Closing" = "마감 중";
+
 /* Dash Portal */
 "Coinbase" = "코인베이스";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "코인베이스(신규 코인)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "코인베이스 2FA 코드";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin은 더 이상 지원되지 않습니다. 믹싱한 코인을 어디로 옮길지 선택하세요.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "담보";
+
+/* DashPay intro: feature title */
+"Coming soon" = "곧 제공";
+
+/* Shielded transfer status */
+"Completed" = "완료됨";
 
 /* No comment provided by engineer. */
 "Confirm" = "승인";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "확인됨";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "확인하면 시작 블록 높이 %u가 저장되고, 다음 앱 실행 시 이 네트워크의 체인 데이터가 지워진 뒤 다시 다운로드되어 해당 높이부터 필터를 다시 스캔합니다. 실행 중인 세션은 기존 스캔 하한을 유지합니다. 앱을 종료했다가 다시 열면 시작됩니다.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "당신의 암호화폐 지갑을 Zenledger 플랫폼에 연결하세요. 자세한 내용을 확인하시고 대시 지갑 거래를 통해 지금 시작하세요.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "연결된 대시 주소";
 
+/* SPV sync */
+"Connected peers" = "연결된 피어";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "단점";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "연락처 요청 실패";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "%@ 님에게 연락처 요청을 보냈습니다";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "연락처 요청";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "연락처";
 
+"Contender %@" = "후보 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "계속";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "계속해서 사용자 이름을 선택하세요. 초대장이 등록 수수료를 부담합니다.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "초대 링크 복사";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "원시 거래 복사";
+
 /* No comment provided by engineer. */
 "Copy text" = "문자 복사";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "입력되지 않거나 잘못 입력된 단어를 자동을 복구할 수 없었습니다.";
 
+/* Log export */
+"Could not create the log archive: %@" = "로그 아카이브를 만들 수 없습니다: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "환율 정보를 찾지 못했습니다.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d개의 아이덴티티를 새로 고칠 수 없습니다";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "잔액을 가져오지 못했습니다(네트워크 오류). 새로 고침을 시도해 보세요.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "지불에 실패하였습니다";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "당신의 사용자 이름을 생성하세요";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "사용자 이름을 만들고, 친구와 가족을 사용자 이름으로 찾아 연락처에 추가하세요";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "신용카드";
+
+/* Masternodes */
+"Credits" = "크레딧";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "대시 지불은 %@보다 적을 수 없습니다";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform이 이 경합을 아직 색인하지 않았습니다. 색인되면 득표수가 여기에 표시됩니다.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform에 아직 연결되지 않았습니다. 동기화가 끝날 때까지 기다린 뒤 다시 시도하세요.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "잘못된 주소로 보낸 Dash는 되찾을 수 없습니다. 주소가 결제하려는 주소와 정확히 일치하는지 확인하세요.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash는 비슷해 보이는 표기에 강한 형태로 사용자 이름을 저장하므로, 저장된 이름은 각자가 입력한 것과 다를 수 있습니다.";
+
 /* No comment provided by engineer. */
 "Dash username" = "대시 사용자 이름";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "대시 지갑";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash 지갑 잔액";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "이 기기의 대시 지갑";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay 활성화됨";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "대시페이 초대";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay는 Dash Platform 위에 구축된 Dash의 소셜 결제 경험입니다. 사용자 이름을 등록하고 다른 사용자를 연락처로 추가한 뒤 이름으로 결제하세요. 더 이상 주소를 복사할 필요가 없습니다.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay는 길고 알아보기 어려운 주소를 사용자 이름으로 대체합니다. 친구를 연락처로 추가하고 이름으로 송금하며 모든 결제를 사람별로 정리하세요.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "대시페이 업그레이드 수수료";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "날짜: 과거부터 현재";
+
+"Deadline unknown" = "마감 기한 알 수 없음";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "입금 완료";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "파생 경로";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "기기 보안이 손상되었습니다\n어떤 '탈옥' 어플이든 다른 어플의 주요 체인 데이터에 접근할 수 있습니다 (당신의 대시가 도난당할 수 있습니다). 이 지갑을 즉시 삭제하시고 안전한 기기에서 지갑을 복구하십시오.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "비활성화됨";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "코인베이스 계정 연결 해제";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "완료";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "완료 — 잔액이 충분히 오래 유지되었습니다";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "주소를 다시 확인하세요";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "각 초대는 이 금액을 통해 지원되며, 이로써 받는 이가 재빨리 대시 네트워크에 사용자 이름을 생성할 수 있습니다";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "각 마스터노드는 경합당 유효한 투표 1표를 가집니다. 나중에 바꿀 수 있지만, Dash Platform은 경합당 마스터노드마다 총 5표까지만 허용합니다.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "탭할 때마다 노드가 하나씩 더 투표하므로, 몇 개를 함께 연결할지 직접 고를 수 있습니다.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "이전";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "간단한 클릭만으로 대시를 손쉽게 스테이킹하고 소극적 소득을 얻으세요.";
+
+/* SPV diagnostics */
+"Edit birth height" = "시작 블록 높이 편집";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "프로필 수정";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "이메일";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "활성화";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay 활성화";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "페이스 ID 활성화";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "터치 ID 활성화";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPay를 활성화하려면 소액의 일회성 네트워크 수수료가 들며, 아이덴티티의 크레딧 잔액에서 지불됩니다. 정확한 예상액은 확인 전에 표시됩니다. 연락처 요청과 결제를 보낼 때는 일반적인 네트워크 수수료가 듭니다.";
+
+"Ending soonest" = "가장 먼저 종료";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "프로필 업데이트 오류";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "예상 네트워크 수수료";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "모든 노드가 함께 투표합니다. 더 빠르지만 마스터노드끼리 공개적으로 연결됩니다.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode 운영자 키";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "CSV 내보내기";
 
+/* Log export */
+"Export Logs" = "로그 내보내기";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "확장된 공개 키 (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "외부 주소";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID 제한";
+
+/* No comment provided by engineer. */
+"Failed" = "실패";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "바코드 로딩 실패";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "환율 불러오는 중...";
 
+/* Masternodes */
+"Fetching…" = "가져오는 중…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "법정 화폐 계좌";
 
 /* No comment provided by engineer. */
 "Filter" = "필터";
+
+/* SPV sync phase */
+"Filter headers" = "필터 헤더";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "거래 필터링하기";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Dash 네트워크에서 사용자 찾기";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "대시를 사고 팔 수 있는 ATM을 찾아보세요.";
+
+/* Identities */
+"Find identities" = "아이덴티티 찾기";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "PIN을 잊어버리셨나요?";
 
+/* Identities */
+"Found %d new identities" = "새 아이덴티티 %d개를 찾았습니다";
+
+/* Identities */
+"Found 1 new identity" = "새 아이덴티티 1개를 찾았습니다";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "입력되지 않은 단어가 발견되었습니다:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "보호 잔액에서 사용자 이름 비용을 충당하세요. 몇 시간 전에 미리 자금을 추가하면, 짧은 대기 시간 동안 사용자 이름이 다른 Dash와 연결되지 않게 됩니다.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "보호 잔액에서 충당됨 — 사용자 이름을 다른 Dash와 연결할 수 없습니다.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "자금 잠김 — 전송을 마무리하는 중";
+
+/* CoinJoin */
+"Funds moved" = "자금 이동 완료";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "대시 마스터노드에 최소 보증금 0.5대시로 리워드를 받아보세요.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "견적 받기";
+
+/* Usernames */
+"Get ready to join DashPay" = "DashPay에 참여할 준비를 하세요";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "지금 리워드 받기";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "구글 페이";
 
 /* No comment provided by engineer. */
+"Got it" = "확인";
+
+/* Governance */
+"Governance" = "거버넌스";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "GPS를 허락하여 당신 근처의 장소를 확인하세요.";
 
 /* Voting */
 "Has blocked votes" = "투표를 차단했습니다";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "님이 친구가 되기를 요청했습니다";
+
+/* DashPay Invitations */
+"Have an invitation?" = "초대장이 있으신가요?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "당신의 필요에 따라 지갑에 대한 완전한 통제를 행사하고 자신의 지갑을 커스터마이징 하세요";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "헤더 %2$d 중 #%1$d";
+
+/* SPV sync phase */
+"Headers" = "헤더";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "블록 높이 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "다음은 이 기기의 대시 지갑 내 크라우드노드 계정에 지정된 대시 주소입니다";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "높음부터 낮음";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "약 7센트로 수수료가 다소 높습니다(비슷한 프라이버시를 제공하는 다른 블록체인보다는 여전히 저렴합니다)";
+
 /* No comment provided by engineer. */
 "History" = "내역";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "테스트 대시는 어떻게 얻나요?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "프라이버시 측면에서 Bitcoin과 비교하면 어떤가요?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "프라이버시 측면에서 Ethereum 계정과 비교하면 어떤가요?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay의 프라이버시 수준은 어느 정도인가요?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "당신의 API 대시 주소를 확인하는 방법";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "옮겨 적었습니다";
 
+/* Identities */
+"Identities" = "아이덴티티";
+
 /* Voting */
 "Identity" = "아이덴티티";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "아이덴티티 크레딧";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "아이덴티티 인덱스";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "아이덴티티 등록";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "아이덴티티 충전";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "체크아웃 페이지의 지불 부분에서 \"기프트 카드\"를 선택하고 카드 번호와 핀 번호를 입력하세요.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "비활성";
+
+/* No comment provided by engineer. */
 "Income" = "수입";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "초기값 설정";
+
+/* Raw transaction inspector */
+"Input %d" = "입력 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "입력 %d — 아웃포인트";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "입력 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "잔액 부족";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "초대 수수료";
 
+/* DashPay Invitations */
+"Invitation from %@" = "%@ 님의 초대장";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "다음에 사용된 초대";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "초대하기";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "누군가를 Dash 네트워크에 초대하기";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "가족을 초대하고, 친구들을 사용자 이름으로 검색해 찾아보세요";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "당신의 친구와 가족이 대시 네트워크에 가입하도록 초대하세요.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "친구와 가족을 Dash 네트워크에 초대하세요";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS 대시 지갑: %@ 이슈 보고됨";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "풀 가입하기";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "이 코인을 비공개로 유지합니다. 네트워크 및 프라이버시 수수료가 적용됩니다.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "당신의 복구 문구를 안전하게 보호하세요";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "키 #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "키 데이터";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "키 소유";
+
 /* No comment provided by engineer. */
 "Keypair" = "키페어";
+
+/* Masternodes */
+"Keys" = "키";
 
 /* Explore Dash */
 "Last device sync" = "마지막 기기 동기화";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "선두";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "더 알아보기";
 
 /* Info Screen */
 "Learn More..." = "더 알아보기...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "거래를 불러오는 중";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "현지 통화";
 
+/* Identities */
+"Local Only" = "로컬 전용";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "요청된 로컬 금액: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "위치";
 
+"Lock" = "잠금";
+
+"Lock the name" = "이름 잠그기";
+
+"Lock “%@” so nobody gets it" = "아무도 가져갈 수 없도록 “%@” 잠그기";
+
 /* No comment provided by engineer. */
 "Locked" = "잠김";
 
+"Locked — nobody receives this username" = "잠김 — 아무도 이 사용자 이름을 받지 못합니다";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "잠금 시간";
 
 /* Log in */
 "Log in" = "로그인";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "낮음";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "일상 결제에 알맞은 낮은 수수료";
+
 /* Voting */
 "Low to high" = "낮음부터 높음";
+
+/* Identities — the wallet's main identity */
+"Main" = "기본";
 
 /* No comment provided by engineer. */
 "Mainnet" = "메인넷";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "마스터노드 IP 주소";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "마스터노드 키체인";
+
+/* Masternode keys */
 "Masternode keys" = "마스터노드 키";
+
+/* SPV sync phase */
+"Masternode list" = "마스터노드 목록";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "마스터노드 리스트%2$d 중 #%1$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "마스터노드 업데이트";
 
+"Masternode votes" = "마스터노드 투표";
+
 /* Voting */
 "Masternode Voting Key" = "마스터노드 투표 키";
+
+/* Tools menu */
+"Masternodes" = "마스터노드";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "이 지갑의 키로 등록된 마스터노드와 Evonode는 지갑 동기화가 끝난 뒤 여기에 표시됩니다.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "이 지갑의 키를 사용하는 마스터노드와 Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "마스터노드는 두 명 이상이 요청한 이름에 투표합니다. 투표가 끝나면 알려 드립니다.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "최대";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "최소: %@";
 
+/* Usernames */
+"Minimum met" = "최소 금액 충족";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "보다 큰 제어";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "추천 더 보기";
+
+"Most lock votes" = "잠금 투표 최다";
+
+"Most votes" = "득표 최다";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "당신의 사진을 이동하고 확대하여 완벽히 맞추어보세요";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "일반 사용 가능 잔액으로 옮깁니다.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "주소로 이동";
+
+/* CoinJoin */
+"Moving funds" = "자금 이동 중";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "이름";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains 같은 이름 서비스는 사람이 읽을 수 있는 이름을 체인상의 고정된 공개 주소에 연결합니다. 누구나 그 이름을 조회해 지금까지의 모든 결제를 볼 수 있습니다. DashPay 사용자 이름은 결코 공개적으로 결제 주소로 연결되지 않습니다. 주소는 각 연락처와의 암호화된 교환 안에서만 공개되므로, 회원님의 이름과 자금은 외부 관찰자에게 연결되지 않습니다.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "도움이 필요하신가요?";
+
+"Needs attention" = "확인 필요";
 
 /* No comment provided by engineer. */
 "Network" = "네트워크";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "이 기기에서 진단 로그를 찾지 못했습니다. 로그는 다음 실행부터 기록됩니다.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "아이덴티티 없음";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "아직 마스터노드가 없습니다";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "일치하는 경합 없음";
+
+/* Identities */
+"No new identities were found for this wallet" = "이 지갑에서 새 아이덴티티를 찾지 못했습니다";
+
+"No open contest matches that search." = "검색과 일치하는 진행 중인 경합이 없습니다.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "검색과 일치하는 진행 중인 경합이 없습니다. 이름은 정규화된 형태로 저장되므로 “alice”는 “a11ce”로 표시됩니다.";
+
+"No open contests" = "진행 중인 경합 없음";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "지불 방법 없음";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "연결된 지갑의 저장된 기록을 찾을 수 없습니다.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "보호 등록 대체 경로에 사용할 Platform 주소가 아직 없습니다. 지갑 동기화가 끝난 뒤 다시 시도하세요.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "결과 없음";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "지금은 경합 중인 사용자 이름이 없습니다. 두 명 이상이 같은 이름을 요청하면 경합이 시작됩니다.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "남은 투표 없음";
+
+"No votes were cast" = "투표가 없었습니다";
+
+"Nobody gets it" = "아무도 가져가지 않음";
+
+/* SPV sync peer type */
+"Node" = "노드";
+
+/* Raw transaction inspector */
+"Non-standard" = "비표준";
 
 /* adjective, security level */
 "None" = "없음";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "이용할 수 없음";
 
+"Not available yet" = "아직 사용할 수 없음";
+
+"Not cast" = "투표하지 않음";
+
+/* Masternodes */
+"Not checked yet" = "아직 확인되지 않음";
+
 /* Location Service Status */
 "Not Determined" = "결정되지 않음";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "아이덴티티를 등록하기에 보호 잔액이 부족합니다";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "지갑 내역에 없음";
+
+"Not now" = "나중에";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "가맹점에서 널리 받아들여지지 않습니다";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "가맹점에서 아직 널리 받아들여지지 않습니다";
+
+/* Masternode keys */
+"Not yet used" = "아직 사용되지 않음";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "과거부터 현재";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoin에는 이름 계층이 없어 사람들이 주소를 공개적으로 공유하고 재사용합니다. 주소가 한 번 알려지면 그 주소가 받은 모든 것을 소유자와 연결할 수 있습니다. DashPay에서는 사용자 이름이 공개되지만 결제 주소를 가리키지는 않습니다. 주소는 연락처별로 비공개로 교환되고 계속 바뀌므로, 이름으로 결제해도 자금의 행선지가 공개되지 않습니다. 둘 다 투명한 체인이므로 코인 자체에는 체인 분석이 여전히 적용됩니다.";
+
+/* Identities */
+"On Network" = "네트워크상";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "%@ 님이 요청을 수락하면 사용자 이름으로 바로 결제할 수 있습니다";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "한 번에 노드 하나";
 
 /* Voting */
 "One vote left" = "한 번의 투표만 남음";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "복사만";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "마스터노드와 Evonode만 사용자 이름에 투표할 수 있습니다. 이 지갑에는 활성 마스터노드 투표 키가 없습니다.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "링크를 가진 요청만";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "링크를 가진 것만";
+
+/* Masternodes */
+"Operator" = "운영자";
+
+/* Masternode keys */
+"Operator keys" = "운영자 키";
+
+/* Masternodes */
+"Operator public key (BLS)" = "운영자 공개 키 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "또는";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "주문 미리보기";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "다른 결과";
+
+/* Masternodes */
+"Outpoint" = "아웃포인트";
+
+/* Raw transaction inspector */
+"Output %d" = "출력 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "출력 (%d)";
+
+/* Masternodes */
+"Owner" = "소유자";
+
 /* No comment provided by engineer. */
 "Owner Address" = "소유자 주소";
+
+/* Masternodes */
+"Owner address" = "소유자 주소";
+
+/* Masternodes */
+"Owner key hash" = "소유자 키 해시";
 
 /* Owner keys */
 "Owner keys" = "소유자 키";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "아이덴티티의 크레딧 잔액에서 지불됩니다.";
 
 /* DashSpend */
 "Password" = "비밀번호";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "여기에 링크 붙여넣기";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "받은 초대 링크를 붙여 넣거나 QR 코드를 스캔하세요. 사용자 이름 등록 비용을 충당해 줍니다.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "이미지 URL 붙여넣기";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "사용하기 쉬운 지불 플로우로 즉시 송금하고 송금 받으세요";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "사용자 이름으로 바로 결제";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "주소가 아니라 사람에게 결제하세요";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "사용자 이름으로 지불하세요. 더이상 알파벳과 숫자로 이루어진 주소는 필요하지 않습니다";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "지불 중...";
 
+/* Raw transaction inspector */
+"Payload hex" = "페이로드 16진값";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "지불 방법";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "결제는 비공개입니다. 연락처와 교환하는 주소는 두 사람만 읽을 수 있는 암호화된 페이로드 안에서 오가며 결코 공개되지 않으므로, 결제를 사용자 이름과 쉽게 연결할 수 없습니다. 다만 이는 여전히 투명한 체인상의 일반 결제이므로 정교한 체인 분석으로 정보가 드러날 수 있습니다. Shielded DashPay(곧 제공)가 이 간극을 메울 예정입니다. 연락처 요청 자체는 현재 비공개가 아닙니다. 두 아이덴티티가 연결되어 있다는 사실은 누구나 볼 수 있습니다. 비공개 연락처 요청은 곧 제공될 기능입니다. 사용자 이름과 프로필도 Dash Platform에 공개됩니다.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "InstantSend로 결제가 몇 초 만에 확인됩니다";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "주소로 직접 보낸 결제는 활동에 보관되지 않습니다.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "연락처별 결제가 한곳에 묶여, 원시 거래 대신 이름과 프로필로 표시됩니다.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "지급 주소";
 
 /* CrowdNode */
 "Payout Options" = "지불 옵션";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform 주소";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 잔액";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform 노드";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform 노드 ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform 결제는 발신자를 식별하지 않습니다. 이 결제는 지갑이 잔액 변동을 감지한 시점에 기록되었으며, 실제로는 더 일찍 도착했을 수 있습니다.";
+
+"Platform SDK not ready" = "Platform SDK가 준비되지 않았습니다";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform 동기화가 실행 중이 아닙니다. 동기화 정보 → Platform 동기화 상태를 열어 시작하세요.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → 보호";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "코인베이스에 지불 방법을 추가해주세요";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "초대 미리보기";
 
+/* Masternode keys */
+"Previously used at: " = "이전 사용일: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "마지막 가격 업데이트가 최소 30분을 경과했습니다. 금액이 정확하지 않을 수 있습니다.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "설계부터 비공개";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "비공개 연락처 요청(누구와 연결되어 있는지 비공개로 유지), Shielded DashPay(비공개 보호 잔액에서 연락처에게 결제), 아직 연락처에 없는 사용자에게 결제하기가 모두 곧 제공됩니다.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "비공개 연락처 요청은 개발 중이며 2026년 9~10월경으로 예상됩니다. 현재는 요청 자체가 공개되어 있어, 안에 담긴 결제 정보가 암호화되어 있더라도 두 아이덴티티가 연결되어 있다는 사실은 누구나 볼 수 있습니다. 비공개 연락처 요청이 제공되면 친구 관계를 공개할지 비공개로 할지 선택할 수 있습니다.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "비공개 연락처 요청, Shielded DashPay, 아직 연락처가 아닌 사람에게 결제하기.";
+
 /* No comment provided by engineer. */
 "Private key" = "비밀 키";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "비공개 결제 주소는 회원님과 연락처 사이에서 교환됩니다. 두 사람 사이 결제의 수신자와 발신자는 회원님과 해당 연락처만 알 수 있습니다.";
+
+/* DashPay intro: feature title */
+"Private payments" = "비공개 결제";
+
+/* Usernames */
+"Private registration" = "비공개 등록";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "처리 시간";
+
+/* Balance info sheet section */
+"Pros" = "장점";
 
 /* CrowdNode Portal */
 "Protect your savings" = "계좌 보호하기";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "공급자 주소";
 
+/* Masternodes */
+"Provider transactions" = "제공자 거래";
+
+/* Masternode keys */
+"Public key" = "공개 키";
+
+/* Masternode keys */
+"Public key (legacy)" = "공개 키(레거시)";
+
+/* Identities */
+"Public keys" = "공개 키";
+
 /* No comment provided by engineer. */
 "Public URL" = "공개 URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "매수에 실패하였습니다";
+
+/* Identities: what a public key is used for */
+"Purpose" = "용도";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "요율: %1$@ = %2$@ ";
 
+/* Raw transaction inspector */
+"Raw transaction" = "원시 거래";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "원시 거래를 사용할 수 없습니다";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "선택한 블록 높이부터 이 지갑의 거래를 찾기 위해 컴팩트 블록 필터를 다시 다운로드하고 다시 대조합니다. 재스캔의 하한은 지갑 생성 블록 높이와 로컬에 저장된 체인 데이터입니다. 그보다 이전 내역을 복구하려면 대신 지갑 시작 블록 높이를 낮추세요.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "출금 약관 읽어보기";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "읽기 전용";
+
+/* Usernames */
+"Ready around %@" = "%@경 준비 완료";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "사유";
 
 /* No comment provided by engineer. */
 "Receive" = "받기";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "다음으로부터 수신하였습니다";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "%@ 님에게서 받음";
+
 /* CrowdNode */
 "Receiving rewards" = "보상 받기";
+
+"Records your masternodes as having voted, without taking a side." = "어느 편도 들지 않고, 회원님의 마스터노드가 투표한 것으로 기록합니다.";
 
 /* No comment provided by engineer. */
 "Recover" = "복구";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "복구 문구는 12, 15, 18, 21 및 24 단어를 지녀야 합니다";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "새로 고침";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "등록합니까?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "등록일";
+
+/* No comment provided by engineer. */
 "Registered from" = "다음으로부터 등록되었습니다";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "등록된 마스터노드";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "비공개 등록에는 보호 잔액에 최소 %@ Dash와 몇 시간의 대기가 필요합니다. 다음 화면에서 단계별로 안내합니다.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "등록";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "이 이름을 요청 중";
+
 /* An action */
 "Rescan" = "재스캔";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "복구한 지갑은 작업 유형을 항상 복원하지는 못합니다. 이 항목은 온체인 메모 데이터로부터 재구성되었습니다.";
+
+/* Location Service Status */
 "Restricted" = "제한됨";
 
 /* Usernames */
 "Results" = "결과";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "블록 높이 %u부터 재동기화가 예약되었습니다. 앱을 종료했다가 다시 열면 시작됩니다.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "상호 거래 내역 보관";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "운영 종료";
 
 /* No comment provided by engineer. */
 "Retry" = "재시도";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "아래 포스팅을 확인하시고 이 사용자 이름의 소유 정보를 인증하세요";
+
+/* Masternodes */
+"Revocation" = "폐기";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "스크린샷은 다른 앱이나 기기에서 볼  수 있습니다. 복원 문구를 새로 만들고 비밀로 간직하세요.";
 
+/* Raw transaction inspector */
+"Script" = "스크립트";
+
+/* Raw transaction inspector */
+"Script signature" = "스크립트 서명";
+
+/* Raw transaction inspector */
+"Script type" = "스크립트 유형";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "연락처 검색";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "연락처 요청 검색";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Dash 네트워크에서 사용자 검색";
+
+/* No comment provided by engineer. */
+"Search for a username" = "사용자 이름 검색";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "검색 결과: \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "영역 검색";
+
+"Search usernames" = "사용자 이름 검색";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Dash 네트워크에서 사용자 이름 %@ 검색 중";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "당신의 지갑을 안전하게 지키세요";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "보안 수준";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "보안 수준";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "대시의 매수, 매도, 환전 및 송금을 위한 서비스를 선택하세요";
 
+"Select all" = "전체 선택";
+
 /* DashSpend denomination selection */
 "Select amount" = "금액 선택하기";
+
+"Select at least one masternode to vote with." = "투표에 사용할 마스터노드를 하나 이상 선택하세요.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "코인 선택";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "선택하는 노드가 적을수록 어떤 마스터노드를 운영하는지 덜 드러납니다.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "셀프 계산";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "다음에 전송합니다";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "연락처에게 보내기";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "실제로 기억하고 확인할 수 있는 사용자 이름으로 보내세요.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "주소로 전송합니다";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "첫 연락처 요청 보내기";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "보내는 중";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "연락처 요청 보내는 중";
+
+/* No comment provided by engineer. */
+"Sending to" = "받는 사람";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "크라우드노드 계정에 보내는 중";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "다음에 전송하였습니다";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "%@ 님에게 보냄";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "시퀀스";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "서버 오류 발생. 나중에 다시 시도하세요.";
+
+/* Masternodes */
+"Service" = "서비스";
+
+/* Identities */
+"Set as Main" = "기본으로 설정";
+
+/* Identities */
+"Set as Main Identity" = "기본 아이덴티티로 설정";
 
 /* No comment provided by engineer. */
 "Set PIN" = "PIN 설정";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "키 공유하기";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "공유 프라이버시 풀이 최소 규모에 도달";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "보호 주소";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "보호 지출";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "보호 지갑을 시작하는 중…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "보호 → Platform";
+
+"Shielded → Transparent" = "보호 → 투명";
 
 /* Explore Dash */
 "Show all locations" = "모든 장소 보기";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "크기";
+
 /* No comment provided by engineer. */
 "Skip" = "건너뛰기";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "일부 마스터노드가 이 목록에서 빠져 있을 수 있습니다. 지갑이 투표 키 전체를 읽지 못했습니다. 동기화를 마친 뒤 이 화면을 다시 열어 주세요.";
 
 /* Usernames */
 "Some usernames can be blocked" = "어떤 사용자 이름은 블록될 수 있습니다";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "분류";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "연락처 정렬";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "할인으로 정렬";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "이름으로 정렬";
+
+/* Raw transaction inspector */
+"Special payload" = "특수 페이로드";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "금액 특정하기";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "스테이킹";
 
+/* Usernames */
+"Starts after you add funds" = "자금을 추가하면 시작됩니다";
+
+/* Transaction details */
+"Status" = "상태";
+
 /* Step 1 */
 "Step %ld" = "%ld 단계";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "저장 형태";
 
 /* Voting */
 "Submit" = "제출";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "동기화 중... 결과가 나타나지 않을 수 있습니다.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "동기화 정보";
+
+/* SPV sync */
+"Sync too slow?" = "동기화가 너무 느린가요?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "카메라로 사진찍기";
 
+"Take no side" = "어느 편도 들지 않음";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "클립보드의 주소를 탭하여 붙여넣기";
+
+/* Raw transaction inspector */
+"Tap to copy" = "탭하여 복사";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "잔고를 숨기시려면 탭하세요";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "일시적으로 이용할 수 없음";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash 노드 키 (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "이용 약관";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "테스트넷";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "잘못된 코드입니다. 확인 후 다시 시도해주십시오!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "네트워크가 출금을 처리한 뒤 Dash가 수신자의 주소에 도착합니다. 최대 10분이 걸릴 수 있습니다.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "네트워크가 출금을 처리하면 Dash가 수신자의 주소에 도착합니다.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "네트워크가 출금을 처리하면 Dash가 투명 잔액에 도착합니다.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "일부 사용자 이름이 생성되기 전, 대시 네트워크가 투표를 통해 승인해야 합니다.";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "당신이 전송한 링크는 대시 네트워크 소유자들만 볼 수 있게 됩니다.";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "기본 아이덴티티는 활성 지갑에서만 선택할 수 있습니다";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "송금 가능한 최소 금액은 %@ 입니다";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Dash를 보관하기에 가장 비공개적인 곳";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "저장된 지갑 기록에 네트워크가 없어 재동기화를 예약할 수 없습니다.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "등록은 제출되었지만 결과를 확인할 수 없습니다. 지갑이 동기화되도록 1분 정도 기다린 뒤 다시 시도하세요. 즉시 다시 제출하지 마세요.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "공유 프라이버시 풀이 아직 커지는 중입니다(입금 %1$ld/%2$ld건). 최소 규모에 도달하면 비공개 등록이 열립니다.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "공유 프라이버시 풀이 아직 커지는 중입니다(입금 %1$ld/%2$ld건). 최소 규모에 도달하면 다시 시도하세요.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "사용자 이름 '%@'이 대시 네트워크에 의해 차단되었습니다. 다른 사용자 이름으로 다시 시도해주십시오.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "지갑의 생성 블록 높이입니다. 필터 스캔과 “지갑 생성 시점부터” 재스캔의 하한이 됩니다. 지갑에 처음 입금된 시점이나 그 이하로 설정하세요. 가져오기의 기본값은 메인넷 200000, 테스트넷 0입니다. 현재 값과 같거나 더 낮은 높이를 저장하면 다음 실행 시 이 네트워크의 체인 데이터가 지워지고 그 높이부터 다시 스캔합니다.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "그 사람 (정보 가져오는 중)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "새 알림이 없습니다";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "표시할 거래가 없습니다";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "이름 %@과(와) 일치하는 사용자가 없습니다";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "연락처에 이름 %@과(와) 일치하는 사용자가 없습니다";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Zenledger에 거래 내역을 내보내던 중 에러가 발생하였습니다";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "오류가 발생했습니다, 다시 시도해주십시오";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "이 자금은 Platform 잔액으로 옮겨지며, 전송이 완료되는 즉시 사용할 수 있습니다.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "이 주소는 %@ 잔액으로 결제할 수 없습니다";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "다른 사용자가 회원님에게 연락처 요청을 보낼 수 있고 회원님이 그 요청을 수락할 수 있도록, 아이덴티티에 키 2개를 추가합니다. 이 작업은 한 번만 진행됩니다.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "선택한 %d개의 사용자 이름 전체에 하나의 선택을 적용합니다.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "이 추가적 단계를 통해 거래를 시도하는 것이 본인임을 확인합니다.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "이 초대 링크는 유효하지 않습니다.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "이 네트워크에서 유효한 Dash 주소가 아닙니다";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "유효한 초대 링크가 아닙니다";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "회원님의 기본 아이덴티티입니다";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "이 마스터노드에는 아직 Platform 아이덴티티가 없습니다.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "이 판매자는 현재 이용할 수 없습니다.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "이것은 전체 마스터노드의 현재 연간 수익률에서 15% 크라우드노드 수수료를 뺀 값을 나타냅니다. 이는 보장된 수익률은 아니며, 크라우드노드 풀의 크기와 대시 가격에 따라 증가하거나 감소할 수 있습니다.";
 
+"This still counts as your masternodes having voted in this contest." = "이 경우에도 회원님의 마스터노드가 이 경합에서 투표한 것으로 처리됩니다.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "이 거래의 원시 바이트는 이 기기에 저장되어 있지 않습니다.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "이 사용자 이름은 다른 사람에게 돌아갔습니다";
+
+"This wallet could not derive the voting key for this node." = "이 지갑은 이 노드의 투표 키를 파생할 수 없습니다.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "이 지갑에는 활성 마스터노드 투표 키가 없어 투표할 수 없습니다. 등록된 노드는 도구 → 마스터노드에 표시됩니다.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Platform 잔액 전체를 한 번의 전송으로 출금합니다. 네트워크가 출금을 처리하면 Dash가 수신자의 주소에 도착합니다.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Platform 잔액 전체를 한 번의 전송으로 출금합니다. 네트워크가 출금을 처리하면 Dash가 투명 잔액에 도착합니다.";
 
 /* Send Screen: to address */
 "to" = "다음으로";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "거래 내역";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "거래 내역을 사용할 수 없습니다";
+
 /* No comment provided by engineer. */
 "Transaction id" = "거래 ID";
+
+/* Raw transaction inspector */
+"Transaction ID" = "거래 ID";
 
 /* A verb, button title. */
 "Transfer" = "송금";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "입금 거래";
 
+/* Balance breakdown */
+"Transfer in" = "전송 수신";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "출금 거래";
+
+/* Balance breakdown */
+"Transfer out" = "전송 발신";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "전송에 시간이 더 걸립니다 — 프라이버시 증명을 만드는 데 시간이 필요합니다";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "다른 Platform 주소와 보호 주소로의 전송은 즉시 이루어지며 되돌릴 수 없습니다";
+
+/* Balance breakdown */
+"Transparent" = "투명";
+
+/* Send screen destination type */
+"Transparent address" = "투명 주소";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "투명 잔액";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "투명 자금으로 충당하면 사용자 이름이 그 자금과 공개적으로 연결됩니다.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "투명 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "투명 → 보호";
 
 /* An action */
 "Try again" = "다시 시도하세요";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "추천을 제공할 수 없습니다";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "알 수 없는 잔고";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "알 수 없는 특수 유형 %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "보호되지 않음";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "지원되지 않는 URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "대시페이로 업그레이드하기";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Evolution으로 업그레이드";
+
+/* No comment provided by engineer. */
 "Uphold" = "업홀드";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "대신 투명 잔액 사용";
+
+/* Masternode keys */
+"Used" = "사용됨";
+
+/* Masternode keys */
+"Used at: " = "사용일: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "사용자 (정보 가져오는 중)";
 
 /* Voting */
 "Username" = "사용자 이름";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "사용자 이름이 성공적으로 요청되었습니다";
 
+/* Identities */
+"Usernames" = "사용자 이름";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "사용자 이름은 비슷해 보이는 이름을 막기 위해 정규화된 형태로 저장되므로, 각자가 입력한 것과 다를 수 있습니다.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "주소가 아닌 사용자 이름";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "%@과(와) 일치하며 현재 연락처에 없는 사용자";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "가장 많이 감사되고 검증된 영지식 라이브러리 중 하나(Orchard)를 사용합니다";
+
+/* DashPay Invitations */
+"Valid invitation" = "유효한 초대장";
+
 /* CrowdNode Portal */
 "Validating address…" = "주소 확인중...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "인증이 필요함";
 
+/* Usernames */
+"Verified during registration" = "등록 시 확인됨";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "성공적으로 인증되었습니다";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "당신의 신원을 인증하세요";
 
+/* Raw transaction inspector */
+"Version" = "버전";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "매우 효율적이며 수수료가 낮습니다";
+
 /* adjective, security level */
 "Very High" = "매우 높음";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "이 지갑의 소유 여부를 검증하기 위해 아주 적은 금액의 대시가 크라우드노드에/로부터 전송됩니다.";
+
+/* No comment provided by engineer. */
+"View All" = "전체 보기";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "탐색기에서 보기";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "복구 문구 확인";
 
+/* Raw transaction inspector */
+"View Transaction" = "거래 보기";
+
 /* No comment provided by engineer. */
 "View transaction details" = "거래 세부 내용 확인하기";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "투표";
+
+"Vote cast" = "투표함";
+
 /* Voting */
 "Vote for All" = "모두 투표하기";
 
 /* Voting */
+"Vote on contested usernames" = "경합 중인 사용자 이름에 투표";
+
+"Vote on several" = "여러 건에 투표";
+
+/* Voting */
 "Vote to Approve" = "투표하여 승인하기";
+
+"Vote with" = "투표에 사용할 노드";
+
+"Votes that nobody should receive these usernames." = "아무도 이 사용자 이름을 받지 못하도록 투표합니다.";
 
 /* Voting */
 "Votes: High to low" = "투표: 높음부터 낮음";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "투표 주소";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "투표 주소";
+
+"Voting ended with no winner" = "투표가 승자 없이 종료되었습니다";
+
+"Voting ends" = "투표 종료";
+
 /* Voting */
 "Voting ends in %dd" = "투표가 %d일 후 종료";
+
+"Voting in progress" = "투표 진행 중";
+
+"Voting in progress — lock votes are ahead" = "투표 진행 중 — 잠금 투표가 앞서고 있습니다";
+
+"Voting in progress — you are ahead" = "투표 진행 중 — 회원님이 앞서고 있습니다";
 
 /* Usernames */
 "Voting is only required in some cases" = "투표는 일부 경우에만 필요합니다";
 
+/* Masternodes */
+"Voting key hash" = "투표 키 해시";
+
 /* Voting keys */
 "Voting keys" = "투표 키";
+
+"Voting on this username has closed. The counts below are the last ones read." = "이 사용자 이름에 대한 투표가 마감되었습니다. 아래 집계는 마지막으로 읽어 온 값입니다.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "“%@”에 대한 투표가 이미 마감되었습니다. 새로 고쳐 결과를 확인하세요.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "거래를 완료하기 위해서는 지갑의 동기화가 끝날 때까지 기다려 주십시오";
 
+"Waiting for Dash Platform" = "Dash Platform 대기 중";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "지갑 주소";
+
+/* SPV diagnostics */
+"Wallet birth height" = "지갑 시작 블록 높이";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "지갑 사용 중지됨";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "대시페이에 오신 것을 환영합니다";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains 같은 이름 서비스는 어떤가요?";
+
+/* DashPay FAQ */
+"What does it cost?" = "비용은 얼마인가요?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "DashPay란 무엇인가요?";
+
 /* Usernames */
 "What is username voting?" = "사용자이름 투표란 무엇인가요?";
+
+/* DashPay FAQ */
+"What's coming next?" = "다음에는 무엇이 오나요?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "연락처 요청은 언제 비공개가 되나요?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "사용 장소";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "어디에 사용하나요?";
+
+"Who is requesting this name" = "이 이름을 요청한 사람";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "왜 활성화해야 하나요?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "왜 모든 거래 내역을 보게 되나요?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "출금이 요청됨";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "전체 잔액을 출금합니다";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "모든 Dash 지갑, 거래소, 가맹점에서 사용할 수 있습니다";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "초대를 수락하시겠습니까?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "어제";
+
+"You" = "회원님";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "%@ 님의 연락처 요청을 수락했습니다";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "당신은 \"%@\"를 사용자 이름으로 선택했습니다.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "현재 연락처가 없습니다";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "이 거래를 완료하기 위해 필요한 자금이 충분하지 않습니다";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "코인베이스 인증 제한을 초과하였습니다.";
+
+/* Usernames */
+"You have %@ Dash so far" = "지금까지 %@ Dash가 있습니다";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "당신은 %1$@ 대시를 보유하고 있습니다.\n일부 사용자 이름은 최대 %2$@ 대시가 소요됩니다.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "%@ 님에게 연락처 요청을 보냈습니다";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "대시 지갑에 잔고가 있어야 합니다.";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "이 사용자 이름을 획득했습니다";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "모두 준비되었습니다. 이제 다른 사용자가 회원님에게 연락처 요청을 보낼 수 있고, 회원님도 요청을 보낼 수 있습니다.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "사용자 이름을 등록하면 Dash Platform 아이덴티티가 여기에 표시됩니다.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "귀하의 이메일은 일회용 비밀번호를 전달하기 위해서만 사용됩니다.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "정리된 내역";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "회원님과 다른 사용자 사이의 연락처 요청을 암호화할 수 있도록 아이덴티티에 키 2개가 더 필요합니다. 활성화하면 네트워크 거래 한 번으로 추가됩니다. 이 작업은 한 번만 진행됩니다.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "%@으로부터의 초대장이 이미 사용되었습니다";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "%@으로부터의 초대장이 유효하지 않습니다";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "초대장이 이 사용자 이름의 등록 수수료를 부담합니다.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "당신의 위치는 지도 상 당신이 있는 곳을 표시하고, 선택한 반경 내 ATM의 위치를 나타내며, 검색 결과를 향상시키는데 사용됩니다.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "당신의 위치는 지도상 당신의 장소와 선택된 반경 내 상점의 위치를 표시하는 것 및 검색 결과 향상을 위해 사용됩니다.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Core 블록체인상의 기본 Dash 잔액입니다. 다른 지갑, 거래소, 가맹점과 주고받는 데 사용합니다.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "믹싱한 코인을 Dash 지갑 잔액으로 옮겼습니다.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "믹싱한 코인을 보호 잔액으로 옮겼습니다. 프라이버시를 위해 이 자금을 사용하기 전에 최소 2시간 기다리세요.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "회원님의 Platform 잔액";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "당신이 현재 크라우드노드 계정을 위해 사용하고 있는 주요 대시 주소";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "비공개 잔액입니다. 금액과 주소가 온체인에서 암호화되어 보유액과 내역이 비밀로 유지됩니다.";
+
 /* Usernames */
 "Your request was cancelled" = "당신의 요청이 취소되었습니다";
 
 /* DashSpend */
 "Your session expired" = "세션이 만료되었습니다";
+
+/* Usernames */
+"Your Shielded balance" = "회원님의 보호 잔액";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "보호 잔액이 거의 준비되었습니다. %@경에 비공개로 등록할 수 있습니다.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "보호 잔액이 준비되었습니다. 지금 사용자 이름을 비공개로 등록하세요";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "보호 잔액을 유지하는 중입니다. %@경에 비공개로 등록할 수 있습니다";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "보호 잔액이 아직 성숙 중입니다. %@경에 준비됩니다.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "회원님의 투명 잔액";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "당신의 사용자 이름인 %@가 대시 네트워크에 성공적으로 생성되었습니다";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "당신의 사용자 이름이 성공적으로 생성되었습니다";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "사용자 이름은 모두에게 보입니다. 자금을 몇 시간 둔 뒤 보호 잔액에서 충당하면, 누구도 사용자 이름을 다른 Dash와 연결할 수 없습니다.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "사용자 이름, 프로필, 연락처가 이 아이덴티티를 따릅니다.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "사용자 이름, 프로필, 연락처가 이 아이덴티티를 따르게 됩니다.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "투표가 취소되었습니다";
 
 /* Voting */
 "Your vote was submitted" = "투표가 제출되었습니다";
 
+"Your votes" = "회원님의 투표";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "이제 당신의 지갑은 안전합니다. 언제든 당신의 복원 문구를 사용하셔서 당신의 계정을 다른 기기에서 복원하실 수 있습니다.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "지갑이 아직 Dash 네트워크와 동기화 중입니다. 동기화가 끝나면 보낼 수 있습니다.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "지갑이 아직 동기화 중입니다. 동기화가 끝나면 투명 잔액에서 보낼 수 있습니다.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "Zenledger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@”을(를) Dash 사용자 이름으로 읽을 수 없습니다.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@”이(가) 등록되었습니다. 초대해 준 사람에게 연락처 요청을 보낼까요?";

--- a/DashWallet/ko.lproj/Localizable.stringsdict
+++ b/DashWallet/ko.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d 키</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>“%2$@”에 %#@votes@ 집계됨</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u표</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@ 중 %1$d개에 투표함</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>사용자 이름 %2$d개</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u표 투표하기</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ 중 %1$d개가 투표함</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>마스터노드 %2$d개</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ 중 %1$d개가 투표함</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>노드 %2$d개</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Evonode %d개</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>총 %u표</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>마스터노드 %d개</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d개 선택됨</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>회원님의 노드 중 %d개는 이미 여기에 투표하여 목록에 없습니다.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>경합당 %u표 — Evonode는 4, 마스터노드는 1로 계산됩니다</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>사용자 이름 %d개에 투표</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u표</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>투표 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>요청 %d건</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Сите јазли одеднаш";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Сите ваши мастерноди гласале за ова корисничко име. За да смените глас, гласајте повторно од кандидатот што сега го претпочитате.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Сите ваши мастерноди гласале за ова корисничко име. За да смените глас, гласајте повторно за кандидатот што сега го претпочитате.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " или ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ не е пронајден на Dash мрежата за да му се испрати барање за контакт.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash достапни";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ го прифати вашето барање за контакт";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d бајти";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld од %ld депозити";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Кредитно салдо на Dash Platform што се користи за инстант плаќања меѓу Platform адреси и за функции како корисничките имиња.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "За апликацијата";
 
+/* DashPay FAQ title */
+"About DashPay" = "За DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Воздржи се";
+
+"Abstain on “%@”" = "Воздржи се за „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Активен";
+
+/* No comment provided by engineer. */
+"Activity" = "Активност";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Активноста е јавна, но не е лесно да се следи";
+
 /* No comment provided by engineer. */
 "Add" = "Додај";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Додај го %@ како контакт";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Додајте го %@ како контакт за да плаќате директно на корисничко име и да ја задржите заедничката историја на трансакции";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Додајте %@ Dash во вашето заштитено салдо и оставете го да отстои неколку часа за да се регистрирате без да го поврзете корисничкото име со останатите средства.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Додајте најмалку %@ Dash во вашето заштитено салдо";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Дополнете го заштитеното салдо сега и регистрирајте го корисничкото име приватно за неколку часа";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Сите јазли одеднаш";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Сите ваши мастерноди гласале за ова корисничко име. За да смените глас, гласајте повторно од кандидатот што сега го претпочитате.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Речиси моментална синхронизација на салдата";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Износите и адресите се јавни на блокчејнот";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum сметката е една адреса што се користи повеќекратно: целото ваше салдо и историјата на плаќања стојат јавно под неа, а името (на пример ENS домен) обично покажува право кон таа адреса, па секој може да ја разреши. DashPay е спротивно поставен — името води до идентитет, а не до адреса за плаќање, а вистинските адреси за плаќање остануваат внатре во шифрирани размени со контактите, нови за секој контакт.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Секој што знае адреса може да ја види нејзината историја";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Одобри";
+
+"Approving a specific request can only be done one username at a time." = "Одобрувањето на конкретно барање може да се направи само за едно корисничко име наеднаш.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Како текст";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Автентикацијата е откажана. Вашиот глас не беше даден.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Автентикацијата не успеа. Вашиот глас не беше даден.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Додели „%@“ на овој кандидат";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Салдо потоа";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Салдата и преносите не се јавно видливи";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Почетната височина е зачувана — покачениот праг на скенирање важи од следното стартување.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Врзан за договор";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Врзан за договор, тип на документ „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Само прегледување";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Ги собира најновите дијагностички дневници во zip за да ги испратите преку AirDrop, по е-пошта или да ги зачувате во Датотеки";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Дај глас";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Смени ги врсниците";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Се проверува…";
+
+"Choice" = "Избор";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Преземете ја вашата покана";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Салдо за подигнување";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Исчисти и синхронизирај повторно";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Да се исчистат податоците од синџирот и да се синхронизира повторно?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Се затвора";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (нови монети)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin повеќе не е поддржан — изберете каде да ги преместите вашите измешани монети.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Обезбедување";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Наскоро";
+
+/* Shielded transfer status */
+"Completed" = "Завршен";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Потврдена";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Потврдувањето ја зачувува почетната височина %u и ги чисти податоците од синџирот на оваа мрежа при следното стартување на апликацијата, ги презема повторно и ги прескенира филтрите од таа височина. Тековната сесија го задржува стариот праг на скенирање — затворете и повторно отворете ја апликацијата за да започне.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Поврзани врсници";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Недостатоци";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Барањето за контакт не успеа";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Барањето за контакт е испратено до %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Барања за контакт";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Кандидат %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Продолжете за да го изберете вашето корисничко име. Поканата ја плаќа таксата за регистрација.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Копирај ја суровата трансакција";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Архивата со дневници не можеше да се создаде: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Не можеа да се освежат %d идентитети";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Салдото не можеше да се преземе (мрежна грешка). Обидете се да освежите.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Создајте го вашето корисничко име, најдете пријатели и семејство преку нивните кориснички имиња и додајте ги во контактите";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Кредити";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform сè уште не го индексирал овој спор. Бројот на гласови ќе се појави овде кога тоа ќе се случи.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform сè уште не е поврзан. Почекајте синхронизацијата да заврши и обидете се повторно.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash испратен на погрешна адреса не може да се врати. Уверете се дека адресата е точно онаа на која сакате да платите.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash ги чува корисничките имиња во форма отпорна на слични записи, па зачуваното име може да се разликува од она што го напишал секој човек.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Салдо на Dash паричникот";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay е овозможен";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay е социјалното платежно искуство на Dash, изградено врз Dash Platform. Регистрирате корисничко име, додавате други корисници како контакти и им плаќате по име — нема повеќе копирање адреси.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay ги заменува долгите и нејасни адреси со кориснички имиња. Додајте пријатели како контакти, испраќајте пари на име и држете го секое плаќање уредено по лице.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Рокот е непознат";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Патека на изведување";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Оневозможен";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Готово — вашето салдо отстоја доволно долго";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Проверете ја адресата уште еднаш";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Секој мастернод има еден важечки глас по спор. Може да го смените подоцна, но Dash Platform дозволува вкупно само 5 гласови по мастернод по спор.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Секое допирање додава уште еден јазол во гласањето, па вие бирате колку ќе поврзете заедно.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Уреди ја почетната височина";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Овозможи";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Овозможи DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Овозможувањето на DashPay чини мала еднократна мрежна такса, платена од кредитното салдо на вашиот идентитет. Точната проценка се прикажува пред да потврдите. Испраќањето барања за контакт и плаќања чини вообичаени мрежни такси.";
+
+"Ending soonest" = "Завршува најрано";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Проценета мрежна такса";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Сите јазли гласаат заедно. Побрзо е, но јавно ги поврзува вашите мастерноди меѓусебно.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Оператор клучеви за Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Извези дневници";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Надворешна адреса";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Неуспешно";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Се презема…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Заглавија на филтри";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Најдете корисник на Dash мрежата";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Најди идентитети";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Пронајдени се %d нови идентитети";
+
+/* Identities */
+"Found 1 new identity" = "Пронајден е 1 нов идентитет";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Финансирајте го корисничкото име од заштитеното салдо. Додајте ги средствата неколку часа однапред — краткото отстојување го прави корисничкото име неповрзливо со останатите ваши Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Финансирано од вашето заштитено салдо — вашето корисничко име не може да се поврзе со останатите ваши Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Средствата се заклучени — преносот се завршува";
+
+/* CoinJoin */
+"Funds moved" = "Средствата се преместени";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Подгответе се да се приклучите на DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Разбрав";
+
+/* Governance */
+"Governance" = "Управување";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "побара да ви биде пријател";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Имате покана?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Заглавија";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Височина %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Повисоки такси, околу 7 центи (сепак пониски од други блокчејни со слична приватност)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Како се споредува ова со Bitcoin во однос на приватноста?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Како се споредува ова со Ethereum сметките во однос на приватноста?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Колку е приватен DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Идентитети";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Кредити на идентитетот";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Индекс на идентитетот";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Регистрација на идентитет";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Дополнување на идентитетот";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Неактивен";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Влез %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Влез %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Влезови (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Покана од %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Поканете некого да се приклучи на Dash мрежата";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Поканете ги пријателите и семејството на Dash мрежата";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Задржи ги овие монети приватни. Се применуваат мрежни такси и такси за приватност.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Клуч бр. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Податоци на клучот";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Сопственост на клучот";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Клучеви";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Води";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Дознајте повеќе";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Се вчитуваат трансакции";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Само локално";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Заклучи";
+
+"Lock the name" = "Заклучи го името";
+
+"Lock “%@” so nobody gets it" = "Заклучи „%@“ за да не го добие никој";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Заклучено — никој не го добива ова корисничко име";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Ниски такси за секојдневно трошење";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Главен";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Приврзок за клучеви на мастернод";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Список на мастерноди";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Гласови на мастерноди";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Мастерноди";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Мастернодите и evonode регистрирани со клучевите на овој паричник ќе се појават овде откако паричникот ќе се синхронизира.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Мастерноди и evonode што ги користат клучевите на овој паричник";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Мастернодите гласаат за имиња што ги побарале повеќе од едно лице. Ќе бидете известени кога гласањето ќе заврши.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Минимумот е достигнат";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Повеќе предлози";
+
+"Most lock votes" = "Најмногу гласови за заклучување";
+
+"Most votes" = "Најмногу гласови";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Премести во твоето вообичаено расположливо салдо.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Се преместуваат средства";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Услугите за имиња како Unstoppable Domains поврзуваат читливо име со фиксна јавна адреса на синџирот. Секој може да го разреши името и да го види секое плаќање што било некогаш направено кон него. Корисничкото име на DashPay никогаш не се разрешува јавно до адреса за плаќање — адресите се откриваат само внатре во шифрираната размена со секој контакт, па вашето име и вашите пари остануваат неповрзани за надворешните набљудувачи.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Бара внимание";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "На овој уред не се пронајдени дијагностички дневници. Дневниците се запишуваат од следното стартување натаму.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Нема идентитети";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Сè уште нема мастерноди";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Нема соодветни спорови";
+
+/* Identities */
+"No new identities were found for this wallet" = "Не се пронајдени нови идентитети за овој паричник";
+
+"No open contest matches that search." = "Ниту еден отворен спор не одговара на тоа пребарување.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ниту еден отворен спор не одговара на тоа пребарување. Имињата се чуваат во нормализирана форма, па „alice“ се наведува како „a11ce“.";
+
+"No open contests" = "Нема отворени спорови";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Не е пронајден зачуван запис за поврзаниот паричник.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Сè уште нема достапна Platform адреса за резервната заштитена регистрација. Обидете се повторно откако паричникот ќе заврши со синхронизација.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Моментално ниту едно корисничко име не е спорно. Спор се отвора кога двајца или повеќе луѓе бараат исто име.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Не беа дадени гласови";
+
+"Nobody gets it" = "Никој не го добива";
+
+/* SPV sync peer type */
+"Node" = "Јазол";
+
+/* Raw transaction inspector */
+"Non-standard" = "Нестандарден";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Сè уште не е достапно";
+
+"Not cast" = "Не е даден";
+
+/* Masternodes */
+"Not checked yet" = "Сè уште не е проверено";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Нема доволно заштитено салдо за регистрација на идентитет";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Не е во историјата на паричникот";
+
+"Not now" = "Не сега";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Не е широко прифатен кај трговците";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Сè уште не е широко прифатен кај трговците";
+
+/* Masternode keys */
+"Not yet used" = "Сè уште не е користен";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "На Bitcoin нема слој со имиња, па луѓето отворено споделуваат и повторно користат адреси — штом адресата стане позната, сè што некогаш примила може да се поврзе со нејзиниот сопственик. Со DashPay вашето корисничко име е јавно, но никогаш не покажува кон адреса за плаќање: адресите се разменуваат приватно со секој контакт и се менуваат, па плаќањето по име не објавува каде одат вашите пари. Двата се транспарентни синџири, па анализата на синџирот сè уште важи за самите монети.";
+
+/* Identities */
+"On Network" = "На мрежата";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Штом %@ ќе го прифати вашето барање, ќе можете да плаќате директно на корисничко име";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Еден по еден јазол";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Само мастерноди и evonode можат да гласаат за кориснички имиња. Овој паричник нема активни клучеви за гласање на мастерноди.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Оператор";
+
+/* Masternode keys */
+"Operator keys" = "Оператор клучеви";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Јавен клуч на операторот (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "или";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Други исходи";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Излез %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Излези (%d)";
+
+/* Masternodes */
+"Owner" = "Сопственик";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Адреса на сопственикот";
+
+/* Masternodes */
+"Owner key hash" = "Хеш на клучот на сопственикот";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Платено од кредитното салдо на вашиот идентитет.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Залепете ја врската за покана што ја добивте или скенирајте го нејзиниот QR код. Таа ја финансира регистрацијата на вашето корисничко име.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "плаќате директно на корисничко име";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Плаќајте на луѓе, а не на адреси";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Корисен товар (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Плаќањата се приватни: адресите што ги разменувате со контакт патуваат внатре во шифрирана содржина што само вие двајцата можете да ја прочитате и никогаш не се објавуваат — па вашите плаќања не може лесно да се поврзат со вашето корисничко име. Сепак, тие остануваат обични плаќања на транспарентен синџир: софистицирана анализа на синџирот може да протече информации. Shielded DashPay (наскоро) ќе го затвори тој јаз. Самите барања за контакт моментално НЕ се приватни: секој може да види дека два идентитета се поврзани. Приватните барања за контакт се функција што доаѓа наскоро. Вашето корисничко име и профилот се исто така јавни на Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Плаќањата се потврдуваат за секунди со InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Плаќањата направени директно на адреси нема да се чуваат во активноста.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Плаќањата со секој контакт се групирани на едно место, со имиња и профили наместо сурови трансакции.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Адреса за исплата";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform адреса";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform салдо";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform јазол";
+
+/* Masternode keys */
+"Platform Node ID" = "ID на Platform јазолот";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform плаќањата не го идентификуваат испраќачот. Ова плаќање беше запишано кога паричникот ја забележа промената на салдото — можеби пристигнало порано.";
+
+"Platform SDK not ready" = "Platform SDK не е спремен";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform синхронизацијата не е активна. Отворете Информации за синхронизација → Статус на Platform синхронизацијата за да ја стартувате.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Заштитено";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Претходно користен на: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Приватен по дизајн";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Приватните барања за контакт (за да остане приватно со кого се поврзувате), Shielded DashPay — плаќања кон контакти од вашето приватно заштитено салдо — и плаќањата кон корисници што сè уште не се во вашите контакти, доаѓаат наскоро.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Приватните барања за контакт се во развој и се очекуваат околу септември–октомври 2026. Денес самото барање е јавно — секој може да види дека два идентитета се поврзани, дури и ако податоците за плаќање во него се шифрирани. Кога ќе излезат приватните барања за контакт, ќе можете да изберете дали вашето пријателство ќе биде јавно или приватно.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Приватни барања за контакт, Shielded DashPay и плаќање на луѓе што сè уште не се контакти.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Приватните адреси за плаќање се разменуваат меѓу вас и вашите контакти. Само вие и вашиот контакт знаете кој е примачот и испраќачот на плаќањата меѓу вас.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Приватни плаќања";
+
+/* Usernames */
+"Private registration" = "Приватна регистрација";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Време на обработка";
+
+/* Balance info sheet section */
+"Pros" = "Предности";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Трансакции на провајдерот";
+
+/* Masternode keys */
+"Public key" = "Јавен клуч";
+
+/* Masternode keys */
+"Public key (legacy)" = "Јавен клуч (стар)";
+
+/* Identities */
+"Public keys" = "Јавни клучеви";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Намена";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Сурова трансакција";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Суровата трансакција не е достапна";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ги проверува повторно компактните блок филтри од избраната височина за трансакции на овој паричник, преземајќи ги и споредувајќи ги одново. Повторните скенирања се ограничени оддолу со височината на создавање на паричникот и со локално зачуваните податоци од синџирот — за да вратите постара историја, наместо тоа намалете ја почетната височина на паричникот.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Само за читање";
+
+/* Usernames */
+"Ready around %@" = "Спремно околу %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Причина";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Примено од %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Ги запишува вашите мастерноди како да гласале, без да застанат на ничија страна.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Освежи";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Регистриран на";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Приватната регистрација бара најмалку %@ Dash во вашето заштитено салдо плус неколку часа отстојување — следните екрани ќе ве водат низ процесот.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Регистрација";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Го бара ова име";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Обновените паричници не можат секогаш да го вратат типот на операцијата. Овој запис е реконструиран од податоците на белешката на синџирот.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Повторната синхронизација е подготвена од височина %u — затворете и повторно отворете ја апликацијата за да започне.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "ја задржите заедничката историја на трансакции";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Повлечен";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Отповикување";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Скрипта";
+
+/* Raw transaction inspector */
+"Script signature" = "Потпис на скриптата";
+
+/* Raw transaction inspector */
+"Script type" = "Тип на скрипта";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Барај контакт";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Барај барање за контакт";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Барај корисник на Dash мрежата";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Барај корисничко име";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Резултати од пребарувањето за \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Барај кориснички имиња";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Се бара корисничкото име %@ на Dash мрежата";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Ниво на безбедност";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Избери ги сите";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Изберете барем еден мастернод со кој ќе гласате.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Избирањето помалку јазли открива помалку за тоа кои мастерноди ги водите.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Испрати на контакт";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Испратете на корисничко име што навистина можете да го запомните и да го проверите.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Испратете го вашето прво барање за контакт";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Се испраќа барање за контакт";
+
+/* No comment provided by engineer. */
+"Sending to" = "Се испраќа на";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Испратено до %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Услуга";
+
+/* Identities */
+"Set as Main" = "Постави како главен";
+
+/* Identities */
+"Set as Main Identity" = "Постави како главен идентитет";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Заедничкиот базен за приватност е на минимална големина";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Заштитена адреса";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Заштитено трошење";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Се стартува заштитениот паричник…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Заштитено → Platform";
+
+"Shielded → Transparent" = "Заштитено → Транспарентно";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Големина";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Некои од вашите мастерноди можеби недостасуваат од овој список — паричникот не можеше да го прочита целиот ваш сет клучеви за гласање. Завршете ја синхронизацијата и повторно отворете го овој екран.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Подреди ги контактите";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Специјален корисен товар";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Започнува откако ќе додадете средства";
+
+/* Transaction details */
+"Status" = "Статус";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Зачувано како";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Информации за синхронизација";
+
+/* SPV sync */
+"Sync too slow?" = "Синхронизацијата е премногу бавна?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Не застанувај на ничија страна";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Допрете за копирање";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Клуч за Tenderdash јазол (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash стигнува на адресата на примачот откако мрежата ќе го обработи повлекувањето — тоа може да потрае до 10 минути.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash стигнува на адресата на примачот штом мрежата го обработи повлекувањето.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash стигнува во вашето транспарентно салдо штом мрежата го обработи повлекувањето.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Главниот идентитет може да се избере само од активниот паричник";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Најприватното место за чување на вашите Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Зачуваниот запис на паричникот нема мрежа — не може да се подготви повторна синхронизација.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Регистрацијата е поднесена, но нејзиниот резултат не можеше да се потврди. Почекајте една минута паричникот да се синхронизира, па обидете се повторно — не поднесувајте веднаш повторно.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Заедничкиот базен за приватност сè уште расте (%1$ld од %2$ld депозити). Приватната регистрација се отклучува кога ќе го достигне минимумот.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Заедничкиот базен за приватност сè уште расте (%1$ld од %2$ld депозити). Обидете се повторно кога ќе го достигне минимумот.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Височината на создавање на паричникот — долната граница за скенирањата на филтри и за повторните скенирања „Од создавањето на паричникот“. Поставете ја на нивото на првото полнење на паричникот или под него; увозите стандардно користат 200000 на mainnet и 0 на testnet. Зачувувањето височина еднаква на тековната или пониска ги чисти податоците од синџирот на оваа мрежа при следното стартување и скенира одново од неа.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "него (се преземаат информации)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Нема нови известувања";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Нема корисници што одговараат на името %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Во вашите контакти нема корисници што одговараат на името %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Овие средства преминуваат во вашето Platform салдо и се спремни за трошење штом преносот заврши.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Оваа адреса не може да се плати од вашето салдо %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ова додава два клуча на вашиот идентитет за да можат други корисници да ви испраќаат барања за контакт и за да можете вие да ги прифаќате нивните. Ова се случува само еднаш.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ова применува еден избор на сите %d избрани кориснички имиња.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Оваа врска за покана не е важечка.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ова не е важечка Dash адреса за оваа мрежа";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ова не е важечка врска за покана";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ова е вашиот главен идентитет";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Овој мастернод сè уште нема Platform идентитет.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Ова сепак се смета дека вашите мастерноди гласале во овој спор.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Суровите бајти на оваа трансакција не се зачувани на овој уред.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ова корисничко име отиде кај некој друг";
+
+"This wallet could not derive the voting key for this node." = "Овој паричник не можеше да го изведе клучот за гласање за овој јазол.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Овој паричник нема активни клучеви за гласање на мастерноди, па не може да гласа. Регистрираните јазли се прикажуваат во Алатки → Мастерноди.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ова го повлекува целото ваше Platform салдо во еден пренос. Dash стигнува на адресата на примачот штом мрежата го обработи повлекувањето.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ова го повлекува целото ваше Platform салдо во еден пренос. Dash стигнува во вашето транспарентно салдо штом мрежата го обработи повлекувањето.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Историјата на трансакции не е достапна";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID на трансакцијата";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Влезен пренос";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Излезен пренос";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Преносите траат подолго — градењето докази за приватност бара време";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Преносите кон други Platform адреси и кон заштитени адреси се моментални и конечни";
+
+/* Balance breakdown */
+"Transparent" = "Транспарентно";
+
+/* Send screen destination type */
+"Transparent address" = "Транспарентна адреса";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Транспарентно салдо";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Транспарентното финансирање јавно го поврзува вашето корисничко име со овие средства.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Транспарентно → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Транспарентно → Заштитено";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Не може да се дадат предлози";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Непознат специјален тип %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Незаштитено";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Надгради на Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Наместо тоа користи транспарентно салдо";
+
+/* Masternode keys */
+"Used" = "Користен";
+
+/* Masternode keys */
+"Used at: " = "Користен на: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Корисник (се преземаат информации)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Кориснички имиња";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Корисничките имиња се чуваат во нормализирана форма за да се спречат слични имиња, па ова може да се разликува од она што го напишал секој човек.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Кориснички имиња, а не адреси";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Корисници што одговараат на %@ и што моментално не се во вашите контакти";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Користи една од најревидираните и најтестираните библиотеки со нулто знаење (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Важечка покана";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Потврдено при регистрацијата";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Верзија";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Многу ефикасно со ниски такси";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Прикажи ги сите";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Прикажи ја трансакцијата";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Гласај";
+
+"Vote cast" = "Гласот е даден";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Гласајте за спорни кориснички имиња";
+
+"Vote on several" = "Гласај за повеќе";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Гласај со";
+
+"Votes that nobody should receive these usernames." = "Гласа никој да не ги добие овие кориснички имиња.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Адреса за гласање";
+
+"Voting ended with no winner" = "Гласањето заврши без победник";
+
+"Voting ends" = "Гласањето завршува";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Гласањето е во тек";
+
+"Voting in progress — lock votes are ahead" = "Гласањето е во тек — гласовите за заклучување водат";
+
+"Voting in progress — you are ahead" = "Гласањето е во тек — вие водите";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Хеш на клучот за гласање";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Гласањето за ова корисничко име е затворено. Броевите подолу се последните прочитани.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Гласањето за „%@“ веќе е затворено. Освежете за да го видите резултатот.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Се чека Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Почетна височина на паричникот";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Што е со Unstoppable Domains и слични услуги за имиња?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Колку чини?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Што е DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Што следува?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Кога барањата за контакт ќе станат приватни?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Кој го бара ова име";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Зошто треба да го овозможам?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Го повлекува целото салдо";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Работи со секој Dash паричник, берза и трговец";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Вие";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Го прифативте барањето за контакт од %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Моментално немате ниту еден контакт";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Досега имате %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Го испративте барањето за контакт до %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Го освоивте ова корисничко име";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Сè е спремно. Другите корисници сега можат да ви испраќаат барања за контакт — а вие можете да ги испраќате вашите.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Вашиот Dash Platform идентитет ќе се појави овде откако ќе регистрирате корисничко име.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Вашата историја, средена";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "На вашиот идентитет му се потребни два дополнителни клуча за да можат барањата за контакт да се шифрираат меѓу вас и другите корисници. Овозможувањето ги додава со една единствена мрежна трансакција. Ова се случува само еднаш.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Вашата покана ја плаќа таксата за регистрација на ова корисничко име.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Вашето главно Dash салдо на Core блокчејнот — она што го испраќате и примате со други паричници, берзи и трговци.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Вашите измешани монети се преместени во салдото на вашиот Dash паричник.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Вашите измешани монети се преместени во вашето заштитено салдо. За најдобра приватност, почекајте најмалку 2 часа пред да ги користите овие средства.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Вашето Platform салдо";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Вашето приватно салдо. Износите и адресите се шифрирани на синџирот, па вашите средства и историја остануваат доверливи.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Вашето заштитено салдо";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Вашето заштитено салдо е речиси спремно — ќе можете приватно да се регистрирате околу %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Вашето заштитено салдо е спремно — регистрирајте го вашето корисничко име приватно сега";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Вашето заштитено салдо отстојува — ќе можете приватно да се регистрирате околу %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Вашето заштитено салдо сè уште созрева. Ќе биде спремно околу %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Вашето транспарентно салдо";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Вашето корисничко име го гледаат сите. Ако го финансирате од заштитеното салдо — откако средствата ќе отстојат неколку часа — никој нема да може да го поврзе вашето корисничко име со останатите ваши Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Вашето корисничко име, профил и контакти го следат овој идентитет.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Вашето корисничко име, профил и контакти ќе го следат овој идентитет.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Вашите гласови";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Вашиот паричник сè уште се синхронизира со Dash мрежата. Испраќањето ќе биде достапно откако синхронизацијата ќе заврши.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Вашиот паричник сè уште се синхронизира. Испраќањето од транспарентното салдо ќе биде достапно откако синхронизацијата ќе заврши.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ не можеше да се прочита како Dash корисничко име.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ е регистрирано. Да се испрати барање за контакт до лицето што ве покани?";

--- a/DashWallet/mk.lproj/Localizable.stringsdict
+++ b/DashWallet/mk.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ избројани за „%2$@“</string>
+		<string>%#@votes@ за „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u глас</string>
+			<string>%1$u избројан глас</string>
 			<key>other</key>
-			<string>%1$u гласови</string>
+			<string>%1$u избројани гласови</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d од %#@nodes@ гласаа</string>
+		<string>Гласање: %1$d од %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d од %#@nodes@ гласаа</string>
+		<string>Гласање: %1$d од %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/mk.lproj/Localizable.stringsdict
+++ b/DashWallet/mk.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ избројани за „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u глас</string>
+			<key>other</key>
+			<string>%1$u гласови</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Гласано за %1$d од %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d корисничко име</string>
+			<key>other</key>
+			<string>%2$d кориснички имиња</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Дај %u глас</string>
+			<key>other</key>
+			<string>Дај %u гласови</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d од %#@nodes@ гласаа</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d мастернод</string>
+			<key>other</key>
+			<string>%2$d мастерноди</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d од %#@nodes@ гласаа</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d јазол</string>
+			<key>other</key>
+			<string>%2$d јазли</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>вкупно %u глас</string>
+			<key>other</key>
+			<string>вкупно %u гласови</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d мастернод</string>
+			<key>other</key>
+			<string>%d мастерноди</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d избран</string>
+			<key>other</key>
+			<string>%d избрани</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d од вашите јазли веќе гласаше овде и не е на списокот.</string>
+			<key>other</key>
+			<string>%d од вашите јазли веќе гласаа овде и не се на списокот.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u глас по спор — evonode се сметаат за 4, мастернодите за 1</string>
+			<key>other</key>
+			<string>%u гласови по спор — evonode се сметаат за 4, мастернодите за 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Гласајте за %d корисничко име</string>
+			<key>other</key>
+			<string>Гласајте за %d кориснички имиња</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u глас</string>
+			<key>other</key>
+			<string>%u гласови</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Глас ×%d</string>
+			<key>other</key>
+			<string>Глас ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d барање</string>
+			<key>other</key>
+			<string>%d барања</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Semua nod sekaligus";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode anda telah mengundi nama pengguna ini. Untuk mengubah undi, undi semula daripada pemohon yang kini anda pilih.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode anda telah mengundi nama pengguna ini. Untuk mengubah undi, undi semula untuk pemohon yang kini anda pilih.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " atau ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ tidak dapat ditemui pada rangkaian Dash untuk menghantar permintaan kenalan.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash tersedia";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ telah menerima permintaan kenalan anda";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bait";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duff";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld daripada %ld deposit";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Baki kredit pada Dash Platform yang digunakan untuk pembayaran serta-merta antara alamat Platform dan untuk ciri seperti nama pengguna.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "About";
 
+/* DashPay FAQ title */
+"About DashPay" = "Perihal DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Berkecuali";
+
+"Abstain on “%@”" = "Berkecuali pada “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktif";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktiviti";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktiviti adalah awam tetapi tidak mudah dijejaki";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Tambah %@ sebagai kenalan";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Tambah %@ sebagai kenalan untuk membayar terus kepada nama pengguna dan menyimpan sejarah transaksi bersama";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Tambah %@ Dash ke baki terlindung anda dan biarkan ia berehat beberapa jam supaya pendaftaran tidak mengaitkan nama pengguna anda dengan dana anda yang lain.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Tambah sekurang-kurangnya %@ Dash ke baki terlindung anda";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Tambah dana ke baki terlindung sekarang dan daftarkan nama pengguna anda secara peribadi beberapa jam kemudian";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Semua nod sekaligus";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Semua masternode anda telah mengundi nama pengguna ini. Untuk mengubah undi, undi semula daripada pemohon yang kini anda pilih.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Penyegerakan baki hampir serta-merta";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Jumlah dan alamat adalah awam pada blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Akaun Ethereum ialah satu alamat yang digunakan berulang kali: keseluruhan baki dan sejarah pembayaran anda berada secara awam di bawahnya, dan satu nama (contohnya domain ENS) biasanya menunjuk terus kepada alamat itu supaya sesiapa sahaja boleh menyelesaikannya. DashPay sebaliknya — nama menyelesaikan kepada identiti, bukan alamat pembayaran, dan alamat pembayaran sebenar kekal di dalam pertukaran kenalan tersulit, baharu bagi setiap kenalan.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Sesiapa yang mengetahui sesuatu alamat boleh melihat sejarahnya";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Luluskan";
+
+"Approving a specific request can only be done one username at a time." = "Meluluskan permohonan tertentu hanya boleh dilakukan bagi satu nama pengguna pada satu masa.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Sebagai teks";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Pengesahan dibatalkan. Undi anda tidak dibuang.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Pengesahan gagal. Undi anda tidak dibuang.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Berikan “%@” kepada pemohon ini";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Baki selepas itu";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Baki dan pemindahan tidak kelihatan secara awam";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Ketinggian mula disimpan — had bawah imbasan yang dinaikkan berkuat kuasa mulai pelancaran seterusnya.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Terikat kepada kontrak";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Terikat kepada kontrak, jenis dokumen “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Melayari sahaja";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Mengumpulkan log diagnostik terkini ke dalam fail zip untuk dihantar melalui AirDrop, e-mel atau disimpan ke Fail";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Buang undi";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Tukar rakan";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Memeriksa…";
+
+"Choice" = "Pilihan";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Tebus jemputan anda";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Baki boleh dituntut";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Kosongkan & segerak semula";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Kosongkan data rantaian dan segerak semula?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Ditutup";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (syiling baharu)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin tidak lagi disokong — pilih ke mana syiling campuran anda hendak dipindahkan.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Cagaran";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Akan datang";
+
+/* Shielded transfer status */
+"Completed" = "Selesai";
 
 /* No comment provided by engineer. */
 "Confirm" = "Terima";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Disahkan";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Mengesahkan akan menyimpan ketinggian mula %u dan mengosongkan data rantaian rangkaian ini pada pelancaran aplikasi seterusnya, memuat turunnya semula dan mengimbas semula penapis dari ketinggian tersebut. Sesi yang sedang berjalan mengekalkan had bawah imbasan lamanya — tutup dan buka semula aplikasi untuk bermula.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Rakan yang disambungkan";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Kelemahan";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Permintaan kenalan gagal";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Permintaan kenalan dihantar kepada %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Permintaan Kenalan";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Pemohon %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Teruskan untuk memilih nama pengguna anda. Jemputan membayar yuran pendaftaran.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Salin transaksi mentah";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Tidak dapat mencipta arkib log: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Tidak dapat menyegar semula %d identiti";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Tidak dapat mendapatkan baki (ralat rangkaian). Cuba segar semula.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Cipta Nama Pengguna anda, cari rakan & keluarga melalui nama pengguna mereka dan tambahkan mereka ke dalam kenalan anda";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kredit";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform belum mengindeks pertandingan ini. Kiraan undi akan muncul di sini setelah ia berbuat demikian.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform belum bersambung. Tunggu penyegerakan selesai dan cuba lagi.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash yang dihantar ke alamat yang salah tidak boleh dipulihkan. Pastikan alamat itu tepat seperti yang anda ingin bayar.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash menyimpan nama pengguna dalam bentuk kalis keserupaan, jadi nama tersimpan mungkin berbeza daripada apa yang ditaip oleh setiap orang.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Baki Dompet Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay didayakan";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay ialah pengalaman pembayaran sosial Dash, dibina di atas Dash Platform. Anda mendaftarkan nama pengguna, menambah pengguna lain sebagai kenalan dan membayar mereka melalui nama — tiada lagi menyalin alamat.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay menggantikan alamat panjang yang sukar difahami dengan nama pengguna. Tambah rakan sebagai kenalan, hantar wang kepada satu nama dan kekalkan setiap pembayaran tersusun mengikut orang.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Tarikh akhir tidak diketahui";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Laluan terbitan";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Dilumpuhkan";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Selesai — baki anda telah berehat cukup lama";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Semak semula alamat itu";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Setiap masternode mempunyai satu undi sah bagi setiap pertandingan. Anda boleh mengubahnya kemudian, tetapi Dash Platform hanya membenarkan 5 undi kesemuanya bagi setiap masternode bagi setiap pertandingan.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Setiap ketikan mengundi dengan satu nod tambahan, jadi anda memilih berapa banyak yang dikaitkan bersama.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Edit ketinggian mula";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Dayakan";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Dayakan DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Mendayakan DashPay memerlukan yuran rangkaian kecil sekali sahaja, dibayar daripada baki kredit identiti anda. Anggaran tepat dipaparkan sebelum anda mengesahkan. Menghantar permintaan kenalan dan pembayaran dikenakan yuran rangkaian biasa.";
+
+"Ending soonest" = "Tamat paling awal";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Anggaran yuran rangkaian";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Setiap nod mengundi bersama. Lebih pantas, tetapi ia mengaitkan masternode anda antara satu sama lain secara awam.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Kunci pengendali Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Eksport Log";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Alamat luaran";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Gagal";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Mendapatkan…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Pengepala penapis";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Cari pengguna pada Rangkaian Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Cari identiti";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "%d identiti baharu ditemui";
+
+/* Identities */
+"Found 1 new identity" = "1 identiti baharu ditemui";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Biayai nama pengguna anda daripada baki terlindung. Tambah dana beberapa jam lebih awal — rehat singkat itu menjadikan nama pengguna anda tidak boleh dikaitkan dengan Dash anda yang lain.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Dibiayai daripada baki terlindung anda — nama pengguna anda tidak boleh dikaitkan dengan Dash anda yang lain.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Dana dikunci — pemindahan sedang diselesaikan";
+
+/* CoinJoin */
+"Funds moved" = "Dana dipindahkan";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Bersedia untuk menyertai DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Faham";
+
+/* Governance */
+"Governance" = "Tadbir Urus";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "telah meminta untuk menjadi rakan anda";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Ada jemputan?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Pengepala";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Ketinggian %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Yuran lebih tinggi sekitar 7 sen (masih lebih rendah daripada blockchain lain yang menawarkan privasi setara)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Bagaimana ini dibandingkan dengan Bitcoin dari segi privasi?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Bagaimana ini dibandingkan dengan akaun Ethereum dari segi privasi?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Sejauh mana DashPay bersifat peribadi?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Saya telah menulisnya";
 
+/* Identities */
+"Identities" = "Identiti";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kredit identiti";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identiti";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Pendaftaran identiti";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Tambah nilai identiti";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Tidak aktif";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Input %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Input %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Input (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Jemputan daripada %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Jemput Seseorang menyertai Rangkaian Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Jemput rakan dan keluarga anda ke Rangkaian Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Kekalkan syiling ini peribadi. Yuran rangkaian dan privasi dikenakan.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Kunci #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Data kunci";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Pemilikan kunci";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Kunci";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Mendahului";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Ketahui Lagi";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Memuatkan transaksi";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Setempat Sahaja";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Kunci";
+
+"Lock the name" = "Kunci nama itu";
+
+"Lock “%@” so nobody gets it" = "Kunci “%@” supaya tiada sesiapa mendapatnya";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Dikunci — tiada sesiapa menerima nama pengguna ini";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Yuran rendah untuk perbelanjaan harian";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Utama";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Rantai Kunci Masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Senarai masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Undi masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode dan evonode yang didaftarkan dengan kunci dompet ini akan muncul di sini selepas dompet disegerakkan.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode dan evonode yang menggunakan kunci dompet ini";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode mengundi nama yang dimohon oleh lebih daripada seorang. Anda akan dimaklumkan apabila pengundian tamat.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum dicapai";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Lagi Cadangan";
+
+"Most lock votes" = "Undi kunci terbanyak";
+
+"Most votes" = "Undi terbanyak";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Pindahkan ke baki boleh belanja biasa anda.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Memindahkan dana";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Perkhidmatan nama seperti Unstoppable Domains memetakan nama yang boleh dibaca kepada satu alamat awam tetap pada rantaian. Sesiapa sahaja boleh menyelesaikan nama itu dan melihat setiap pembayaran yang pernah dibuat kepadanya. Nama pengguna DashPay tidak pernah menyelesaikan secara awam kepada alamat pembayaran — alamat hanya didedahkan di dalam pertukaran tersulit dengan setiap kenalan, jadi nama dan wang anda kekal tidak berkait bagi pemerhati luar.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Perlukan perhatian";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Tiada log diagnostik ditemui pada peranti ini. Log ditulis mulai pelancaran seterusnya.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Tiada Identiti";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Belum ada masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Tiada pertandingan yang sepadan";
+
+/* Identities */
+"No new identities were found for this wallet" = "Tiada identiti baharu ditemui untuk dompet ini";
+
+"No open contest matches that search." = "Tiada pertandingan terbuka sepadan dengan carian itu.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Tiada pertandingan terbuka sepadan dengan carian itu. Nama disimpan dalam bentuk ternormal, jadi “alice” disenaraikan sebagai “a11ce”.";
+
+"No open contests" = "Tiada pertandingan terbuka";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Tiada baris dompet tersimpan ditemui bagi dompet yang terikat.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Belum ada alamat Platform tersedia untuk pendaftaran terlindung sandaran. Cuba lagi selepas dompet selesai disegerakkan.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Tiada nama pengguna sedang dipertandingkan sekarang. Pertandingan dibuka apabila dua orang atau lebih memohon nama yang sama.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Tiada undi dibuang";
+
+"Nobody gets it" = "Tiada sesiapa mendapatnya";
+
+/* SPV sync peer type */
+"Node" = "Nod";
+
+/* Raw transaction inspector */
+"Non-standard" = "Bukan standard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Belum tersedia";
+
+"Not cast" = "Tidak dibuang";
+
+/* Masternodes */
+"Not checked yet" = "Belum diperiksa";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Baki terlindung tidak mencukupi untuk mendaftarkan identiti";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Tiada dalam sejarah dompet";
+
+"Not now" = "Bukan sekarang";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Tidak diterima secara meluas oleh peniaga";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Belum diterima secara meluas oleh peniaga";
+
+/* Masternode keys */
+"Not yet used" = "Belum digunakan";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Pada Bitcoin tiada lapisan nama, jadi orang berkongsi dan menggunakan semula alamat secara terbuka — sebaik sahaja sesuatu alamat diketahui, segala yang pernah diterimanya boleh dikaitkan dengan pemiliknya. Dengan DashPay, nama pengguna anda adalah awam tetapi tidak pernah menunjuk kepada alamat pembayaran: alamat ditukar secara peribadi bagi setiap kenalan dan sentiasa berganti, jadi membayar melalui nama tidak mendedahkan ke mana wang anda pergi. Kedua-duanya rantaian telus, jadi analisis rantaian masih terpakai kepada syiling itu sendiri.";
+
+/* Identities */
+"On Network" = "Pada Rangkaian";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Sebaik sahaja %@ menerima permintaan anda, anda boleh membayar terus kepada nama pengguna";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Satu nod pada satu masa";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Hanya masternode dan evonode boleh mengundi nama pengguna. Dompet ini tiada kunci pengundian masternode yang aktif.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Pengendali";
+
+/* Masternode keys */
+"Operator keys" = "Kunci pengendali";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Kunci awam pengendali (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "atau";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Hasil lain";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Output %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Output (%d)";
+
+/* Masternodes */
+"Owner" = "Pemilik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Alamat pemilik";
+
+/* Masternodes */
+"Owner key hash" = "Cincangan kunci pemilik";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Dibayar daripada baki kredit identiti anda.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Tampalkan pautan jemputan yang anda terima, atau imbas kod QR-nya. Ia membiayai pendaftaran nama pengguna anda.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "Membayar Terus kepada Nama Pengguna";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Bayar kepada orang, bukan alamat";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Muatan heks";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Pembayaran adalah peribadi: alamat yang anda tukar dengan kenalan bergerak di dalam muatan tersulit yang hanya boleh dibaca oleh anda berdua, dan tidak pernah diterbitkan — jadi pembayaran anda tidak mudah dikaitkan dengan nama pengguna anda. Namun begitu, ia masih pembayaran biasa pada rantaian telus: analisis rantaian yang canggih mungkin membocorkan maklumat. Shielded DashPay (akan datang) akan menutup jurang itu. Permintaan kenalan itu sendiri kini TIDAK peribadi: sesiapa sahaja boleh melihat bahawa dua identiti berhubung. Permintaan kenalan peribadi ialah ciri yang akan datang. Nama pengguna dan profil anda juga awam pada Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Pembayaran disahkan dalam beberapa saat dengan InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Pembayaran yang dibuat terus kepada alamat tidak akan disimpan dalam aktiviti.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Pembayaran dengan setiap kenalan dikumpulkan di satu tempat, dengan nama dan profil, bukan transaksi mentah.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Alamat pembayaran";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Alamat Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Baki Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nod Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID Nod Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Pembayaran Platform tidak mengenal pasti penghantar. Pembayaran ini direkodkan apabila dompet menyedari perubahan baki — ia mungkin telah tiba lebih awal.";
+
+"Platform SDK not ready" = "SDK Platform belum sedia";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Penyegerakan Platform tidak berjalan. Buka Maklumat Penyegerakan → Status Penyegerakan Platform untuk memulakannya.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Terlindung";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Sebelum ini digunakan pada: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Peribadi mengikut reka bentuk";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Permintaan kenalan peribadi (supaya dengan siapa anda berhubung kekal peribadi), Shielded DashPay — pembayaran kepada kenalan daripada baki terlindung peribadi anda — dan pembayaran kepada pengguna yang belum ada dalam kenalan anda, semuanya akan datang tidak lama lagi.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Permintaan kenalan peribadi sedang dibangunkan dan dijangka sekitar September–Oktober 2026. Kini permintaan itu sendiri adalah awam — sesiapa sahaja boleh melihat bahawa dua identiti berhubung, walaupun butiran pembayaran di dalamnya tersulit. Setelah permintaan kenalan peribadi tersedia, anda boleh memilih sama ada persahabatan anda awam atau peribadi.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Permintaan kenalan peribadi, Shielded DashPay dan pembayaran kepada orang yang belum menjadi kenalan.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Alamat pembayaran peribadi ditukar antara anda dan kenalan anda. Hanya anda dan kenalan anda tahu penerima dan penghantar bagi pembayaran antara kamu berdua.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pembayaran peribadi";
+
+/* Usernames */
+"Private registration" = "Pendaftaran peribadi";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Masa pemprosesan";
+
+/* Balance info sheet section */
+"Pros" = "Kelebihan";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transaksi pembekal";
+
+/* Masternode keys */
+"Public key" = "Kunci awam";
+
+/* Masternode keys */
+"Public key (legacy)" = "Kunci awam (lama)";
+
+/* Identities */
+"Public keys" = "Kunci awam";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Tujuan";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transaksi mentah";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transaksi mentah tidak tersedia";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Memeriksa semula penapis blok padat dari ketinggian yang dipilih untuk transaksi dompet ini, dengan memuat turun dan memadankannya semula. Imbasan semula dihadkan di bawah oleh ketinggian penciptaan dompet dan data rantaian yang disimpan setempat — untuk memulihkan sejarah di bawah itu, turunkan ketinggian mula dompet sebagai gantinya.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Baca sahaja";
+
+/* Usernames */
+"Ready around %@" = "Sedia sekitar %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Sebab";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Diterima daripada %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Merekodkan masternode anda sebagai telah mengundi, tanpa memihak.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Segar semula";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Didaftarkan pada";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Pendaftaran peribadi memerlukan sekurang-kurangnya %@ Dash dalam baki terlindung anda serta beberapa jam masa rehat — skrin seterusnya akan memandu anda.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Pendaftaran";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Memohon nama ini";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Dompet yang dipulihkan tidak selalu dapat memulihkan jenis operasi. Entri ini dibina semula daripada data nota pada rantaian.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Penyegerakan semula disediakan dari ketinggian %u — tutup dan buka semula aplikasi untuk bermula.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "Menyimpan Sejarah Transaksi Bersama";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Bersara";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Pembatalan";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skrip";
+
+/* Raw transaction inspector */
+"Script signature" = "Tandatangan skrip";
+
+/* Raw transaction inspector */
+"Script type" = "Jenis skrip";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Cari kenalan";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Cari permintaan kenalan";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Cari Pengguna pada Rangkaian Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Cari nama pengguna";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Hasil carian untuk \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Cari nama pengguna";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Mencari nama pengguna %@ pada Rangkaian Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Tahap keselamatan";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Pilih semua";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Pilih sekurang-kurangnya satu masternode untuk mengundi.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Memilih lebih sedikit nod mendedahkan lebih sedikit tentang masternode yang anda kendalikan.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Hantar kepada Kenalan";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Hantar kepada nama pengguna yang benar-benar boleh anda ingat dan sahkan.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Hantar permintaan kenalan pertama anda";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Menghantar Permintaan Kenalan";
+
+/* No comment provided by engineer. */
+"Sending to" = "Menghantar kepada";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Dihantar kepada %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Perkhidmatan";
+
+/* Identities */
+"Set as Main" = "Tetapkan sebagai Utama";
+
+/* Identities */
+"Set as Main Identity" = "Tetapkan sebagai Identiti Utama";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Kolam privasi berkongsi pada saiz minimum";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Alamat terlindung";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Perbelanjaan terlindung";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Memulakan dompet terlindung…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Terlindung → Platform";
+
+"Shielded → Transparent" = "Terlindung → Telus";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Saiz";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Sebahagian masternode anda mungkin tiada dalam senarai ini — dompet tidak dapat membaca keseluruhan set kunci pengundian anda. Selesaikan penyegerakan dan buka semula skrin ini.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Isih Kenalan";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Muatan khas";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Bermula selepas anda menambah dana";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Disimpan sebagai";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Maklumat Penyegerakan";
+
+/* SPV sync */
+"Sync too slow?" = "Penyegerakan terlalu perlahan?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Tidak memihak";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Ketik untuk menyalin";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Kunci nod Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash tiba di alamat penerima selepas rangkaian memproses pengeluaran — ini boleh mengambil masa sehingga 10 minit.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash tiba di alamat penerima sebaik sahaja rangkaian memproses pengeluaran.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash tiba di baki telus anda sebaik sahaja rangkaian memproses pengeluaran.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Identiti utama hanya boleh dipilih daripada dompet aktif";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Tempat paling peribadi untuk menyimpan Dash anda";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Baris dompet tersimpan tiada rangkaian — tidak dapat menyediakan penyegerakan semula.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Pendaftaran telah dihantar tetapi keputusannya tidak dapat disahkan. Tunggu seminit untuk dompet disegerakkan, kemudian cuba lagi — jangan hantar semula serta-merta.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Kolam privasi berkongsi masih berkembang (%1$ld daripada %2$ld deposit). Pendaftaran peribadi dibuka apabila ia mencapai minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Kolam privasi berkongsi masih berkembang (%1$ld daripada %2$ld deposit). Cuba lagi apabila ia mencapai minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Ketinggian penciptaan dompet — had bawah bagi imbasan penapis dan imbasan semula “Dari penciptaan dompet”. Tetapkan pada atau di bawah pembiayaan pertama dompet; import menggunakan 200000 secara lalai pada mainnet dan 0 pada testnet. Menyimpan ketinggian yang sama atau lebih rendah daripada yang semasa akan mengosongkan data rantaian rangkaian ini pada pelancaran seterusnya dan mengimbas semula dari situ.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "dia (Mendapatkan Maklumat)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Tiada pemberitahuan baharu";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Tiada pengguna yang sepadan dengan nama %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Tiada pengguna dalam kenalan anda yang sepadan dengan nama %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Dana ini berpindah ke baki Platform anda dan sedia untuk dibelanjakan sebaik sahaja pemindahan selesai.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Alamat ini tidak boleh dibayar daripada baki %@ anda";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ini menambah dua kunci pada identiti anda supaya pengguna lain boleh menghantar permintaan kenalan kepada anda, dan supaya anda boleh menerima permintaan mereka. Ini berlaku sekali sahaja.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ini menerapkan satu pilihan kepada kesemua %d nama pengguna yang dipilih.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Pautan jemputan ini tidak sah.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ini bukan alamat Dash yang sah untuk rangkaian ini";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ini bukan pautan jemputan yang sah";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ini ialah identiti utama anda";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Masternode ini belum mempunyai identiti Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Ini tetap dikira sebagai masternode anda telah mengundi dalam pertandingan ini.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Bait mentah transaksi ini tidak disimpan pada peranti ini.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Nama pengguna ini jatuh kepada orang lain";
+
+"This wallet could not derive the voting key for this node." = "Dompet ini tidak dapat menerbitkan kunci pengundian bagi nod ini.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Dompet ini tiada kunci pengundian masternode yang aktif, jadi ia tidak boleh mengundi. Nod berdaftar muncul di bawah Alat → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ini mengeluarkan keseluruhan baki Platform anda dalam satu pemindahan. Dash tiba di alamat penerima sebaik sahaja rangkaian memproses pengeluaran.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ini mengeluarkan keseluruhan baki Platform anda dalam satu pemindahan. Dash tiba di baki telus anda sebaik sahaja rangkaian memproses pengeluaran.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Sejarah transaksi tidak tersedia";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID Transaksi";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Pemindahan masuk";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Pemindahan keluar";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Pemindahan mengambil masa lebih lama — membina bukti privasi memerlukan masa";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Pemindahan ke alamat Platform lain dan ke alamat terlindung adalah serta-merta dan muktamad";
+
+/* Balance breakdown */
+"Transparent" = "Telus";
+
+/* Send screen destination type */
+"Transparent address" = "Alamat telus";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Baki telus";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Pembiayaan telus mengaitkan nama pengguna anda dengan dana ini secara awam.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Telus → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Telus → Terlindung";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Tidak dapat memberikan cadangan";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Jenis khas tidak diketahui %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Tidak terlindung";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Naik taraf ke Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Guna baki telus sebagai gantinya";
+
+/* Masternode keys */
+"Used" = "Digunakan";
+
+/* Masternode keys */
+"Used at: " = "Digunakan pada: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Pengguna (Mendapatkan Maklumat)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Nama Pengguna";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Nama pengguna disimpan dalam bentuk ternormal untuk mengelakkan nama yang serupa, jadi ini mungkin berbeza daripada apa yang ditaip oleh setiap orang.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nama pengguna, bukan alamat";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Pengguna yang sepadan dengan %@ yang kini tiada dalam kenalan anda";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Menggunakan salah satu pustaka pengetahuan sifar yang paling banyak diaudit dan diuji (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Jemputan sah";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Disahkan semasa pendaftaran";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versi";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Sangat cekap dengan yuran rendah";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Lihat Semua";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Lihat Transaksi";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Undi";
+
+"Vote cast" = "Undi dibuang";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Undi nama pengguna yang dipertandingkan";
+
+"Vote on several" = "Undi beberapa";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Undi dengan";
+
+"Votes that nobody should receive these usernames." = "Mengundi supaya tiada sesiapa menerima nama pengguna ini.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Alamat pengundian";
+
+"Voting ended with no winner" = "Pengundian tamat tanpa pemenang";
+
+"Voting ends" = "Pengundian tamat";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Pengundian sedang berjalan";
+
+"Voting in progress — lock votes are ahead" = "Pengundian sedang berjalan — undi kunci mendahului";
+
+"Voting in progress — you are ahead" = "Pengundian sedang berjalan — anda mendahului";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Cincangan kunci pengundian";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Pengundian bagi nama pengguna ini telah ditutup. Kiraan di bawah ialah yang terakhir dibaca.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Pengundian bagi “%@” sudah ditutup. Segar semula untuk melihat keputusan.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Menunggu Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Ketinggian mula dompet";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Bagaimana pula dengan Unstoppable Domains dan perkhidmatan nama yang serupa?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Berapa kosnya?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Apakah DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Apa yang akan datang seterusnya?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Bilakah permintaan kenalan akan menjadi peribadi?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Siapa yang memohon nama ini";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Mengapa saya perlu mendayakannya?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Mengeluarkan keseluruhan baki";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Berfungsi dengan setiap dompet, bursa dan peniaga Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Anda";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Anda menerima permintaan kenalan daripada %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Anda tiada sebarang kenalan buat masa ini";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Anda mempunyai %@ Dash setakat ini";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Anda menghantar permintaan kenalan kepada %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Anda memenangi nama pengguna ini";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Semuanya sedia. Pengguna lain kini boleh menghantar permintaan kenalan kepada anda — dan anda boleh menghantar permintaan anda.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Identiti Dash Platform anda muncul di sini setelah anda mendaftarkan nama pengguna.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Sejarah anda, tersusun";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identiti anda memerlukan dua kunci tambahan supaya permintaan kenalan boleh disulitkan antara anda dan pengguna lain. Mendayakannya menambah kunci tersebut dengan satu transaksi rangkaian sahaja. Ini berlaku sekali sahaja.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Jemputan anda membayar yuran pendaftaran bagi nama pengguna ini.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Baki Dash utama anda pada blockchain Core — apa yang anda hantar dan terima dengan dompet, bursa dan peniaga lain.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Syiling campuran anda telah dipindahkan ke baki Dompet Dash anda.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Syiling campuran anda telah dipindahkan ke baki terlindung anda. Untuk privasi terbaik, tunggu sekurang-kurangnya 2 jam sebelum menggunakan dana ini.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Baki Platform anda";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Baki peribadi anda. Jumlah dan alamat disulitkan pada rantaian, jadi pegangan dan sejarah anda kekal sulit.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Baki terlindung anda";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Baki terlindung anda hampir sedia — anda boleh mendaftar secara peribadi sekitar %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Baki terlindung anda sudah sedia — daftarkan nama pengguna anda secara peribadi sekarang";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Baki terlindung anda sedang berehat — anda boleh mendaftar secara peribadi sekitar %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Baki terlindung anda masih matang. Ia akan sedia sekitar %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Baki telus anda";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Nama pengguna anda kelihatan oleh semua orang. Membiayainya daripada baki terlindung — selepas membiarkan dana berehat beberapa jam — bermakna tiada sesiapa boleh mengaitkan nama pengguna anda dengan Dash anda yang lain.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Nama pengguna, profil dan kenalan anda mengikuti identiti ini.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Nama pengguna, profil dan kenalan anda akan mengikuti identiti ini.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Undi anda";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Dompet anda masih disegerakkan dengan rangkaian Dash. Penghantaran akan tersedia setelah penyegerakan selesai.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Dompet anda masih disegerakkan. Penghantaran daripada baki telus akan tersedia setelah penyegerakan selesai.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@” tidak dapat dibaca sebagai nama pengguna Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” telah didaftarkan. Hantar permintaan kenalan kepada orang yang menjemput anda?";

--- a/DashWallet/ms.lproj/Localizable.stringsdict
+++ b/DashWallet/ms.lproj/Localizable.stringsdict
@@ -82,5 +82,215 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ dikira untuk “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u undi</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d daripada %#@names@ telah diundi</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d nama pengguna</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>Buang %u undi</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d daripada %#@nodes@ telah mengundi</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d daripada %#@nodes@ telah mengundi</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d nod</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u undi kesemuanya</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d dipilih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d nod anda telah mengundi di sini dan tidak disenaraikan.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u undi bagi setiap pertandingan — evonode dikira 4, masternode 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Undi %d nama pengguna</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u undi</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Undi ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d permintaan</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Alle noder samtidig";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle masternodene dine har stemt over dette brukernavnet. Stem på nytt fra søkeren du nå foretrekker, for å endre en stemme.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle masternodene dine har stemt over dette brukernavnet. Stem på nytt på søkeren du nå foretrekker, for å endre en stemme.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " eller ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ ble ikke funnet på Dash-nettverket, så det kan ikke sendes en kontaktforespørsel.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash tilgjengelig";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ har godtatt kontaktforespørselen din";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld av %ld innskudd";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "En kredittsaldo på Dash Platform som brukes til øyeblikkelige betalinger mellom Platform-adresser og til funksjoner som brukernavn.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Om";
 
+/* DashPay FAQ title */
+"About DashPay" = "Om DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Avstå";
+
+"Abstain on “%@”" = "Avstå på «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiv";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivitet";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktiviteten er offentlig, men ikke lett å spore";
+
 /* No comment provided by engineer. */
 "Add" = "Legg til";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Legg til %@ som kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Legg til %@ som kontakt for å betale direkte til brukernavnet og beholde den felles transaksjonshistorikken";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Legg %@ Dash i den skjermede saldoen din, og la den hvile noen timer, slik at du kan registrere deg uten å knytte brukernavnet ditt til de andre midlene dine.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Legg minst %@ Dash i den skjermede saldoen din";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Fyll på den skjermede saldoen nå, og registrer brukernavnet ditt privat om noen timer";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Alle noder samtidig";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alle masternodene dine har stemt over dette brukernavnet. Stem på nytt fra søkeren du nå foretrekker, for å endre en stemme.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Nesten umiddelbar synkronisering av saldoer";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Beløp og adresser er offentlige på blokkjeden";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "En Ethereum-konto er én gjenbrukt adresse: hele saldoen og betalingshistorikken din ligger offentlig under den, og et navn (for eksempel et ENS-domene) peker vanligvis rett på den adressen, så hvem som helst kan slå den opp. DashPay er stikk motsatt — navnet fører til en identitet, ikke til en betalingsadresse, og de faktiske betalingsadressene forblir inne i krypterte kontaktutvekslinger, nye for hver kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Alle som kjenner en adresse, kan se historikken til den";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Godkjenn";
+
+"Approving a specific request can only be done one username at a time." = "Å godkjenne en bestemt forespørsel kan bare gjøres for ett brukernavn om gangen.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Som tekst";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autentiseringen ble avbrutt. Stemmen din ble ikke avgitt.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autentiseringen mislyktes. Stemmen din ble ikke avgitt.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Tildel «%@» til denne søkeren";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Saldo etterpå";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldoer og overføringer er ikke offentlig synlige";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Starthøyde lagret — den hevede skannegrensen gjelder fra neste oppstart.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Bundet til kontrakt";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Bundet til kontrakt, dokumenttype «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Kun visning";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Samler de siste diagnoseloggene i en zip-fil så du kan AirDroppe, sende på e-post eller lagre dem i Filer";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Avgi stemme";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Bytt noder";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrollerer…";
+
+"Choice" = "Valg";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Løs inn invitasjonen din";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo til uttak";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Tøm og synkroniser på nytt";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Vil du tømme kjededata og synkronisere på nytt?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Stenger";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nye mynter)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin støttes ikke lenger — velg hvor de blandede myntene dine skal flyttes.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Sikkerhet";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Kommer snart";
+
+/* Shielded transfer status */
+"Completed" = "Fullført";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Bekreftet";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Bekreftelsen lagrer starthøyden %u og tømmer kjededataene for dette nettverket ved neste oppstart av appen, laster dem ned på nytt og skanner filtrene på nytt fra den høyden. Den pågående økten beholder den gamle skannegrensen sin — avslutt og åpne appen på nytt for å starte.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Tilkoblede noder";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Ulemper";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktforespørselen mislyktes";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktforespørsel sendt til %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktforespørsler";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Søker %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Fortsett for å velge brukernavnet ditt. Invitasjonen betaler registreringsgebyret.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopier rå transaksjon";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Kunne ikke opprette loggarkivet: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Kunne ikke finne valutakurser.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Kunne ikke oppdatere %d identiteter";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Kunne ikke hente saldoen (nettverksfeil). Prøv å oppdatere.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Opprett brukernavnet ditt, finn venner og familie via brukernavnene deres og legg dem til blant kontaktene dine";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kreditter";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform har ikke indeksert denne tvisten ennå. Stemmetallene vises her når det skjer.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform er ikke tilkoblet ennå. Vent til synkroniseringen er ferdig, og prøv igjen.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash som er sendt til feil adresse, kan ikke hentes tilbake. Kontroller at adressen er nøyaktig den du har tenkt å betale til.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash lagrer brukernavn i en forvekslingssikker form, så det lagrede navnet kan avvike fra det hver enkelt skrev.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo i Dash-lommeboken";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay er aktivert";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay er Dash sin sosiale betalingsopplevelse, bygget på Dash Platform. Du registrerer et brukernavn, legger til andre brukere som kontakter og betaler dem med navn — ikke mer kopiering av adresser.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay erstatter lange, kryptiske adresser med brukernavn. Legg til venner som kontakter, send penger til et navn, og hold hver betaling ordnet per person.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Frist ukjent";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Avledningsbane";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Deaktivert";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Ferdig — saldoen din har hvilt lenge nok";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Dobbeltsjekk adressen";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Hver masternode har én gyldig stemme per tvist. Du kan endre den senere, men Dash Platform tillater bare 5 stemmer totalt per masternode per tvist.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Hvert trykk stemmer med én node til, så du velger hvor mange du knytter sammen.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Rediger starthøyde";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktiver";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Aktiver DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Å aktivere DashPay koster et lite engangsgebyr til nettverket, som betales fra kredittsaldoen til identiteten din. Det nøyaktige anslaget vises før du bekrefter. Å sende kontaktforespørsler og betalinger koster de vanlige nettverksgebyrene.";
+
+"Ending soonest" = "Avsluttes først";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Anslått nettverksgebyr";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Alle noder stemmer sammen. Raskere, men det knytter masternodene dine offentlig til hverandre.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operatørnøkler for Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Eksporter logger";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Ekstern adresse";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Mislyktes";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Henter…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filterhoder";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Finn en bruker på Dash-nettverket";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Finn identiteter";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Fant %d nye identiteter";
+
+/* Identities */
+"Found 1 new identity" = "Fant 1 ny identitet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finansier brukernavnet ditt fra den skjermede saldoen. Legg inn midlene noen timer i forveien — den korte hvilen gjør at brukernavnet ditt ikke kan knyttes til de andre Dash-ene dine.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finansiert fra den skjermede saldoen din — brukernavnet ditt kan ikke knyttes til de andre Dash-ene dine.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Midlene er låst — overføringen fullføres";
+
+/* CoinJoin */
+"Funds moved" = "Midlene er flyttet";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Gjør deg klar til å bli med i DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Forstått";
+
+/* Governance */
+"Governance" = "Styring";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "har bedt om å bli vennen din";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Har du en invitasjon?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Blokkhoder";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Høyde %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Høyere gebyrer rundt 7 cent (fortsatt lavere enn andre blokkjeder med tilsvarende personvern)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Hvordan er dette sammenlignet med Bitcoin når det gjelder personvern?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Hvordan er dette sammenlignet med Ethereum-kontoer når det gjelder personvern?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Hvor privat er DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Jeg har skrevet ned frasen";
 
+/* Identities */
+"Identities" = "Identiteter";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identitetskreditter";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identitetsindeks";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identitetsregistrering";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Påfyll av identitet";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inaktiv";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Inndata %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Inndata %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Inndata (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitasjon fra %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Inviter noen til å bli med i Dash-nettverket";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Inviter venner og familie til Dash-nettverket";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Hold disse myntene private. Nettverks- og personverngebyrer påløper.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Nøkkel nr. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Nøkkeldata";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Nøkkeleierskap";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Nøkler";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Leder";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Les mer";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Laster inn transaksjoner";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Kun lokalt";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Lås";
+
+"Lock the name" = "Lås navnet";
+
+"Lock “%@” so nobody gets it" = "Lås «%@» slik at ingen får det";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Låst — ingen får dette brukernavnet";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Lave gebyrer til daglig bruk";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Hoved";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Nøkkelknippe for masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternodeliste";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternodestemmer";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternoder";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternoder og evonoder som er registrert med nøklene til denne lommeboken, vises her etter at lommeboken har synkronisert.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternoder og evonoder som bruker nøklene til denne lommeboken";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternoder stemmer over navn som mer enn én person har bedt om. Du får beskjed når avstemningen er over.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum er nådd";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Flere forslag";
+
+"Most lock votes" = "Flest låsestemmer";
+
+"Most votes" = "Flest stemmer";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Flytt til den vanlige disponible saldoen din.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Flytter midler";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Navnetjenester som Unstoppable Domains knytter et lesbart navn til en fast offentlig adresse på kjeden. Hvem som helst kan slå opp navnet og se hver eneste betaling som noen gang er gjort til det. Et DashPay-brukernavn fører aldri offentlig til en betalingsadresse — adresser avsløres bare inne i den krypterte utvekslingen med hver kontakt, så navnet og pengene dine forblir ukoblet for utenforstående.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Krever oppmerksomhet";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Ingen diagnoselogger ble funnet på denne enheten. Logger skrives fra neste oppstart.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Ingen identiteter";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ingen masternoder ennå";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Ingen samsvarende tvister";
+
+/* Identities */
+"No new identities were found for this wallet" = "Ingen nye identiteter ble funnet for denne lommeboken";
+
+"No open contest matches that search." = "Ingen åpen tvist samsvarer med det søket.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ingen åpen tvist samsvarer med det søket. Navn lagres i normalisert form, så «alice» står som «a11ce».";
+
+"No open contests" = "Ingen åpne tvister";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Ingen lagret lommebokoppføring ble funnet for den tilknyttede lommeboken.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Ingen Platform-adresse er tilgjengelig ennå for den skjermede reserveregistreringen. Prøv igjen når lommeboken er ferdig med å synkronisere.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Ingen brukernavn er omstridt akkurat nå. Tvister åpnes når to eller flere personer ber om samme navn.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Ingen stemmer ble avgitt";
+
+"Nobody gets it" = "Ingen får det";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Ikke-standard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Ikke tilgjengelig ennå";
+
+"Not cast" = "Ikke avgitt";
+
+/* Masternodes */
+"Not checked yet" = "Ikke kontrollert ennå";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Ikke nok skjermet saldo til å registrere en identitet";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ikke i lommebokhistorikken";
+
+"Not now" = "Ikke nå";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Ikke bredt akseptert av forhandlere";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Ikke bredt akseptert av forhandlere ennå";
+
+/* Masternode keys */
+"Not yet used" = "Ikke brukt ennå";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "På Bitcoin finnes det ikke noe navnelag, så folk deler og gjenbruker adresser helt åpent — når en adresse først er kjent, kan alt den noen gang har mottatt, knyttes til eieren. Med DashPay er brukernavnet ditt offentlig, men det peker aldri på en betalingsadresse: adresser utveksles privat per kontakt og roterer, så det å betale til et navn avslører ikke hvor pengene dine går. Begge er transparente kjeder, så kjedeanalyse gjelder fortsatt for selve myntene.";
+
+/* Identities */
+"On Network" = "På nettverket";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Når %@ godtar forespørselen din, kan du betale direkte til brukernavnet";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Én node om gangen";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Bare masternoder og evonoder kan stemme over brukernavn. Denne lommeboken har ingen aktive stemmenøkler for masternoder.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operatør";
+
+/* Masternode keys */
+"Operator keys" = "Operatørnøkler";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operatørens offentlige nøkkel (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "eller";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Andre utfall";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Utdata %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Utdata (%d)";
+
+/* Masternodes */
+"Owner" = "Eier";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Eierens adresse";
+
+/* Masternodes */
+"Owner key hash" = "Hash for eiernøkkel";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Betales fra kredittsaldoen til identiteten din.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Lim inn invitasjonslenken du fikk, eller skann QR-koden dens. Den betaler registreringen av brukernavnet ditt.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "betale direkte til brukernavnet";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Betal mennesker, ikke adresser";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Nyttelast (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Betalingene er private: adressene du utveksler med en kontakt, reiser inne i en kryptert nyttelast som bare dere to kan lese, og de publiseres aldri — derfor kan ikke betalingene dine enkelt knyttes til brukernavnet ditt. De er likevel helt vanlige betalinger på en transparent kjede: avansert kjedeanalyse kan lekke informasjon. Shielded DashPay (kommer snart) tetter det hullet. Selve kontaktforespørslene er for øyeblikket IKKE private: hvem som helst kan se at to identiteter er koblet sammen. Private kontaktforespørsler er en funksjon som kommer snart. Brukernavnet og profilen din er også offentlige på Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Betalinger bekreftes på sekunder med InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Betalinger som gjøres direkte til adresser, beholdes ikke i aktiviteten.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Betalingene med hver kontakt er samlet på ett sted, med navn og profiler i stedet for rå transaksjoner.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Utbetalingsadresse";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-adresse";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-node";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-node-ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-betalinger identifiserer ikke avsenderen. Denne betalingen ble registrert da lommeboken merket saldoendringen — den kan ha kommet tidligere.";
+
+"Platform SDK not ready" = "Platform-SDK-en er ikke klar";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform-synkroniseringen kjører ikke. Åpne Synkroniseringsinfo → Platform-synkroniseringsstatus for å starte den.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Skjermet";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Tidligere brukt den: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat i utgangspunktet";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Private kontaktforespørsler (så det forblir privat hvem du kobler deg til), Shielded DashPay — kontaktbetalinger fra den private skjermede saldoen din — og betalinger til brukere som ennå ikke er blant kontaktene dine, kommer alle snart.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Private kontaktforespørsler er under utvikling og ventes rundt september–oktober 2026. I dag er selve forespørselen offentlig — hvem som helst kan se at to identiteter er koblet sammen, selv om betalingsdetaljene inni er krypterte. Når private kontaktforespørsler kommer, kan du velge om vennskapet ditt skal være offentlig eller privat.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Private kontaktforespørsler, Shielded DashPay og betalinger til folk som ennå ikke er kontakter.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Private betalingsadresser utveksles mellom deg og kontaktene dine. Bare du og kontakten din vet hvem som er mottaker og avsender for betalingene mellom dere.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Private betalinger";
+
+/* Usernames */
+"Private registration" = "Privat registrering";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Behandlingstid";
+
+/* Balance info sheet section */
+"Pros" = "Fordeler";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Leverandørtransaksjoner";
+
+/* Masternode keys */
+"Public key" = "Offentlig nøkkel";
+
+/* Masternode keys */
+"Public key (legacy)" = "Offentlig nøkkel (eldre)";
+
+/* Identities */
+"Public keys" = "Offentlige nøkler";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Formål";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Rå transaksjon";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Rå transaksjon er ikke tilgjengelig";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Sjekker de kompakte blokkfiltrene fra den valgte høyden på nytt for transaksjoner i denne lommeboken, ved å laste dem ned og matche dem på nytt. Nye skanninger er nedad begrenset av lommebokens opprettelseshøyde og av lokalt lagrede kjededata — senk heller lommebokens starthøyde for å hente tilbake historikk under det nivået.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Skrivebeskyttet";
+
+/* Usernames */
+"Ready around %@" = "Klar rundt %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Årsak";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Mottatt fra %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Registrerer at masternodene dine har stemt, uten å ta stilling.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Oppdater";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrert den";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privat registrering krever minst %@ Dash i den skjermede saldoen din pluss noen timers hvile — de neste skjermene veileder deg.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrering";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Ber om dette navnet";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Gjenopprettede lommebøker klarer ikke alltid å hente tilbake operasjonstypen. Denne oppføringen er rekonstruert fra notatdata på kjeden.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ny synkronisering klargjort fra høyde %u — avslutt og åpne appen på nytt for å starte.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "beholde den felles transaksjonshistorikken";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Avviklet";
 
 /* No comment provided by engineer. */
 "Retry" = "Prøv igjen";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Tilbakekalling";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Skjermbilder er synlige for andre programmer og enheter. Generer en ny gjenopprettingsfrase og hold den hemmelig.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Skriptsignatur";
+
+/* Raw transaction inspector */
+"Script type" = "Skripttype";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Søk etter en kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Søk etter en kontaktforespørsel";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Søk etter en bruker på Dash-nettverket";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Søk etter et brukernavn";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Søkeresultater for \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Søk etter brukernavn";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Søker etter brukernavnet %@ på Dash-nettverket";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Sikkerhetsnivå";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Velg alle";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Velg minst én masternode å stemme med.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Å velge færre noder avslører mindre om hvilke masternoder du driver.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Send til en kontakt";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Send til et brukernavn du faktisk klarer å huske og bekrefte.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Send din første kontaktforespørsel";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Sender kontaktforespørsel";
+
+/* No comment provided by engineer. */
+"Sending to" = "Sender til";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Sendt til %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Tjeneste";
+
+/* Identities */
+"Set as Main" = "Angi som hoved";
+
+/* Identities */
+"Set as Main Identity" = "Angi som hovedidentitet";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Den delte personvernpuljen er på minstestørrelse";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Skjermet adresse";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Skjermet bruk";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Starter den skjermede lommeboken…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Skjermet → Platform";
+
+"Shielded → Transparent" = "Skjermet → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Størrelse";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Noen av masternodene dine mangler kanskje i denne listen — lommeboken klarte ikke å lese hele settet med stemmenøkler. Fullfør synkroniseringen, og åpne denne skjermen på nytt.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sorter kontakter";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Spesiell nyttelast";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Starter når du legger inn midler";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Lagret som";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Synkroniseringsinfo";
+
+/* SPV sync */
+"Sync too slow?" = "Går synkroniseringen for sakte?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ikke ta stilling";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Trykk for å kopiere";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-nodenøkkel (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash når mottakerens adresse etter at nettverket har behandlet uttaket — det kan ta opptil 10 minutter.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash når mottakerens adresse så snart nettverket behandler uttaket.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash når den transparente saldoen din så snart nettverket behandler uttaket.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Hovedidentiteten kan bare velges fra den aktive lommeboken";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Det mest private stedet å oppbevare Dash-ene dine";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Den lagrede lommebokoppføringen mangler nettverk — kan ikke klargjøre ny synkronisering.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registreringen ble sendt inn, men resultatet kunne ikke bekreftes. Vent et minutt mens lommeboken synkroniserer, og prøv så igjen — ikke send inn på nytt med én gang.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Den delte personvernpuljen vokser fortsatt (%1$ld av %2$ld innskudd). Privat registrering låses opp når den når minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Den delte personvernpuljen vokser fortsatt (%1$ld av %2$ld innskudd). Prøv igjen når den når minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Lommebokens opprettelseshøyde — nedre grense for filterskanninger og for nye skanninger av typen «Fra lommeboken ble opprettet». Sett den ved eller under lommebokens første innskudd; import bruker som standard 200000 på mainnet og 0 på testnet. Hvis du lagrer en høyde som er lik eller lavere enn den nåværende, tømmes dette nettverkets kjededata ved neste oppstart, og det skannes på nytt derfra.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "ham (henter info)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Det er ingen nye varsler";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Det finnes ingen brukere som samsvarer med navnet %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Det finnes ingen brukere blant kontaktene dine som samsvarer med navnet %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Disse midlene flyttes til Platform-saldoen din og er klare til bruk så snart overføringen er fullført.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Denne adressen kan ikke betales fra %@-saldoen din";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Dette legger to nøkler til identiteten din, slik at andre brukere kan sende deg kontaktforespørsler, og slik at du kan godta deres. Det skjer bare én gang.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Dette bruker ett valg på alle de %d valgte brukernavnene.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Denne invitasjonslenken er ikke gyldig.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Dette er ikke en gyldig Dash-adresse for dette nettverket";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Dette er ikke en gyldig invitasjonslenke";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Dette er hovedidentiteten din";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Denne masternoden har ingen Platform-identitet ennå.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Dette teller fortsatt som at masternodene dine har stemt i denne tvisten.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "De rå bytene til denne transaksjonen er ikke lagret på denne enheten.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Dette brukernavnet gikk til noen andre";
+
+"This wallet could not derive the voting key for this node." = "Denne lommeboken klarte ikke å utlede stemmenøkkelen for denne noden.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Denne lommeboken har ingen aktive stemmenøkler for masternoder og kan derfor ikke stemme. Registrerte noder vises under Verktøy → Masternoder.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dette tar ut hele Platform-saldoen din i én overføring. Dash når mottakerens adresse så snart nettverket behandler uttaket.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dette tar ut hele Platform-saldoen din i én overføring. Dash når den transparente saldoen din så snart nettverket behandler uttaket.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Transaksjonshistorikken er ikke tilgjengelig";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaksjons-ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Overføring inn";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Overføring ut";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Overføringer tar lengre tid — det tar tid å bygge personvernbevisene";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Overføringer til andre Platform-adresser og til skjermede adresser er umiddelbare og endelige";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Transparent adresse";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparent saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparent finansiering knytter brukernavnet ditt offentlig til disse midlene.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Skjermet";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Kan ikke gi forslag";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Ukjent spesialtype %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Uskjermet";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Oppgrader til Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Bruk den transparente saldoen i stedet";
+
+/* Masternode keys */
+"Used" = "Brukt";
+
+/* Masternode keys */
+"Used at: " = "Brukt den: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Bruker (henter info)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Brukernavn";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Brukernavn lagres i normalisert form for å hindre forvekslingsnavn, så dette kan avvike fra det hver enkelt skrev.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Brukernavn, ikke adresser";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Brukere som samsvarer med %@, og som for øyeblikket ikke er blant kontaktene dine";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Bruker ett av de mest reviderte og testede nullkunnskapsbibliotekene (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Gyldig invitasjon";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Bekreftet under registreringen";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versjon";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Svært effektiv med lave gebyrer";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Vis alle";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Vis transaksjon";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Stem";
+
+"Vote cast" = "Stemme avgitt";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Stem over omstridte brukernavn";
+
+"Vote on several" = "Stem over flere";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Stem med";
+
+"Votes that nobody should receive these usernames." = "Stemmer for at ingen skal få disse brukernavnene.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Stemmeadresse";
+
+"Voting ended with no winner" = "Avstemningen endte uten vinner";
+
+"Voting ends" = "Avstemningen avsluttes";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Avstemning pågår";
+
+"Voting in progress — lock votes are ahead" = "Avstemning pågår — låsestemmene leder";
+
+"Voting in progress — you are ahead" = "Avstemning pågår — du leder";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash for stemmenøkkel";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Avstemningen om dette brukernavnet er stengt. Tallene nedenfor er de sist avleste.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Avstemningen om «%@» er allerede stengt. Oppdater for å se resultatet.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Venter på Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Lommebokens starthøyde";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Hva med Unstoppable Domains og lignende navnetjenester?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Hva koster det?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Hva er DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Hva kommer nå?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Når blir kontaktforespørsler private?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Hvem som ber om dette navnet";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Hvorfor må jeg aktivere det?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Tar ut hele saldoen";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Fungerer med alle Dash-lommebøker, børser og forhandlere";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Deg";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Du godtok kontaktforespørselen fra %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Du har ingen kontakter for øyeblikket";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Du har %@ Dash så langt";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Du sendte kontaktforespørselen til %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Du vant dette brukernavnet";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Alt er klart. Andre brukere kan nå sende deg kontaktforespørsler — og du kan sende dine.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Dash Platform-identiteten din vises her når du registrerer et brukernavn.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Historikken din, ordnet";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identiteten din trenger to ekstra nøkler for at kontaktforespørsler skal kunne krypteres mellom deg og andre brukere. Aktiveringen legger dem til med én enkelt nettverkstransaksjon. Det skjer bare én gang.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Invitasjonen din betaler registreringsgebyret for dette brukernavnet.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Hoved-Dash-saldoen din på Core-blokkjeden — det du sender og mottar med andre lommebøker, børser og forhandlere.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "De blandede myntene dine er flyttet til saldoen i Dash-lommeboken din.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "De blandede myntene dine er flyttet til den skjermede saldoen din. For best mulig personvern bør du vente minst 2 timer før du bruker disse midlene.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Platform-saldoen din";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Den private saldoen din. Beløp og adresser er kryptert på kjeden, så beholdningen og historikken din forblir konfidensielle.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Den skjermede saldoen din";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Den skjermede saldoen din er nesten klar — du kan registrere deg privat rundt %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Den skjermede saldoen din er klar — registrer brukernavnet ditt privat nå";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Den skjermede saldoen din hviler — du kan registrere deg privat rundt %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Den skjermede saldoen din modnes fortsatt. Den er klar rundt %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Den transparente saldoen din";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Brukernavnet ditt er synlig for alle. Å finansiere det fra den skjermede saldoen — etter å ha latt midlene hvile noen timer — betyr at ingen kan knytte brukernavnet ditt til de andre Dash-ene dine.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Brukernavnet, profilen og kontaktene dine følger denne identiteten.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Brukernavnet, profilen og kontaktene dine vil følge denne identiteten.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Stemmene dine";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Lommeboken din synkroniserer fortsatt med Dash-nettverket. Du kan sende når synkroniseringen er ferdig.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Lommeboken din synkroniserer fortsatt. Du kan sende fra den transparente saldoen når synkroniseringen er ferdig.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "«%@» kunne ikke leses som et Dash-brukernavn.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» er registrert. Vil du sende en kontaktforespørsel til personen som inviterte deg?";

--- a/DashWallet/nb.lproj/Localizable.stringsdict
+++ b/DashWallet/nb.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ telt for «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u stemme</string>
+			<key>other</key>
+			<string>%1$u stemmer</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Stemt på %1$d av %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d brukernavn</string>
+			<key>other</key>
+			<string>%2$d brukernavn</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Avgi %u stemme</string>
+			<key>other</key>
+			<string>Avgi %u stemmer</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d av %#@nodes@ har stemt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d av %#@nodes@ har stemt</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d node</string>
+			<key>other</key>
+			<string>%2$d noder</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonoder</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme totalt</string>
+			<key>other</key>
+			<string>%u stemmer totalt</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d valgt</string>
+			<key>other</key>
+			<string>%d valgt</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d av nodene dine har allerede stemt her og vises ikke.</string>
+			<key>other</key>
+			<string>%d av nodene dine har allerede stemt her og vises ikke.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme per tvist — evonoder teller som 4, masternoder som 1</string>
+			<key>other</key>
+			<string>%u stemmer per tvist — evonoder teller som 4, masternoder som 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stem over %d brukernavn</string>
+			<key>other</key>
+			<string>Stem over %d brukernavn</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stemme</string>
+			<key>other</key>
+			<string>%u stemmer</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stem ×%d</string>
+			<key>other</key>
+			<string>Stem ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d forespørsel</string>
+			<key>other</key>
+			<string>%d forespørsler</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Alle nodes tegelijk";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Al je masternodes hebben over deze gebruikersnaam gestemd. Om een stem te wijzigen, stem je opnieuw vanaf de kandidaat die je nu verkiest.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Al je masternodes hebben over deze gebruikersnaam gestemd. Om een stem te wijzigen, stem je opnieuw op de kandidaat die je nu verkiest.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " of ";
+
 /* CrowdNode */
 " Privacy Policy " = "Privacybeleid";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ kon niet op het Dash-netwerk worden gevonden om een contactverzoek te sturen.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash beschikbaar";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ heeft je contactverzoek geaccepteerd";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacten / %3$lu profiel updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "Er zullen %d stemmen worden uitgebracht omdat je meerdere stemsleutels in de portemonnee hebt opgeslagen.";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicaten";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld van %ld stortingen";
 
 /* Voting */
 "%ld requests" = "%ld verzoeken";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is geen herstelzinwoord. Wil je het correcte woord herstellen dat er zou moeten staan?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Een kredietsaldo op Dash Platform dat wordt gebruikt voor directe betalingen tussen Platform-adressen en voor functies zoals gebruikersnamen.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Een toegangscode is nog om je portemonnee te beschermen. Ga naar de instellingen en zet de toegangscode aan om door te gaan.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Over";
 
+/* DashPay FAQ title */
+"About DashPay" = "Over DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Over mij";
+
+"Abstain" = "Onthouden";
+
+"Abstain on “%@”" = "Onthouden bij “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accepteren";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Accountherstel";
 
+/* Masternode status */
+"Active" = "Actief";
+
+/* No comment provided by engineer. */
+"Activity" = "Activiteit";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Activiteit is openbaar, maar niet makkelijk te traceren";
+
 /* No comment provided by engineer. */
 "Add" = "Toevoegen";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ als contact toevoegen";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Voeg %@ toe als contact om rechtstreeks aan een gebruikersnaam te betalen en de wederzijdse transactiegeschiedenis te behouden";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Voeg %@ Dash toe aan je afgeschermde saldo en laat het een paar uur rusten om te registreren zonder je gebruikersnaam aan je overige tegoeden te koppelen.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Voeg een nieuw contact toe";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Voeg minstens %@ Dash toe aan je afgeschermde saldo";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Voeg nu tegoed toe aan je afgeschermde saldo en registreer je gebruikersnaam een paar uur later privé";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Alles";
 
+"All nodes at once" = "Alle nodes tegelijk";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Al je masternodes hebben over deze gebruikersnaam gestemd. Om een stem te wijzigen, stem je opnieuw vanaf de kandidaat die je nu verkiest.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Toestaan ​​dat alle transacties van je Dash portemonnee naar Zenledger worden verzonden?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Vrijwel direct synchroniseren van saldi";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Bedragen en adressen zijn openbaar op de blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Er is een fout opgetreden";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Een Ethereum-account is één herbruikbaar adres: je volledige saldo en betalingsgeschiedenis staan er openbaar onder, en een naam (zoals een ENS-domein) verwijst doorgaans rechtstreeks naar dat adres, dat iedereen kan opzoeken. DashPay werkt precies andersom: de naam verwijst naar een identiteit, niet naar een betaaladres, en de echte betaaladressen blijven binnen versleutelde contactuitwisselingen, telkens nieuw per contact.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Een intuïtieve en vertrouwde ervaring op al je apparaten";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Elke gebruikersnaam met een cijfer 2-9, meer dan 20 tekens of met een koppelteken wordt automatisch goedgekeurd";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Iedereen die een adres kent, kan de geschiedenis ervan bekijken";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Pas toe";
 
+"Approve" = "Goedkeuren";
+
+"Approving a specific request can only be done one username at a time." = "Een specifieke aanvraag goedkeuren kan maar voor één gebruikersnaam tegelijk.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Weet je zeker dat je deze bestelling wilt annuleren?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Als tekst";
 
 /* DashSpend */
 "at" = "ter hoogte van";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Verificatie geannuleerd. Je stem is niet uitgebracht.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Verificatie mislukt. Je stem is niet uitgebracht.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authenticatie is niet beschikbaar";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "“%@” aan deze kandidaat toekennen";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo daarna";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Saldo bij CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Saldo:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldi en overboekingen zijn niet openbaar zichtbaar";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bankrekening";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Toegang tot biometrie vereist";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Starthoogte opgeslagen — de verhoogde scanondergrens geldt vanaf de volgende start.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Gebruikersnaam '%@' geblokkeerd";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Gebonden aan contract";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Gebonden aan contract, documenttype “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Alleen bekijken";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Recente diagnostische logbestanden bundelen in een zip om te AirDroppen, mailen of op te slaan in Bestanden";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Stem uitbrengen";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Van peers wisselen";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Wijzig pin";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Controleren…";
+
+"Choice" = "Keuze";
+
 /* Choose your Dash username */
 "Choose your" = "Kies je";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Kies je gebruikersnaam";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Claim je uitnodiging";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Claimbaar saldo";
+
 /* No comment provided by engineer. */
 "Claimed" = "Geclaimd";
+
+/* SPV diagnostics */
+"Clear & resync" = "Wissen en opnieuw synchroniseren";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Ketengegevens wissen en opnieuw synchroniseren?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Sluit app af";
 
+"Closing" = "Wordt gesloten";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nieuwe munten)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin wordt niet langer ondersteund — kies waar je je gemixte munten naartoe verplaatst.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Onderpand";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Binnenkort";
+
+/* Shielded transfer status */
+"Completed" = "Voltooid";
 
 /* No comment provided by engineer. */
 "Confirm" = "Bevestig";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Bevestigd";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Bevestigen slaat starthoogte %u op en wist de ketengegevens van dit netwerk bij de volgende start van de app, waarna ze opnieuw worden gedownload en de filters vanaf die hoogte opnieuw worden gescand. De lopende sessie behoudt zijn oude scanondergrens — sluit de app af en open hem opnieuw om te beginnen.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Verbind je crypto portemonnees met het ZenLedger platform. Kom meer te weten en ga aan de slag met je Dash portemonnee transacties.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Verbonden Dash adres";
 
+/* SPV sync */
+"Connected peers" = "Verbonden peers";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nadelen";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Contactverzoek mislukt";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Contactverzoek verzonden naar %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Contactverzoeken";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacten";
 
+"Contender %@" = "Kandidaat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Ga door";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Ga verder om je gebruikersnaam te kiezen. De uitnodiging betaalt de registratiekosten.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Uitnodiging link kopiëren";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Ruwe transactie kopiëren";
+
 /* No comment provided by engineer. */
 "Copy text" = "Kopieer tekst";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Kon niet automatisch ontbrekende of incorrecte woorden herstellen";
 
+/* Log export */
+"Could not create the log archive: %@" = "Kon het logarchief niet aanmaken: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "De wisselkoers kon niet worden gevonden.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Kon %d identiteiten niet vernieuwen";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Kon het saldo niet ophalen (netwerkfout). Probeer te vernieuwen.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Kon betaling niet maken";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Maak je gebruikersnaam aan";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Maak je gebruikersnaam aan, vind vrienden en familie via hun gebruikersnaam en voeg ze toe aan je contacten";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credticard";
+
+/* Masternodes */
+"Credits" = "Krediet";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash-betalingen mogen niet kleiner zijn dan %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform heeft dit geschil nog niet geïndexeerd. Stemtellingen verschijnen hier zodra dat gebeurt.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform is nog niet verbonden. Wacht tot het synchroniseren klaar is en probeer het opnieuw.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash die naar een verkeerd adres is gestuurd, kan niet worden teruggehaald. Zorg dat het adres precies het adres is waaraan je wilt betalen.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash slaat gebruikersnamen op in een vorm die bestand is tegen lijkende namen, dus de opgeslagen naam kan afwijken van wat elke persoon heeft getypt.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash gebruikersnaam";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash portemonnee";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash-portemonneesaldo";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash portemonnee op dit apparaat";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay ingeschakeld";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay uitnodiging";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay is de sociale betaalervaring van Dash, gebouwd op Dash Platform. Je registreert een gebruikersnaam, voegt andere gebruikers toe als contact en betaalt ze op naam — geen adressen meer kopiëren.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay vervangt lange cryptische adressen door gebruikersnamen. Voeg vrienden toe als contact, stuur geld naar een naam en houd elke betaling per persoon georganiseerd.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay upgrade vergoeding";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Datum: Oud naar nieuw";
+
+"Deadline unknown" = "Deadline onbekend";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Storting is verzonden";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Afleidingspad";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "BEVEILIGING VAN HET APPARAAT IN GEVAAR\nEen 'jailbreak'-app heeft toegang tot de sleutelhanger van andere apps (en de mogelijkheid om je dash te stelen). Verwijder deze portemonnee direct en herstel op een veilig apparaat.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Uitgeschakeld";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Koppel Coinbase account los";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Klaar";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Klaar — je saldo heeft lang genoeg gerust";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Controleer het adres nog eens";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Elke uitnodiging wordt met dit bedrag gefinancierd, zodat de ontvanger snel zijn gebruikersnaam op het Dash Network kan aanmaken";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Elke masternode heeft één geldige stem per geschil. Je kunt hem later wijzigen, maar Dash Platform staat in totaal slechts 5 stemmen per masternode per geschil toe.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Elke tik laat één node extra meestemmen, zodat jij kiest hoeveel je aan elkaar koppelt.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Eerder";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Stake makkelijk Dash en verdien passief inkomen met een paar eenvoudige kliks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Starthoogte bewerken";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Bewerk profiel";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-mail";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Inschakelen";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay inschakelen";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Gezichtsherkenning inschakelen";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Vingeridentificatie inschakelen";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPay inschakelen kost een kleine eenmalige netwerkvergoeding, betaald uit het kredietsaldo van je identiteit. De exacte schatting wordt getoond voordat je bevestigt. Het versturen van contactverzoeken en betalingen kost de gebruikelijke netwerkkosten.";
+
+"Ending soonest" = "Eindigt het eerst";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Fout bij bijwerken van je profiel";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Geschatte netwerkkosten";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Elke node stemt samen. Sneller, maar het koppelt je masternodes openbaar aan elkaar.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode-operatorsleutels";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "CSV exporteren";
 
+/* Log export */
+"Export Logs" = "Logbestanden exporteren";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Uitgebreide publieke sleutels (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Extern adres";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limiet";
+
+/* No comment provided by engineer. */
+"Failed" = "Mislukt";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Laden van streepjescode mislukt";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Koersen ophalen...";
 
+/* Masternodes */
+"Fetching…" = "Ophalen…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat rekening";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filterheaders";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Transacties filteren";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Vind een gebruiker op het Dash-netwerk";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Vind geldautomaten waar je Dash kunt kopen of verkopen.";
+
+/* Identities */
+"Find identities" = "Identiteiten zoeken";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "PIN vergeten?";
 
+/* Identities */
+"Found %d new identities" = "%d nieuwe identiteiten gevonden";
+
+/* Identities */
+"Found 1 new identity" = "1 nieuwe identiteit gevonden";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Ontbrekend woord is gevonden:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financier je gebruikersnaam vanuit je afgeschermde saldo. Voeg het tegoed een paar uur van tevoren toe — die korte rust zorgt dat je gebruikersnaam niet aan je overige Dash gekoppeld kan worden.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Gefinancierd vanuit je afgeschermde saldo — je gebruikersnaam kan niet aan je overige Dash worden gekoppeld.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Tegoed vergrendeld — overboeking wordt afgerond";
+
+/* CoinJoin */
+"Funds moved" = "Tegoed verplaatst";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Ontvang beloningen van deposito's in Dash Masternodes vanaf slechts 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Offerte aanvragen";
+
+/* Usernames */
+"Get ready to join DashPay" = "Maak je klaar om lid te worden van DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Ontvang direct beloningen";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Begrepen";
+
+/* Governance */
+"Governance" = "Bestuur";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Sta gpsrechten toe zodat we locaties bij je in de buurt kunnen tonen.";
 
 /* Voting */
 "Has blocked votes" = "Heeft geblokkeerde stemmen";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "heeft gevraagd om je vriend te worden";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Heb je een uitnodiging?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Heb volledige controle en pas uw portemonnee aan op basis van je behoeften";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "koptekst #%1$d van %2$d";
+
+/* SPV sync phase */
+"Headers" = "Headers";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Hoogte %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Dit is het Dash adres op dit apparaat dat is toegewezen aan je CrowdNode account";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Hoog naar laag";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Hogere kosten rond 7 cent (nog steeds lager dan andere blockchains met vergelijkbare privacy)";
+
 /* No comment provided by engineer. */
 "History" = "Geschiedenis";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Hoe verkrijg ik test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Hoe verhoudt dit zich tot Bitcoin op het gebied van privacy?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Hoe verhoudt dit zich tot Ethereum-accounts op het gebied van privacy?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Hoe privé is DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Hoe je het API Dash adres kunt bevestigen";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "ik heb het opgeschreven";
 
+/* Identities */
+"Identities" = "Identiteiten";
+
 /* Voting */
 "Identity" = "Identiteit";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identiteitskrediet";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identiteitsindex";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identiteitsregistratie";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Identiteit bijvullen";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In het betalingsgedeelte van de checkout, selecteer \"cadeaukaart\" en voer je kaartnummer en pincode in.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactief";
+
+/* No comment provided by engineer. */
 "Income" = "Inkomen";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initialiseren";
+
+/* Raw transaction inspector */
+"Input %d" = "Invoer %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Invoer %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Invoer (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Ontoereikende fondsen";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Vergoeding uitnodiging";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Uitnodiging van %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Uitnodiging gebruikt door";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Nodig uit";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Nodig iemand uit voor het Dash-netwerk";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Nodig je familie uit, vind je vrienden door hun gebruikersnamen te zoeken";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Nodig je vrienden en familie uit om lid te worden van het Dash Netwerk.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Nodig je vrienden en familie uit voor het Dash-netwerk";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash portemonnee: %@ Gemeld probleem";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Deelnemen aan de pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Houd deze munten privé. Netwerk- en privacykosten zijn van toepassing.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Bewaar de wachtwoordzin veilig";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Sleutel #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Sleutelgegevens";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Sleuteleigendom";
+
 /* No comment provided by engineer. */
 "Keypair" = "Sleutelpaar";
+
+/* Masternodes */
+"Keys" = "Sleutels";
 
 /* Explore Dash */
 "Last device sync" = "Laatste apparaatsynchronisatie";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Aan de leiding";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Kom meer te weten";
 
 /* Info Screen */
 "Learn More..." = "Kom meer te weten...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Transacties laden";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Lokale munteenheid";
 
+/* Identities */
+"Local Only" = "Alleen lokaal";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Lokaal verzocht bedrag: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Locatie";
 
+"Lock" = "Vergrendelen";
+
+"Lock the name" = "De naam vergrendelen";
+
+"Lock “%@” so nobody gets it" = "“%@” vergrendelen zodat niemand hem krijgt";
+
 /* No comment provided by engineer. */
 "Locked" = "Vergrendeld";
 
+"Locked — nobody receives this username" = "Vergrendeld — niemand krijgt deze gebruikersnaam";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Laag";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Lage kosten voor dagelijkse uitgaven";
+
 /* Voting */
 "Low to high" = "Laag naar hoog";
+
+/* Identities — the wallet's main identity */
+"Main" = "Hoofd";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Masternode IP adres";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Masternode-sleutelbos";
+
+/* Masternode keys */
 "Masternode keys" = "Masternode sleutels";
+
+/* SPV sync phase */
+"Masternode list" = "Masternodelijst";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "lijst masternodes #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Updaten masternode";
 
+"Masternode votes" = "Masternodestemmen";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode stem-sleutel";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodes en evonodes die met de sleutels van deze portemonnee zijn geregistreerd, verschijnen hier nadat de portemonnee is gesynchroniseerd.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes en evonodes die de sleutels van deze portemonnee gebruiken";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodes stemmen over namen die door meer dan één persoon zijn aangevraagd. Je krijgt bericht wanneer de stemming eindigt.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum bereikt";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Meer controle";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Meer suggesties";
+
+"Most lock votes" = "Meeste vergrendelstemmen";
+
+"Most votes" = "Meeste stemmen";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Verplaats en zoom je foto voor een perfecte pasvorm";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Verplaats naar je gewone besteedbare saldo.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Verplaatst naar adres";
+
+/* CoinJoin */
+"Moving funds" = "Tegoed verplaatsen";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Naam";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Naamdiensten zoals Unstoppable Domains koppelen een leesbare naam aan een vast openbaar adres op de keten. Iedereen kan de naam opzoeken en elke betaling zien die er ooit aan is gedaan. Een DashPay-gebruikersnaam verwijst nooit openbaar naar een betaaladres — adressen worden alleen onthuld binnen de versleutelde uitwisseling met elk contact, zodat je naam en je geld ongekoppeld blijven voor buitenstaanders.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Hulp nodig?";
+
+"Needs attention" = "Vereist aandacht";
 
 /* No comment provided by engineer. */
 "Network" = "Netwerk";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Er zijn geen diagnostische logbestanden op dit apparaat gevonden. Logbestanden worden vanaf de volgende start geschreven.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Geen identiteiten";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Nog geen masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Geen overeenkomende geschillen";
+
+/* Identities */
+"No new identities were found for this wallet" = "Er zijn geen nieuwe identiteiten gevonden voor deze portemonnee";
+
+"No open contest matches that search." = "Geen open geschil komt overeen met die zoekopdracht.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Geen open geschil komt overeen met die zoekopdracht. Namen worden in genormaliseerde vorm opgeslagen, dus “alice” staat er als “a11ce”.";
+
+"No open contests" = "Geen open geschillen";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Geen betalingsmethodes";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Geen opgeslagen portemonnee-record gevonden voor de gekoppelde portemonnee.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Er is nog geen Platform-adres beschikbaar voor de afgeschermde registratie-terugval. Probeer het opnieuw nadat de portemonnee klaar is met synchroniseren.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Geen resultaten gevonden";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Op dit moment wordt er geen gebruikersnaam betwist. Geschillen ontstaan wanneer twee of meer mensen dezelfde naam aanvragen.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Geen stemmen over";
+
+"No votes were cast" = "Er zijn geen stemmen uitgebracht";
+
+"Nobody gets it" = "Niemand krijgt hem";
+
+/* SPV sync peer type */
+"Node" = "Node";
+
+/* Raw transaction inspector */
+"Non-standard" = "Niet-standaard";
 
 /* adjective, security level */
 "None" = "Geen";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Niet beschikbaar";
 
+"Not available yet" = "Nog niet beschikbaar";
+
+"Not cast" = "Niet uitgebracht";
+
+/* Masternodes */
+"Not checked yet" = "Nog niet gecontroleerd";
+
 /* Location Service Status */
 "Not Determined" = "Niet bepaald";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Onvoldoende afgeschermd saldo om een identiteit te registreren";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Niet in portemonneegeschiedenis";
+
+"Not now" = "Niet nu";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Niet breed geaccepteerd door verkopers";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Nog niet breed geaccepteerd door verkopers";
+
+/* Masternode keys */
+"Not yet used" = "Nog niet gebruikt";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Oud naar nieuw";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Op Bitcoin is er geen naamlaag, dus delen en hergebruiken mensen adressen in het openbaar — zodra een adres bekend is, kan alles wat het ooit ontving aan de eigenaar worden gekoppeld. Met DashPay is je gebruikersnaam openbaar, maar verwijst hij nooit naar een betaaladres: adressen worden per contact privé uitgewisseld en wisselen, dus betalen op naam maakt niet openbaar waar je geld heen gaat. Beide zijn transparante ketens, dus ketenanalyse blijft van toepassing op de munten zelf.";
+
+/* Identities */
+"On Network" = "Op het netwerk";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Zodra %@ je verzoek accepteert, kun je rechtstreeks aan de gebruikersnaam betalen";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Eén node tegelijk";
 
 /* Voting */
 "One vote left" = "Eén stem over";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Alleen duplicaten";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Alleen masternodes en evonodes kunnen over gebruikersnamen stemmen. Deze portemonnee bevat geen actieve masternode-stemsleutels.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Alleen aanvragen met links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Alleen met links";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Operatorsleutels";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Publieke operatorsleutel (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "of";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Voorbeeld bestelling";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Andere uitkomsten";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Uitvoer %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Uitvoer (%d)";
+
+/* Masternodes */
+"Owner" = "Eigenaar";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Adres eigenaar";
+
+/* Masternodes */
+"Owner address" = "Adres van eigenaar";
+
+/* Masternodes */
+"Owner key hash" = "Hash van eigenaarssleutel";
 
 /* Owner keys */
 "Owner keys" = "Eigenaar sleutels";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Betaald uit het kredietsaldo van je identiteit.";
 
 /* DashSpend */
 "Password" = "Wachtwoord";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Plak link hier";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Plak de uitnodigingslink die je hebt ontvangen, of scan de QR-code ervan. Hij financiert de registratie van je gebruikersnaam.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Plak uw afbeelding URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Betaal en word betaald met eenvoudig te gebruiken betaalverkeer";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "rechtstreeks aan een gebruikersnaam betalen";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Betaal mensen, geen adressen";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Betaal via gebruikersnamen. Geen alfanumerieke adressen meer";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Aan het betalen...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload-hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Betalingsmethode";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Betalingen zijn privé: de adressen die je met een contact uitwisselt, reizen in een versleutelde payload die alleen jullie tweeën kunnen lezen, en worden nooit gepubliceerd — je betalingen zijn dus niet eenvoudig aan je gebruikersnaam te koppelen. Het blijven wel gewone betalingen op een transparante keten: geavanceerde ketenanalyse kan informatie prijsgeven. Shielded DashPay (binnenkort) sluit dat gat. De contactverzoeken zelf zijn momenteel NIET privé: iedereen kan zien dat twee identiteiten verbonden zijn. Privé-contactverzoeken zijn een functie die binnenkort komt. Je gebruikersnaam en profiel zijn ook openbaar op Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Betalingen worden binnen seconden bevestigd met InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Betalingen die rechtstreeks naar adressen worden gedaan, worden niet bewaard in de activiteit.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Betalingen met elk contact staan op één plek bij elkaar, met namen en profielen in plaats van ruwe transacties.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Uitbetalingsadres";
 
 /* CrowdNode */
 "Payout Options" = "Uitbetaalopties";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-adres";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-node";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-node-ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-betalingen identificeren de afzender niet. Deze betaling is vastgelegd toen de portemonnee de saldowijziging opmerkte — hij kan eerder zijn aangekomen.";
+
+"Platform SDK not ready" = "Platform-SDK niet gereed";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "De Platform-synchronisatie loopt niet. Open Synchronisatie-info → Platform-synchronisatiestatus om hem te starten.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Afgeschermd";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Voeg een betaalmethode toe op Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Voorbeeld van de uitnodiging";
 
+/* Masternode keys */
+"Previously used at: " = "Eerder gebruikt op: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prijzen zijn minstens 30 minuten oud. Fiat waarden kunnen onjuist zijn.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privé van opzet";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privé-contactverzoeken (zodat privé blijft met wie je verbinding maakt), Shielded DashPay — contactbetalingen vanuit je privé afgeschermde saldo — en betalen aan gebruikers die nog niet in je contacten staan, komen er allemaal aan.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privé-contactverzoeken zijn in ontwikkeling en worden rond september–oktober 2026 verwacht. Vandaag is het verzoek zelf openbaar — iedereen kan zien dat twee identiteiten verbonden zijn, ook al zijn de betalingsgegevens erin versleuteld. Zodra privé-contactverzoeken er zijn, kun je kiezen of je vriendschap openbaar of privé is.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privé-contactverzoeken, Shielded DashPay en betalen aan mensen die nog geen contact zijn.";
+
 /* No comment provided by engineer. */
 "Private key" = "persoonlijke sleutel";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privé-betaaladressen worden uitgewisseld tussen jou en je contacten. Alleen jij en je contact weten wie de ontvanger en afzender zijn van betalingen tussen jullie.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privébetalingen";
+
+/* Usernames */
+"Private registration" = "Privéregistratie";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Verwerkingstijd";
+
+/* Balance info sheet section */
+"Pros" = "Voordelen";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Bescherm uw spaargeld";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider adres";
 
+/* Masternodes */
+"Provider transactions" = "Providertransacties";
+
+/* Masternode keys */
+"Public key" = "Publieke sleutel";
+
+/* Masternode keys */
+"Public key (legacy)" = "Publieke sleutel (verouderd)";
+
+/* Identities */
+"Public keys" = "Publieke sleutels";
+
 /* No comment provided by engineer. */
 "Public URL" = "Openbare URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Aankoop mislukt";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Doel";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Tarief: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Ruwe transactie";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Ruwe transactie niet beschikbaar";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Controleert de compacte blokfilters vanaf de gekozen hoogte opnieuw op transacties van deze portemonnee door ze opnieuw te downloaden en te vergelijken. Herscans hebben als ondergrens de aanmaakhoogte van de portemonnee en de lokaal opgeslagen ketengegevens — om geschiedenis daaronder te herstellen, verlaag je in plaats daarvan de starthoogte van de portemonnee.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Lees het uitbetalingsbeleid";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Alleen-lezen";
+
+/* Usernames */
+"Ready around %@" = "Klaar rond %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Reden";
 
 /* No comment provided by engineer. */
 "Receive" = "Ontvangen";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Ontvangen van";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Ontvangen van %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Beloningen ontvangen";
+
+"Records your masternodes as having voted, without taking a side." = "Legt vast dat je masternodes hebben gestemd, zonder partij te kiezen.";
 
 /* No comment provided by engineer. */
 "Recover" = "Herstel";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Herstelzin moet 12, 15, 18, 21 of 24 woorden hebben";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Vernieuwen";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registreren?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Geregistreerd op";
+
+/* No comment provided by engineer. */
 "Registered from" = "Geregistreerd van";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Geregistreerde masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privé registreren vereist minstens %@ Dash op je afgeschermde saldo plus een paar uur rusttijd — de volgende schermen leiden je erdoorheen.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registratie";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Vraagt deze naam aan";
+
 /* An action */
 "Rescan" = "Scan opnieuw";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Herstelde portemonnees kunnen het bewerkingstype niet altijd achterhalen. Deze vermelding is gereconstrueerd uit notitiegegevens op de keten.";
+
+/* Location Service Status */
 "Restricted" = "Beperkt";
 
 /* Usernames */
 "Results" = "Resultaten";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Hersynchronisatie ingesteld vanaf hoogte %u — sluit de app af en open hem opnieuw om te beginnen.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "de wederzijdse transactiegeschiedenis behouden";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Uit bedrijf";
 
 /* No comment provided by engineer. */
 "Retry" = "Probeer opnieuw";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Bekijk het onderstaande bericht om het eigendom van deze gebruikersnaam te verifiëren";
+
+/* Masternodes */
+"Revocation" = "Intrekking";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Schermafdrukken zijn zichtbaar voor andere apps en apparaten. Genereer een nieuwe herstelzin en houdt deze geheim.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Scripthandtekening";
+
+/* Raw transaction inspector */
+"Script type" = "Scripttype";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Zoek een contact";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Zoek een contactverzoek";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Zoek een gebruiker op het Dash-netwerk";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Zoek een gebruikersnaam";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Zoekresultaten voor \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Zoek gebieden";
+
+"Search usernames" = "Gebruikersnamen zoeken";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Zoeken naar gebruikersnaam %@ op het Dash-netwerk";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Beveilig je portemonnee";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Beveiligingsniveau";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Beveiligingsniveau";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Selecteer een service om Dash te kopen, verkopen, converteren, of over te maken";
 
+"Select all" = "Alles selecteren";
+
 /* DashSpend denomination selection */
 "Select amount" = "selecteer bedrag";
+
+"Select at least one masternode to vote with." = "Selecteer minstens één masternode om mee te stemmen.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Selecteer de munt";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Minder nodes selecteren onthult minder over welke masternodes je draait.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Zelf afrekenen";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Verstuur naar";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Naar een contact sturen";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Stuur naar een gebruikersnaam die je echt kunt onthouden en verifiëren.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Versturen naar adres";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Stuur je eerste contactverzoek";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Bezig met verzenden";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Contactverzoek versturen";
+
+/* No comment provided by engineer. */
+"Sending to" = "Versturen naar";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Wordt verzonden naar CrowdNode account";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Verstuur naar";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Verzonden naar %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Serverfout opgetreden. Probeer het later opnieuw.";
+
+/* Masternodes */
+"Service" = "Dienst";
+
+/* Identities */
+"Set as Main" = "Instellen als hoofd";
+
+/* Identities */
+"Set as Main Identity" = "Instellen als hoofdidentiteit";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Stel PIN in";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Deel sleutel";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Gedeelde privacypool op minimale grootte";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Afgeschermd adres";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Afgeschermde uitgave";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Afgeschermde portemonnee wordt gestart…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Afgeschermd → Platform";
+
+"Shielded → Transparent" = "Afgeschermd → Transparant";
 
 /* Explore Dash */
 "Show all locations" = "Alle locaties weergeven";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Grootte";
+
 /* No comment provided by engineer. */
 "Skip" = "Overslaan";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Sommige van je masternodes ontbreken mogelijk in deze lijst — de portemonnee kon je volledige set stemsleutels niet lezen. Rond het synchroniseren af en open dit scherm opnieuw.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Sommige gebruikersnamen kunnen worden geblokkeerd.";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sorteer op";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Contacten sorteren";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Gesorteerd op korting";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Gesorteerd op naam";
+
+/* Raw transaction inspector */
+"Special payload" = "Speciale payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specificeer bedrag";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Start nadat je tegoed toevoegt";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Stap %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Opgeslagen als";
 
 /* Voting */
 "Submit" = "Indienen";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Synchronisatie bezig... Resultaten zijn mogelijk niet compleet.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Synchronisatie-info";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronisatie te traag?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Maak een foto met de camera";
 
+"Take no side" = "Geen partij kiezen";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tik op het adres van het klembord om het te plakken";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tik om te kopiëren";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tik om saldo te verbergen";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = " Tijdelijk niet beschikbaar";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-nodesleutel (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Voorwaarden";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "De code is onjuist. Controleer en probeer het opnieuw.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "De Dash komt aan op het adres van de ontvanger nadat het netwerk de opname heeft verwerkt — dit kan tot 10 minuten duren.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "De Dash komt aan op het adres van de ontvanger zodra het netwerk de opname verwerkt.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "De Dash komt aan op je transparante saldo zodra het netwerk de opname verwerkt.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Het Dash netwerk moet stemmen om sommige gebruikersnamen goed te keuren voordat ze worden aangemaakt";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "De link die je stuurt, zal alleen zichtbaar zijn voor de netwerkbeheerders.";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "De hoofdidentiteit kan alleen uit de actieve portemonnee worden gekozen";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Het minimumbedrag dat je kan verzenden is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "De meest private plek om je Dash te bewaren";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Het opgeslagen portemonnee-record heeft geen netwerk — kan geen hersynchronisatie instellen.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "De registratie is ingediend, maar het resultaat kon niet worden bevestigd. Wacht een minuut tot de portemonnee is gesynchroniseerd en probeer het dan opnieuw — dien hem niet meteen opnieuw in.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "De gedeelde privacypool groeit nog (%1$ld van %2$ld stortingen). Privéregistratie wordt ontgrendeld zodra het minimum is bereikt.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "De gedeelde privacypool groeit nog (%1$ld van %2$ld stortingen). Probeer het opnieuw zodra het minimum is bereikt.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "De gebruikersnaam '%@' werd geblokkeerd door het Dash Netwerk. Probeer het opnieuw door een andere gebruikersnaam aan te vragen.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "De aanmaakhoogte van de portemonnee — de ondergrens voor filterscans en “Vanaf aanmaak portemonnee”-herscans. Stel deze in op of onder de eerste financiering van de portemonnee; imports gebruiken standaard 200000 op mainnet en 0 op testnet. Een hoogte opslaan die gelijk is aan of lager dan de huidige, wist de ketengegevens van dit netwerk bij de volgende start en scant er opnieuw vanaf.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "hem (info ophalen)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Er zijn geen nieuwe meldingen";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Er zijn geen transacties om weer te geven";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Er zijn geen gebruikers die overeenkomen met de naam %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Er zijn in je contacten geen gebruikers die overeenkomen met de naam %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Er is een fout opgetreden bij het exporteren van de transactiegeschiedenis naar ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Er is een fout opgetreden, probeer het later opnieuw";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Dit tegoed gaat naar je Platform-saldo en is klaar om uit te geven zodra de overboeking is voltooid.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Dit adres kan niet worden betaald vanuit je %@-saldo";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Dit voegt twee sleutels toe aan je identiteit zodat andere gebruikers je contactverzoeken kunnen sturen en jij die van hen kunt accepteren. Dit gebeurt eenmalig.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Dit past één keuze toe op alle %d geselecteerde gebruikersnamen.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Deze extra stap laat zien dat jij het bent die een transactie probeert te doen.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Deze uitnodigingslink is niet geldig.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Dit is geen geldig Dash-adres voor dit netwerk";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Dit is geen geldige uitnodigingslink";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Dit is je hoofdidentiteit";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Deze masternode heeft nog geen Platform-identiteit.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Deze winkelier is momenteel niet beschikbaar.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Dit vertegenwoordigt het huidig jaarlijkse procentuele rendement van een volledige Masternode minus de 15% vergoeding voor CrowdNode. Het is geen gegarandeerd rendement en kan stijgen of dalen op basis van de grootte van de CrowdNode pools en de prijs van Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Dit telt nog steeds als een stem van je masternodes in dit geschil.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "De ruwe bytes van deze transactie zijn niet op dit apparaat opgeslagen.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Deze gebruikersnaam is naar iemand anders gegaan";
+
+"This wallet could not derive the voting key for this node." = "Deze portemonnee kon de stemsleutel voor deze node niet afleiden.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Deze portemonnee bevat geen actieve masternode-stemsleutels en kan dus niet stemmen. Geregistreerde nodes verschijnen onder Hulpmiddelen → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Hiermee neem je je volledige Platform-saldo op in één overboeking. De Dash komt aan op het adres van de ontvanger zodra het netwerk de opname verwerkt.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Hiermee neem je je volledige Platform-saldo op in één overboeking. De Dash komt aan op je transparante saldo zodra het netwerk de opname verwerkt.";
 
 /* Send Screen: to address */
 "to" = "naar";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Transactiegeschiedenis";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Transactiegeschiedenis is niet beschikbaar";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transactie id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transactie-ID";
 
 /* A verb, button title. */
 "Transfer" = "overdracht";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Inkomend";
 
+/* Balance breakdown */
+"Transfer in" = "Overboeking in";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Uitgaand";
+
+/* Balance breakdown */
+"Transfer out" = "Overboeking uit";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Overboekingen duren langer — het opbouwen van privacybewijzen kost tijd";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Overboekingen naar andere Platform-adressen en afgeschermde adressen zijn direct en definitief";
+
+/* Balance breakdown */
+"Transparent" = "Transparant";
+
+/* Send screen destination type */
+"Transparent address" = "Transparant adres";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparant saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparante financiering koppelt je gebruikersnaam openbaar aan dit tegoed.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparant → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparant → Afgeschermd";
 
 /* An action */
 "Try again" = "Probeer opnieuw";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Kan geen suggesties geven";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Onbekend saldo";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Onbekend speciaal type %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Niet afgeschermd";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Niet-ondersteunde URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Upgraden naar DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Upgraden naar Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "In plaats daarvan transparant saldo gebruiken";
+
+/* Masternode keys */
+"Used" = "Gebruikt";
+
+/* Masternode keys */
+"Used at: " = "Gebruikt op: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Gebruiker (info ophalen)";
 
 /* Voting */
 "Username" = "Gebruikersnaam";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "De gebruikersnaam is met succes aangevraagd";
 
+/* Identities */
+"Usernames" = "Gebruikersnamen";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Gebruikersnamen worden in genormaliseerde vorm opgeslagen om lijkende namen te voorkomen, dus dit kan afwijken van wat elke persoon heeft getypt.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Gebruikersnamen, geen adressen";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Gebruikers die overeenkomen met %@ en die momenteel niet in je contacten staan";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Gebruikt een van de best gecontroleerde en meest geteste zero-knowledge-bibliotheken (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Geldige uitnodiging";
+
 /* CrowdNode Portal */
 "Validating address…" = "Adres valideren…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verificatie vereist";
 
+/* Usernames */
+"Verified during registration" = "Geverifieerd tijdens registratie";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Succesvol geverifieerd";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verifieer je identiteit";
 
+/* Raw transaction inspector */
+"Version" = "Versie";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Zeer efficiënt met lage kosten";
+
 /* adjective, security level */
 "Very High" = "Heel hoog";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Er worden zeer kleine hoeveelheden Dash van en naar CrowdNode verzonden om te verifiëren dat je de eigenaar bent van dit adres in de  portemonnee.";
+
+/* No comment provided by engineer. */
+"View All" = "Alles bekijken";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Bekijk in Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Toon herstelzin";
 
+/* Raw transaction inspector */
+"View Transaction" = "Transactie bekijken";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Bekijk transactiedetails";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Stemmen";
+
+"Vote cast" = "Stem uitgebracht";
+
 /* Voting */
 "Vote for All" = "Stem voor alle";
 
 /* Voting */
+"Vote on contested usernames" = "Stem over betwiste gebruikersnamen";
+
+"Vote on several" = "Over meerdere stemmen";
+
+/* Voting */
 "Vote to Approve" = "Stem om goed te keuren";
+
+"Vote with" = "Stemmen met";
+
+"Votes that nobody should receive these usernames." = "Stemt dat niemand deze gebruikersnamen zou moeten krijgen.";
 
 /* Voting */
 "Votes: High to low" = "Stemmen: van hoog naar laag";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Stem adres";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Stemadres";
+
+"Voting ended with no winner" = "De stemming eindigde zonder winnaar";
+
+"Voting ends" = "Stemmen eindigt";
+
 /* Voting */
 "Voting ends in %dd" = "Stemming eindigt over %d d";
+
+"Voting in progress" = "Stemming loopt";
+
+"Voting in progress — lock votes are ahead" = "Stemming loopt — vergrendelstemmen staan voor";
+
+"Voting in progress — you are ahead" = "Stemming loopt — jij staat voor";
 
 /* Usernames */
 "Voting is only required in some cases" = "Stemmen is alleen in sommige gevallen vereist.";
 
+/* Masternodes */
+"Voting key hash" = "Hash van stemsleutel";
+
 /* Voting keys */
 "Voting keys" = "Stem sleutels";
+
+"Voting on this username has closed. The counts below are the last ones read." = "De stemming over deze gebruikersnaam is gesloten. De tellingen hieronder zijn de laatst gelezen waarden.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "De stemming over “%@” is al gesloten. Vernieuw om het resultaat te zien.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wacht tot de portemonnee is gesynchroniseerd om de transactie te voltooien";
 
+"Waiting for Dash Platform" = "Wachten op Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Portemonnee-adres";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Starthoogte portemonnee";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Portemonnee is uitgeschakeld";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welkom bij DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Hoe zit het met Unstoppable Domains en vergelijkbare naamdiensten?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Wat kost het?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Wat is DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Wat is stemmen met gebruikersnaam?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Wat komt er hierna?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Wanneer worden contactverzoeken privé?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Waar uit te geven";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Waar uit te geven?";
+
+"Who is requesting this name" = "Wie deze naam aanvraagt";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Waarom moet ik het inschakelen?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Waarom zie ik al deze transacties?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Opname is aangevraagd";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Neemt het volledige saldo op";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Werkt met elke Dash-portemonnee, beurs en verkoper";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Wil je de uitnodiging accepteren?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Gisteren";
+
+"You" = "Jij";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Je hebt het contactverzoek van %@ geaccepteerd";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Je koos \"%@\" als je gebruikersnaam.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Je hebt op dit moment geen contacten";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Je hebt onvoldoende saldo om deze transactie te voltooien";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Je hebt de autorisatielimiet op Coinbase overschreden.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Je hebt tot nu toe %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Je hebt %1$@ Dash.\nSommige gebruikersnamen kosten tot %2$@ Dash. ";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Je hebt het contactverzoek naar %@ gestuurd";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Je zou een positief saldo moeten hebben in de Dash portemonnee";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Je hebt deze gebruikersnaam gewonnen";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Alles staat klaar. Andere gebruikers kunnen je nu contactverzoeken sturen — en jij kunt de jouwe versturen.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Je Dash Platform-identiteit verschijnt hier zodra je een gebruikersnaam registreert.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Het e-mailadres wordt alleen gebruikt om een ​​eenmalig wachtwoord te verzenden.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Je geschiedenis, georganiseerd";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Je identiteit heeft twee extra sleutels nodig zodat contactverzoeken tussen jou en andere gebruikers kunnen worden versleuteld. Bij het inschakelen worden ze met één netwerktransactie toegevoegd. Dit gebeurt eenmalig.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Je uitnodiging van %@ is al geclaimd";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Je uitnodiging van %@ is niet geldig";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Je uitnodiging betaalt de registratiekosten voor deze gebruikersnaam.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Je locatie wordt gebruikt om je positie op de kaart te tonen, geldautomaten in de geselecteerde straal te tonen, en om zoekresultaten te verbeteren.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Je locatie wordt gebruikt om uw positie op de kaart, om winkels in de geselecteerde radius te tonen, en de zoekresultaten te verbeteren.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Je belangrijkste Dash-saldo op de Core-blockchain — wat je verstuurt en ontvangt met andere portemonnees, beurzen en verkopers.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Je gemixte munten zijn verplaatst naar je Dash-portemonneesaldo.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Je gemixte munten zijn verplaatst naar je afgeschermde saldo. Wacht voor de beste privacy minstens 2 uur voordat je dit tegoed gebruikt.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Je Platform-saldo";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Het primaire Dash adres dat je momenteel gebruikt voor je CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Je privésaldo. Bedragen en adressen zijn versleuteld op de keten, zodat je bezit en geschiedenis vertrouwelijk blijven.";
+
 /* Usernames */
 "Your request was cancelled" = "Je aanvraag is geannuleerd";
 
 /* DashSpend */
 "Your session expired" = "Je sessie is verlopen";
+
+/* Usernames */
+"Your Shielded balance" = "Je afgeschermde saldo";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Je afgeschermde saldo is bijna klaar — je kunt je rond %@ privé registreren.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Je afgeschermde saldo is klaar — registreer je gebruikersnaam nu privé";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Je afgeschermde saldo rust — je kunt je rond %@ privé registreren";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Je afgeschermde saldo rijpt nog. Het is rond %@ klaar.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Je transparante saldo";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Uw gebruikersnaam %@ is met succes aangemaakt op het Dash netwerk";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Je gebruikersnaam is succesvol aangemaakt";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Je gebruikersnaam is voor iedereen zichtbaar. Door hem te financieren vanuit je afgeschermde saldo — nadat het tegoed een paar uur heeft gerust — kan niemand je gebruikersnaam aan je overige Dash koppelen.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Je gebruikersnaam, profiel en contacten volgen deze identiteit.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Je gebruikersnaam, profiel en contacten zullen deze identiteit volgen.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Je stem is geannuleerd";
 
 /* Voting */
 "Your vote was submitted" = "je stem is verzonden";
 
+"Your votes" = "Jouw stemmen";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Uw portemonnee is nu beveiligd. U kunt uw herstelzin op elk gewenst moment gebruiken om uw account op een ander apparaat te herstellen.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Je portemonnee synchroniseert nog met het Dash-netwerk. Versturen is beschikbaar zodra het synchroniseren klaar is.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Je portemonnee synchroniseert nog. Versturen vanuit je transparante saldo is beschikbaar zodra het synchroniseren klaar is.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@” kon niet als Dash-gebruikersnaam worden gelezen.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” is geregistreerd. Wil je een contactverzoek sturen naar de persoon die je heeft uitgenodigd?";

--- a/DashWallet/nl.lproj/Localizable.stringsdict
+++ b/DashWallet/nl.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ geteld voor “%2$@”</string>
+		<string>%#@votes@ voor “%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u stem</string>
+			<string>%1$u getelde stem</string>
 			<key>other</key>
-			<string>%1$u stemmen</string>
+			<string>%1$u getelde stemmen</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d van %#@nodes@ hebben gestemd</string>
+		<string>Gestemd: %1$d van %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d van %#@nodes@ hebben gestemd</string>
+		<string>Gestemd: %1$d van %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/nl.lproj/Localizable.stringsdict
+++ b/DashWallet/nl.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d sleutels</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ geteld voor “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u stem</string>
+			<key>other</key>
+			<string>%1$u stemmen</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Op %1$d van %#@names@ gestemd</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d gebruikersnaam</string>
+			<key>other</key>
+			<string>%2$d gebruikersnamen</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stem uitbrengen</string>
+			<key>other</key>
+			<string>%u stemmen uitbrengen</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d van %#@nodes@ hebben gestemd</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d van %#@nodes@ hebben gestemd</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d node</string>
+			<key>other</key>
+			<string>%2$d nodes</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stem in totaal</string>
+			<key>other</key>
+			<string>%u stemmen in totaal</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d geselecteerd</string>
+			<key>other</key>
+			<string>%d geselecteerd</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d van je nodes heeft hier al gestemd en staat niet in de lijst.</string>
+			<key>other</key>
+			<string>%d van je nodes hebben hier al gestemd en staan niet in de lijst.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stem per geschil — evonodes tellen als 4, masternodes als 1</string>
+			<key>other</key>
+			<string>%u stemmen per geschil — evonodes tellen als 4, masternodes als 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stemmen over %d gebruikersnaam</string>
+			<key>other</key>
+			<string>Stemmen over %d gebruikersnamen</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u stem</string>
+			<key>other</key>
+			<string>%u stemmen</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Stemmen ×%d</string>
+			<key>other</key>
+			<string>Stemmen ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d verzoek</string>
+			<key>other</key>
+			<string>%d verzoeken</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " lub ";
+
 /* CrowdNode */
 " Privacy Policy " = "Polityka Prywatności";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Nie znaleziono %@ w sieci Dash, aby wysłać zaproszenie do kontaktów.";
+
+/* Usernames */
+"%@ Dash available" = "Dostępne %@ Dash";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ zaakceptował Twoje zaproszenie do kontaktów";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu kontakty/ %3$lu aktualizacje profilu";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtów";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffów";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d głosów będzie oddawanych, jeśli masz wiele kluczy do głosowania zapisanych w portfelu";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplikatów";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld z %ld wpłat";
 
 /* Voting */
 "%ld requests" = "%ld żądań";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" nie jest właściwym słowem odzyskiwania. Czy chciałbyś spróbować odzyskać właściwe słowo, które powinno być na miejscu?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Saldo kredytowe na Dash Platform używane do natychmiastowych płatności między adresami Platform oraz do funkcji takich jak nazwy użytkowników.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Do zabezpieczenia portfela potrzebny jest kod dostępu do urządzenia. Przejdź do ustawień i włącz hasło, aby kontynuować.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "O aplikacji";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "O mnie";
+
+"Abstain" = "Wstrzymaj się";
+
+"Abstain on “%@”" = "Wstrzymaj się w sprawie „%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Akceptuj";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Odzyskiwanie Konta";
 
+/* Masternode status */
+"Active" = "Aktywny";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktywność";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktywność jest publiczna, ale niełatwa do prześledzenia";
+
 /* No comment provided by engineer. */
 "Add" = "Dodaj";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Dodaj %@ do kontaktów";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Dodaj %@ do kontaktów, aby płacić bezpośrednio na nazwę użytkownika i zachować wspólną historię transakcji";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Dodaj %@ Dash do salda osłoniętego i pozwól mu odpocząć kilka godzin, aby zarejestrować się bez powiązania nazwy użytkownika z pozostałymi środkami.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Dodaj Nowy Kontakt";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Dodaj co najmniej %@ Dash do salda osłoniętego";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Zasil teraz saldo osłonięte i zarejestruj nazwę użytkownika prywatnie kilka godzin później";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Wszystko";
 
+"All nodes at once" = "Wszystkie węzły naraz";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Wszystkie Twoje masternody zagłosowały nad tą nazwą użytkownika. Aby zmienić głos, zagłosuj ponownie z poziomu kandydata, którego teraz preferujesz.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Pozwól na wysyłanie wszystkich transakcji z Dash Wallet do Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Niemal natychmiastowa synchronizacja sald";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Kwoty i adresy są publiczne w blockchainie";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Pojawił się błąd";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Konto Ethereum to jeden wielokrotnego użytku adres: całe Twoje saldo i historia płatności są pod nim publicznie widoczne, a nazwa (np. domena ENS) zwykle wskazuje wprost na ten adres, który każdy może rozwiązać. DashPay ma odwrotną budowę — nazwa prowadzi do tożsamości, a nie do adresu płatności, a rzeczywiste adresy płatności pozostają wewnątrz zaszyfrowanej wymiany z kontaktami, nowe dla każdego kontaktu.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Intuicyjne i znane doświadczenie na wszystkich urządzeniach";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Każda nazwa użytkownika, która zawiera cyfrę od 2-9, ma więcej niż 20 znaków lub zawiera myślnik, zostanie automatycznie zatwierdzona.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Każdy, kto zna adres, może zobaczyć jego historię";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Zastosuj";
 
+"Approve" = "Zatwierdź";
+
+"Approving a specific request can only be done one username at a time." = "Zatwierdzenie konkretnego wniosku jest możliwe tylko dla jednej nazwy użytkownika naraz.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Czy na pewno chcesz anulować to zlecenie?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Jako tekst";
 
 /* DashSpend */
 "at" = "przy";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Uwierzytelnienie anulowane. Twój głos nie został oddany.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Uwierzytelnienie nie powiodło się. Twój głos nie został oddany.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Autoryzacja jest niedostępna";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Przyznaj „%@” temu kandydatowi";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo po";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Saldo na CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Saldo:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Salda i transfery nie są publicznie widoczne";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Konto Bankowe";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Wymagany dostęp biometryczny";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Zapisano wysokość początkową — podniesiona granica skanowania obowiązuje od następnego uruchomienia.";
+
 /* Voting */
 "Block" = "Blok";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Zablokowano '%@' nazwę użytkownika";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Powiązany z kontraktem";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Powiązany z kontraktem, typ dokumentu „%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Tylko przeglądanie";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Spakuj ostatnie dzienniki diagnostyczne do archiwum zip, aby wysłać je przez AirDrop, pocztą lub zapisać w Plikach";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Oddaj głos";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Zmień peery";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Zmień kod PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Sprawdzanie…";
+
+"Choice" = "Wybór";
+
 /* Choose your Dash username */
 "Choose your" = "Wybierz swój";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Wybierz swoją nazwę użytkownika";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Odbierz swoje zaproszenie";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo do odebrania";
+
 /* No comment provided by engineer. */
 "Claimed" = "Odebrane";
+
+/* SPV diagnostics */
+"Clear & resync" = "Wyczyść i zsynchronizuj ponownie";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Wyczyścić dane łańcucha i zsynchronizować ponownie?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Zamknij Aplikacje";
 
+"Closing" = "Zamykanie";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nowe monety)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Kod 2FA";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin nie jest już obsługiwany — wybierz, dokąd przenieść zmiksowane monety.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Zabezpieczenie";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Wkrótce";
+
+/* Shielded transfer status */
+"Completed" = "Zakończony";
 
 /* No comment provided by engineer. */
 "Confirm" = "Potwierdź";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potwierdzona";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potwierdzenie zapisuje wysokość początkową %u i czyści dane łańcucha tej sieci przy następnym uruchomieniu aplikacji, pobierając je ponownie i skanując filtry od tej wysokości. Bieżąca sesja zachowuje starą granicę skanowania — zamknij i otwórz aplikację ponownie, aby rozpocząć.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Połącz swoje portfele kryptowalut z platformą ZenLedger. Dowiedz się więcej i rozpocznij wysyłanie lub otrzymywanie transakcji z Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Połączony adres Dash";
 
+/* SPV sync */
+"Connected peers" = "Połączone peery";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Wady";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Zaproszenie do kontaktów nie powiodło się";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Wysłano zaproszenie do kontaktów do %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Zaproszenia do kontaktów";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kontakty";
 
+"Contender %@" = "Kandydat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Dalej";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Kontynuuj, aby wybrać nazwę użytkownika. Zaproszenie pokrywa opłatę rejestracyjną.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Kopiuj link do zaproszenia";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiuj surową transakcję";
+
 /* No comment provided by engineer. */
 "Copy text" = "Skopiuj tekst";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Nie jest możliwe automatyczne odzyskanie brakujących lub niewłaściwych słów";
 
+/* Log export */
+"Could not create the log archive: %@" = "Nie udało się utworzyć archiwum dzienników: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Kurs nie został znaleziony";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nie udało się odświeżyć %d tożsamości";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Nie udało się pobrać salda (błąd sieci). Spróbuj odświeżyć.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Nie można dokonać płatności";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Stwórz swoją nazwę użytkownika";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Utwórz swoją nazwę użytkownika, znajdź znajomych i rodzinę po ich nazwach użytkowników i dodaj ich do kontaktów";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Karta Kredytowa";
+
+/* Masternodes */
+"Credits" = "Kredyty";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Płatności Dash nie mogą być mniejsze niż %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform nie zindeksowało jeszcze tego sporu. Liczby głosów pojawią się tutaj, gdy to zrobi.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform nie jest jeszcze połączone. Poczekaj na zakończenie synchronizacji i spróbuj ponownie.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash wysłane na zły adres nie mogą zostać odzyskane. Upewnij się, że adres jest dokładnie tym, na który chcesz zapłacić.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash przechowuje nazwy użytkowników w formie odpornej na łudząco podobne zapisy, więc zapisana nazwa może różnić się od tego, co wpisała każda osoba.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nazwa Użytkownika Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Portfel Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo portfela Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Portfel Dash na tym urządzeniu";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay włączone";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Zaproszenie do DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay to społecznościowe płatności Dash, zbudowane na Dash Platform. Rejestrujesz nazwę użytkownika, dodajesz innych użytkowników do kontaktów i płacisz im po nazwie — koniec z kopiowaniem adresów.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay zastępuje długie, niezrozumiałe adresy nazwami użytkowników. Dodawaj znajomych do kontaktów, wysyłaj pieniądze na nazwę i miej każdą płatność uporządkowaną według osoby.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Opłata za ulepszenie DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Data: od najstarszej do najnowszej:";
+
+"Deadline unknown" = "Termin nieznany";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Wpłata została wysłana";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Ścieżka derywacji";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "BEZPIECZEŃSTWO URZĄDZENIA ZŁAMANE\nKażda aplikacja \"jailbreak\" ma dostęp do twoich kluczy w innych aplikacjach (i może ukraść twoje Dashe). Natychmiast wyczyść ten portfel i przywróć na bezpiecznym urządzeniu.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Wyłączony";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Rozłącz Konto Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Zrobione";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Gotowe — Twoje saldo odpoczywało wystarczająco długo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Sprawdź adres jeszcze raz";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Każde zaproszenie będzie opłacone tą sumą, aby odbiorca mógł szybko stworzyć swój własny profil na Sieci Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Każdy masternod ma jeden ważny głos na spór. Możesz go później zmienić, ale Dash Platform dopuszcza łącznie tylko 5 głosów na masternod w jednym sporze.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Każde dotknięcie dokłada do głosowania kolejny węzeł, więc sam(a) wybierasz, ile ich powiązać.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Wcześniej";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Z łatwością ulokuj swoje monety Dash i zarabiaj pasywny dochód za pomocą kilku prostych kliknięć. ";
+
+/* SPV diagnostics */
+"Edit birth height" = "Edytuj wysokość początkową";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edytuj Profil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Włącz";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Włącz DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Włącz Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Włącz Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Włączenie DashPay kosztuje niewielką jednorazową opłatę sieciową, pobieraną z salda kredytowego Twojej tożsamości. Dokładny szacunek pokazujemy przed potwierdzeniem. Wysyłanie zaproszeń do kontaktów i płatności kosztuje zwykłe opłaty sieciowe.";
+
+"Ending soonest" = "Kończy się najwcześniej";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Wystąpił błąd podczas aktualizacji twojego profilu";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Szacowana opłata sieci";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Wszystkie węzły głosują razem. Szybciej, ale publicznie łączy Twoje masternody ze sobą.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Klucze operatora Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Eksportuj CSV";
 
+/* Log export */
+"Export Logs" = "Eksportuj dzienniki";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Wydłużone klucze publiczne (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Adres zewnętrzny";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Nie powiodło się";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Załadowanie kodu kreskowego się nie powiodło";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Pobieram kursy…";
 
+/* Masternodes */
+"Fetching…" = "Pobieranie…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Konto Walutowe";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtrowanie";
+
+/* SPV sync phase */
+"Filter headers" = "Nagłówki filtrów";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtruj transakcje";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Znajdź użytkownika w sieci Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Wyszukaj ATMy gdzie możesz kupić lub sprzedać Dash";
+
+/* Identities */
+"Find identities" = "Znajdź tożsamości";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Zapomniałeś kodu PIN?";
 
+/* Identities */
+"Found %d new identities" = "Znaleziono %d nowych tożsamości";
+
+/* Identities */
+"Found 1 new identity" = "Znaleziono 1 nową tożsamość";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Znaleziono brakujące słowo:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Sfinansuj nazwę użytkownika z salda osłoniętego. Dodaj środki kilka godzin wcześniej — krótki odpoczynek sprawia, że nazwy użytkownika nie da się powiązać z pozostałymi Twoimi Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Sfinansowano z salda osłoniętego — nazwy użytkownika nie da się powiązać z pozostałymi Twoimi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Środki zablokowane — kończenie transferu";
+
+/* CoinJoin */
+"Funds moved" = "Środki przeniesione";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Pozwól aby twoje monety Dash pracowały na siebie jako zabezpieczenie Masternoda. Możesz zacząć z 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Otrzymaj wycenę";
+
+/* Usernames */
+"Get ready to join DashPay" = "Przygotuj się na dołączenie do DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Otrzymuj Zarobki Natychmiastowo";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Rozumiem";
+
+/* Governance */
+"Governance" = "Zarządzanie";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Daj pozwolenie na dostęp do GPS abyśmy mogli pokazać miejsca w twoim pobliżu.";
 
 /* Voting */
 "Has blocked votes" = "Ma zablokowane głosy";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "poprosił(a) o dodanie do znajomych";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Masz zaproszenie?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Miej pełną kontrolę oraz dostosuj swój portfel w zależności od potrzeb";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "nagłówek #%1$d z %2$d";
+
+/* SPV sync phase */
+"Headers" = "Nagłówki";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Wysokość %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Tutaj jest adres Dash wyznaczony dla tojego konta CrowdNode w Porfelu Dash na tym urządzeniu. ";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Wysoki do niskiego";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Wyższe opłaty, około 7 centów (nadal niższe niż w innych blockchainach oferujących podobną prywatność)";
+
 /* No comment provided by engineer. */
 "History" = "Historia";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Jak mogę otrzymać Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Jak to wypada w porównaniu z Bitcoinem pod względem prywatności?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Jak to wypada w porównaniu z kontami Ethereum pod względem prywatności?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Jak prywatne jest DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Jak potwierdzić adres API Dash";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Zapisałem to";
 
+/* Identities */
+"Identities" = "Tożsamości";
+
 /* Voting */
 "Identity" = "Tożsamość";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kredyty tożsamości";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks tożsamości";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Rejestracja tożsamości";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Doładowanie tożsamości";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "W sekcji płatności podczas finalizacji zakupu wybierz „karta podarunkowa” i wprowadź numer karty oraz kod PIN.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Nieaktywny";
+
+/* No comment provided by engineer. */
 "Income" = "Przychód";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Rozpoczynanie";
+
+/* Raw transaction inspector */
+"Input %d" = "Wejście %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Wejście %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Wejścia (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Niewystarczająca ilość funduszy";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Opłata za zaproszenie";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Zaproszenie od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Zaproszenie zostało użyte przez";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Zaproś";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Zaproś kogoś do sieci Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Zaproś rodzię i znajdź przyjaciół zapomocą wyszukiwarki nazw użytkowników";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Zaproś przyjaciół i rodzinę aby dołączyli do sieci Dash";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Zaproś znajomych i rodzinę do sieci Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Zgłoszono problem";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Dołączanie do Puli CrowdNode";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Zachowaj te monety prywatne. Obowiązują opłaty sieciowe i za prywatność.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Zabezpiecz swoją listę słów do odzysku konta oraz hasło.";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Klucz nr %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Dane klucza";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Własność klucza";
+
 /* No comment provided by engineer. */
 "Keypair" = "Para kluczy";
+
+/* Masternodes */
+"Keys" = "Klucze";
 
 /* Explore Dash */
 "Last device sync" = "Ostatnia synchronizacja urządzenia";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Prowadzi";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Dowiedz się więcej";
 
 /* Info Screen */
 "Learn More..." = "Dowiedz się więcej...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Wczytywanie transakcji";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Lokalna Waluta";
 
+/* Identities */
+"Local Only" = "Tylko lokalnie";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Lokalna żądana kwota %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Miejsce";
 
+"Lock" = "Zablokuj";
+
+"Lock the name" = "Zablokuj nazwę";
+
+"Lock “%@” so nobody gets it" = "Zablokuj „%@”, aby nikt jej nie dostał";
+
 /* No comment provided by engineer. */
 "Locked" = "Zablokowane";
 
+"Locked — nobody receives this username" = "Zablokowana — nikt nie otrzyma tej nazwy użytkownika";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Zaloguj się";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Niski";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Niskie opłaty przy codziennych wydatkach";
+
 /* Voting */
 "Low to high" = "Od niskiego do wysokiego";
+
+/* Identities — the wallet's main identity */
+"Main" = "Główna";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Adres IP masternoda";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Pęk kluczy masternoda";
+
+/* Masternode keys */
 "Masternode keys" = "Klucze Masternoda";
+
+/* SPV sync phase */
+"Masternode list" = "Lista masternodów";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "lista masternodów #%1$d z %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Aktualizacji Masternoda";
 
+"Masternode votes" = "Głosy masternodów";
+
 /* Voting */
 "Masternode Voting Key" = "Klucz Masternoda  do głosowania";
+
+/* Tools menu */
+"Masternodes" = "Masternody";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternody i evonody zarejestrowane kluczami tego portfela pojawią się tutaj po zsynchronizowaniu portfela.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternody i evonody używające kluczy tego portfela";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternody głosują nad nazwami, o które poprosiła więcej niż jedna osoba. Powiadomimy Cię, gdy głosowanie się zakończy.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Osiągnięto minimum";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Więcej Kontroli";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Więcej sugestii";
+
+"Most lock votes" = "Najwięcej głosów blokujących";
+
+"Most votes" = "Najwięcej głosów";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Przesuń lub przybliż zdjęcie aby znaleźć idealny rozmiar";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Przenieś na zwykłe saldo do wydania.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Przeniesione na Adres";
+
+/* CoinJoin */
+"Moving funds" = "Przenoszenie środków";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Imię";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Usługi nazw takie jak Unstoppable Domains przypisują czytelną nazwę do stałego publicznego adresu w łańcuchu. Każdy może rozwiązać tę nazwę i zobaczyć każdą płatność, jaka kiedykolwiek na nią trafiła. Nazwa użytkownika DashPay nigdy nie prowadzi publicznie do adresu płatności — adresy są ujawniane wyłącznie w zaszyfrowanej wymianie z każdym kontaktem, więc Twoja nazwa i Twoje pieniądze pozostają dla postronnych niepowiązane.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Potrzebujesz pomocy?";
+
+"Needs attention" = "Wymaga uwagi";
 
 /* No comment provided by engineer. */
 "Network" = "Sieć";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Nie znaleziono dzienników diagnostycznych na tym urządzeniu. Dzienniki są zapisywane od następnego uruchomienia.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Brak tożsamości";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Brak masternodów";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Brak pasujących sporów";
+
+/* Identities */
+"No new identities were found for this wallet" = "Nie znaleziono nowych tożsamości dla tego portfela";
+
+"No open contest matches that search." = "Żaden otwarty spór nie pasuje do tego wyszukiwania.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Żaden otwarty spór nie pasuje do tego wyszukiwania. Nazwy są przechowywane w formie znormalizowanej, więc „alice” figuruje jako „a11ce”.";
+
+"No open contests" = "Brak otwartych sporów";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Brak metody płatności";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Nie znaleziono zapisanego wpisu portfela dla powiązanego portfela.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Nie ma jeszcze dostępnego adresu Platform do awaryjnej rejestracji osłoniętej. Spróbuj ponownie, gdy portfel zakończy synchronizację.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Nie znaleźliśmy żadnych wyników";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Obecnie żadna nazwa użytkownika nie jest sporna. Spory otwierają się, gdy dwie lub więcej osób poprosi o tę samą nazwę.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Nie możesz oddać więcej głosów";
+
+"No votes were cast" = "Nie oddano żadnych głosów";
+
+"Nobody gets it" = "Nikt jej nie dostanie";
+
+/* SPV sync peer type */
+"Node" = "Węzeł";
+
+/* Raw transaction inspector */
+"Non-standard" = "Niestandardowy";
 
 /* adjective, security level */
 "None" = "Żaden";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Niedostępne";
 
+"Not available yet" = "Jeszcze niedostępne";
+
+"Not cast" = "Nieoddany";
+
+/* Masternodes */
+"Not checked yet" = "Jeszcze nie sprawdzono";
+
 /* Location Service Status */
 "Not Determined" = "Nieustalony";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Za małe saldo osłonięte, aby zarejestrować tożsamość";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Brak w historii portfela";
+
+"Not now" = "Nie teraz";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Niezbyt szeroko akceptowany przez sprzedawców";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Nie jest jeszcze szeroko akceptowany przez sprzedawców";
+
+/* Masternode keys */
+"Not yet used" = "Jeszcze nieużywany";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Od starego do nowego";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "W Bitcoinie nie ma warstwy nazw, więc ludzie udostępniają i wielokrotnie używają adresów na widoku — gdy adres jest już znany, wszystko, co kiedykolwiek otrzymał, można powiązać z jego właścicielem. W DashPay Twoja nazwa użytkownika jest publiczna, ale nigdy nie wskazuje adresu płatności: adresy są wymieniane prywatnie z każdym kontaktem i rotują, więc płacenie na nazwę nie ujawnia, dokąd trafiają Twoje pieniądze. Oba łańcuchy są przejrzyste, więc analiza łańcucha nadal dotyczy samych monet.";
+
+/* Identities */
+"On Network" = "W sieci";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Gdy %@ zaakceptuje Twoje zaproszenie, będziesz mógł(a) płacić bezpośrednio na nazwę użytkownika";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Po jednym węźle";
 
 /* Voting */
 "One vote left" = "Został ci tylko jeden głos";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Tylko duplikaty";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Tylko masternody i evonody mogą głosować nad nazwami użytkowników. Ten portfel nie zawiera aktywnych kluczy głosowania masternodów.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Tylko żądania z linkami";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Tylko z linkami";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Klucze operatora";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Klucz publiczny operatora (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "lub";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Podgląd Zamówienia";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Inne wyniki";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Wyjście %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Wyjścia (%d)";
+
+/* Masternodes */
+"Owner" = "Właściciel";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Adres Właściciela";
+
+/* Masternodes */
+"Owner address" = "Adres właściciela";
+
+/* Masternodes */
+"Owner key hash" = "Skrót klucza właściciela";
 
 /* Owner keys */
 "Owner keys" = "Klucze właściciela";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Opłacone z salda kredytowego Twojej tożsamości.";
 
 /* DashSpend */
 "Password" = "Hasło";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Wklej link tutaj";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Wklej otrzymany link zaproszenia albo zeskanuj jego kod QR. Pokrywa on rejestrację Twojej nazwy użytkownika.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Wklej URL swojego obrazka ";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Płać i otrzymuj natychmiastowe płatności dzięki łatwym w użyciu przepływom płatności";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "płacić bezpośrednio na nazwę użytkownika";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Płać ludziom, nie adresom";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Użwaj normalnych nazw do wysyłania funduszy. Nie musisz się męczyć z długimi losowymi adresami. ";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Płacę...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Metoda płatności";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Płatności są prywatne: adresy, które wymieniasz z kontaktem, podróżują w zaszyfrowanej treści, którą możecie odczytać tylko wy dwoje, i nigdy nie są publikowane — więc Twoich płatności nie da się łatwo powiązać z Twoją nazwą użytkownika. Nadal są to jednak zwykłe płatności w przejrzystym łańcuchu: zaawansowana analiza łańcucha może ujawnić informacje. Shielded DashPay (wkrótce) zamknie tę lukę. Same zaproszenia do kontaktów obecnie NIE są prywatne: każdy może zobaczyć, że dwie tożsamości są połączone. Prywatne zaproszenia do kontaktów to funkcja, która pojawi się wkrótce. Twoja nazwa użytkownika i profil są również publiczne na Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Płatności potwierdzają się w kilka sekund dzięki InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Płatności wykonane bezpośrednio na adresy nie będą zachowywane w aktywności.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Płatności z każdym kontaktem są zebrane w jednym miejscu, z nazwami i profilami zamiast surowych transakcji.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adres wypłaty";
 
 /* CrowdNode */
 "Payout Options" = "Opcje Wypłaty";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adres Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Węzeł Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID węzła Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Płatności Platform nie identyfikują nadawcy. Ta płatność została zapisana, gdy portfel zauważył zmianę salda — mogła dotrzeć wcześniej.";
+
+"Platform SDK not ready" = "SDK Platform nie jest gotowe";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Synchronizacja Platform nie działa. Otwórz Informacje o synchronizacji → Stan synchronizacji Platform, aby ją uruchomić.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Osłonięte";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Dodaj metodę płatności na Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Podgląd zaproszenia";
 
+/* Masternode keys */
+"Previously used at: " = "Poprzednio użyty: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Ceny są sprzed co najmniej 30 minut. Ceny papierowego pieniądza mogą być nieprawidłowe.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Prywatny z założenia";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Prywatne zaproszenia do kontaktów (aby to, z kim się łączysz, pozostało prywatne), Shielded DashPay — płatności do kontaktów z prywatnego salda osłoniętego — oraz płacenie użytkownikom, których nie masz jeszcze w kontaktach, pojawią się wkrótce.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Prywatne zaproszenia do kontaktów są w trakcie prac i spodziewane około września–października 2026. Dziś samo zaproszenie jest publiczne — każdy może zobaczyć, że dwie tożsamości są połączone, nawet jeśli zawarte w nim dane płatności są zaszyfrowane. Gdy pojawią się prywatne zaproszenia do kontaktów, będziesz mieć wybór, czy Twoja znajomość ma być publiczna, czy prywatna.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Prywatne zaproszenia do kontaktów, Shielded DashPay oraz płacenie osobom, które nie są jeszcze kontaktami.";
+
 /* No comment provided by engineer. */
 "Private key" = "Klucz prywatny";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Prywatne adresy płatności są wymieniane między Tobą a Twoimi kontaktami. Tylko Ty i Twój kontakt znacie odbiorcę i nadawcę płatności między wami.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Płatności prywatne";
+
+/* Usernames */
+"Private registration" = "Rejestracja prywatna";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Czas przetwarzania";
+
+/* Balance info sheet section */
+"Pros" = "Zalety";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Chroń Swoje Oszczędnosci";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Dostawca Adresu";
 
+/* Masternodes */
+"Provider transactions" = "Transakcje dostawcy";
+
+/* Masternode keys */
+"Public key" = "Klucz publiczny";
+
+/* Masternode keys */
+"Public key (legacy)" = "Klucz publiczny (starszy)";
+
+/* Identities */
+"Public keys" = "Klucze publiczne";
+
 /* No comment provided by engineer. */
 "Public URL" = "Publiczny URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Zakup się nie udał";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Przeznaczenie";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Stawka %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Surowa transakcja";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Surowa transakcja niedostępna";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ponownie sprawdza kompaktowe filtry bloków od wybranej wysokości pod kątem transakcji tego portfela, pobierając je i dopasowując na nowo. Ponowne skanowanie jest ograniczone od dołu wysokością utworzenia portfela oraz lokalnie zapisanymi danymi łańcucha — aby odzyskać historię poniżej, obniż zamiast tego wysokość początkową portfela.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Przeczytaj zasady wypłat";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Tylko do odczytu";
+
+/* Usernames */
+"Ready around %@" = "Gotowe około %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Powód";
 
 /* No comment provided by engineer. */
 "Receive" = "Odbierz";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Odebrane z";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Otrzymano od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Otrzymywanie wynagrodzenia";
+
+"Records your masternodes as having voted, without taking a side." = "Zapisuje Twoje masternody jako głosujące, bez opowiadania się za żadną stroną.";
 
 /* No comment provided by engineer. */
 "Recover" = "Odzyskaj";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Hasła odzyskiwania muszą mieć 12, 15, 18, 21 lub 24 slowa";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Odśwież";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Zarejestruj?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Zarejestrowano";
+
+/* No comment provided by engineer. */
 "Registered from" = "Zarejestrowany z";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Zarejestrowany Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Rejestracja prywatna wymaga co najmniej %@ Dash na saldzie osłoniętym oraz kilku godzin odpoczynku — kolejne ekrany przeprowadzą Cię przez ten proces.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Rejestracja";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Prosi o tę nazwę";
+
 /* An action */
 "Rescan" = "Ponownie zeskanuj";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Odtworzone portfele nie zawsze potrafią odzyskać typ operacji. Ten wpis został zrekonstruowany z danych notatki w łańcuchu.";
+
+/* Location Service Status */
 "Restricted" = "Zabronione";
 
 /* Usernames */
 "Results" = "Wyniki";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ponowna synchronizacja przygotowana od wysokości %u — zamknij i otwórz aplikację ponownie, aby rozpocząć.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "zachować wspólną historię transakcji";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Wycofany";
 
 /* No comment provided by engineer. */
 "Retry" = "Ponów";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Przejrzyj poniższy wpis, aby zweryfikować własność tej nazwy użytkownika";
+
+/* Masternodes */
+"Revocation" = "Unieważnienie";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screeny są widoczne dla innych aplikacji i urządzeń. Wygeneruj nową frazę odzyskiwania danych i zachowaj ją w tajemnicy.";
 
+/* Raw transaction inspector */
+"Script" = "Skrypt";
+
+/* Raw transaction inspector */
+"Script signature" = "Podpis skryptu";
+
+/* Raw transaction inspector */
+"Script type" = "Typ skryptu";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Szukaj kontaktu";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Szukaj zaproszenia do kontaktów";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Szukaj użytkownika w sieci Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Szukaj nazwy użytkownika";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Wyniki wyszukiwania dla \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Wyszukaj terytoria";
+
+"Search usernames" = "Szukaj nazw użytkowników";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Szukanie nazwy użytkownika %@ w sieci Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Zabezpiecz swój portfel ";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Poziom Bezpieczeństwa";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Poziom bezpieczeństwa";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Wybierz usługę, aby kupić, sprzedać, przekonwertować i przetransferować Dash";
 
+"Select all" = "Zaznacz wszystko";
+
 /* DashSpend denomination selection */
 "Select amount" = "Wybierz kwotę";
+
+"Select at least one masternode to vote with." = "Wybierz co najmniej jeden masternod do głosowania.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Wybierz monetę";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Wybranie mniejszej liczby węzłów mniej zdradza o tym, które masternody prowadzisz.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Samoobsługowa płatność";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Wyślij do";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Wyślij do kontaktu";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Wysyłaj na nazwę użytkownika, którą naprawdę zapamiętasz i zweryfikujesz.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Zapłać na Adres";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Wyślij swoje pierwsze zaproszenie do kontaktów";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Wysyłam";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Wysyłanie zaproszenia do kontaktów";
+
+/* No comment provided by engineer. */
+"Sending to" = "Wysyłanie do";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Wpłacanie na konto CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Wysłane do";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Wysłano do %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Wystąpił błąd serwera. Spróbuj ponownie później.";
+
+/* Masternodes */
+"Service" = "Usługa";
+
+/* Identities */
+"Set as Main" = "Ustaw jako główną";
+
+/* Identities */
+"Set as Main Identity" = "Ustaw jako główną tożsamość";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Ustaw PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Udostępnij klucz";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Wspólna pula prywatności o minimalnym rozmiarze";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Adres osłonięty";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Wydatek osłonięty";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Uruchamianie portfela osłoniętego…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Osłonięte → Platform";
+
+"Shielded → Transparent" = "Osłonięte → Transparentne";
 
 /* Explore Dash */
 "Show all locations" = "Pokaż wszyskie miejsca";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Rozmiar";
+
 /* No comment provided by engineer. */
 "Skip" = "Pomiń";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Niektórych Twoich masternodów może brakować na tej liście — portfel nie mógł odczytać pełnego zestawu Twoich kluczy głosowania. Zakończ synchronizację i otwórz ten ekran ponownie.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Niektóre nazwy użytkowników mogą zostać zablokowane";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sortuj według";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortuj kontakty";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sortuj wg zniżek";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sortuj wg nazwy";
+
+/* Raw transaction inspector */
+"Special payload" = "Specjalny payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Określ Kwotę";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Lokata";
 
+/* Usernames */
+"Starts after you add funds" = "Zacznie się po dodaniu środków";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Krok %Id";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Zapisano jako";
 
 /* Voting */
 "Submit" = "Wyślij";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Synchronizacja w toku... Wyniki mogą nie być kompletne.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacje o synchronizacji";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronizacja zbyt wolna?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Zrób zdjęcie";
 
+"Take no side" = "Nie opowiadaj się za żadną stroną";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Naciśnij, adres ze schowka, aby go wkleić";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Dotknij, aby skopiować";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Stuknij by ukryć saldo";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Tymczasowo niedostępny";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Klucz węzła Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Warunki i zasady";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Kod jest nieprawidłowy. Spróbuj ponownie!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash trafią na adres odbiorcy po przetworzeniu wypłaty przez sieć — może to potrwać do 10 minut.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash trafią na adres odbiorcy, gdy tylko sieć przetworzy wypłatę.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash trafią na Twoje saldo transparentne, gdy tylko sieć przetworzy wypłatę.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Sieć Dash musi głosować nad zatwierdzeniem Twojej nazwy użytkownika zanim zostanie ona stworzona.";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Wysłany przez Ciebie link będzie widoczny tylko dla właścicieli sieci";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Główną tożsamość można wybrać tylko z aktywnego portfela";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Minimalna kwota jaką możesz wysłać to %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najbardziej prywatne miejsce na Twoje Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Zapisany wpis portfela nie ma sieci — nie można przygotować ponownej synchronizacji.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Rejestracja została wysłana, ale nie udało się potwierdzić jej wyniku. Odczekaj minutę, aż portfel się zsynchronizuje, a potem spróbuj ponownie — nie wysyłaj od razu drugi raz.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Wspólna pula prywatności wciąż rośnie (%1$ld z %2$ld wpłat). Rejestracja prywatna odblokuje się, gdy osiągnie minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Wspólna pula prywatności wciąż rośnie (%1$ld z %2$ld wpłat). Spróbuj ponownie, gdy osiągnie minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Nazwa użytkownika '%@' została zablokowana przez sieć Dash. Spróbuj zażądać inną nazwę użytkownika.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Wysokość utworzenia portfela — dolna granica skanowania filtrów oraz ponownych skanów „Od utworzenia portfela”. Ustaw ją na poziomie pierwszego zasilenia portfela lub poniżej; importy domyślnie używają 200000 w mainnecie i 0 w testnecie. Zapisanie wysokości równej bieżącej lub niższej wyczyści dane łańcucha tej sieci przy następnym uruchomieniu i przeskanuje od niej.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "go (pobieranie informacji)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nie ma nowych powiadomień";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Brak transakcji do wyświetlenia";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nie ma użytkowników pasujących do nazwy %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "W Twoich kontaktach nie ma użytkowników pasujących do nazwy %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Wystąpił błąd podczas eksportowania historii transakcji do ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Wystąpił błąd, spróbuj ponownie później";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Te środki trafiają na Twoje saldo Platform i będą gotowe do wydania, gdy tylko transfer się zakończy.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Tego adresu nie można opłacić z Twojego salda %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "To dodaje dwa klucze do Twojej tożsamości, aby inni użytkownicy mogli wysyłać Ci zaproszenia do kontaktów, a Ty mógł(a) przyjmować ich zaproszenia. Dzieje się to tylko raz.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "To zastosuje jeden wybór do wszystkich %d zaznaczonych nazw użytkowników.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Ten dodatkowy krok potwierdza, że to naprawdę ty dokonujesz  tej transakcji. ";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ten link zaproszenia jest nieprawidłowy.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "To nie jest prawidłowy adres Dash dla tej sieci";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "To nie jest prawidłowy link zaproszenia";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "To jest Twoja główna tożsamość";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ten masternod nie ma jeszcze tożsamości Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Ten sprzedawca jest obecnie niedostępny.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Odpowiada to aktualnemu rocznemu oprocentowania pełnego Masternode pomniejszonemu o 15% jako opłata dla CrowdNode. Nie jest to gwarantowana stopa zwrotu i może wzrosnąć lub spaść w zależności od wielkości pul na CrowdNode i ceny Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "To nadal liczy się jako oddanie głosu przez Twoje masternody w tym sporze.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Surowe bajty tej transakcji nie są zapisane na tym urządzeniu.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ta nazwa użytkownika trafiła do kogoś innego";
+
+"This wallet could not derive the voting key for this node." = "Ten portfel nie mógł wyprowadzić klucza głosowania dla tego węzła.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ten portfel nie zawiera aktywnych kluczy głosowania masternodów, więc nie może głosować. Zarejestrowane węzły pojawiają się w Narzędzia → Masternody.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "To wypłaca całe saldo Platform w jednym transferze. Dash trafią na adres odbiorcy, gdy tylko sieć przetworzy wypłatę.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "To wypłaca całe saldo Platform w jednym transferze. Dash trafią na Twoje saldo transparentne, gdy tylko sieć przetworzy wypłatę.";
 
 /* Send Screen: to address */
 "to" = "Do";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Historia Transakcji";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Historia transakcji jest niedostępna";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transakcja id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcji";
 
 /* A verb, button title. */
 "Transfer" = "Prześlij";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer do wewnatrz";
 
+/* Balance breakdown */
+"Transfer in" = "Transfer przychodzący";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer na zewnątrz";
+
+/* Balance breakdown */
+"Transfer out" = "Transfer wychodzący";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transfery trwają dłużej — budowanie dowodów prywatności wymaga czasu";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transfery na inne adresy Platform i adresy osłonięte są natychmiastowe i ostateczne";
+
+/* Balance breakdown */
+"Transparent" = "Transparentne";
+
+/* Send screen destination type */
+"Transparent address" = "Adres transparentny";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo transparentne";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Finansowanie transparentne publicznie łączy Twoją nazwę użytkownika z tymi środkami.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentne → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentne → Osłonięte";
 
 /* An action */
 "Try again" = "Spróbuj jeszcze raz";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nie można przedstawić sugestii";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Nieznane Saldo";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Nieznany typ specjalny %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nieosłonięte";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Nieobsługiwany URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Ulepszenie do DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Przejdź na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Użyj zamiast tego salda transparentnego";
+
+/* Masternode keys */
+"Used" = "Użyty";
+
+/* Masternode keys */
+"Used at: " = "Użyty: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Użytkownik (pobieranie informacji)";
 
 /* Voting */
 "Username" = "Nazwa użytkownika";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Pomyślnie poproszono o nazwę użytkownika";
 
+/* Identities */
+"Usernames" = "Nazwy użytkowników";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Nazwy użytkowników są przechowywane w formie znormalizowanej, aby zapobiec łudząco podobnym nazwom, więc może się to różnić od tego, co wpisała każda osoba.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nazwy użytkowników, nie adresy";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Użytkownicy pasujący do %@, których obecnie nie masz w kontaktach";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Używa jednej z najlepiej zaudytowanych i przetestowanych bibliotek zero-knowledge (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Prawidłowe zaproszenie";
+
 /* CrowdNode Portal */
 "Validating address…" = "Walidacja adresu...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Wymagana jest Weryfikacja";
 
+/* Usernames */
+"Verified during registration" = "Zweryfikowano podczas rejestracji";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Zweryfikowano Pomyślnie";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Zweryfikuj swoją tożsamość";
 
+/* Raw transaction inspector */
+"Version" = "Wersja";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Bardzo wydajne przy niskich opłatach";
+
 /* adjective, security level */
 "Very High" = "Bardzo Wysoki";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Mała kwota Dash zostanie wysłana z i do CrowdNode aby zweryfikować że jesteś właścicielem tego adresu. ";
+
+/* No comment provided by engineer. */
+"View All" = "Zobacz wszystko";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Zobacz na Eksplorerze";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Pokaż Frazę Odzyskiwania Portfela";
 
+/* Raw transaction inspector */
+"View Transaction" = "Zobacz transakcję";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Zobacz szczegóły transakcji";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Głosuj";
+
+"Vote cast" = "Głos oddany";
+
 /* Voting */
 "Vote for All" = "Głosuj nad wszyskimi";
 
 /* Voting */
+"Vote on contested usernames" = "Głosuj nad spornymi nazwami użytkowników";
+
+"Vote on several" = "Głosuj nad kilkoma";
+
+/* Voting */
 "Vote to Approve" = "Głosuj, aby zatwierdzić";
+
+"Vote with" = "Głosuj z";
+
+"Votes that nobody should receive these usernames." = "Głosuje za tym, aby nikt nie otrzymał tych nazw użytkowników.";
 
 /* Voting */
 "Votes: High to low" = "Głosy: od najwięcej do najmniej";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Adres Głosowania";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adres głosowania";
+
+"Voting ended with no winner" = "Głosowanie zakończyło się bez zwycięzcy";
+
+"Voting ends" = "Głosowanie kończy się";
+
 /* Voting */
 "Voting ends in %dd" = "Głosowanie kończy się za %d dni";
+
+"Voting in progress" = "Głosowanie trwa";
+
+"Voting in progress — lock votes are ahead" = "Głosowanie trwa — głosy blokujące prowadzą";
+
+"Voting in progress — you are ahead" = "Głosowanie trwa — prowadzisz";
 
 /* Usernames */
 "Voting is only required in some cases" = "Głosowanie jest wymagane tylko w niektórych przypadkach";
 
+/* Masternodes */
+"Voting key hash" = "Skrót klucza głosowania";
+
 /* Voting keys */
 "Voting keys" = "Klucze głosowania";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Głosowanie nad tą nazwą użytkownika zostało zamknięte. Poniższe liczby to ostatnie odczytane wartości.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Głosowanie nad „%@” zostało już zamknięte. Odśwież, aby zobaczyć wynik.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Poczekaj aż portfel będzie zsynchronizowany z siecią, aby dokończyć transakcję.";
 
+"Waiting for Dash Platform" = "Oczekiwanie na Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Adres Portfela";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Wysokość początkowa portfela";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Portfel zdezaktywowany";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Witaj w DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "A co z Unstoppable Domains i podobnymi usługami nazw?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Ile to kosztuje?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Czym jest DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Na czym polega głosowanie nad nazwą użytkownika?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Co dalej?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kiedy zaproszenia do kontaktów staną się prywatne?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Gdzie kupować";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Gdzie Kupować?";
+
+"Who is requesting this name" = "Kto prosi o tę nazwę";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Dlaczego muszę to włączyć?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Dlaczego widzę te wszystkie transakcje?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Żądanie wypłaty";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Wypłaca całe saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Działa z każdym portfelem, giełdą i sprzedawcą Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Chcesz zaakcptować zaprosznie?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Wczoraj";
+
+"You" = "Ty";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Zaakceptowałeś(-aś) zaproszenie do kontaktów od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Wybrałeś “%@” jako swoją nazwę użytkownika.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Nie masz obecnie żadnych kontaktów";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Nie posiadasz wystarczających środków aby dokonać tej transakcji";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Przekroczyłeś limit autoryzacji na Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Masz jak dotąd %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Posiadasz %1$@ Dash.\nNiektóre nazwy użytkownika kosztują do %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Wysłałeś(-aś) zaproszenie do kontaktów do %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Powinieneś mieć dodatnie saldo na portfelu Dash";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Wygrałeś(-aś) tę nazwę użytkownika";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Wszystko gotowe. Inni użytkownicy mogą teraz wysyłać Ci zaproszenia do kontaktów — a Ty możesz wysyłać swoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Twoja tożsamość Dash Platform pojawi się tutaj, gdy zarejestrujesz nazwę użytkownika.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Twój adres e-mail służy wyłącznie do wysyłania hasła jednorazowego.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Twoja historia, uporządkowana";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Twoja tożsamość potrzebuje dwóch dodatkowych kluczy, aby zaproszenia do kontaktów mogły być szyfrowane między Tobą a innymi użytkownikami. Włączenie dodaje je jedną transakcją sieciową. Dzieje się to tylko raz.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Twoje zaproszenie od %@ zostało już odebrane";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Twoje zaproszenie od %@ jest nieważne";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Twoje zaproszenie pokrywa opłatę rejestracyjną tej nazwy użytkownika.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Twoja lokalizacja  jest używana aby pokazać Twoją pozycje na mapie, ATMy w zaznaczonym okręgu oraz by usprawnić wyniki wyszukiwania.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Używamy twojej lokalizacji do pokazania twojej pozycji na mapie, kupców w wybranym promieniu oraz do ulepszenia wyników wyszukiwania.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Twoje główne saldo Dash na blockchainie Core — to, co wysyłasz i odbierasz z innymi portfelami, giełdami i sprzedawcami.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Twoje zmiksowane monety zostały przeniesione na saldo portfela Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Twoje zmiksowane monety zostały przeniesione na saldo osłonięte. Dla najlepszej prywatności odczekaj co najmniej 2 godziny przed użyciem tych środków.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Twoje saldo Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Twój główny adres Dash które jest obecnie połączone z kontem CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Twoje prywatne saldo. Kwoty i adresy są zaszyfrowane w łańcuchu, więc Twoje środki i historia pozostają poufne.";
+
 /* Usernames */
 "Your request was cancelled" = "Twoja prośba została anulowana";
 
 /* DashSpend */
 "Your session expired" = "Twoja sesja wygasła";
+
+/* Usernames */
+"Your Shielded balance" = "Twoje saldo osłonięte";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Twoje saldo osłonięte jest prawie gotowe — będziesz mógł(a) zarejestrować się prywatnie około %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Twoje saldo osłonięte jest gotowe — zarejestruj teraz nazwę użytkownika prywatnie";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Twoje saldo osłonięte odpoczywa — będziesz mógł(a) zarejestrować się prywatnie około %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Twoje saldo osłonięte wciąż dojrzewa. Będzie gotowe około %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Twoje saldo transparentne";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Twoja nazwa użytkownika %@ została stworzona na Sieci Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Twoja nazwa użytkownika została stworzona";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Twoja nazwa użytkownika jest widoczna dla wszystkich. Sfinansowanie jej z salda osłoniętego — po pozostawieniu środków na kilka godzin — sprawia, że nikt nie powiąże Twojej nazwy użytkownika z pozostałymi Twoimi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Twoja nazwa użytkownika, profil i kontakty są związane z tą tożsamością.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Twoja nazwa użytkownika, profil i kontakty będą związane z tą tożsamością.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Twój głos został anulowany";
 
 /* Voting */
 "Your vote was submitted" = "Twój głos został przesłany";
 
+"Your votes" = "Twoje głosy";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Twój portfel jest teraz zabezpieczony. Możesz użyć swojej frazy odzyskiwania w dowolnym momencie, aby odzyskać konto na innym urządzeniu.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Twój portfel wciąż synchronizuje się z siecią Dash. Wysyłanie będzie dostępne po zakończeniu synchronizacji.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Twój portfel wciąż się synchronizuje. Wysyłanie z salda transparentnego będzie dostępne po zakończeniu synchronizacji.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Nie udało się odczytać „%@” jako nazwy użytkownika Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@” zostało zarejestrowane. Wysłać zaproszenie do kontaktów osobie, która Cię zaprosiła?";

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Wszystkie węzły naraz";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Wszystkie Twoje masternody zagłosowały nad tą nazwą użytkownika. Aby zmienić głos, zagłosuj ponownie z poziomu kandydata, którego teraz preferujesz.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Wszystkie Twoje masternody zagłosowały nad tą nazwą użytkownika. Aby zmienić głos, zagłosuj ponownie na kandydata, którego teraz preferujesz.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/pl.lproj/Localizable.stringsdict
+++ b/DashWallet/pl.lproj/Localizable.stringsdict
@@ -105,7 +105,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ policzonych dla „%2$@”</string>
+		<string>%#@votes@ dla „%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -113,13 +113,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u głos</string>
+			<string>%1$u policzony głos</string>
 			<key>few</key>
-			<string>%1$u głosy</string>
+			<string>%1$u policzone głosy</string>
 			<key>many</key>
-			<string>%1$u głosów</string>
+			<string>%1$u policzonych głosów</string>
 			<key>other</key>
-			<string>%1$u głosu</string>
+			<string>%1$u policzonego głosu</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -165,7 +165,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ zagłosowało</string>
+		<string>Głosowanie: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -185,7 +185,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ zagłosowało</string>
+		<string>Głosowanie: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/pl.lproj/Localizable.stringsdict
+++ b/DashWallet/pl.lproj/Localizable.stringsdict
@@ -102,5 +102,305 @@
 			<string>%d kluczy</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ policzonych dla „%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u głos</string>
+			<key>few</key>
+			<string>%1$u głosy</string>
+			<key>many</key>
+			<string>%1$u głosów</string>
+			<key>other</key>
+			<string>%1$u głosu</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Zagłosowano nad %1$d z %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nazwy użytkownika</string>
+			<key>few</key>
+			<string>%2$d nazw użytkowników</string>
+			<key>many</key>
+			<string>%2$d nazw użytkowników</string>
+			<key>other</key>
+			<string>%2$d nazw użytkowników</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Oddaj %u głos</string>
+			<key>few</key>
+			<string>Oddaj %u głosy</string>
+			<key>many</key>
+			<string>Oddaj %u głosów</string>
+			<key>other</key>
+			<string>Oddaj %u głosu</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ zagłosowało</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternoda</string>
+			<key>few</key>
+			<string>%2$d masternodów</string>
+			<key>many</key>
+			<string>%2$d masternodów</string>
+			<key>other</key>
+			<string>%2$d masternodów</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ zagłosowało</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d węzła</string>
+			<key>few</key>
+			<string>%2$d węzłów</string>
+			<key>many</key>
+			<string>%2$d węzłów</string>
+			<key>other</key>
+			<string>%2$d węzłów</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonody</string>
+			<key>many</key>
+			<string>%d evonodów</string>
+			<key>other</key>
+			<string>%d evonoda</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>łącznie %u głos</string>
+			<key>few</key>
+			<string>łącznie %u głosy</string>
+			<key>many</key>
+			<string>łącznie %u głosów</string>
+			<key>other</key>
+			<string>łącznie %u głosu</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternod</string>
+			<key>few</key>
+			<string>%d masternody</string>
+			<key>many</key>
+			<string>%d masternodów</string>
+			<key>other</key>
+			<string>%d masternoda</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d wybrany</string>
+			<key>few</key>
+			<string>%d wybrane</string>
+			<key>many</key>
+			<string>%d wybranych</string>
+			<key>other</key>
+			<string>%d wybranego</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d Twój węzeł już tu zagłosował i nie jest wymieniony.</string>
+			<key>few</key>
+			<string>%d Twoje węzły już tu zagłosowały i nie są wymienione.</string>
+			<key>many</key>
+			<string>%d Twoich węzłów już tu zagłosowało i nie są wymienione.</string>
+			<key>other</key>
+			<string>%d Twoich węzłów już tu zagłosowało i nie są wymienione.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u głos na spór — evonody liczą się jako 4, masternody jako 1</string>
+			<key>few</key>
+			<string>%u głosy na spór — evonody liczą się jako 4, masternody jako 1</string>
+			<key>many</key>
+			<string>%u głosów na spór — evonody liczą się jako 4, masternody jako 1</string>
+			<key>other</key>
+			<string>%u głosu na spór — evonody liczą się jako 4, masternody jako 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Głosuj nad %d nazwą użytkownika</string>
+			<key>few</key>
+			<string>Głosuj nad %d nazwami użytkowników</string>
+			<key>many</key>
+			<string>Głosuj nad %d nazwami użytkowników</string>
+			<key>other</key>
+			<string>Głosuj nad %d nazwami użytkowników</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u głos</string>
+			<key>few</key>
+			<string>%u głosy</string>
+			<key>many</key>
+			<string>%u głosów</string>
+			<key>other</key>
+			<string>%u głosu</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Głosuj ×%d</string>
+			<key>few</key>
+			<string>Głosuj ×%d</string>
+			<key>many</key>
+			<string>Głosuj ×%d</string>
+			<key>other</key>
+			<string>Głosuj ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d prośba</string>
+			<key>few</key>
+			<string>%d prośby</string>
+			<key>many</key>
+			<string>%d próśb</string>
+			<key>other</key>
+			<string>%d prośby</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Todos os nós de uma vez";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos os seus masternodes votaram neste nome de usuário. Para mudar um voto, vote novamente a partir do candidato que você agora prefere.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos os seus masternodes votaram neste nome de usuário. Para mudar um voto, vote novamente no candidato que você agora prefere.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ou ";
+
 /* CrowdNode */
 " Privacy Policy " = "Política de Privacidade";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Não foi possível encontrar %@ na rede Dash para enviar uma solicitação de contato.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponíveis";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ aceitou sua solicitação de contato";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contatos / %3$lu atualizações de perfil";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bytes";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votos serão contabilizados, pois você possui várias chaves de votação armazenadas na carteira ";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicados";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld de %ld depósitos";
 
 /* Voting */
 "%ld requests" = "%ld solicitações";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" não é uma palavra da frase de recuperação. Você gostaria de tentar recuperar a palavra correta que deveria estar em seu lugar?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Um saldo de crédito na Dash Platform usado para pagamentos instantâneos entre endereços da Platform e para recursos como nomes de usuário.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Uma senha de dispositivo é necessária para proteger a sua carteira. Vá para ajustes e ative a senha para continuar.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Sobre";
 
+/* DashPay FAQ title */
+"About DashPay" = "Sobre o DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Sobre mim";
+
+"Abstain" = "Abster-se";
+
+"Abstain on “%@”" = "Abster-se em “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Aceitar";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Recuperação de Conta";
 
+/* Masternode status */
+"Active" = "Ativo";
+
+/* No comment provided by engineer. */
+"Activity" = "Atividade";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "A atividade é pública, mas não é fácil de rastrear";
+
 /* No comment provided by engineer. */
 "Add" = "Adicionar";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Adicionar %@ como contato";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Adicione %@ como contato para pagar diretamente ao nome de usuário e manter o histórico mútuo de transações";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Adicione %@ Dash ao seu saldo blindado e deixe descansar algumas horas para registrar sem vincular seu nome de usuário aos seus outros fundos.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Adicione um Novo Contato";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Adicione pelo menos %@ Dash ao seu saldo blindado";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Adicione fundos ao seu saldo blindado agora e registre seu nome de usuário de forma privada algumas horas depois";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Todos";
 
+"All nodes at once" = "Todos os nós de uma vez";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Todos os seus masternodes votaram neste nome de usuário. Para mudar um voto, vote novamente a partir do candidato que você agora prefere.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Permitir enviar todas as transações da Carteira Dash para o Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sincronização de saldos quase instantânea";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Os valores e endereços são públicos na blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Ocorreu um erro";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Uma conta Ethereum é um único endereço reutilizável: todo o seu saldo e histórico de pagamentos ficam publicamente sob ele, e um nome (como um domínio ENS) normalmente aponta diretamente para esse endereço, para qualquer um resolver. O DashPay tem o formato oposto: o nome resolve para uma identidade, não para um endereço de pagamento, e os endereços de pagamento reais permanecem dentro de trocas de contato criptografadas, novos para cada contato.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Uma experiência familiar e através de todos os seus dispositivos";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Qualquer nome de usuário que contenha um número de 2 a 9, tenha mais de 20 caracteres ou que possua um hífen será automaticamente aprovado";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Qualquer pessoa que saiba um endereço pode ver seu histórico";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Aplicar";
 
+"Approve" = "Aprovar";
+
+"Approving a specific request can only be done one username at a time." = "Aprovar uma solicitação específica só pode ser feito para um nome de usuário por vez.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Tem certeza de que deseja cancelar este pedido?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Como texto";
 
 /* DashSpend */
 "at" = "em";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autenticação cancelada. Seu voto não foi registrado.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Falha na autenticação. Seu voto não foi registrado.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Autenticação indisponível";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Conceder “%@” a este candidato";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo depois";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Saldo no CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Saldo:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldos e transferências não são visíveis publicamente";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Conta bancária";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Acesso biométrico necessário";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Altura de origem salva — o piso de varredura elevado se aplica a partir da próxima inicialização.";
+
 /* Voting */
 "Block" = "Bloquear";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Usuário '%@' bloqueado";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vinculada a um contrato";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vinculada a um contrato, tipo de documento “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Apenas visualização";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Agrupa os registros de diagnóstico recentes em um zip para enviar por AirDrop, e-mail ou salvar em Arquivos";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Registrar voto";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Trocar de pares";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Mudar PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Verificando…";
+
+"Choice" = "Escolha";
+
 /* Choose your Dash username */
 "Choose your" = "Escolha seu";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Escolha seu nome de usuário";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Resgate seu convite";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo resgatável";
+
 /* No comment provided by engineer. */
 "Claimed" = "Reivindicar";
+
+/* SPV diagnostics */
+"Clear & resync" = "Limpar e ressincronizar";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Limpar os dados da cadeia e ressincronizar?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Fechar App";
 
+"Closing" = "Encerrando";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (moedas novas)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Código 2FA da Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "O CoinJoin não é mais compatível — escolha para onde mover suas moedas misturadas.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Garantia";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Em breve";
+
+/* Shielded transfer status */
+"Completed" = "Concluída";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirme";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confirmada";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Confirmar salva a altura de origem %u e limpa os dados da cadeia desta rede na próxima inicialização do app, baixando-os novamente e revarrendo os filtros a partir dessa altura. A sessão atual mantém seu piso de varredura antigo — feche e reabra o app para começar.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Conecte suas carteiras de criptomoedas à plataforma ZenLedger. Saiba mais e comece com suas transações da carteira Dash.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Endereço Dash conectado";
 
+/* SPV sync */
+"Connected peers" = "Pares conectados";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Contras";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Falha na solicitação de contato";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Solicitação de contato enviada para %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Solicitações de contato";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contatos";
 
+"Contender %@" = "Candidato %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continuar";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continue para escolher seu nome de usuário. O convite paga a taxa de registro.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copiar link de convite ";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copiar transação bruta";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copiar texto";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Não foi possível recuperar automaticamente palavras ausentes ou incorretas";
 
+/* Log export */
+"Could not create the log archive: %@" = "Não foi possível criar o arquivo de registros: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Não foi possível encontrar a taxa de câmbio.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Não foi possível atualizar %d identidades";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Não foi possível obter o saldo (erro de rede). Tente atualizar.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Não foi possível fazer o pagamento";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Criar seu nome de usuário";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Crie seu nome de usuário, encontre amigos e familiares pelos nomes de usuário deles e adicione-os aos seus contatos";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Cartão de crédito";
+
+/* Masternodes */
+"Credits" = "Créditos";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Pagamentos Dash não podem ser menores que %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "A Dash Platform ainda não indexou esta disputa. As contagens de votos aparecerão aqui quando isso acontecer.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "A Dash Platform ainda não está conectada. Espere a sincronização terminar e tente novamente.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash enviados para um endereço errado não podem ser recuperados. Certifique-se de que o endereço é exatamente aquele que você pretende pagar.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "O Dash armazena nomes de usuário em uma forma à prova de nomes parecidos, então o nome armazenado pode diferir do que cada pessoa digitou.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Nome de usuário Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Carteira Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo da carteira Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Carteira Dash neste dispositivo";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay ativado";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Convite DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "O DashPay é a experiência de pagamentos sociais do Dash, construída sobre a Dash Platform. Você registra um nome de usuário, adiciona outros usuários como contatos e paga a eles pelo nome — chega de copiar endereços.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "O DashPay substitui endereços longos e crípticos por nomes de usuário. Adicione amigos como contatos, envie dinheiro para um nome e mantenha cada pagamento organizado por pessoa.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Taxa de Upgrade do DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Data: Da mais antiga para a mais recente";
+
+"Deadline unknown" = "Prazo desconhecido";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Depósito enviado";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Caminho de derivação";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "SEGURANÇA DO DISPOSITIVO COMPROMETIDA\nQualquer aplicativo \"jailbreak\" consegue acessar os dados de outros aplicativos (e roubar seus Dash). Limpe essa carteira imediatamente e restaure em um dispositivo seguro.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Desativada";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Desconectar conta Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Feito";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Pronto — seu saldo descansou tempo suficiente";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Confira o endereço com atenção";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Cada convite será financiado com esse valor para que o destinatário possa criar rapidamente seu nome de usuário na Rede Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Cada masternode tem um voto válido por disputa. Você pode mudá-lo depois, mas a Dash Platform permite apenas 5 votos no total por masternode por disputa.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Cada toque vota com mais um nó, então você escolhe quantos vincular entre si.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Recentes";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Realize facilmente operações de stake no Dash e ganhe renda passiva com apenas alguns cliques.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Editar a altura de origem";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Editar Perfil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-mail";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Ativar";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Ativar o DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Habilitar Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Habilitar Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Ativar o DashPay custa uma pequena taxa de rede única, paga com o saldo de crédito da sua identidade. A estimativa exata é mostrada antes de você confirmar. Enviar solicitações de contato e pagamentos custa as taxas de rede habituais.";
+
+"Ending soonest" = "Termina mais cedo";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Erro ao atualizar seu perfil";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Taxa de rede estimada";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Todos os nós votam juntos. É mais rápido, mas vincula publicamente seus masternodes entre si.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Chaves de operador de Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Exportar CSV";
 
+/* Log export */
+"Export Logs" = "Exportar registros";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Chave pública estendida (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Endereço externo";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Limite de ID de face";
+
+/* No comment provided by engineer. */
+"Failed" = "Falhou";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Falha ao carregar código de barras";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Buscando taxas...";
 
+/* Masternodes */
+"Fetching…" = "Obtendo…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Conta Fiat";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtro";
+
+/* SPV sync phase */
+"Filter headers" = "Cabeçalhos de filtro";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtrar transações";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Encontre um usuário na rede Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Encontre caixas eletrônicos onde você pode comprar ou vender Dash.";
+
+/* Identities */
+"Find identities" = "Encontrar identidades";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Esqueceu o PIN?";
 
+/* Identities */
+"Found %d new identities" = "%d novas identidades encontradas";
+
+/* Identities */
+"Found 1 new identity" = "1 nova identidade encontrada";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Palavra faltando encontrada:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financie seu nome de usuário com o seu saldo blindado. Adicione os fundos com algumas horas de antecedência — o breve descanso mantém seu nome de usuário não vinculável aos seus outros Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financiado com o seu saldo blindado — seu nome de usuário não pode ser vinculado aos seus outros Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fundos bloqueados — finalizando a transferência";
+
+/* CoinJoin */
+"Funds moved" = "Fundos movidos";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Ganhe recompensas de depósitos em Dash Masternodes com apenas 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Obter cotação";
+
+/* Usernames */
+"Get ready to join DashPay" = "Prepare-se para entrar no DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Receba Recompensas Instantaneamente";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Entendi";
+
+/* Governance */
+"Governance" = "Governança";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Conceda permissões de GPS para que possamos mostrar locais próximos a você.";
 
 /* Voting */
 "Has blocked votes" = "Tem votos bloqueados";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "solicitou ser seu amigo";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Tem um convite?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Tenha controle completo e customize sua carteira de acordo com suas necessidades";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "cabeçalho #%1$d de %2$d";
+
+/* SPV sync phase */
+"Headers" = "Cabeçalhos";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Altura %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Aqui está um endereço Dash designado para sua conta CrowdNode na Carteira Dash neste dispositivo";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Do mais alto para o mais baixo";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Taxas mais altas, em torno de 7 centavos (ainda mais baixas que outras blockchains que oferecem privacidade semelhante)";
+
 /* No comment provided by engineer. */
 "History" = "Histórico";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Como eu consigo Dash de teste?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Como isso se compara ao Bitcoin em termos de privacidade?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Como isso se compara às contas Ethereum em termos de privacidade?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Quão privado é o DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Como confirmar seu endereço de API Dash";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Eu anotei";
 
+/* Identities */
+"Identities" = "Identidades";
+
 /* Voting */
 "Identity" = "Identidade";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Créditos de identidade";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Índice da identidade";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registro de identidade";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Recarga de identidade";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "Na seção de pagamento do seu checkout, selecione \"cartão-presente\" e insira o número do cartão e o PIN.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inativo";
+
+/* No comment provided by engineer. */
 "Income" = "Receita";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Inicializando";
+
+/* Raw transaction inspector */
+"Input %d" = "Entrada %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Entrada %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Entradas (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Fundos insuficientes";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Taxa de Convite";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Convite de %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Convite utilizado por";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Convidar";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Convide alguém para entrar na rede Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Convide sua família e encontre seus amigos pesquisando seus nomes de usuário";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Convide seus amigos e familiares para participar da Rede Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Convide seus amigos e familiares para a rede Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "Carteira Dash iOS: %@ Problema reportado";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Entrando no \"pool\"";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Mantenha estas moedas privadas. Aplicam-se taxas de rede e de privacidade.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Mantenha sua frase de recuperação segura";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Chave nº %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Dados da chave";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Propriedade da chave";
+
 /* No comment provided by engineer. */
 "Keypair" = "Par de chaves";
+
+/* Masternodes */
+"Keys" = "Chaves";
 
 /* Explore Dash */
 "Last device sync" = "Última sincronização do dispositivo";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Liderando";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Saiba mais";
 
 /* Info Screen */
 "Learn More..." = "Saiba mais...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Carregando transações";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Moeda Local";
 
+/* Identities */
+"Local Only" = "Apenas local";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Total local solicitado: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Localização";
 
+"Lock" = "Bloquear";
+
+"Lock the name" = "Bloquear o nome";
+
+"Lock “%@” so nobody gets it" = "Bloquear “%@” para que ninguém fique com ele";
+
 /* No comment provided by engineer. */
 "Locked" = "Bloqueado";
 
+"Locked — nobody receives this username" = "Bloqueado — ninguém recebe este nome de usuário";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Entrar";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Baixo";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Taxas baixas para gastos do dia a dia";
+
 /* Voting */
 "Low to high" = "Do mais baixo para o mais alto";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principal";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Endereço IP do Masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Chaveiro do masternode";
+
+/* Masternode keys */
 "Masternode keys" = "Chaves do masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Lista de masternodes";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "lista de masternode #%1$d de %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Atualização de Masternode";
 
+"Masternode votes" = "Votos de masternodes";
+
 /* Voting */
 "Masternode Voting Key" = "Chave de Votação de Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternodes";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Os masternodes e evonodes registrados com as chaves desta carteira aparecerão aqui depois que a carteira sincronizar.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodes e evonodes que usam as chaves desta carteira";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Os masternodes votam em nomes pedidos por mais de uma pessoa. Você será notificado quando a votação terminar.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Máx";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Mín: %@";
 
+/* Usernames */
+"Minimum met" = "Mínimo atingido";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Mais Controle";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Mais sugestões";
+
+"Most lock votes" = "Mais votos de bloqueio";
+
+"Most votes" = "Mais votos";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Mova e amplie sua foto para encontrar o ajuste perfeito";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Mover para o seu saldo gastável normal.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Movido para Endereço";
+
+/* CoinJoin */
+"Moving funds" = "Movendo fundos";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Nome";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Serviços de nomes como o Unstoppable Domains associam um nome legível a um endereço público fixo na cadeia. Qualquer pessoa pode resolver o nome e ver todos os pagamentos já feitos a ele. Um nome de usuário do DashPay nunca resolve publicamente para um endereço de pagamento — os endereços só são revelados dentro da troca criptografada com cada contato, então seu nome e seu dinheiro permanecem desvinculados para observadores externos.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Precisa de ajuda?";
+
+"Needs attention" = "Precisa de atenção";
 
 /* No comment provided by engineer. */
 "Network" = "Rede";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Nenhum registro de diagnóstico foi encontrado neste dispositivo. Os registros são gravados a partir da próxima inicialização.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nenhuma identidade";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ainda não há masternodes";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nenhuma disputa correspondente";
+
+/* Identities */
+"No new identities were found for this wallet" = "Nenhuma identidade nova foi encontrada para esta carteira";
+
+"No open contest matches that search." = "Nenhuma disputa aberta corresponde a essa busca.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nenhuma disputa aberta corresponde a essa busca. Os nomes são armazenados em uma forma normalizada, então “alice” aparece como “a11ce”.";
+
+"No open contests" = "Nenhuma disputa aberta";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Sem métodos de pagamento";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Nenhum registro de carteira salvo foi encontrado para a carteira vinculada.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Ainda não há endereço da Platform disponível para o registro blindado alternativo. Tente novamente depois que a carteira terminar de sincronizar.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Nenhum Resultado Encontrado";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Nenhum nome de usuário está em disputa no momento. As disputas abrem quando duas ou mais pessoas pedem o mesmo nome.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Sem votos restantes";
+
+"No votes were cast" = "Nenhum voto foi registrado";
+
+"Nobody gets it" = "Ninguém fica com ele";
+
+/* SPV sync peer type */
+"Node" = "Nó";
+
+/* Raw transaction inspector */
+"Non-standard" = "Fora do padrão";
 
 /* adjective, security level */
 "None" = "Nenhuma";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Não disponível";
 
+"Not available yet" = "Ainda não disponível";
+
+"Not cast" = "Não registrado";
+
+/* Masternodes */
+"Not checked yet" = "Ainda não verificado";
+
 /* Location Service Status */
 "Not Determined" = "Não determinado";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Saldo blindado insuficiente para registrar uma identidade";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Não está no histórico da carteira";
+
+"Not now" = "Agora não";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Não é amplamente aceito por comerciantes";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Ainda não é amplamente aceito por comerciantes";
+
+/* Masternode keys */
+"Not yet used" = "Ainda não usada";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Do mais antigo para o mais recente";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "No Bitcoin não há uma camada de nomes, então as pessoas compartilham e reutilizam endereços abertamente — uma vez que um endereço é conhecido, tudo o que ele já recebeu pode ser vinculado ao seu dono. Com o DashPay seu nome de usuário é público, mas nunca aponta para um endereço de pagamento: os endereços são trocados de forma privada com cada contato e são rotacionados, então pagar por nome não publica para onde vai o seu dinheiro. Ambas são cadeias transparentes, portanto a análise de cadeia ainda se aplica às moedas em si.";
+
+/* Identities */
+"On Network" = "Na rede";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Assim que %@ aceitar sua solicitação, você poderá pagar diretamente ao nome de usuário";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Um nó por vez";
 
 /* Voting */
 "One vote left" = "Um voto restante";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Apenas duplicados";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Apenas masternodes e evonodes podem votar em nomes de usuário. Esta carteira não possui chaves de votação de masternode ativas.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Apenas solicitações com links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Apenas com links";
+
+/* Masternodes */
+"Operator" = "Operador";
+
+/* Masternode keys */
+"Operator keys" = "Chaves de operador";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Chave pública do operador (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ou";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Visualização do pedido";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Outros resultados";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Saída %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Saídas (%d)";
+
+/* Masternodes */
+"Owner" = "Proprietário";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Endereço do Proprietário";
+
+/* Masternodes */
+"Owner address" = "Endereço do proprietário";
+
+/* Masternodes */
+"Owner key hash" = "Hash da chave do proprietário";
 
 /* Owner keys */
 "Owner keys" = "Chaves do proprietário";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Pago com o saldo de crédito da sua identidade.";
 
 /* DashSpend */
 "Password" = "Senha";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Copiar link aqui";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Cole o link de convite que você recebeu ou escaneie o código QR dele. Ele financia o registro do seu nome de usuário.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Cole a URL da sua imagem";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pague e receba imediatamente com fluxos de pagamento fáceis de usar";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "pagar diretamente ao nome de usuário";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Pague a pessoas, não a endereços";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pague aos nomes de usuário. Não há mais endereços alfanuméricos";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Pagando...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Hex da carga útil";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Método de pagamento";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Os pagamentos são privados: os endereços que você troca com um contato viajam dentro de uma carga criptografada que só vocês dois podem ler, e nunca são publicados — então seus pagamentos não são facilmente vinculáveis ao seu nome de usuário. Ainda assim, são pagamentos comuns em uma cadeia transparente: uma análise de cadeia sofisticada pode vazar informações. O Shielded DashPay (em breve) vai fechar essa lacuna. As próprias solicitações de contato atualmente NÃO são privadas: qualquer um pode ver que duas identidades estão conectadas. Solicitações de contato privadas são um recurso que virá em breve. Seu nome de usuário e seu perfil também são públicos na Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Os pagamentos são confirmados em segundos com o InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Pagamentos feitos diretamente para endereços não serão mantidos na atividade.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Os pagamentos com cada contato ficam agrupados em um só lugar, com nomes e perfis em vez de transações brutas.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Endereço de pagamento";
 
 /* CrowdNode */
 "Payout Options" = "Opções de Pagamento";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Endereço da Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Saldo da Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nó da Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID do nó da Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Os pagamentos da Platform não identificam o remetente. Este pagamento foi registrado quando a carteira notou a mudança de saldo — ele pode ter chegado antes.";
+
+"Platform SDK not ready" = "SDK da Platform não está pronto";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "A sincronização da Platform não está em execução. Abra Informações de sincronização → Status de sincronização da Platform para iniciá-la.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Blindado";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Por favor, adicione um método de pagamento na Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Visualizar Convite";
 
+/* Masternode keys */
+"Previously used at: " = "Usada anteriormente em: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Os preços têm pelo menos 30 minutos de atraso. Os valores em fiat podem estar incorretos.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privado por design";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Solicitações de contato privadas (para que com quem você se conecta continue privado), Shielded DashPay — pagamentos a contatos a partir do seu saldo blindado privado — e pagamentos a usuários que ainda não estão nos seus contatos estão todos por vir.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "As solicitações de contato privadas estão em desenvolvimento e são esperadas por volta de setembro–outubro de 2026. Hoje a própria solicitação é pública — qualquer um pode ver que duas identidades estão conectadas, mesmo que os detalhes de pagamento dentro dela sejam criptografados. Quando as solicitações de contato privadas chegarem, você poderá escolher se sua amizade será pública ou privada.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Solicitações de contato privadas, Shielded DashPay e pagamentos a pessoas que ainda não são contatos.";
+
 /* No comment provided by engineer. */
 "Private key" = "Chave privada";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Endereços de pagamento privados são trocados entre você e seus contatos. Só você e seu contato sabem quem é o destinatário e o remetente dos pagamentos entre vocês.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pagamentos privados";
+
+/* Usernames */
+"Private registration" = "Registro privado";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Tempo de processamento";
+
+/* Balance info sheet section */
+"Pros" = "Prós";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Proteja suas economias";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Endereço do Provedor";
 
+/* Masternodes */
+"Provider transactions" = "Transações de provedor";
+
+/* Masternode keys */
+"Public key" = "Chave pública";
+
+/* Masternode keys */
+"Public key (legacy)" = "Chave pública (legado)";
+
+/* Identities */
+"Public keys" = "Chaves públicas";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL Pública";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "A compra falhou";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Finalidade";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Cotação: %1$@= %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transação bruta";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transação bruta indisponível";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Verifica novamente os filtros de bloco compactos a partir da altura escolhida em busca das transações desta carteira, baixando-os e comparando-os de novo. As revarreduras têm como piso a altura de criação da carteira e os dados da cadeia armazenados localmente — para recuperar o histórico abaixo disso, reduza a altura de origem da carteira.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Ler a Política de Retirada";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Somente leitura";
+
+/* Usernames */
+"Ready around %@" = "Pronto por volta de %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motivo";
 
 /* No comment provided by engineer. */
 "Receive" = "Recebe";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Recebido de";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Recebido de %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Recebendo recompensas";
+
+"Records your masternodes as having voted, without taking a side." = "Registra seus masternodes como tendo votado, sem tomar partido.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recuperar";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "A frase de recuperação deve ter 12, 15, 18, 21 ou 24 palavras";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Atualizar";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registrar?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrado em";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registrado desde";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternode Registrado";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Registrar de forma privada exige pelo menos %@ Dash no seu saldo blindado mais algumas horas de descanso — as próximas telas guiam você pelo processo.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registro";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Está pedindo este nome";
+
 /* An action */
 "Rescan" = "Reescanear";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Carteiras restauradas nem sempre conseguem recuperar o tipo de operação. Esta entrada foi reconstruída a partir dos dados de nota on-chain.";
+
+/* Location Service Status */
 "Restricted" = "Restrito";
 
 /* Usernames */
 "Results" = "Resultados";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ressincronização preparada a partir da altura %u — feche e reabra o app para começar.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "manter o histórico mútuo de transações";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Aposentado";
 
 /* No comment provided by engineer. */
 "Retry" = "Tentar novamente";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Revise a postagem abaixo para verificar a propriedade deste nome de usuário";
+
+/* Masternodes */
+"Revocation" = "Revogação";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Capturas de Tela são visíveis para outros dispositivos e aplicativos. Gere uma nova frase de recuperação e a mantenha secreta.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Assinatura do script";
+
+/* Raw transaction inspector */
+"Script type" = "Tipo de script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Buscar um contato";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Buscar uma solicitação de contato";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Buscar um usuário na rede Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Buscar um nome de usuário";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Resultados da busca por \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Pesquisar territórios";
+
+"Search usernames" = "Buscar nomes de usuário";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Buscando o nome de usuário %@ na rede Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Proteja sua Carteira";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Nível de Segurança";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Nível de segurança";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Selecione um serviço para comprar, vender, converter e transferir Dash";
 
+"Select all" = "Selecionar tudo";
+
 /* DashSpend denomination selection */
 "Select amount" = "Selecionar valor";
+
+"Select at least one masternode to vote with." = "Selecione pelo menos um masternode com o qual votar.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Selecione a moeda";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Selecionar menos nós revela menos sobre quais masternodes você opera.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Pagamento automático";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Enviar para";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Enviar para um contato";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Envie para um nome de usuário que você realmente consiga lembrar e verificar.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Enviar para Endereço";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Envie sua primeira solicitação de contato";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Enviando";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Enviando solicitação de contato";
+
+/* No comment provided by engineer. */
+"Sending to" = "Enviando para";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Enviando para a conta CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Enviado para";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Enviado para %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Ocorreu um erro no servidor. Por favor, tente novamente mais tarde.";
+
+/* Masternodes */
+"Service" = "Serviço";
+
+/* Identities */
+"Set as Main" = "Definir como principal";
+
+/* Identities */
+"Set as Main Identity" = "Definir como identidade principal";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Definir PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Compartilhar chave";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Pool de privacidade compartilhado no tamanho mínimo";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Endereço blindado";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Gasto blindado";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Iniciando a carteira blindada…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Blindado → Platform";
+
+"Shielded → Transparent" = "Blindado → Transparente";
 
 /* Explore Dash */
 "Show all locations" = "Mostrar todos os locais";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Tamanho";
+
 /* No comment provided by engineer. */
 "Skip" = "Pular";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Alguns dos seus masternodes podem estar faltando nesta lista — a carteira não conseguiu ler todo o seu conjunto de chaves de votação. Termine a sincronização e reabra esta tela.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Algumas contas de usuário podem ser bloqueadas";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Ordenar por";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Ordenar contatos";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Ordenado por desconto";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Ordenado por nome";
+
+/* Raw transaction inspector */
+"Special payload" = "Carga útil especial";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Especificar Valor";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Começa depois que você adicionar fundos";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Passo %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Armazenado como";
 
 /* Voting */
 "Submit" = "Enviar";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sincronização em andamento... Os resultados podem não estar completos.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informações de sincronização";
+
+/* SPV sync */
+"Sync too slow?" = "Sincronização muito lenta?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Tirar uma foto da câmera";
 
+"Take no side" = "Não tomar partido";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Toque no endereço da área de transferência para colá-lo";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Toque para copiar";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Toque para esconder o saldo";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Indisponível temporariamente";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Chave do nó Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Termos & Condições";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Código incorreto. Por favor, verifique e tente novamente!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Os Dash chegam ao endereço do destinatário depois que a rede processar o saque — isso pode levar até 10 minutos.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Os Dash chegam ao endereço do destinatário assim que a rede processar o saque.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Os Dash chegam ao seu saldo transparente assim que a rede processar o saque.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "A rede Dash precisa votar para aprovar alguns nomes de usuário antes que eles sejam criados";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "O link que você enviar será visível apenas para os proprietários da rede";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "A identidade principal só pode ser escolhida na carteira ativa";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "A quantidade mínima que você pode enviar é %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "O lugar mais privado para guardar seus Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "O registro de carteira salvo não tem rede — não é possível preparar uma ressincronização.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "O registro foi enviado, mas não foi possível confirmar seu resultado. Espere um minuto para a carteira sincronizar e tente de novo — não reenvie imediatamente.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "O pool de privacidade compartilhado ainda está crescendo (%1$ld de %2$ld depósitos). O registro privado é liberado quando ele atingir o mínimo.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "O pool de privacidade compartilhado ainda está crescendo (%1$ld de %2$ld depósitos). Tente novamente quando ele atingir o mínimo.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "O usuário '%@' foi bloqueado pela Rede Dash. Por favor, tente novamente solicitando outro nome de usuário.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "A altura de criação da carteira — o piso para as varreduras de filtros e para as revarreduras “Desde a criação da carteira”. Defina-a igual ou abaixo do primeiro financiamento da carteira; as importações usam 200000 por padrão na mainnet e 0 na testnet. Salvar uma altura igual ou inferior à atual limpa os dados da cadeia desta rede na próxima inicialização e revarre a partir dela.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "ele (obtendo informações)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Não há notificações novas";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Não há transações para mostrar";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Não há usuários que correspondam ao nome %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Não há usuários que correspondam ao nome %@ nos seus contatos";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Ocorreu um erro ao exportar seu histórico de transações para o ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Ocorreu um erro, por favor tente novamente mais tarde";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Estes fundos vão para o seu saldo da Platform e ficam prontos para gastar assim que a transferência for concluída.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Este endereço não pode ser pago com o seu saldo %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Isso adiciona duas chaves à sua identidade para que outros usuários possam lhe enviar solicitações de contato e para que você possa aceitar as deles. Isso acontece uma única vez.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Isso aplica uma escolha a todos os %d nomes de usuário selecionados.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Esta etapa extra mostra que é realmente você tentando fazer uma transação.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Este link de convite não é válido.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Este não é um endereço Dash válido para esta rede";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Este não é um link de convite válido";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Esta é a sua identidade principal";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Este masternode ainda não tem uma identidade na Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Este comércio está atualmente indisponível. ";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Isso representa o Rendimento Percentual Anual (Annual Percentage Yield - APY) atual de um Masternode completo menos a taxa de 15% do CrowdNode. Não é uma taxa de retorno garantida e pode aumentar ou diminuir com base no tamanho dos pools do CrowdNode e no preço do Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Isso ainda conta como seus masternodes tendo votado nesta disputa.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Os bytes brutos desta transação não estão armazenados neste dispositivo.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Este nome de usuário ficou com outra pessoa";
+
+"This wallet could not derive the voting key for this node." = "Esta carteira não conseguiu derivar a chave de votação deste nó.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Esta carteira não possui chaves de votação de masternode ativas, então não pode votar. Os nós registrados aparecem em Ferramentas → Masternodes.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Isso saca todo o seu saldo da Platform em uma única transferência. Os Dash chegam ao endereço do destinatário assim que a rede processar o saque.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Isso saca todo o seu saldo da Platform em uma única transferência. Os Dash chegam ao seu saldo transparente assim que a rede processar o saque.";
 
 /* Send Screen: to address */
 "to" = "para";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Histórico de Transações";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "O histórico de transações não está disponível";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Id da transação";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID da transação";
 
 /* A verb, button title. */
 "Transfer" = "Transferir";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transferência de entrada";
 
+/* Balance breakdown */
+"Transfer in" = "Transferência de entrada";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transferência de saída";
+
+/* Balance breakdown */
+"Transfer out" = "Transferência de saída";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "As transferências demoram mais — construir as provas de privacidade leva tempo";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "As transferências para outros endereços da Platform e endereços blindados são instantâneas e definitivas";
+
+/* Balance breakdown */
+"Transparent" = "Transparente";
+
+/* Send screen destination type */
+"Transparent address" = "Endereço transparente";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Saldo transparente";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "O financiamento transparente vincula publicamente seu nome de usuário a estes fundos.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparente → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparente → Blindado";
 
 /* An action */
 "Try again" = "Tentar de novo";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Não é possível oferecer sugestões";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Saldo desconhecido";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tipo especial desconhecido %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Não blindado";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "URL não suportada";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Atualize para o DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Atualizar para o Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Usar o saldo transparente em vez disso";
+
+/* Masternode keys */
+"Used" = "Usada";
+
+/* Masternode keys */
+"Used at: " = "Usada em: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Usuário (obtendo informações)";
 
 /* Voting */
 "Username" = "Nome de usuário";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "O nome de usuário foi solicitado com sucesso";
 
+/* Identities */
+"Usernames" = "Nomes de usuário";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Os nomes de usuário são armazenados em uma forma normalizada para evitar nomes parecidos, então isto pode diferir do que cada pessoa digitou.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nomes de usuário, não endereços";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Usuários que correspondem a %@ e que atualmente não estão nos seus contatos";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Usa uma das bibliotecas de conhecimento zero mais auditadas e testadas (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Convite válido";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validando endereço…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verificação Necessária";
 
+/* Usernames */
+"Verified during registration" = "Verificado durante o registro";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verificado com Sucesso";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verifique sua identidade";
 
+/* Raw transaction inspector */
+"Version" = "Versão";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Muito eficiente e com taxas baixas";
+
 /* adjective, security level */
 "Very High" = "Muito Alto";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Quantidades muito pequenas de Dash serão enviadas de/para CrowdNode para verificar se você é o proprietário desta carteira.";
+
+/* No comment provided by engineer. */
+"View All" = "Ver tudo";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Ver no Explorador";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Ver Frase de Recuperação";
 
+/* Raw transaction inspector */
+"View Transaction" = "Ver transação";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Ver detalhes da transação";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Votar";
+
+"Vote cast" = "Voto registrado";
+
 /* Voting */
 "Vote for All" = "Votar em todos";
 
 /* Voting */
+"Vote on contested usernames" = "Votar em nomes de usuário disputados";
+
+"Vote on several" = "Votar em vários";
+
+/* Voting */
 "Vote to Approve" = "Votar para Aprovar";
+
+"Vote with" = "Votar com";
+
+"Votes that nobody should receive these usernames." = "Vota para que ninguém receba estes nomes de usuário.";
 
 /* Voting */
 "Votes: High to low" = "Votos: Do mais alto para o mais baixo";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Endereço de Votação";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Endereço de votação";
+
+"Voting ended with no winner" = "A votação terminou sem vencedor";
+
+"Voting ends" = "A votação termina";
+
 /* Voting */
 "Voting ends in %dd" = "Votação encerra em %d d";
+
+"Voting in progress" = "Votação em andamento";
+
+"Voting in progress — lock votes are ahead" = "Votação em andamento — os votos de bloqueio estão à frente";
+
+"Voting in progress — you are ahead" = "Votação em andamento — você está à frente";
 
 /* Usernames */
 "Voting is only required in some cases" = "Votar é obrigatório apenas em alguns casos";
 
+/* Masternodes */
+"Voting key hash" = "Hash da chave de votação";
+
 /* Voting keys */
 "Voting keys" = "Chaves de votação";
+
+"Voting on this username has closed. The counts below are the last ones read." = "A votação neste nome de usuário foi encerrada. As contagens abaixo são as últimas lidas.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "A votação em “%@” já foi encerrada. Atualize para ver o resultado.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Aguarde até que a carteira seja sincronizada para concluir a transação";
 
+"Waiting for Dash Platform" = "Aguardando a Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Endereço da carteira";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Altura de origem da carteira";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Carteira desabilitada";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Bem-vindo ao DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "E quanto ao Unstoppable Domains e serviços de nomes semelhantes?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Quanto custa?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "O que é o DashPay?";
+
 /* Usernames */
 "What is username voting?" = "O que é a votação de nomes de usuário?";
+
+/* DashPay FAQ */
+"What's coming next?" = "O que vem a seguir?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Quando as solicitações de contato se tornarão privadas?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Onde Gastar";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Onde gastar?";
+
+"Who is requesting this name" = "Quem está pedindo este nome";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Por que preciso ativá-lo?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Por que vejo todas essas transações?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Saque solicitado";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Saca todo o saldo";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funciona com todas as carteiras, corretoras e comerciantes Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Você gostaria de aceitar o convite?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Ontem";
+
+"You" = "Você";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Você aceitou a solicitação de contato de %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Você escolher “%@” como seu nome de usuário.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Você não tem nenhum contato no momento";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Você não tem fundos suficientes para completar esta transação";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Você excedeu o limite de autorização na Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Você tem %@ Dash até agora";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Você tem %1$@ Dash.\nAlguns nomes de usuário custam até %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Você enviou a solicitação de contato para %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Você deve ter um saldo positivo na Carteira Dash";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Você ganhou este nome de usuário";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Tudo pronto. Outros usuários já podem lhe enviar solicitações de contato — e você pode enviar as suas.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Sua identidade da Dash Platform aparecerá aqui assim que você registrar um nome de usuário.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Seu email é usado apenas para enviar uma senha única.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Seu histórico, organizado";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Sua identidade precisa de duas chaves extras para que as solicitações de contato possam ser criptografadas entre você e outros usuários. A ativação as adiciona com uma única transação de rede. Isso acontece uma única vez.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Seu convite de %@ já foi reivindicado";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Seu convite de %@ não é válido";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Seu convite paga a taxa de registro deste nome de usuário.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Sua localização é usada para mostrar sua posição no mapa, caixas eletrônicos no raio selecionado e melhorar os resultados da pesquisa.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Sua localização é usada para mostrar sua posição no mapa, comércios no raio selecionado e melhorar os resultados da pesquisa.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Seu saldo Dash principal na blockchain Core — o que você envia e recebe com outras carteiras, corretoras e comerciantes.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Suas moedas misturadas foram movidas para o saldo da sua carteira Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Suas moedas misturadas foram movidas para o seu saldo blindado. Para uma privacidade melhor, espere pelo menos 2 horas antes de usar estes fundos.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Seu saldo da Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Seu endereço primário Dash que você usa atualmente para sua conta CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Seu saldo privado. Os valores e endereços são criptografados on-chain, então seus fundos e seu histórico permanecem confidenciais.";
+
 /* Usernames */
 "Your request was cancelled" = "Sua solicitação foi cancelada";
 
 /* DashSpend */
 "Your session expired" = "Sua sessão expirou";
+
+/* Usernames */
+"Your Shielded balance" = "Seu saldo blindado";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Seu saldo blindado está quase pronto — você poderá se registrar de forma privada por volta de %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Seu saldo blindado está pronto — registre seu nome de usuário de forma privada agora";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Seu saldo blindado está descansando — você poderá se registrar de forma privada por volta de %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Seu saldo blindado ainda está amadurecendo. Ele estará pronto por volta de %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Seu saldo transparente";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Seu nome de usuário %@ foi criado com sucesso na Rede Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Seu nome de usuário foi criado com sucesso";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Seu nome de usuário é visível para todos. Financiá-lo com o seu saldo blindado — depois de deixar os fundos descansarem algumas horas — faz com que ninguém consiga vincular seu nome de usuário aos seus outros Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Seu nome de usuário, perfil e contatos seguem esta identidade.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Seu nome de usuário, perfil e contatos seguirão esta identidade.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Seu voto foi cancelado";
 
 /* Voting */
 "Your vote was submitted" = "Seu voto foi enviado";
 
+"Your votes" = "Seus votos";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = " Sua carteira está segura agora. Você pode usar sua frase de recuperação em qualquer momento para recuperar sua conta em outro dispositivo.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Sua carteira ainda está sincronizando com a rede Dash. O envio ficará disponível quando a sincronização terminar.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Sua carteira ainda está sincronizando. O envio a partir do seu saldo transparente ficará disponível quando a sincronização terminar.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Não foi possível ler “%@” como um nome de usuário Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” foi registrado. Enviar uma solicitação de contato para a pessoa que convidou você?";

--- a/DashWallet/pt.lproj/Localizable.stringsdict
+++ b/DashWallet/pt.lproj/Localizable.stringsdict
@@ -95,7 +95,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ contabilizados para “%2$@”</string>
+		<string>%#@votes@ para “%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -103,9 +103,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u voto</string>
+			<string>%1$u voto contabilizado</string>
 			<key>other</key>
-			<string>%1$u votos</string>
+			<string>%1$u votos contabilizados</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -143,7 +143,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ votaram</string>
+		<string>Votado: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -159,7 +159,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d de %#@nodes@ votaram</string>
+		<string>Votado: %1$d de %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/pt.lproj/Localizable.stringsdict
+++ b/DashWallet/pt.lproj/Localizable.stringsdict
@@ -92,5 +92,245 @@
 			<string>%d chaves</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ contabilizados para “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u voto</string>
+			<key>other</key>
+			<string>%1$u votos</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Votado em %1$d de %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nome de usuário</string>
+			<key>other</key>
+			<string>%2$d nomes de usuário</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Registrar %u voto</string>
+			<key>other</key>
+			<string>Registrar %u votos</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ votaram</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d de %#@nodes@ votaram</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nó</string>
+			<key>other</key>
+			<string>%2$d nós</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonodes</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto no total</string>
+			<key>other</key>
+			<string>%u votos no total</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternodes</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d selecionado</string>
+			<key>other</key>
+			<string>%d selecionados</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d dos seus nós já votou aqui e não está listado.</string>
+			<key>other</key>
+			<string>%d dos seus nós já votaram aqui e não estão listados.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto por disputa — evonodes contam como 4, masternodes como 1</string>
+			<key>other</key>
+			<string>%u votos por disputa — evonodes contam como 4, masternodes como 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votar em %d nome de usuário</string>
+			<key>other</key>
+			<string>Votar em %d nomes de usuário</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u voto</string>
+			<key>other</key>
+			<string>%u votos</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votar ×%d</string>
+			<key>other</key>
+			<string>Votar ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d solicitação</string>
+			<key>other</key>
+			<string>%d solicitações</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Toate nodurile deodată";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Toate masternode-urile tale au votat pentru acest nume de utilizator. Pentru a schimba un vot, votează din nou de la candidatul pe care îl preferi acum.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Toate masternode-urile tale au votat pentru acest nume de utilizator. Pentru a schimba un vot, votează din nou pentru candidatul pe care îl preferi acum.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " sau ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ nu a putut fi găsit în rețeaua Dash pentru a-i trimite o cerere de contact.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash disponibili";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ ți-a acceptat cererea de contact";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d octeți";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld din %ld depuneri";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Un sold de credite pe Dash Platform, folosit pentru plăți instantanee între adrese Platform și pentru funcții precum numele de utilizator.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Este necesar un cod de acces pentru a-ți proteja portofelul. Accesează setările și activează codul de acces pentru a continua.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Despre";
 
+/* DashPay FAQ title */
+"About DashPay" = "Despre DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Abține-te";
+
+"Abstain on “%@”" = "Abține-te la „%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Activ";
+
+/* No comment provided by engineer. */
+"Activity" = "Activitate";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Activitatea este publică, dar nu este ușor de urmărit";
+
 /* No comment provided by engineer. */
 "Add" = "Adaugă";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Adaugă %@ ca persoană de contact";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Adaugă-l pe %@ la contacte ca să plătești direct către numele de utilizator și să păstrezi istoricul comun al tranzacțiilor";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Adaugă %@ Dash în soldul tău protejat și lasă-l să se odihnească câteva ore, ca să te înregistrezi fără a-ți lega numele de utilizator de restul fondurilor.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Adaugă cel puțin %@ Dash în soldul tău protejat";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Alimentează-ți acum soldul protejat și înregistrează-ți numele de utilizator în mod privat peste câteva ore";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Toate nodurile deodată";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Toate masternode-urile tale au votat pentru acest nume de utilizator. Pentru a schimba un vot, votează din nou de la candidatul pe care îl preferi acum.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sincronizare aproape instantanee a soldurilor";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Sumele și adresele sunt publice pe blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Un cont Ethereum este o singură adresă refolosită: întregul tău sold și istoricul plăților stau public sub ea, iar un nume (de exemplu un domeniu ENS) indică de obicei direct către acea adresă, astfel încât oricine o poate rezolva. DashPay este exact invers — numele se rezolvă către o identitate, nu către o adresă de plată, iar adresele de plată reale rămân în interiorul schimburilor criptate cu contactele, noi pentru fiecare contact.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Oricine cunoaște o adresă îi poate vedea istoricul";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Aprobă";
+
+"Approving a specific request can only be done one username at a time." = "Aprobarea unei cereri anume se poate face doar pentru câte un nume de utilizator pe rând.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Ca text";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autentificare anulată. Votul tău nu a fost exprimat.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autentificarea a eșuat. Votul tău nu a fost exprimat.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Acordă „%@” acestui candidat";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Sold";
 
 /* CrowdNode */
+"Balance after" = "Soldul după aceea";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Soldurile și transferurile nu sunt vizibile public";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Înălțimea de start a fost salvată — pragul ridicat de scanare se aplică de la următoarea pornire.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Legat de un contract";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Legat de un contract, tipul documentului „%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Doar răsfoire";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Grupează jurnalele de diagnosticare recente într-o arhivă zip pentru a le trimite prin AirDrop, e-mail sau a le salva în Fișiere";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Exprimă votul";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Schimbă nodurile";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Se verifică…";
+
+"Choice" = "Alegere";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Revendică-ți invitația";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Sold revendicabil";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Șterge și resincronizează";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Ștergi datele lanțului și resincronizezi?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Se închide";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (monede noi)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin nu mai este acceptat — alege unde să îți muți monedele amestecate.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Garanție";
+
+/* DashPay intro: feature title */
+"Coming soon" = "În curând";
+
+/* Shielded transfer status */
+"Completed" = "Finalizat";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirmă";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Confirmată";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Confirmarea salvează înălțimea de start %u și șterge datele lanțului acestei rețele la următoarea pornire a aplicației, le descarcă din nou și rescanează filtrele de la acea înălțime. Sesiunea curentă își păstrează vechiul prag de scanare — închide și redeschide aplicația pentru a începe.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Noduri conectate";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Dezavantaje";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Cererea de contact a eșuat";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Cerere de contact trimisă către %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Cereri de contact";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Candidatul %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Continuă pentru a-ți alege numele de utilizator. Invitația plătește taxa de înregistrare.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Copiază tranzacția brută";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Arhiva de jurnale nu a putut fi creată: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Nu se poate găsi cursul de schimb.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nu s-au putut împrospăta %d identități";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Soldul nu a putut fi obținut (eroare de rețea). Încearcă să împrospătezi.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Plata nu a putut fi efectuată";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Creează-ți numele de utilizator, găsește-ți prietenii și familia după numele lor de utilizator și adaugă-i la contacte";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Credite";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Plățile Dash nu pot fi mai mici decât %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform nu a indexat încă această dispută. Numărul de voturi va apărea aici când o va face.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform nu este încă conectat. Așteaptă finalizarea sincronizării și încearcă din nou.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash trimis la o adresă greșită nu poate fi recuperat. Asigură-te că adresa este exact cea pe care vrei să o plătești.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash stochează numele de utilizator într-o formă rezistentă la asemănări, așa că numele stocat poate diferi de ce a tastat fiecare persoană.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Soldul portofelului Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay a fost activat";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay este experiența de plăți sociale a Dash, construită pe Dash Platform. Îți înregistrezi un nume de utilizator, adaugi alți utilizatori ca persoane de contact și le plătești pe nume — gata cu copiatul adreselor.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay înlocuiește adresele lungi și criptice cu nume de utilizator. Adaugă-ți prietenii la contacte, trimite bani către un nume și ține fiecare plată organizată pe persoane.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Termen necunoscut";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Cale de derivare";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "SECURITATEA DISPOZITIVULUI ESTE COMPROMISĂ\nOrice aplicație \"jailbreak\" poate accesa datele keychain ale oricărei alte aplicații (și îți poate fura Dash). Șterge imediat portofelul și restaurează-l pe un dispozitiv securizat.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Dezactivat";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Gata";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Gata — soldul tău s-a odihnit suficient";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Verifică adresa încă o dată";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Fiecare masternode are un vot valabil per dispută. Îl poți schimba ulterior, dar Dash Platform permite în total doar 5 voturi per masternode per dispută.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Fiecare atingere votează cu încă un nod, așa că tu alegi câte legi împreună.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Editează înălțimea de start";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Activează";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Activează DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Activarea DashPay costă o mică taxă de rețea, o singură dată, plătită din soldul de credite al identității tale. Estimarea exactă este afișată înainte să confirmi. Trimiterea cererilor de contact și a plăților costă taxele obișnuite de rețea.";
+
+"Ending soonest" = "Se încheie cel mai devreme";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Taxă de rețea estimată";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Toate nodurile votează împreună. Este mai rapid, dar îți leagă public masternode-urile între ele.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Chei de operator Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Exportă jurnalele";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Adresă externă";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "limita Face ID-ului";
+
+/* No comment provided by engineer. */
+"Failed" = "Eșuat";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Se obține…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtru";
+
+/* SPV sync phase */
+"Filter headers" = "Anteturi de filtru";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Găsește un utilizator în rețeaua Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Găsește identități";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Au fost găsite %d identități noi";
+
+/* Identities */
+"Found 1 new identity" = "A fost găsită 1 identitate nouă";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finanțează-ți numele de utilizator din soldul protejat. Adaugă fondurile cu câteva ore înainte — scurta odihnă face ca numele tău de utilizator să nu poată fi legat de restul Dash-ilor tăi.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finanțat din soldul tău protejat — numele tău de utilizator nu poate fi legat de restul Dash-ilor tăi.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fonduri blocate — se finalizează transferul";
+
+/* CoinJoin */
+"Funds moved" = "Fonduri mutate";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pregătește-te să te alături DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Am înțeles";
+
+/* Governance */
+"Governance" = "Guvernanță";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "a cerut să îți fie prieten";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Ai o invitație?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Anteturi";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Înălțime %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Taxe mai mari, în jur de 7 cenți (tot mai mici decât la alte blockchain-uri care oferă o confidențialitate similară)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Cum se compară asta cu Bitcoin din punctul de vedere al confidențialității?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Cum se compară asta cu conturile Ethereum din punctul de vedere al confidențialității?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Cât de privat este DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Am scris-o";
 
+/* Identities */
+"Identities" = "Identități";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Credite de identitate";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Index de identitate";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Înregistrarea identității";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Realimentarea identității";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inactiv";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Intrare %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Intrare %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Intrări (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Fonduri nesuficiente";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Invitație de la %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Invită pe cineva să se alăture rețelei Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Invită-ți prietenii și familia în rețeaua Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Păstrează aceste monede private. Se aplică taxe de rețea și de confidențialitate.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Cheia nr. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Datele cheii";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Proprietatea cheii";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Chei";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "În frunte";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Află mai multe";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Se încarcă tranzacțiile";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Monedă Locală";
 
+/* Identities */
+"Local Only" = "Doar local";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Suma solicitată local: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Blochează";
+
+"Lock the name" = "Blochează numele";
+
+"Lock “%@” so nobody gets it" = "Blochează „%@” ca să nu îl primească nimeni";
+
 /* No comment provided by engineer. */
 "Locked" = "Blocat";
 
+"Locked — nobody receives this username" = "Blocat — nimeni nu primește acest nume de utilizator";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Taxe mici pentru cheltuielile de zi cu zi";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Principală";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Breloc de chei masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Listă de masternode-uri";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Voturi de masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode-uri";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode-urile și evonode-urile înregistrate cu cheile acestui portofel vor apărea aici după ce portofelul se sincronizează.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode-uri și evonode-uri care folosesc cheile acestui portofel";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode-urile votează pentru numele cerute de mai mult de o persoană. Vei fi notificat când se încheie votul.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimul a fost atins";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Mai multe sugestii";
+
+"Most lock votes" = "Cele mai multe voturi de blocare";
+
+"Most votes" = "Cele mai multe voturi";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Mută în soldul tău obișnuit disponibil.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Se mută fondurile";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Serviciile de nume precum Unstoppable Domains asociază un nume lizibil unei adrese publice fixe din lanț. Oricine poate rezolva numele și poate vedea fiecare plată făcută vreodată către el. Un nume de utilizator DashPay nu se rezolvă niciodată public către o adresă de plată — adresele sunt dezvăluite doar în cadrul schimbului criptat cu fiecare contact, așa că numele și banii tăi rămân nelegați pentru observatorii din exterior.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Necesită atenție";
 
 /* No comment provided by engineer. */
 "Network" = "Rețea";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Pe acest dispozitiv nu au fost găsite jurnale de diagnosticare. Jurnalele se scriu începând cu următoarea pornire.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nicio identitate";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Încă niciun masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nicio dispută potrivită";
+
+/* Identities */
+"No new identities were found for this wallet" = "Nu au fost găsite identități noi pentru acest portofel";
+
+"No open contest matches that search." = "Nicio dispută deschisă nu corespunde acestei căutări.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nicio dispută deschisă nu corespunde acestei căutări. Numele sunt stocate într-o formă normalizată, așa că „alice” apare ca „a11ce”.";
+
+"No open contests" = "Nicio dispută deschisă";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Nu a fost găsită nicio înregistrare salvată pentru portofelul asociat.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Încă nu este disponibilă nicio adresă Platform pentru înregistrarea protejată de rezervă. Încearcă din nou după ce portofelul termină sincronizarea.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Momentan niciun nume de utilizator nu este disputat. Disputele se deschid când două sau mai multe persoane cer același nume.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nu a fost exprimat niciun vot";
+
+"Nobody gets it" = "Nimeni nu îl primește";
+
+/* SPV sync peer type */
+"Node" = "Nod";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Încă indisponibil";
+
+"Not cast" = "Neexprimat";
+
+/* Masternodes */
+"Not checked yet" = "Încă neverificat";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Sold protejat insuficient pentru a înregistra o identitate";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nu este în istoricul portofelului";
+
+"Not now" = "Nu acum";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Nu este acceptat pe scară largă de comercianți";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Încă nu este acceptat pe scară largă de comercianți";
+
+/* Masternode keys */
+"Not yet used" = "Încă nefolosit";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Pe Bitcoin nu există un strat de nume, așa că oamenii împart și refolosesc adresele la vedere — odată ce o adresă este cunoscută, tot ce a primit vreodată poate fi legat de proprietarul ei. Cu DashPay numele tău de utilizator este public, dar nu indică niciodată o adresă de plată: adresele sunt schimbate privat cu fiecare contact și se rotesc, așa că plata pe nume nu publică unde îți merg banii. Ambele sunt lanțuri transparente, deci analiza lanțului se aplică în continuare monedelor în sine.";
+
+/* Identities */
+"On Network" = "În rețea";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Odată ce %@ îți acceptă cererea, vei putea plăti direct către numele de utilizator";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Câte un nod pe rând";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Doar masternode-urile și evonode-urile pot vota pentru numele de utilizator. Acest portofel nu deține chei active de vot de masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operator";
+
+/* Masternode keys */
+"Operator keys" = "Chei de operator";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Cheie publică de operator (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "sau";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Alte rezultate";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Ieșire %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Ieșiri (%d)";
+
+/* Masternodes */
+"Owner" = "Proprietar";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adresa proprietarului";
+
+/* Masternodes */
+"Owner key hash" = "Hash-ul cheii proprietarului";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Cheile Proprietarului";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Plătit din soldul de credite al identității tale.";
 
 /* DashSpend */
 "Password" = "Parolă";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Lipește linkul de invitație pe care l-ai primit sau scanează-i codul QR. El finanțează înregistrarea numelui tău de utilizator.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "plăti direct către numele de utilizator";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plătește oameni, nu adrese";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Plățile sunt private: adresele pe care le schimbi cu un contact circulă într-un conținut criptat pe care doar voi doi îl puteți citi și nu sunt publicate niciodată — așa că plățile tale nu pot fi legate ușor de numele tău de utilizator. Cu toate acestea, rămân plăți obișnuite pe un lanț transparent: o analiză sofisticată a lanțului ar putea dezvălui informații. Shielded DashPay (în curând) va acoperi acest gol. Cererile de contact în sine NU sunt private momentan: oricine poate vedea că două identități sunt conectate. Cererile de contact private sunt o funcție care urmează în curând. Numele tău de utilizator și profilul tău sunt de asemenea publice pe Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Plățile se confirmă în câteva secunde cu InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Plățile făcute direct către adrese nu vor fi păstrate în activitate.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Plățile cu fiecare contact sunt grupate într-un singur loc, cu nume și profiluri în loc de tranzacții brute.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adresă de plată";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adresă Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Sold Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nod Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID-ul nodului Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Plățile Platform nu identifică expeditorul. Această plată a fost înregistrată când portofelul a observat modificarea soldului — este posibil să fi sosit mai devreme.";
+
+"Platform SDK not ready" = "SDK-ul Platform nu este pregătit";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Sincronizarea Platform nu rulează. Deschide Informații despre sincronizare → Stare sincronizare Platform pentru a o porni.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Protejat";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Folosită anterior la: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat prin proiectare";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Cererile de contact private (ca să rămână privat cu cine te conectezi), Shielded DashPay — plăți către contacte din soldul tău protejat privat — și plățile către utilizatori care nu sunt încă în contactele tale urmează toate în curând.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Cererile de contact private sunt în dezvoltare și sunt așteptate în jurul lunilor septembrie–octombrie 2026. Astăzi cererea în sine este publică — oricine poate vedea că două identități sunt conectate, chiar dacă detaliile de plată din interior sunt criptate. Odată ce apar cererile de contact private, vei putea alege dacă prietenia ta este publică sau privată.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Cereri de contact private, Shielded DashPay și plăți către oameni care nu sunt încă în contacte.";
+
 /* No comment provided by engineer. */
 "Private key" = "Cheia privată";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Adresele de plată private sunt schimbate între tine și contactele tale. Doar tu și contactul tău știți cine este destinatarul și expeditorul plăților dintre voi.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Plăți private";
+
+/* Usernames */
+"Private registration" = "Înregistrare privată";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Timp de procesare";
+
+/* Balance info sheet section */
+"Pros" = "Avantaje";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Tranzacții de furnizor";
+
+/* Masternode keys */
+"Public key" = "Cheie publică";
+
+/* Masternode keys */
+"Public key (legacy)" = "Cheie publică (veche)";
+
+/* Identities */
+"Public keys" = "Chei publice";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Scop";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Tranzacție brută";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Tranzacția brută nu este disponibilă";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Reverifică filtrele compacte de blocuri de la înălțimea aleasă pentru tranzacțiile acestui portofel, redescărcându-le și repotrivindu-le. Rescanările sunt limitate inferior de înălțimea de creare a portofelului și de datele lanțului stocate local — pentru a recupera istoricul de sub acest nivel, scade în schimb înălțimea de start a portofelului.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Doar citire";
+
+/* Usernames */
+"Ready around %@" = "Gata în jurul orei %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Motiv";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Primit de la %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Înregistrează masternode-urile tale ca având votat, fără a lua vreo parte.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Împrospătează";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Înregistrat la";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Înregistrarea privată necesită cel puțin %@ Dash în soldul tău protejat plus câteva ore de odihnă — ecranele următoare te vor ghida.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Înregistrare";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Cere acest nume";
+
 /* An action */
 "Rescan" = "Scanează din nou";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Portofelele restaurate nu pot recupera întotdeauna tipul operațiunii. Această intrare a fost reconstruită din datele notei de pe lanț.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Resincronizare pregătită de la înălțimea %u — închide și redeschide aplicația pentru a începe.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "păstrezi istoricul comun al tranzacțiilor";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Retras";
 
 /* No comment provided by engineer. */
 "Retry" = "Reîncercă";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Revocare";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshot-urile sunt vizibile altor aplicații și dispozitive. Generează o nouă frază de recuperare și păstreaz-o secretă.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Semnătura scriptului";
+
+/* Raw transaction inspector */
+"Script type" = "Tipul scriptului";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Caută un contact";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Caută o cerere de contact";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Caută un utilizator în rețeaua Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Caută un nume de utilizator";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultatele căutării pentru \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Caută nume de utilizator";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Se caută numele de utilizator %@ în rețeaua Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Nivel de securitate";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Selectează tot";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Selectează cel puțin un masternode cu care să votezi.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Selectarea mai puținor noduri dezvăluie mai puțin despre ce masternode-uri administrezi.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Trimite către un contact";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Trimite către un nume de utilizator pe care chiar îl poți reține și verifica.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Trimite prima ta cerere de contact";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Se trimite cererea de contact";
+
+/* No comment provided by engineer. */
+"Sending to" = "Se trimite către";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Trimis către %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Serviciu";
+
+/* Identities */
+"Set as Main" = "Setează ca principală";
+
+/* Identities */
+"Set as Main Identity" = "Setează ca identitate principală";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Bazinul de confidențialitate partajat este la dimensiunea minimă";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Adresă protejată";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Cheltuială protejată";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Se pornește portofelul protejat…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Protejat → Platform";
+
+"Shielded → Transparent" = "Protejat → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Dimensiune";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Unele dintre masternode-urile tale ar putea lipsi din această listă — portofelul nu a putut citi setul complet de chei de vot. Finalizează sincronizarea și redeschide acest ecran.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortează contactele";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Payload special";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Începe după ce adaugi fonduri";
+
+/* Transaction details */
+"Status" = "Stare";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Stocat ca";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informații despre sincronizare";
+
+/* SPV sync */
+"Sync too slow?" = "Sincronizarea este prea lentă?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Nu lua nicio parte";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Atinge pentru a copia";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Cheie de nod Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash ajunge la adresa destinatarului după ce rețeaua procesează retragerea — asta poate dura până la 10 minute.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash ajunge la adresa destinatarului imediat ce rețeaua procesează retragerea.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash ajunge în soldul tău transparent imediat ce rețeaua procesează retragerea.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Identitatea principală poate fi aleasă doar din portofelul activ";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Cel mai privat loc pentru a-ți ține Dash-ii";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Înregistrarea salvată a portofelului nu are rețea — resincronizarea nu poate fi pregătită.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Înregistrarea a fost trimisă, dar rezultatul ei nu a putut fi confirmat. Așteaptă un minut ca portofelul să se sincronizeze, apoi încearcă din nou — nu retrimite imediat.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Bazinul de confidențialitate partajat încă crește (%1$ld din %2$ld depuneri). Înregistrarea privată se deblochează când atinge minimul.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Bazinul de confidențialitate partajat încă crește (%1$ld din %2$ld depuneri). Încearcă din nou când atinge minimul.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Înălțimea de creare a portofelului — pragul inferior pentru scanările de filtre și pentru rescanările „De la crearea portofelului”. Setează-o la nivelul primei alimentări a portofelului sau sub el; importurile folosesc implicit 200000 pe mainnet și 0 pe testnet. Salvarea unei înălțimi egale cu cea curentă sau mai mici șterge datele lanțului acestei rețele la următoarea pornire și rescanează de acolo.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "el (Se obțin informațiile)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nu există notificări noi";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nu există utilizatori care să corespundă numelui %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "În contactele tale nu există utilizatori care să corespundă numelui %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Aceste fonduri trec în soldul tău Platform și sunt gata de cheltuit imediat ce transferul se finalizează.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Această adresă nu poate fi plătită din soldul tău %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Aceasta adaugă două chei identității tale, ca alți utilizatori să îți poată trimite cereri de contact și ca tu să le poți accepta pe ale lor. Se întâmplă o singură dată.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Aceasta aplică o singură alegere tuturor celor %d nume de utilizator selectate.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Acest link de invitație nu este valid.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Aceasta nu este o adresă Dash validă pentru această rețea";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Acesta nu este un link de invitație valid";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Aceasta este identitatea ta principală";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Acest masternode nu are încă o identitate Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Asta contează în continuare drept vot al masternode-urilor tale în această dispută.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Octeții bruți ai acestei tranzacții nu sunt stocați pe acest dispozitiv.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Acest nume de utilizator a mers la altcineva";
+
+"This wallet could not derive the voting key for this node." = "Acest portofel nu a putut deriva cheia de vot pentru acest nod.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Acest portofel nu deține chei active de vot de masternode, deci nu poate vota. Nodurile înregistrate apar în Instrumente → Masternode-uri.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Aceasta retrage întregul tău sold Platform într-un singur transfer. Dash ajunge la adresa destinatarului imediat ce rețeaua procesează retragerea.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Aceasta retrage întregul tău sold Platform într-un singur transfer. Dash ajunge în soldul tău transparent imediat ce rețeaua procesează retragerea.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Istoricul tranzacțiilor nu este disponibil";
+
 /* No comment provided by engineer. */
 "Transaction id" = "ID-ul de tranzacție";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID-ul tranzacției";
 
 /* A verb, button title. */
 "Transfer" = "Transferă";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Transfer de intrare";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Transfer de ieșire";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transferurile durează mai mult — construirea dovezilor de confidențialitate necesită timp";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transferurile către alte adrese Platform și către adrese protejate sunt instantanee și definitive";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Adresă transparentă";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Sold transparent";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Finanțarea transparentă îți leagă public numele de utilizator de aceste fonduri.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Protejat";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nu pot fi oferite sugestii";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Tip special necunoscut %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Neprotejat";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Treci la Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Folosește în schimb soldul transparent";
+
+/* Masternode keys */
+"Used" = "Folosită";
+
+/* Masternode keys */
+"Used at: " = "Folosită la: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Utilizator (Se obțin informațiile)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Nume de utilizator";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Numele de utilizator sunt stocate într-o formă normalizată pentru a preveni numele asemănătoare, așa că acesta poate diferi de ce a tastat fiecare persoană.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Nume de utilizator, nu adrese";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Utilizatori care corespund cu %@ și care momentan nu sunt în contactele tale";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Folosește una dintre cele mai auditate și testate biblioteci cu cunoaștere zero (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Invitație validă";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Verificat în timpul înregistrării";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versiune";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Foarte eficient, cu taxe mici";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Vezi toate";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Vezi tranzacția";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Votează";
+
+"Vote cast" = "Vot exprimat";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Votează pentru numele de utilizator disputate";
+
+"Vote on several" = "Votează pentru mai multe";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Votează cu";
+
+"Votes that nobody should receive these usernames." = "Votează ca nimeni să nu primească aceste nume de utilizator.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresă de vot";
+
+"Voting ended with no winner" = "Votul s-a încheiat fără câștigător";
+
+"Voting ends" = "Votul se încheie";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Vot în desfășurare";
+
+"Voting in progress — lock votes are ahead" = "Vot în desfășurare — voturile de blocare conduc";
+
+"Voting in progress — you are ahead" = "Vot în desfășurare — conduci";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash-ul cheii de vot";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Chei de Vot";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Votul pentru acest nume de utilizator s-a închis. Numerele de mai jos sunt ultimele citite.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Votul pentru „%@” s-a închis deja. Împrospătează pentru a vedea rezultatul.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Se așteaptă Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Înălțimea de start a portofelului";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Portofelul este dezactivat";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Dar Unstoppable Domains și serviciile de nume similare?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Cât costă?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Ce este DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Ce urmează?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Când vor deveni private cererile de contact?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Cine cere acest nume";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "De ce trebuie să îl activez?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Retrage întregul sold";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funcționează cu orice portofel, bursă și comerciant Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Tu";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Ai acceptat cererea de contact de la %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Momentan nu ai niciun contact";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Ai %@ Dash până acum";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Ai trimis cererea de contact către %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Ai câștigat acest nume de utilizator";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Totul este gata. Alți utilizatori îți pot trimite acum cereri de contact — iar tu le poți trimite pe ale tale.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Identitatea ta Dash Platform apare aici după ce înregistrezi un nume de utilizator.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Istoricul tău, organizat";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identitatea ta are nevoie de două chei suplimentare pentru ca cererile de contact să poată fi criptate între tine și ceilalți utilizatori. Activarea le adaugă printr-o singură tranzacție în rețea. Se întâmplă o singură dată.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Invitația ta plătește taxa de înregistrare pentru acest nume de utilizator.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Soldul tău principal de Dash de pe blockchain-ul Core — ceea ce trimiți și primești cu alte portofele, burse și comercianți.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Monedele tale amestecate au fost mutate în soldul portofelului tău Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Monedele tale amestecate au fost mutate în soldul protejat. Pentru cea mai bună confidențialitate, așteaptă cel puțin 2 ore înainte de a folosi aceste fonduri.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Soldul tău Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Soldul tău privat. Sumele și adresele sunt criptate pe lanț, așa că deținerile și istoricul tău rămân confidențiale.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Soldul tău protejat";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Soldul tău protejat este aproape gata — te vei putea înregistra privat în jurul orei %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Soldul tău protejat este gata — înregistrează-ți acum numele de utilizator în mod privat";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Soldul tău protejat se odihnește — te vei putea înregistra privat în jurul orei %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Soldul tău protejat încă se maturizează. Va fi gata în jurul orei %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Soldul tău transparent";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Numele tău de utilizator este vizibil pentru toată lumea. Dacă îl finanțezi din soldul protejat — după ce lași fondurile să se odihnească câteva ore — nimeni nu îți poate lega numele de utilizator de restul Dash-ilor tăi.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Numele tău de utilizator, profilul și contactele urmează această identitate.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Numele tău de utilizator, profilul și contactele vor urma această identitate.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Voturile tale";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Portofelul tău încă se sincronizează cu rețeaua Dash. Trimiterea va fi disponibilă după ce sincronizarea se încheie.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Portofelul tău încă se sincronizează. Trimiterea din soldul transparent va fi disponibilă după ce sincronizarea se încheie.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@” nu a putut fi citit ca nume de utilizator Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@” a fost înregistrat. Trimiți o cerere de contact persoanei care te-a invitat?";

--- a/DashWallet/ro.lproj/Localizable.stringsdict
+++ b/DashWallet/ro.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ numărate pentru „%2$@”</string>
+		<string>%#@votes@ pentru „%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,11 +93,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u vot</string>
+			<string>%1$u vot numărat</string>
 			<key>few</key>
-			<string>%1$u voturi</string>
+			<string>%1$u voturi numărate</string>
 			<key>other</key>
-			<string>%1$u de voturi</string>
+			<string>%1$u de voturi numărate</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -139,7 +139,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d din %#@nodes@ au votat</string>
+		<string>Votat: %1$d din %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d din %#@nodes@ au votat</string>
+		<string>Votat: %1$d din %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/ro.lproj/Localizable.stringsdict
+++ b/DashWallet/ro.lproj/Localizable.stringsdict
@@ -82,5 +82,275 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ numărate pentru „%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u vot</string>
+			<key>few</key>
+			<string>%1$u voturi</string>
+			<key>other</key>
+			<string>%1$u de voturi</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>S-a votat pentru %1$d din %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nume de utilizator</string>
+			<key>few</key>
+			<string>%2$d nume de utilizator</string>
+			<key>other</key>
+			<string>%2$d de nume de utilizator</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Exprimă %u vot</string>
+			<key>few</key>
+			<string>Exprimă %u voturi</string>
+			<key>other</key>
+			<string>Exprimă %u de voturi</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d din %#@nodes@ au votat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>few</key>
+			<string>%2$d masternode-uri</string>
+			<key>other</key>
+			<string>%2$d de masternode-uri</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d din %#@nodes@ au votat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nod</string>
+			<key>few</key>
+			<string>%2$d noduri</string>
+			<key>other</key>
+			<string>%2$d de noduri</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode-uri</string>
+			<key>other</key>
+			<string>%d de evonode-uri</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot în total</string>
+			<key>few</key>
+			<string>%u voturi în total</string>
+			<key>other</key>
+			<string>%u de voturi în total</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>few</key>
+			<string>%d masternode-uri</string>
+			<key>other</key>
+			<string>%d de masternode-uri</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d selectat</string>
+			<key>few</key>
+			<string>%d selectate</string>
+			<key>other</key>
+			<string>%d de selectate</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d dintre nodurile tale a votat deja aici și nu este afișat.</string>
+			<key>few</key>
+			<string>%d dintre nodurile tale au votat deja aici și nu sunt afișate.</string>
+			<key>other</key>
+			<string>%d dintre nodurile tale au votat deja aici și nu sunt afișate.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot per dispută — evonode-urile contează ca 4, masternode-urile ca 1</string>
+			<key>few</key>
+			<string>%u voturi per dispută — evonode-urile contează ca 4, masternode-urile ca 1</string>
+			<key>other</key>
+			<string>%u de voturi per dispută — evonode-urile contează ca 4, masternode-urile ca 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votează pentru %d nume de utilizator</string>
+			<key>few</key>
+			<string>Votează pentru %d nume de utilizator</string>
+			<key>other</key>
+			<string>Votează pentru %d de nume de utilizator</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u vot</string>
+			<key>few</key>
+			<string>%u voturi</string>
+			<key>other</key>
+			<string>%u de voturi</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Votează ×%d</string>
+			<key>few</key>
+			<string>Votează ×%d</string>
+			<key>other</key>
+			<string>Votează ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d cerere</string>
+			<key>few</key>
+			<string>%d cereri</string>
+			<key>other</key>
+			<string>%d de cereri</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " или ";
+
 /* CrowdNode */
 " Privacy Policy " = "Политика конфиденциальности";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Не удалось найти %@ в сети Dash, чтобы отправить запрос на добавление в контакты.";
+
+/* Usernames */
+"%@ Dash available" = "Доступно %@ Dash";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ принял ваш запрос на добавление в контакты";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu контактов / %3$lu обновлений профиля";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d байт";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d даффов";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "В вашем кошельке храниться несколько ключей для голосования, поэтому будет отдано %d голосов.";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld дубликатов";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld из %ld депозитов";
 
 /* Voting */
 "%ld requests" = "%ld запросов";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" не является словом из фразы восстановления. Вы желаете восстановить правильное слово, которое должно быть вместо него?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Баланс кредитов на Dash Platform, который используется для мгновенных платежей между адресами Platform и для таких функций, как имена пользователей.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Код-пароль необходим для защиты Вашего кошелька. Перейдите в Настройки и включите код-пароль, чтобы продолжить.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "О программе";
 
+/* DashPay FAQ title */
+"About DashPay" = "О DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Обо мне";
+
+"Abstain" = "Воздержаться";
+
+"Abstain on “%@”" = "Воздержаться по «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Подтвердить";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Восстановление аккаунта";
 
+/* Masternode status */
+"Active" = "Активна";
+
+/* No comment provided by engineer. */
+"Activity" = "Активность";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Активность публична, но её нелегко отследить";
+
 /* No comment provided by engineer. */
 "Add" = "Добавить";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Добавить %@ в контакты";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Добавьте %@ в контакты, чтобы платить напрямую на имя пользователя и сохранять общую историю транзакций";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Добавьте %@ Dash на экранированный баланс и дайте им отлежаться несколько часов, чтобы зарегистрироваться, не связывая имя пользователя с остальными вашими средствами.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Добавить новый контакт";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Добавьте не менее %@ Dash на экранированный баланс";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Пополните экранированный баланс сейчас и приватно зарегистрируйте имя пользователя через несколько часов";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Все";
 
+"All nodes at once" = "Все узлы сразу";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Все ваши мастерноды проголосовали за это имя пользователя. Чтобы изменить голос, проголосуйте снова за того претендента, которого вы теперь предпочитаете.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Разрешить переcылать все транзакции из Dash Wallet в Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Практически мгновенная синхронизация балансов";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Суммы и адреса публичны в блокчейне";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Возникла ошибка";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Аккаунт Ethereum — это один многоразовый адрес: весь ваш баланс и история платежей публично находятся под ним, а имя (например, домен ENS) обычно указывает прямо на этот адрес, и любой может его разрешить. DashPay устроен наоборот — имя разрешается в идентификатор, а не в платёжный адрес, и реальные платёжные адреса остаются внутри зашифрованных обменов с контактами, новые для каждого контакта.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Интуитивный и привычный интерфейс на всех ваших устройствах";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Любое имя пользователя, содержащее цифры от 2-9, больше 20 символов или дефис, будет автоматически одобрено";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Любой, кто знает адрес, может посмотреть его историю";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Применить";
 
+"Approve" = "Одобрить";
+
+"Approving a specific request can only be done one username at a time." = "Одобрить конкретный запрос можно только по одному имени пользователя за раз.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Вы уверены, что хотите отменить этот ордер?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Как текст";
 
 /* DashSpend */
 "at" = "в";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Аутентификация отменена. Ваш голос не был отдан.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Аутентификация не удалась. Ваш голос не был отдан.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Авторизация недоступна";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Присудить «%@» этому претенденту";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Баланс";
 
 /* CrowdNode */
+"Balance after" = "Баланс после";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Баланс CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Баланс:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Балансы и переводы не видны публично";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Расчётный счёт";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Требуется разрешение на доступ к биометрии.";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Начальная высота сохранена — повышенная граница сканирования применится со следующего запуска.";
+
 /* Voting */
 "Block" = "Блок";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Заблокировано '%@' имя пользователя";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Привязан к контракту";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Привязан к контракту, тип документа «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Только просмотр";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Собрать последние диагностические журналы в zip-архив, чтобы отправить через AirDrop, по почте или сохранить в Файлы";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Отдать голос";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Сменить пиров";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Изменить PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Проверка…";
+
+"Choice" = "Выбор";
+
 /* Choose your Dash username */
 "Choose your" = "Выберите ваше";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Выберите имя пользователя";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Активируйте приглашение";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Доступный к получению баланс";
+
 /* No comment provided by engineer. */
 "Claimed" = "Уже занято";
+
+/* SPV diagnostics */
+"Clear & resync" = "Очистить и пересинхронизировать";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Очистить данные блокчейна и пересинхронизировать?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Закрыть приложение";
 
+"Closing" = "Закрывается";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (новые монеты)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "2FA код Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin больше не поддерживается — выберите, куда переместить смешанные монеты.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Залоговое обеспечение";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Скоро";
+
+/* Shielded transfer status */
+"Completed" = "Завершён";
 
 /* No comment provided by engineer. */
 "Confirm" = "Подтвердить";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Подтверждена";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Подтверждение сохранит начальную высоту %u и очистит данные блокчейна этой сети при следующем запуске приложения, после чего они будут загружены заново, а фильтры пересканированы с этой высоты. Текущая сессия сохранит прежнюю границу сканирования — закройте и снова откройте приложение, чтобы начать.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Подключите свои криптокошельки к платформе ZenLedger. Узнайте больше и начните с транзакций в Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Связанный адрес Dash ";
 
+/* SPV sync */
+"Connected peers" = "Подключённые пиры";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Минусы";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Не удалось отправить запрос на добавление в контакты";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Запрос на добавление в контакты отправлен %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Запросы на добавление в контакты";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Контакты";
 
+"Contender %@" = "Претендент %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Продолжить";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Продолжите, чтобы выбрать имя пользователя. Приглашение оплачивает комиссию за регистрацию.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Скопировать ссылку-приглашение";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Скопировать необработанную транзакцию";
+
 /* No comment provided by engineer. */
 "Copy text" = "Копировать текст";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Не удалось автоматически восстановить отсутствующие или неправильные слова";
 
+/* Log export */
+"Could not create the log archive: %@" = "Не удалось создать архив журналов: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Не удалось найти обменный курс.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Не удалось обновить %d идентификаторов";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Не удалось получить баланс (ошибка сети). Попробуйте обновить.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Не удалось совершить платёж";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Создать имя пользователя";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Создайте своё имя пользователя, находите друзей и родных по их именам пользователя и добавляйте их в контакты";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Кредитная карта";
+
+/* Masternodes */
+"Credits" = "Кредиты";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Платежи Dash не могут быть меньше, чем %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ещё не проиндексировала этот спор. Количество голосов появится здесь, когда это произойдёт.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ещё не подключена. Дождитесь окончания синхронизации и попробуйте снова.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash, отправленные на неверный адрес, вернуть невозможно. Убедитесь, что адрес точно тот, на который вы собираетесь платить.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash хранит имена пользователей в защищённом от похожих написаний виде, поэтому сохранённое имя может отличаться от того, что ввёл каждый человек.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Имя пользователя Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Баланс кошелька Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet на этом устройстве";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay включён";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Приглашение DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay — это социальные платежи Dash, построенные на Dash Platform. Вы регистрируете имя пользователя, добавляете других пользователей в контакты и платите им по имени — больше не нужно копировать адреса.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay заменяет длинные непонятные адреса именами пользователей. Добавляйте друзей в контакты, отправляйте деньги на имя и держите все платежи упорядоченными по людям.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Комиссия за обновление DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "По дате: Сначала старые";
+
+"Deadline unknown" = "Срок неизвестен";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Средства отправлены";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Путь деривации";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "БЕЗОПАСНОСТЬ УСТРОЙСТВА ПОД УГРОЗОЙ\nЛюбое «jailbreak» приложение может получить доступ к Вашим приватным ключам (и украсть Ваши Dash). Немедленно удалите этот кошелёк и восстановите его на доверенном устройстве.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Отключён";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Отключить аккаунт Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Готово";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Готово — ваш баланс отлежался достаточно долго";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Проверьте адрес ещё раз";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Каждое приглашение сопровождается этой суммой, чтобы получатель мог тут же создать своё имя пользователя в сети Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "У каждой мастерноды есть один действующий голос в споре. Вы можете изменить его позже, но Dash Platform допускает всего 5 голосов на мастерноду в одном споре.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Каждое нажатие добавляет к голосованию ещё один узел, так что вы выбираете, сколько их связать вместе.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Ранее";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Отправьте Dash в стейкинг и получите пассивный доход всего за несколько кликов.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Изменить начальную высоту";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Редактировать профиль";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Почта";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Включить";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Включить DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Включить Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Включить Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Включение DashPay стоит небольшую разовую комиссию сети, которая списывается с баланса кредитов вашего идентификатора. Точная оценка показывается перед подтверждением. Отправка запросов на добавление в контакты и платежей стоит обычных комиссий сети.";
+
+"Ending soonest" = "Заканчивается раньше всех";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Ошибка при обновлении профиля";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Ориентировочная комиссия сети";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Все узлы голосуют вместе. Быстрее, но публично связывает ваши мастерноды друг с другом.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Ключи оператора Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Экспортировать CSV";
 
+/* Log export */
+"Export Logs" = "Экспортировать журналы";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Расширенный публичный ключ (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Внешний адрес";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Лимит Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Не удалось";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Ошибка при загрузке штрихкода";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Обновление курса…";
 
+/* Masternodes */
+"Fetching…" = "Получение…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Фиатный счёт";
 
 /* No comment provided by engineer. */
 "Filter" = "Фильтр";
+
+/* SPV sync phase */
+"Filter headers" = "Заголовки фильтров";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Сортировать транзакции";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Найти пользователя в сети Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Найдите банкоматы, где можно купить или продать Dash.";
+
+/* Identities */
+"Find identities" = "Найти идентификаторы";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Забыли PIN?";
 
+/* Identities */
+"Found %d new identities" = "Найдено %d новых идентификаторов";
+
+/* Identities */
+"Found 1 new identity" = "Найден 1 новый идентификатор";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Найдено пропущенное слово:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Профинансируйте имя пользователя с экранированного баланса. Пополните его за несколько часов заранее — короткая выдержка не позволит связать ваше имя пользователя с остальными вашими Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Профинансировано с экранированного баланса — ваше имя пользователя нельзя связать с остальными вашими Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Средства заблокированы — завершение перевода";
+
+/* CoinJoin */
+"Funds moved" = "Средства перемещены";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Получайте вознаграждение за инвестирование в мастерноды Dash, начиная с 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Получить Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Приготовьтесь присоединиться к DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Получайте мгновенные вознаграждения";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Понятно";
+
+/* Governance */
+"Governance" = "Управление";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Предоставьте разрешения GPS, чтобы мы могли показывать вам точки поблизости с вами.";
 
 /* Voting */
 "Has blocked votes" = "Заблокированных голосов";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "хочет добавить вас в друзья";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Есть приглашение?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Полный контроль и настройки кошелька для Ваших нужд";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "заголовок блока #%1$d из %2$d";
+
+/* SPV sync phase */
+"Headers" = "Заголовки";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Высота %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Это Dash адрес, созданный для вашего аккаунта CrowdNode в Dash Wallet на этом устройстве";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "По убыванию";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Более высокие комиссии, около 7 центов (всё равно ниже, чем у других блокчейнов с сопоставимой приватностью)";
+
 /* No comment provided by engineer. */
 "History" = "История";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Как получить тестовый Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Как это соотносится с Bitcoin с точки зрения приватности?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Как это соотносится с аккаунтами Ethereum с точки зрения приватности?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Насколько приватен DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Как подтвердить свой API Dash адрес";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Я записал";
 
+/* Identities */
+"Identities" = "Идентификаторы";
+
 /* Voting */
 "Identity" = "ID";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Кредиты идентификатора";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Индекс идентификатора";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Регистрация идентификатора";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Пополнение идентификатора";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "В разделе оплата выберите \"Подарочная карта\", введите номер карты и пин-код.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Неактивна";
+
+/* No comment provided by engineer. */
 "Income" = "Доходы";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Инициализация";
+
+/* Raw transaction inspector */
+"Input %d" = "Вход %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Вход %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Входы (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Недостаточно средств";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Комиссия за приглашение";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Приглашение от %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Приглашением воспользовался";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Пригласить";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Пригласите кого-нибудь присоединиться к сети Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Пригласите членов семьи, найдите друзей по имени пользователя";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Пригласите друзей и членов семьи присоединиться к сети Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Пригласите друзей и родных в сеть Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Сообщений о проблеме";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Как присоединиться к пулу";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Сохранить эти монеты приватными. Взимаются комиссии сети и за приватность.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Храните кодовую фразу в надёжном месте";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ключ №%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Данные ключа";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Владение ключом";
+
 /* No comment provided by engineer. */
 "Keypair" = "Пара ключей";
+
+/* Masternodes */
+"Keys" = "Ключи";
 
 /* Explore Dash */
 "Last device sync" = "Синхронизация с последним устройством";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Лидирует";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Узнать больше";
 
 /* Info Screen */
 "Learn More..." = "Узнать больше";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Загрузка транзакций";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Валюта";
 
+/* Identities */
+"Local Only" = "Только локально";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Сумма в местной валюте: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Место нахождения";
 
+"Lock" = "Заблокировать";
+
+"Lock the name" = "Заблокировать имя";
+
+"Lock “%@” so nobody gets it" = "Заблокировать «%@», чтобы никто его не получил";
+
 /* No comment provided by engineer. */
 "Locked" = "Зафиксировано";
 
+"Locked — nobody receives this username" = "Заблокировано — никто не получит это имя пользователя";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Войти";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Низкий";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Низкие комиссии для повседневных трат";
+
 /* Voting */
 "Low to high" = "По возрастанию";
+
+/* Identities — the wallet's main identity */
+"Main" = "Основной";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Основная сеть";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "IP-адрес мастерноды";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Связка ключей мастерноды";
+
+/* Masternode keys */
 "Masternode keys" = "Ключи мастерноды";
+
+/* SPV sync phase */
+"Masternode list" = "Список мастернод";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "список мастернод #%1$d из %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Обновление masternode";
 
+"Masternode votes" = "Голоса мастернод";
+
 /* Voting */
 "Masternode Voting Key" = "Ключ для голосования мастерноды";
+
+/* Tools menu */
+"Masternodes" = "Мастерноды";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Мастерноды и evonode, зарегистрированные с ключами этого кошелька, появятся здесь после синхронизации кошелька.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Мастерноды и evonode, использующие ключи этого кошелька";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Мастерноды голосуют за имена, которые запросил более чем один человек. Вы получите уведомление, когда голосование закончится.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Макс";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Минимум: %@";
 
+/* Usernames */
+"Minimum met" = "Минимум достигнут";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Больше контроля";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Ещё предложения";
+
+"Most lock votes" = "Больше всего голосов за блокировку";
+
+"Most votes" = "Больше всего голосов";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Подвигайте и увеличьте фото, чтобы подобрать идеальный вариант";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Переместить на обычный доступный баланс.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Перемещно на адрес";
+
+/* CoinJoin */
+"Moving funds" = "Перемещение средств";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Имя";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Сервисы имён вроде Unstoppable Domains сопоставляют понятное человеку имя с фиксированным публичным адресом в блокчейне. Любой может разрешить это имя и увидеть каждый платёж, когда-либо сделанный на него. Имя пользователя DashPay никогда не разрешается публично в платёжный адрес — адреса раскрываются только внутри зашифрованного обмена с каждым контактом, поэтому ваше имя и ваши деньги остаются не связанными для сторонних наблюдателей.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Нужна помощь?";
+
+"Needs attention" = "Требует внимания";
 
 /* No comment provided by engineer. */
 "Network" = "Сеть";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "На этом устройстве не найдено диагностических журналов. Журналы записываются начиная со следующего запуска.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Нет идентификаторов";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Мастернод пока нет";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Нет подходящих споров";
+
+/* Identities */
+"No new identities were found for this wallet" = "Для этого кошелька новых идентификаторов не найдено";
+
+"No open contest matches that search." = "Ни один открытый спор не соответствует этому запросу.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ни один открытый спор не соответствует этому запросу. Имена хранятся в нормализованном виде, поэтому «alice» отображается как «a11ce».";
+
+"No open contests" = "Нет открытых споров";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Отсутствуют способы оплаты";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Для привязанного кошелька не найдено сохранённой записи.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Для резервной экранированной регистрации пока нет доступного адреса Platform. Повторите попытку после того, как кошелёк завершит синхронизацию.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Результатов не найдено";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Сейчас ни одно имя пользователя не оспаривается. Спор открывается, когда два или более человека запрашивают одно и то же имя.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Голосов больше нет";
+
+"No votes were cast" = "Голоса не были отданы";
+
+"Nobody gets it" = "Никто его не получит";
+
+/* SPV sync peer type */
+"Node" = "Узел";
+
+/* Raw transaction inspector */
+"Non-standard" = "Нестандартный";
 
 /* adjective, security level */
 "None" = "Отсутствует";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Недоступно";
 
+"Not available yet" = "Пока недоступно";
+
+"Not cast" = "Не отдан";
+
+/* Masternodes */
+"Not checked yet" = "Ещё не проверено";
+
 /* Location Service Status */
 "Not Determined" = "Не определён";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Недостаточно экранированного баланса для регистрации идентификатора";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Отсутствует в истории кошелька";
+
+"Not now" = "Не сейчас";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Не широко принимается продавцами";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Пока не широко принимается продавцами";
+
+/* Masternode keys */
+"Not yet used" = "Ещё не использовался";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Сначала старые";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "В Bitcoin нет слоя имён, поэтому люди открыто делятся адресами и используют их повторно — как только адрес становится известен, всё, что он когда-либо получал, можно связать с его владельцем. В DashPay ваше имя пользователя публично, но оно никогда не указывает на платёжный адрес: адреса обмениваются приватно с каждым контактом и меняются, поэтому платёж по имени не раскрывает, куда уходят ваши деньги. Обе сети — прозрачные блокчейны, так что анализ цепочки по-прежнему применим к самим монетам.";
+
+/* Identities */
+"On Network" = "В сети";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Как только %@ примет ваш запрос, вы сможете платить напрямую на имя пользователя";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "По одному узлу";
 
 /* Voting */
 "One vote left" = "Остался один голос";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Только дубликаты";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Голосовать за имена пользователей могут только мастерноды и evonode. В этом кошельке нет активных ключей голосования мастернод.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Только запросы со ссылками";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Только со ссылками";
+
+/* Masternodes */
+"Operator" = "Оператор";
+
+/* Masternode keys */
+"Operator keys" = "Ключи оператора";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Публичный ключ оператора (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "или";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Просмотр заказа";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Другие исходы";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Выход %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Выходы (%d)";
+
+/* Masternodes */
+"Owner" = "Владелец";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Адрес владельца";
+
+/* Masternodes */
+"Owner address" = "Адрес владельца";
+
+/* Masternodes */
+"Owner key hash" = "Хеш ключа владельца";
 
 /* Owner keys */
 "Owner keys" = "Ключи владельца";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Оплачено с баланса кредитов вашего идентификатора.";
 
 /* DashSpend */
 "Password" = "Пароль";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Вставьте сюда ссылку";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Вставьте полученную ссылку-приглашение или отсканируйте её QR-код. Она оплачивает регистрацию вашего имени пользователя.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Вставьте ссылку на изображение";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Платите и получайте переводы мгновенно с помощью простых в использовании механизмов платежей";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "платить напрямую на имя пользователя";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Платите людям, а не адресам";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Оплата по имени пользователя. Больше никаких цифробуквенных адресов";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Оплата...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Полезная нагрузка (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Способ оплаты";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Платежи приватны: адреса, которыми вы обмениваетесь с контактом, передаются внутри зашифрованных данных, которые можете прочитать только вы двое, и никогда не публикуются — поэтому ваши платежи нелегко связать с вашим именем пользователя. Тем не менее это обычные платежи в прозрачном блокчейне: продвинутый анализ цепочки может раскрыть информацию. Shielded DashPay (скоро) закроет этот пробел. Сами запросы на добавление в контакты сейчас НЕ приватны: любой может увидеть, что два идентификатора связаны. Приватные запросы на добавление в контакты появятся в ближайшее время. Ваше имя пользователя и профиль также публичны в Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Платежи подтверждаются за секунды с InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Платежи, сделанные напрямую на адреса, не будут сохраняться в активности.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Платежи с каждым контактом собраны в одном месте — с именами и профилями вместо необработанных транзакций.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Адрес выплаты";
 
 /* CrowdNode */
 "Payout Options" = "Варианты выплат";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Адрес Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Баланс Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Узел Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID узла Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Платежи Platform не идентифицируют отправителя. Этот платёж был записан, когда кошелёк заметил изменение баланса — он мог прийти раньше.";
+
+"Platform SDK not ready" = "SDK Platform не готов";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Синхронизация Platform не запущена. Откройте Информация о синхронизации → Состояние синхронизации Platform, чтобы запустить её.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Экранированный";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Добавьте способ оплаты на Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Предпросмотр приглашения";
 
+/* Masternode keys */
+"Previously used at: " = "Ранее использован: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Данные о курсе были получены не менее 30 минут назад. Курс валют может быть неточным.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Приватность по умолчанию";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Приватные запросы на добавление в контакты (чтобы то, с кем вы связаны, оставалось приватным), Shielded DashPay — платежи контактам с вашего приватного экранированного баланса — и платежи пользователям, которых ещё нет в ваших контактах, появятся в ближайшее время.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Приватные запросы на добавление в контакты находятся в разработке и ожидаются примерно в сентябре–октябре 2026 года. Сегодня сам запрос публичен — любой может увидеть, что два идентификатора связаны, даже если платёжные данные внутри зашифрованы. Когда приватные запросы появятся, вы сможете выбирать, будет ли ваша связь публичной или приватной.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Приватные запросы на добавление в контакты, Shielded DashPay и платежи людям, которые ещё не в ваших контактах.";
+
 /* No comment provided by engineer. */
 "Private key" = "Приватный ключ";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Приватные платёжные адреса обмениваются между вами и вашими контактами. Только вы и ваш контакт знаете получателя и отправителя платежей между вами.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Приватные платежи";
+
+/* Usernames */
+"Private registration" = "Приватная регистрация";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Время обработки";
+
+/* Balance info sheet section */
+"Pros" = "Плюсы";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Защитите свои сбережения";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Адрес провайдера";
 
+/* Masternodes */
+"Provider transactions" = "Транзакции провайдера";
+
+/* Masternode keys */
+"Public key" = "Публичный ключ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Публичный ключ (устаревший)";
+
+/* Identities */
+"Public keys" = "Публичные ключи";
+
 /* No comment provided by engineer. */
 "Public URL" = "Публичная ссылка";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Ошибка при заказе";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Назначение";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Курс: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Необработанная транзакция";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Необработанная транзакция недоступна";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Повторно проверяет компактные блочные фильтры с выбранной высоты на предмет транзакций этого кошелька, заново загружая и сопоставляя их. Пересканирование ограничено высотой создания кошелька и локально сохранёнными данными блокчейна — чтобы восстановить историю ниже, вместо этого понизьте начальную высоту кошелька.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Прочитать Правила вывода средств";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Только для чтения";
+
+/* Usernames */
+"Ready around %@" = "Готово примерно к %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Причина";
 
 /* No comment provided by engineer. */
 "Receive" = "Получить";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Получено от";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Получено от %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Получение вознаграждений";
+
+"Records your masternodes as having voted, without taking a side." = "Отмечает ваши мастерноды как проголосовавшие, не занимая сторону.";
 
 /* No comment provided by engineer. */
 "Recover" = "Восстановить";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Фраза восстановления должна состоять из 12, 15, 18, 21 или 24 слов";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Обновить";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Зарегистрировать?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Зарегистрирована";
+
+/* No comment provided by engineer. */
 "Registered from" = "Зарегистрировано от";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Зарегистрирована masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Приватная регистрация требует не менее %@ Dash на экранированном балансе и нескольких часов выдержки — следующие экраны проведут вас по шагам.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Регистрация";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Запрашивает это имя";
+
 /* An action */
 "Rescan" = "Синхронизировать снова";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Восстановленные кошельки не всегда могут определить тип операции. Эта запись восстановлена из данных заметки в блокчейне.";
+
+/* Location Service Status */
 "Restricted" = "Ограничен";
 
 /* Usernames */
 "Results" = "Результаты";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Пересинхронизация подготовлена с высоты %u — закройте и снова откройте приложение, чтобы начать.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "сохранять общую историю транзакций";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Выведена из эксплуатации";
 
 /* No comment provided by engineer. */
 "Retry" = "Повторить";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Изучите сообщение ниже, чтобы подтвердить владение этим именем пользователя";
+
+/* Masternodes */
+"Revocation" = "Отзыв";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Скриншоты видимы другими приложениями и устройствами. Создайте новую фразу восстановления и держите её в секрете.";
 
+/* Raw transaction inspector */
+"Script" = "Скрипт";
+
+/* Raw transaction inspector */
+"Script signature" = "Подпись скрипта";
+
+/* Raw transaction inspector */
+"Script type" = "Тип скрипта";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Поиск контакта";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Поиск запроса на добавление в контакты";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Поиск пользователя в сети Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Поиск имени пользователя";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Результаты поиска по \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Поиск по территории";
+
+"Search usernames" = "Поиск имён пользователей";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Поиск имени пользователя %@ в сети Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Сохранить кошелёк";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Уровень безопасности";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Уровень безопасности";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Выберите сервис, чтобы купить, продать, обменять и перевести Dash";
 
+"Select all" = "Выбрать все";
+
 /* DashSpend denomination selection */
 "Select amount" = "Выбрать сумму";
+
+"Select at least one masternode to vote with." = "Выберите хотя бы одну мастерноду для голосования.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Выбрать монету";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Чем меньше узлов выбрано, тем меньше раскрывается о том, какие мастерноды вы держите.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Самообслуживание";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Отправить";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Отправить контакту";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Отправляйте на имя пользователя, которое вы действительно можете запомнить и проверить.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Отправить на адрес";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Отправьте свой первый запрос на добавление в контакты";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Отправка";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Отправка запроса на добавление в контакты";
+
+/* No comment provided by engineer. */
+"Sending to" = "Отправка на";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Отправляется на аккаунт CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Отправлено";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Отправлено %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Ошибка сервера. Пожалуйста, попробуйте снова.";
+
+/* Masternodes */
+"Service" = "Сервис";
+
+/* Identities */
+"Set as Main" = "Сделать основным";
+
+/* Identities */
+"Set as Main Identity" = "Сделать основным идентификатором";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Установить PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Поделиться ключом";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Общий пул приватности достиг минимального размера";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Экранированный адрес";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Экранированная трата";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Запуск экранированного кошелька…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Экранированный → Platform";
+
+"Shielded → Transparent" = "Экранированный → Прозрачный";
 
 /* Explore Dash */
 "Show all locations" = "Показать все точки";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Размер";
+
 /* No comment provided by engineer. */
 "Skip" = "Пропустить";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Некоторых из ваших мастернод может не быть в этом списке — кошелёк не смог прочитать весь набор ваших ключей голосования. Завершите синхронизацию и снова откройте этот экран.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Некоторые Имена пользователей могут быть заблокированы";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Упорядочить по";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Сортировать контакты";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Сортировка по скидке";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Сортировать по названию";
+
+/* Raw transaction inspector */
+"Special payload" = "Специальная полезная нагрузка";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Введите сумму";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Стейкинг";
 
+/* Usernames */
+"Starts after you add funds" = "Начнётся после пополнения";
+
+/* Transaction details */
+"Status" = "Статус";
+
 /* Step 1 */
 "Step %ld" = "Шаг %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Хранится как";
 
 /* Voting */
 "Submit" = "Отправить";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Синхронизация… Результаты могут быть неполными.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Информация о синхронизации";
+
+/* SPV sync */
+"Sync too slow?" = "Синхронизация слишком медленная?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Сделать фото с камеры";
 
+"Take no side" = "Не занимать сторону";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Чтобы вставить адрес из буфера обмена, нажмите на него";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Нажмите, чтобы скопировать";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Нажмите, чтобы скрыть баланс";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Временно недоступно";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ключ узла Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Положения и условия";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Тестовая сеть";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Неверный код. Попробуйте ещё раз!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash поступят на адрес получателя после того, как сеть обработает вывод — это может занять до 10 минут.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash поступят на адрес получателя, как только сеть обработает вывод.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash поступят на ваш прозрачный баланс, как только сеть обработает вывод.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Сеть Dash должна проголосовать за утверждение некоторых имён пользователей, прежде чем они будут созданы";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Отправленную ссылку увидят только владельцы сети";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Основной идентификатор можно выбрать только из активного кошелька";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Минимальная сумма для отправки составляет %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Самое приватное место для хранения ваших Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "У сохранённой записи кошелька нет сети — невозможно подготовить пересинхронизацию.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Регистрация отправлена, но подтвердить её результат не удалось. Подождите минуту, пока кошелёк синхронизируется, затем попробуйте снова — не отправляйте повторно сразу.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Общий пул приватности ещё растёт (%1$ld из %2$ld депозитов). Приватная регистрация разблокируется, когда он достигнет минимума.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Общий пул приватности ещё растёт (%1$ld из %2$ld депозитов). Повторите попытку, когда он достигнет минимума.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Имя пользователя '%@' было заблокировано сетью Dash. Пожалуйста, попробуйте запросить другое имя пользователя.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Высота создания кошелька — нижняя граница для сканирования фильтров и пересканирования «С момента создания кошелька». Установите её на уровне первого пополнения кошелька или ниже; при импорте по умолчанию используется 200000 в mainnet и 0 в testnet. Сохранение высоты, равной текущей или меньше, очистит данные блокчейна этой сети при следующем запуске и пересканирует с неё.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "его (получение информации)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Новых уведомлений нет";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Нет транзакций для отображения";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Нет пользователей, соответствующих имени %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "В ваших контактах нет пользователей, соответствующих имени %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "При переносе истории транзакций в ZenLedger произошла ошибка";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Произошла ошибка. Пожалуйста, попробуйте ещё раз позже";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Эти средства переходят на ваш баланс Platform и готовы к трате, как только перевод завершится.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "На этот адрес нельзя платить с вашего баланса %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Это добавит к вашему идентификатору два ключа, чтобы другие пользователи могли отправлять вам запросы на добавление в контакты, а вы — принимать их. Это происходит один раз.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Это применит один выбор ко всем %d выбранным именам пользователей.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Этот дополнительный шаг подтверждает, что транзакцию совершаете именно вы.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Эта ссылка-приглашение недействительна.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Это недопустимый адрес Dash для этой сети";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Это недействительная ссылка-приглашение";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Это ваш основной идентификатор";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "У этой мастерноды пока нет идентификатора Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Этот продавец сейчас недоступен.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Это текущая годовая процентная доходность полной мастерноды за минусом 15% комиссии CrowdNode. Эта сумма не является точной и может колебаться в зависимости от размера пулов CrowdNode и курса Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Это всё равно засчитывается как участие ваших мастернод в голосовании по этому спору.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Необработанные байты этой транзакции не хранятся на этом устройстве.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Это имя пользователя досталось другому";
+
+"This wallet could not derive the voting key for this node." = "Этот кошелёк не смог получить ключ голосования для этого узла.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "В этом кошельке нет активных ключей голосования мастернод, поэтому голосовать нельзя. Зарегистрированные узлы отображаются в Инструменты → Мастерноды.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Это выведет весь ваш баланс Platform одним переводом. Dash поступят на адрес получателя, как только сеть обработает вывод.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Это выведет весь ваш баланс Platform одним переводом. Dash поступят на ваш прозрачный баланс, как только сеть обработает вывод.";
 
 /* Send Screen: to address */
 "to" = "на";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "История транзакций";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "История транзакций недоступна";
+
 /* No comment provided by engineer. */
 "Transaction id" = "ID транзакции";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID транзакции";
 
 /* A verb, button title. */
 "Transfer" = "Перевод средств";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Входящий перевод";
 
+/* Balance breakdown */
+"Transfer in" = "Перевод входящий";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Исходящий перевод";
+
+/* Balance breakdown */
+"Transfer out" = "Перевод исходящий";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Переводы занимают больше времени — построение доказательств приватности требует времени";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Переводы на другие адреса Platform и экранированные адреса мгновенны и окончательны";
+
+/* Balance breakdown */
+"Transparent" = "Прозрачный";
+
+/* Send screen destination type */
+"Transparent address" = "Прозрачный адрес";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Прозрачный баланс";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Прозрачное финансирование публично связывает ваше имя пользователя с этими средствами.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Прозрачный → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Прозрачный → Экранированный";
 
 /* An action */
 "Try again" = "Попробовать снова";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Не удалось предоставить предложения";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Баланс неизвестен";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Неизвестный специальный тип %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Не экранировано";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Неподдерживаемый URL-адрес";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Обновить до DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Перейти на Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Использовать прозрачный баланс";
+
+/* Masternode keys */
+"Used" = "Использован";
+
+/* Masternode keys */
+"Used at: " = "Использован: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Пользователь (получение информации)";
 
 /* Voting */
 "Username" = "Имя пользователя";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Запрос на Имя пользователя успешно отправлен";
 
+/* Identities */
+"Usernames" = "Имена пользователей";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Имена пользователей хранятся в нормализованном виде, чтобы не допустить похожих имён, поэтому это может отличаться от того, что ввёл каждый человек.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Имена пользователей, а не адреса";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Пользователи, соответствующие %@, которых сейчас нет в ваших контактах";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Использует одну из наиболее проверенных и протестированных библиотек с нулевым разглашением (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Действительное приглашение";
+
 /* CrowdNode Portal */
 "Validating address…" = "Подтверждение адреса...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Требуется верификация";
 
+/* Usernames */
+"Verified during registration" = "Проверено при регистрации";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Успешно подтверждено";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Подтвердите свою личность";
 
+/* Raw transaction inspector */
+"Version" = "Версия";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Очень эффективно и с низкими комиссиями";
+
 /* adjective, security level */
 "Very High" = "Очень высокий";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Чтобы удостовериться, что вы действительно являетесь владельцем этого кошелька, на счёт CrowdNode будут зачислены и списаны небольшие суммы Dash.";
+
+/* No comment provided by engineer. */
+"View All" = "Показать все";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Посмотреть в Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Посмотреть фразу восстановления";
 
+/* Raw transaction inspector */
+"View Transaction" = "Посмотреть транзакцию";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Посмотреть детали транзакции";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Голосовать";
+
+"Vote cast" = "Голос отдан";
+
 /* Voting */
 "Vote for All" = "Голосовать за все";
 
 /* Voting */
+"Vote on contested usernames" = "Голосовать за оспариваемые имена пользователей";
+
+"Vote on several" = "Голосовать за несколько";
+
+/* Voting */
 "Vote to Approve" = "Голосовать \"За\"";
+
+"Vote with" = "Голосовать с";
+
+"Votes that nobody should receive these usernames." = "Голосует за то, чтобы никто не получил эти имена пользователей.";
 
 /* Voting */
 "Votes: High to low" = "Голоса: По убыванию";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Адрес голосования";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Адрес голосования";
+
+"Voting ended with no winner" = "Голосование завершилось без победителя";
+
+"Voting ends" = "Голосование заканчивается";
+
 /* Voting */
 "Voting ends in %dd" = "Голосование закончится через %dд";
+
+"Voting in progress" = "Голосование идёт";
+
+"Voting in progress — lock votes are ahead" = "Голосование идёт — голоса за блокировку впереди";
+
+"Voting in progress — you are ahead" = "Голосование идёт — вы впереди";
 
 /* Usernames */
 "Voting is only required in some cases" = "Голосование понадобится только в определённых случаях";
 
+/* Masternodes */
+"Voting key hash" = "Хеш ключа голосования";
+
 /* Voting keys */
 "Voting keys" = "Ключи голосования";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Голосование по этому имени пользователя закрыто. Значения ниже — последние считанные.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Голосование по «%@» уже закрыто. Обновите, чтобы увидеть результат.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Для завершения транзакции дождитесь синхронизации кошелька";
 
+"Waiting for Dash Platform" = "Ожидание Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Адрес кошелька";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Начальная высота кошелька";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Кошелёк отключён";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Добро пожаловать в DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "А как насчёт Unstoppable Domains и подобных сервисов имён?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Сколько это стоит?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Что такое DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Что такое голосование за имя пользователя?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Что дальше?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Когда запросы на добавление в контакты станут приватными?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Где потратить";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Где потратить?";
+
+"Who is requesting this name" = "Кто запрашивает это имя";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Почему мне нужно это включать?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Почему я вижу все эти транзакции?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Запрос на вывод средств отправлен";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Выводит весь баланс";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Работает с любым кошельком Dash, биржей и продавцом";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Хотите принять приглашение?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Вчера";
+
+"You" = "Вы";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Вы приняли запрос на добавление в контакты от %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Вы выбрали “%@” в качестве своего имени пользователя. ";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "У вас пока нет контактов";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "У вас недостаточно средств для завершения этой транзакции";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Превышен лимит авторизаций на Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Пока у вас %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "У вас есть %1$@ Dash.\nНекоторые имена пользователей стоят до %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Вы отправили запрос на добавление в контакты %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Для этого в вашем Dash Wallet должен быть положительный баланс";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Вы выиграли это имя пользователя";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Всё готово. Другие пользователи теперь могут отправлять вам запросы на добавление в контакты — и вы можете отправлять свои.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Ваш идентификатор Dash Platform появится здесь, как только вы зарегистрируете имя пользователя.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "На вашу почту будет отправлен одноразовый пароль.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Ваша история, упорядоченная";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Вашему идентификатору нужны два дополнительных ключа, чтобы запросы на добавление в контакты можно было шифровать между вами и другими пользователями. При включении они добавляются одной транзакцией в сети. Это происходит один раз.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Приглашение от %@уже подтверждено. ";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Приглашение от %@имеет недопустимый формат.";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Ваше приглашение оплачивает комиссию за регистрацию этого имени пользователя.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Ваше местоположение используется для отображения его на карте, показа банкоматов в выбранном радиусе и улучшения результатов поиска.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Ваше местоположение используется для отображения вашего положения на карте, продавцов в выбранном радиусе и улучшения результатов поиска.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Ваш основной баланс Dash в блокчейне Core — то, что вы отправляете и получаете с другими кошельками, биржами и продавцами.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Ваши смешанные монеты перемещены на баланс кошелька Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Ваши смешанные монеты перемещены на экранированный баланс. Для лучшей приватности подождите не менее 2 часов, прежде чем использовать эти средства.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Ваш баланс Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Основной адрес Dash, который сейчас используется для аккаунта CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Ваш приватный баланс. Суммы и адреса зашифрованы в блокчейне, поэтому ваши средства и история остаются конфиденциальными.";
+
 /* Usernames */
 "Your request was cancelled" = "Ваш запрос был отклонён";
 
 /* DashSpend */
 "Your session expired" = "Сессия была завершена";
+
+/* Usernames */
+"Your Shielded balance" = "Ваш экранированный баланс";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Ваш экранированный баланс почти готов — вы сможете приватно зарегистрироваться примерно к %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Ваш экранированный баланс готов — зарегистрируйте имя пользователя приватно прямо сейчас";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Ваш экранированный баланс отлёживается — вы сможете приватно зарегистрироваться примерно к %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Ваш экранированный баланс ещё созревает. Он будет готов примерно к %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Ваш прозрачный баланс";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Ваше имя пользователя %@ успешно создано в сети Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Ваше имя пользователя успешно создано";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Ваше имя пользователя видно всем. Если профинансировать его с экранированного баланса — дав средствам отлежаться несколько часов, — никто не сможет связать ваше имя пользователя с остальными вашими Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Ваше имя пользователя, профиль и контакты привязаны к этому идентификатору.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Ваше имя пользователя, профиль и контакты будут привязаны к этому идентификатору.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Ваш голос отозван";
 
 /* Voting */
 "Your vote was submitted" = "Ваш голос учтён";
 
+"Your votes" = "Ваши голоса";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Ваш кошелёк защищён. Вы можете использовать фразу восстановления в любое время, чтобы получить доступ к Вашему кошельку на другом устройстве.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Ваш кошелёк ещё синхронизируется с сетью Dash. Отправка станет доступна после завершения синхронизации.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Ваш кошелёк ещё синхронизируется. Отправка с прозрачного баланса станет доступна после завершения синхронизации.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Не удалось прочитать «%@» как имя пользователя Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» зарегистрировано. Отправить запрос на добавление в контакты человеку, который вас пригласил?";

--- a/DashWallet/ru.lproj/Localizable.stringsdict
+++ b/DashWallet/ru.lproj/Localizable.stringsdict
@@ -165,7 +165,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d из %#@nodes@ проголосовали</string>
+		<string>Голосование: %1$d из %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -185,7 +185,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d из %#@nodes@ проголосовали</string>
+		<string>Голосование: %1$d из %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/ru.lproj/Localizable.stringsdict
+++ b/DashWallet/ru.lproj/Localizable.stringsdict
@@ -102,5 +102,305 @@
 			<string>ключи</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ за «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u голос</string>
+			<key>few</key>
+			<string>%1$u голоса</string>
+			<key>many</key>
+			<string>%1$u голосов</string>
+			<key>other</key>
+			<string>%1$u голоса</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Проголосовано за %1$d из %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d имени пользователя</string>
+			<key>few</key>
+			<string>%2$d имён пользователей</string>
+			<key>many</key>
+			<string>%2$d имён пользователей</string>
+			<key>other</key>
+			<string>%2$d имён пользователей</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Отдать %u голос</string>
+			<key>few</key>
+			<string>Отдать %u голоса</string>
+			<key>many</key>
+			<string>Отдать %u голосов</string>
+			<key>other</key>
+			<string>Отдать %u голоса</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d из %#@nodes@ проголосовали</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d мастерноды</string>
+			<key>few</key>
+			<string>%2$d мастернод</string>
+			<key>many</key>
+			<string>%2$d мастернод</string>
+			<key>other</key>
+			<string>%2$d мастернод</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d из %#@nodes@ проголосовали</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d узла</string>
+			<key>few</key>
+			<string>%2$d узлов</string>
+			<key>many</key>
+			<string>%2$d узлов</string>
+			<key>other</key>
+			<string>%2$d узлов</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>many</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>всего %u голос</string>
+			<key>few</key>
+			<string>всего %u голоса</string>
+			<key>many</key>
+			<string>всего %u голосов</string>
+			<key>other</key>
+			<string>всего %u голоса</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d мастернода</string>
+			<key>few</key>
+			<string>%d мастерноды</string>
+			<key>many</key>
+			<string>%d мастернод</string>
+			<key>other</key>
+			<string>%d мастерноды</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d выбран</string>
+			<key>few</key>
+			<string>%d выбрано</string>
+			<key>many</key>
+			<string>%d выбрано</string>
+			<key>other</key>
+			<string>%d выбрано</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ваш узел уже проголосовал здесь и не показан.</string>
+			<key>few</key>
+			<string>%d ваших узла уже проголосовали здесь и не показаны.</string>
+			<key>many</key>
+			<string>%d ваших узлов уже проголосовали здесь и не показаны.</string>
+			<key>other</key>
+			<string>%d ваших узлов уже проголосовали здесь и не показаны.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u голос за спор — evonode считаются как 4, мастерноды как 1</string>
+			<key>few</key>
+			<string>%u голоса за спор — evonode считаются как 4, мастерноды как 1</string>
+			<key>many</key>
+			<string>%u голосов за спор — evonode считаются как 4, мастерноды как 1</string>
+			<key>other</key>
+			<string>%u голосов за спор — evonode считаются как 4, мастерноды как 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Голосовать за %d имя пользователя</string>
+			<key>few</key>
+			<string>Голосовать за %d имени пользователя</string>
+			<key>many</key>
+			<string>Голосовать за %d имён пользователей</string>
+			<key>other</key>
+			<string>Голосовать за %d имён пользователей</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u голос</string>
+			<key>few</key>
+			<string>%u голоса</string>
+			<key>many</key>
+			<string>%u голосов</string>
+			<key>other</key>
+			<string>%u голоса</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Голосовать ×%d</string>
+			<key>few</key>
+			<string>Голосовать ×%d</string>
+			<key>many</key>
+			<string>Голосовать ×%d</string>
+			<key>other</key>
+			<string>Голосовать ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d запрос</string>
+			<key>few</key>
+			<string>%d запроса</string>
+			<key>many</key>
+			<string>%d запросов</string>
+			<key>other</key>
+			<string>%d запроса</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " alebo ";
+
 /* CrowdNode */
 " Privacy Policy " = " Zásady ochrany osobných údajov";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Používateľa %@ sa v sieti Dash nepodarilo nájsť, takže mu nemožno poslať žiadosť o kontakt.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash k dispozícii";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ prijal vašu žiadosť o kontakt";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu kontaktov / %3$lu aktualizácií profilu";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtov";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffov";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "Bude odovzdaných %d hlasov, pretože v peňaženke máte uložených viacero hlasovacích kľúčov";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplikátov";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld z %ld vkladov";
 
 /* Voting */
 "%ld requests" = "%ld žiadostí";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" nie je slovo frázy pre obnovenie. Chcete sa pokúsiť nájsť správne slovo, ktoré by malo byť na jeho mieste?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditný zostatok na Dash Platform, ktorý sa používa na okamžité platby medzi adresami Platform a na funkcie, ako sú používateľské mená.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Na zabezpečenie vašej peňaženky je potrebný prístupový kód zariadenia. Ak chcete pokračovať, prejdite na nastavenia a zapnite prístupový kód.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "O programe";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "O mne";
+
+"Abstain" = "Zdržať sa";
+
+"Abstain on “%@”" = "Zdržať sa pri „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Prijať";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Obnovenie účtu";
 
+/* Masternode status */
+"Active" = "Aktívny";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivita";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivita je verejná, no nie je ľahké ju sledovať";
+
 /* No comment provided by engineer. */
 "Add" = "Pridať";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Pridať %@ ako kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Pridajte %@ medzi kontakty, aby ste mohli platiť priamo na používateľské meno a uchovávať spoločnú históriu transakcií";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Pridajte %@ Dash do tieneného zostatku a nechajte ich pár hodín odpočívať, aby registrácia nespojila vaše používateľské meno s ostatnými prostriedkami.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Pridať nový kontakt";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Pridajte do tieneného zostatku aspoň %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Doplňte teraz tienený zostatok a používateľské meno si o pár hodín zaregistrujte súkromne";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Všetko";
 
+"All nodes at once" = "Všetky uzly naraz";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všetky vaše masternódy o tomto používateľskom mene hlasovali. Ak chcete hlas zmeniť, zahlasujte znova od uchádzača, ktorého teraz uprednostňujete.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Povoliť odosielanie všetkých transakcií z Dash Wallet do Zenledgeru?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Takmer okamžitá synchronizácia zostatkov";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Sumy a adresy sú v blockchaine verejné";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Vyskytla sa chyba";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Účet Ethereum je jedna opakovane používaná adresa: celý váš zostatok aj história platieb sú pod ňou verejne dostupné a meno (napríklad doména ENS) zvyčajne ukazuje priamo na túto adresu, takže ju môže preložiť ktokoľvek. DashPay má opačnú podobu — meno sa prekladá na identitu, nie na platobnú adresu, a skutočné platobné adresy zostávajú vo vnútri šifrovaných výmen s kontaktmi, pre každý kontakt nové.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Intuitívny a známy zážitok vo všetkých vašich zariadeniach";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Akékoľvek používateľské meno, ktoré má číslice 2-9, je dlhšie ako 20 znakov alebo obsahuje pomlčku, bude automaticky schválené.";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Ktokoľvek, kto pozná adresu, si môže pozrieť jej históriu";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Použiť";
 
+"Approve" = "Schváliť";
+
+"Approving a specific request can only be done one username at a time." = "Schváliť konkrétnu žiadosť možno len pre jedno používateľské meno naraz.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Naozaj chcete zrušiť túto objednávku?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Ako text";
 
 /* DashSpend */
 "at" = "v";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Overenie zrušené. Váš hlas nebol odovzdaný.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Overenie zlyhalo. Váš hlas nebol odovzdaný.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Autentifikácia nie je k dispozícii";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Prideliť „%@“ tomuto uchádzačovi";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Zostatok";
 
 /* CrowdNode */
+"Balance after" = "Zostatok potom";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Zostatok na CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Zostatok: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Zostatky a prevody nie sú verejne viditeľné";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bankový účet";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Vyžaduje sa prístup k biometrickým údajom";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Počiatočná výška uložená — zvýšená spodná hranica skenovania platí od najbližšieho spustenia.";
+
 /* Voting */
 "Block" = "Blok";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Zablokované používateľské meno '%@'";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Viazaný na kontrakt";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Viazaný na kontrakt, typ dokumentu „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Iba prehliadanie";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Zbalí posledné diagnostické záznamy do zipu, aby ste ich mohli poslať cez AirDrop, e‑mailom alebo uložiť do Súborov";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Odovzdať hlas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Zmeniť rovesníkov";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Zmeniť PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontroluje sa…";
+
+"Choice" = "Voľba";
+
 /* Choose your Dash username */
 "Choose your" = "Vybrať vaše";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Zvoľte si používateľské meno";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Uplatnite svoju pozvánku";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Nárokovateľný zostatok";
+
 /* No comment provided by engineer. */
 "Claimed" = "Vyžiadať";
+
+/* SPV diagnostics */
+"Clear & resync" = "Vymazať a znovu synchronizovať";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Vymazať dáta reťazca a znovu synchronizovať?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Zatvoriť Aplikáciu";
 
+"Closing" = "Uzatvára sa";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nové mince)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA kód";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin už nie je podporovaný — vyberte, kam presunúť vaše zmiešané mince.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolaterál";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Už čoskoro";
+
+/* Shielded transfer status */
+"Completed" = "Dokončené";
 
 /* No comment provided by engineer. */
 "Confirm" = "Potvrdiť";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potvrdená";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potvrdením sa uloží počiatočná výška %u a pri najbližšom spustení aplikácie sa vymažú dáta reťazca tejto siete, znovu sa stiahnu a filtre sa od tejto výšky znovu prehľadajú. Bežiaca relácia si ponechá pôvodnú spodnú hranicu skenovania — ukončite a znovu otvorte aplikáciu, aby sa spustilo.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Pripojte svoje kryptopeňaženky k platforme ZenLedger. Získajte viac informácií a začnite s Dash Wallet transakciami.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Pripojená Dash adresa";
 
+/* SPV sync */
+"Connected peers" = "Pripojení rovesníci";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nevýhody";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Žiadosť o kontakt zlyhala";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Žiadosť o kontakt odoslaná používateľovi %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Žiadosti o kontakt";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kontakty";
 
+"Contender %@" = "Uchádzač %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Pokračovať";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Pokračujte a vyberte si používateľské meno. Pozvánka pokryje registračný poplatok.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Skopírovať odkaz na pozvánku";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopírovať surovú transakciu";
+
 /* No comment provided by engineer. */
 "Copy text" = "Skopírovať text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Chýbajúce alebo nesprávne slová sa nepodarilo automaticky obnoviť.";
 
+/* Log export */
+"Could not create the log archive: %@" = "Nepodarilo sa vytvoriť archív záznamov: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Nepodarilo sa nájsť výmenný kurz.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nepodarilo sa obnoviť %d identít";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Nepodarilo sa načítať zostatok (chyba siete). Skúste obnoviť.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Platba sa nedá uskutočniť ";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Vytvorte si používateľské meno";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Vytvorte si používateľské meno, nájdite priateľov a rodinu podľa ich používateľských mien a pridajte si ich medzi kontakty";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Kreditná karta";
+
+/* Masternodes */
+"Credits" = "Kredity";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash platby nemôžu byť menšie ako %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform tento spor ešte nezaindexovala. Počty hlasov sa tu zobrazia, keď sa tak stane.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ešte nie je pripojená. Počkajte na dokončenie synchronizácie a skúste to znova.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash odoslaný na nesprávnu adresu sa nedá získať späť. Uistite sa, že adresa je presne tá, ktorej chcete zaplatiť.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash ukladá používateľské mená v podobe odolnej voči zameniteľným zápisom, takže uložené meno sa môže líšiť od toho, čo jednotliví ľudia napísali.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash používateľské meno";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Peňaženka Dash";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Zostatok peňaženky Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Peňaženka Dash v tomto zariadení";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay povolené";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Pozvánka DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je sociálny platobný zážitok Dash, postavený na Dash Platform. Zaregistrujete si používateľské meno, pridáte ďalších používateľov ako kontakty a platíte im na meno — už žiadne kopírovanie adries.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay nahrádza dlhé nezrozumiteľné adresy používateľskými menami. Pridajte si priateľov ako kontakty, posielajte peniaze na meno a majte každú platbu usporiadanú podľa osoby.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Poplatok za inováciu DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Dátum: Od najstarších";
+
+"Deadline unknown" = "Termín neznámy";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Vklad odoslaný";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Odvodzovacia cesta";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "ZABEZPEČENIE ZARIADENIA KOMPROMITOVANÉ\nKaždá \"jailbreak\" aplikácia môže pristupovať k údajom o kľúčových reťazcoch každej inej aplikácie (a ukradnúť vaše Dash). Zmažte urýchlene túto peňaženku a obnovte zabezpečenie zariadenia.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Zakázaný";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Odpojte Coinbase účet";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Hotovo";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Hotovo — váš zostatok odpočíval dosť dlho";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Skontrolujte adresu ešte raz";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Každá pozvánka bude financovaná touto sumou, aby si príjemca mohol rýchlo vytvoriť svoje používateľské meno v sieti Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Každý masternód má v jednom spore jeden platný hlas. Neskôr ho môžete zmeniť, no Dash Platform povoľuje celkovo len 5 hlasov na masternód v jednom spore.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Každé ťuknutie pridá do hlasovania ďalší uzol, takže si vyberiete, koľko ich spojíte dokopy.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "pred";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Jednoducho stávkujte Dash a získajte pasívny príjem niekoľkými jednoduchými kliknutiami.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Upraviť počiatočnú výšku";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Upraviť profil";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Povoliť";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Povoliť DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Povoliť Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Povoliť Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Povolenie DashPay stojí malý jednorazový sieťový poplatok, ktorý sa uhrádza z kreditného zostatku vašej identity. Presný odhad sa zobrazí pred potvrdením. Za odosielanie žiadostí o kontakt a platieb sa účtujú bežné sieťové poplatky.";
+
+"Ending soonest" = "Končí najskôr";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Pri aktualizácii vášho profilu sa vyskytla chyba";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Odhadovaný sieťový poplatok";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Všetky uzly hlasujú spoločne. Je to rýchlejšie, ale verejne to navzájom spája vaše masternódy.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operátorské kľúče Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Exportovať CSV";
 
+/* Log export */
+"Export Logs" = "Exportovať záznamy";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Rozšírený verejný kľúč (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Externá adresa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Limit pre Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Zlyhalo";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Čiarový kód sa nepodarilo načítať";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Načítavam kurzy…";
 
+/* Masternodes */
+"Fetching…" = "Načítava sa…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Hotovostný účet";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Hlavičky filtrov";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filtrovať transakcie";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Nájdite používateľa v sieti Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Nájdite bankomaty, kde si môžete kúpiť alebo predať Dash.";
+
+/* Identities */
+"Find identities" = "Nájsť identity";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Zabudli ste PIN?";
 
+/* Identities */
+"Found %d new identities" = "Nájdených %d nových identít";
+
+/* Identities */
+"Found 1 new identity" = "Nájdená 1 nová identita";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Nájdené chýbajúce slovo:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financujte svoje používateľské meno z tieneného zostatku. Prostriedky pridajte pár hodín vopred — krátke odpočívanie zabráni spojeniu vášho používateľského mena s ostatnými Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financované z tieneného zostatku — vaše používateľské meno nemožno spojiť s ostatnými vašimi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Prostriedky uzamknuté — prevod sa dokončuje";
+
+/* CoinJoin */
+"Funds moved" = "Prostriedky presunuté";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Získajte odmeny z vkladov v Dash Masternodes už za 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Získajte ponuku";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pripravte sa vstúpiť do DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Získajte odmeny okamžite";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Rozumiem";
+
+/* Governance */
+"Governance" = "Správa siete";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Udeľte povolenia GPS, aby sme vám mohli zobrazovať miesta vo vašej blízkosti.";
 
 /* Voting */
 "Has blocked votes" = "Má zablokované hlasy";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "vás požiadal o priateľstvo";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Máte pozvánku?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Majte úplnú kontrolu a prispôsobte si vašu peňaženku podľa svojich potrieb";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "hlavička číslo %1$d z %2$d";
+
+/* SPV sync phase */
+"Headers" = "Hlavičky";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Výška %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Tu je Dash adresa určená pre váš CrowdNode účet v Dash peňaženke na tomto zariadení.";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Od najvyšších";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Vyššie poplatky okolo 7 centov (stále nižšie než pri iných blockchainoch s podobným súkromím)";
+
 /* No comment provided by engineer. */
 "History" = "História";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Ako získať testovací Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Ako je to v porovnaní s Bitcoinom z hľadiska súkromia?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Ako je to v porovnaní s účtami Ethereum z hľadiska súkromia?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Aké súkromné je DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Ako potvrdiť svoju API Dash adresu ";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Zapísal som si ju";
 
+/* Identities */
+"Identities" = "Identity";
+
 /* Voting */
 "Identity" = "Identita";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kredity identity";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Index identity";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registrácia identity";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Dobitie identity";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "V platobnej sekcii pri pokladni vyberte možnosť „darčeková karta“ a potom zadajte číslo karty a PIN.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktívny";
+
+/* No comment provided by engineer. */
 "Income" = "Príjem";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Inicializuje sa";
+
+/* Raw transaction inspector */
+"Input %d" = "Vstup %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Vstup %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Vstupy (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Nedostatok prostriedkov";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Poplatok za pozvanie";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Pozvánka od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Pozvanie použité používateľom";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Pozvať";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Pozvite niekoho do siete Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Pozvite svoju rodinu, nájdite svojich priateľov vyhľadaním ich používateľských mien";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Pozvite svojich priateľov a rodinu, aby sa pripojili k sieti Dash.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Pozvite priateľov a rodinu do siete Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "Peňaženka iOS Dash: %@ Nahlásený problém";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Pripojenie k členstvu";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Ponechať tieto mince súkromné. Účtujú sa sieťové poplatky a poplatky za súkromie.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Udržujte prístupovú frázu v bezpečí";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Kľúč č. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Údaje kľúča";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Vlastníctvo kľúča";
+
 /* No comment provided by engineer. */
 "Keypair" = "Kľúčový pár";
+
+/* Masternodes */
+"Keys" = "Kľúče";
 
 /* Explore Dash */
 "Last device sync" = "Posledná synchronizácia zariadenia";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vedie";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Ďalšie informácie";
 
 /* Info Screen */
 "Learn More..." = "Ďalšie informácie...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Načítavajú sa transakcie";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Miestna mena";
 
+/* Identities */
+"Local Only" = "Iba lokálne";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Miestna vyžadovaná suma: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Miesto";
 
+"Lock" = "Uzamknúť";
+
+"Lock the name" = "Uzamknúť meno";
+
+"Lock “%@” so nobody gets it" = "Uzamknúť „%@“, aby ho nikto nezískal";
+
 /* No comment provided by engineer. */
 "Locked" = "Uzamknuté";
 
+"Locked — nobody receives this username" = "Uzamknuté — toto používateľské meno nezíska nikto";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Prihlásiť sa";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Nízke";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Nízke poplatky pri každodenných výdavkoch";
+
 /* Voting */
 "Low to high" = "Od najmenších";
+
+/* Identities — the wallet's main identity */
+"Main" = "Hlavná";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Hlavná sieť";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "IP adresa Masternode";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Zväzok kľúčov masternódu";
+
+/* Masternode keys */
 "Masternode keys" = "Kľúče Masternode";
+
+/* SPV sync phase */
+"Masternode list" = "Zoznam masternódov";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "zoznam mastenódov: %1$d z %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Aktualizácia masternódu";
 
+"Masternode votes" = "Hlasy masternódov";
+
 /* Voting */
 "Masternode Voting Key" = "Hlasovacie kľúče Masternode";
+
+/* Tools menu */
+"Masternodes" = "Masternódy";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternódy a evonódy zaregistrované kľúčmi tejto peňaženky sa tu zobrazia po synchronizácii peňaženky.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternódy a evonódy používajúce kľúče tejto peňaženky";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternódy hlasujú o menách, o ktoré požiadala viac než jedna osoba. Po skončení hlasovania vám dáme vedieť.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum splnené";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Viac kontroly";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Ďalšie návrhy";
+
+"Most lock votes" = "Najviac uzamykacích hlasov";
+
+"Most votes" = "Najviac hlasov";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Posuňte a priblížte svoju fotografiu, aby ste našli to najlepšie";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Presunúť do bežného použiteľného zostatku.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Presunuté k adrese";
+
+/* CoinJoin */
+"Moving funds" = "Presúvajú sa prostriedky";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Meno";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Menné služby ako Unstoppable Domains priraďujú čitateľné meno k pevnej verejnej adrese v reťazci. Ktokoľvek dokáže meno preložiť a vidieť každú platbu, ktorá naň kedy prišla. Používateľské meno DashPay sa nikdy verejne neprekladá na platobnú adresu — adresy sa odhaľujú len vo vnútri šifrovanej výmeny s každým kontaktom, takže vaše meno a vaše peniaze zostávajú pre vonkajších pozorovateľov nespojené.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Potrebujete pomoc?";
+
+"Needs attention" = "Vyžaduje pozornosť";
 
 /* No comment provided by engineer. */
 "Network" = "Sieť";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "V tomto zariadení sa nenašli žiadne diagnostické záznamy. Záznamy sa zapisujú od najbližšieho spustenia.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Žiadne identity";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Zatiaľ žiadne masternódy";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Žiadne zodpovedajúce spory";
+
+/* Identities */
+"No new identities were found for this wallet" = "Pre túto peňaženku sa nenašli žiadne nové identity";
+
+"No open contest matches that search." = "Tomuto vyhľadávaniu nezodpovedá žiadny otvorený spor.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Tomuto vyhľadávaniu nezodpovedá žiadny otvorený spor. Mená sa ukladajú v normalizovanej podobe, takže „alice“ je uvedená ako „a11ce“.";
+
+"No open contests" = "Žiadne otvorené spory";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Žiadne spôsoby platby";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Pre pripojenú peňaženku sa nenašiel uložený záznam.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Pre záložnú tienenú registráciu zatiaľ nie je k dispozícii žiadna adresa Platform. Skúste to znova po dokončení synchronizácie peňaženky.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Neboli nájdené žiadne výsledky";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Momentálne nie je sporné žiadne používateľské meno. Spor vznikne, keď o rovnaké meno požiadajú dvaja alebo viacerí ľudia.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Nezostávajú žiadne hlasy";
+
+"No votes were cast" = "Neodovzdali sa žiadne hlasy";
+
+"Nobody gets it" = "Nezíska ho nikto";
+
+/* SPV sync peer type */
+"Node" = "Uzol";
+
+/* Raw transaction inspector */
+"Non-standard" = "Neštandardný";
 
 /* adjective, security level */
 "None" = "Žiadne";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Nie je k dispozícií";
 
+"Not available yet" = "Zatiaľ nedostupné";
+
+"Not cast" = "Neodovzdaný";
+
+/* Masternodes */
+"Not checked yet" = "Zatiaľ neskontrolované";
+
 /* Location Service Status */
 "Not Determined" = "Neurčené";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nedostatočný tienený zostatok na registráciu identity";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nie je v histórii peňaženky";
+
+"Not now" = "Teraz nie";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Obchodníci ho neprijímajú vo veľkom";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Obchodníci ho zatiaľ neprijímajú vo veľkom";
+
+/* Masternode keys */
+"Not yet used" = "Zatiaľ nepoužitý";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Od najstarších";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "V Bitcoine neexistuje vrstva mien, takže ľudia zdieľajú a opakovane používajú adresy verejne — len čo je adresa známa, všetko, čo kedy prijala, sa dá spojiť s jej vlastníkom. V DashPay je vaše používateľské meno verejné, no nikdy neukazuje na platobnú adresu: adresy sa vymieňajú súkromne pre každý kontakt a striedajú sa, takže platba na meno nezverejňuje, kam vaše peniaze idú. Oba sú transparentné reťazce, takže analýza reťazca sa na samotné mince stále vzťahuje.";
+
+/* Identities */
+"On Network" = "V sieti";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Keď %@ prijme vašu žiadosť, budete môcť platiť priamo na používateľské meno";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Po jednom uzle";
 
 /* Voting */
 "One vote left" = "Zostáva jeden hlas";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Iba duplikáty";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "O používateľských menách môžu hlasovať len masternódy a evonódy. Táto peňaženka neobsahuje aktívne hlasovacie kľúče masternódov.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Iba žiadosti s odkazmi";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Len s odkazmi";
+
+/* Masternodes */
+"Operator" = "Operátor";
+
+/* Masternode keys */
+"Operator keys" = "Operátorské kľúče";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Verejný kľúč operátora (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "alebo";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Ukážka objednávky";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Iné výsledky";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Výstup %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Výstupy (%d)";
+
+/* Masternodes */
+"Owner" = "Vlastník";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Adresa vlastníka";
+
+/* Masternodes */
+"Owner address" = "Adresa vlastníka";
+
+/* Masternodes */
+"Owner key hash" = "Hash kľúča vlastníka";
 
 /* Owner keys */
 "Owner keys" = "Kľúče vlastníka";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Uhradené z kreditného zostatku vašej identity.";
 
 /* DashSpend */
 "Password" = "Heslo";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Sem vložte odkaz";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Vložte pozývací odkaz, ktorý ste dostali, alebo naskenujte jeho QR kód. Pokryje registráciu vášho používateľského mena.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Vložte URL vášho obrázku";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Plaťte a dostaňte okamžite zaplatené pomocou ľahko použiteľných platobných tokov";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "platiť priamo na používateľské meno";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plaťte ľuďom, nie adresám";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Platba na používateľské mená. Už žiadne alfanumerické adresy";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Platí sa...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Spôsob platby";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Platby sú súkromné: adresy, ktoré si vymieňate s kontaktom, putujú v šifrovanom obsahu, ktorý viete prečítať len vy dvaja, a nikdy sa nezverejňujú — vaše platby teda nemožno ľahko spojiť s vaším používateľským menom. Stále však ide o bežné platby v transparentnom reťazci: pokročilá analýza reťazca môže odhaliť informácie. Shielded DashPay (už čoskoro) túto medzeru uzavrie. Samotné žiadosti o kontakt momentálne NIE sú súkromné: ktokoľvek vidí, že dve identity sú prepojené. Súkromné žiadosti o kontakt sú funkcia, ktorá príde čoskoro. Vaše používateľské meno aj profil sú na Dash Platform tiež verejné.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Platby sa vďaka InstantSend potvrdia v priebehu sekúnd";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Platby uskutočnené priamo na adresy sa v aktivite neuchovajú.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Platby s každým kontaktom sú zoskupené na jednom mieste, s menami a profilmi namiesto surových transakcií.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Výplatná adresa";
 
 /* CrowdNode */
 "Payout Options" = "Možnosti výplaty";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adresa Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Zostatok Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Uzol Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID uzla Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platby Platform neidentifikujú odosielateľa. Táto platba bola zaznamenaná vtedy, keď peňaženka zaznamenala zmenu zostatku — mohla prísť aj skôr.";
+
+"Platform SDK not ready" = "SDK Platform nie je pripravené";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Synchronizácia Platform nebeží. Otvorte Informácie o synchronizácii → Stav synchronizácie Platform a spustite ju.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Tienený";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Pridajte spôsob platby na Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Ukážka pozvánky";
 
+/* Masternode keys */
+"Previously used at: " = "Predtým použitý dňa: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Ceny sú staré minimálne 30 minút. Hotovostné ceny môžu byť nesprávne.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Súkromný už z návrhu";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Súkromné žiadosti o kontakt (aby zostalo súkromné, s kým sa spájate), Shielded DashPay — platby kontaktom z vášho súkromného tieneného zostatku — a platby používateľom, ktorých ešte nemáte medzi kontaktmi, prídu už čoskoro.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Súkromné žiadosti o kontakt sa vyvíjajú a očakávajú sa približne v septembri – októbri 2026. Dnes je samotná žiadosť verejná — ktokoľvek vidí, že dve identity sú prepojené, aj keď sú platobné údaje v nej zašifrované. Keď súkromné žiadosti o kontakt vyjdú, budete si môcť vybrať, či bude vaše priateľstvo verejné alebo súkromné.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Súkromné žiadosti o kontakt, Shielded DashPay a platby ľuďom, ktorí ešte nie sú kontakty.";
+
 /* No comment provided by engineer. */
 "Private key" = "Privátny kľúč";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Súkromné platobné adresy si vymieňate vy a vaše kontakty. Príjemcu a odosielateľa platieb medzi vami poznáte len vy a váš kontakt.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Súkromné platby";
+
+/* Usernames */
+"Private registration" = "Súkromná registrácia";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Čas spracovania";
+
+/* Balance info sheet section */
+"Pros" = "Výhody";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Chráňte svoje úspory";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Adresa poskytovateľa";
 
+/* Masternodes */
+"Provider transactions" = "Transakcie poskytovateľa";
+
+/* Masternode keys */
+"Public key" = "Verejný kľúč";
+
+/* Masternode keys */
+"Public key (legacy)" = "Verejný kľúč (staršia verzia)";
+
+/* Identities */
+"Public keys" = "Verejné kľúče";
+
 /* No comment provided by engineer. */
 "Public URL" = "Verejná adresa URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Nákup zlyhal";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Účel";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Kurz: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Surová transakcia";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Surová transakcia nie je k dispozícii";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Znovu skontroluje kompaktné blokové filtre od zvolenej výšky, či neobsahujú transakcie tejto peňaženky, pričom ich znovu stiahne a porovná. Opakované skenovanie je zdola ohraničené výškou vytvorenia peňaženky a lokálne uloženými dátami reťazca — ak chcete obnoviť staršiu históriu, znížte radšej počiatočnú výšku peňaženky.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Prečítajte si zásady výberu";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Iba na čítanie";
+
+/* Usernames */
+"Ready around %@" = "Pripravené približne o %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Dôvod";
 
 /* No comment provided by engineer. */
 "Receive" = "Prijať";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Prijaté od";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Prijaté od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Prijímané odmeny";
+
+"Records your masternodes as having voted, without taking a side." = "Zaznamená vaše masternódy ako hlasujúce bez toho, aby sa pridali na niektorú stranu.";
 
 /* No comment provided by engineer. */
 "Recover" = "Obnoviť";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Fráza pre obnovenie musí mať 12, 15, 18, 21 alebo 24 slov";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Obnoviť";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Registrovať?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Zaregistrovaný dňa";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registrované z";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registrovaný masternód";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Súkromná registrácia vyžaduje aspoň %@ Dash v tienenom zostatku a niekoľko hodín odpočinku — ďalšie obrazovky vás prevedú postupom.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrácia";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Žiada toto meno";
+
 /* An action */
 "Rescan" = "Pre-skenovať";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovené peňaženky nedokážu vždy zistiť typ operácie. Tento záznam bol zrekonštruovaný z poznámkových údajov v reťazci.";
+
+/* Location Service Status */
 "Restricted" = "Obmedzené";
 
 /* Usernames */
 "Results" = "Výsledky";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Opakovaná synchronizácia pripravená od výšky %u — ukončite a znovu otvorte aplikáciu, aby sa spustila.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "uchovávať spoločnú históriu transakcií";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Vyradený";
 
 /* No comment provided by engineer. */
 "Retry" = "Znovu";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Ak chcete overiť vlastníctvo tohto používateľského mena, skontrolujte príspevok nižšie";
+
+/* Masternodes */
+"Revocation" = "Odvolanie";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Snímky obrazovky sú viditeľné pre iné aplikácie a zariadenia. Vytvorte novú frázu obnovenia a držte ju v tajnosti.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Podpis skriptu";
+
+/* Raw transaction inspector */
+"Script type" = "Typ skriptu";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Hľadať kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Hľadať žiadosť o kontakt";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Hľadať používateľa v sieti Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Hľadať používateľské meno";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Výsledky hľadania pre \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Prehľadať územia";
+
+"Search usernames" = "Hľadať používateľské mená";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Hľadá sa používateľské meno %@ v sieti Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Zabezpečte svoju peňaženku";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Úroveň zabezpečenia";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Úroveň zabezpečenia";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Vyberte službu pre nákup, predaj, konverziu a prevod Dashu";
 
+"Select all" = "Vybrať všetko";
+
 /* DashSpend denomination selection */
 "Select amount" = "Vyberte sumu";
+
+"Select at least one masternode to vote with." = "Vyberte aspoň jeden masternód, s ktorým budete hlasovať.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Vyberte mincu";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Výber menšieho počtu uzlov prezradí menej o tom, ktoré masternódy prevádzkujete.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Samoobslužná pokladňa";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Poslať ku";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Poslať kontaktu";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Posielajte na používateľské meno, ktoré si naozaj zapamätáte a overíte.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Poslať na adresu";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Odošlite svoju prvú žiadosť o kontakt";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Odosielam";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Odosiela sa žiadosť o kontakt";
+
+/* No comment provided by engineer. */
+"Sending to" = "Odosiela sa na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Odošle sa na účet CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Poslané na";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Odoslané používateľovi %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Vyskytla sa chyba servera. Skúste to znova neskôr.";
+
+/* Masternodes */
+"Service" = "Služba";
+
+/* Identities */
+"Set as Main" = "Nastaviť ako hlavnú";
+
+/* Identities */
+"Set as Main Identity" = "Nastaviť ako hlavnú identitu";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Nastaviť PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Zdieľať kľúč";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Zdieľaný fond súkromia má minimálnu veľkosť";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Tienená adresa";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Tienený výdavok";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Spúšťa sa tienená peňaženka…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Tienený → Platform";
+
+"Shielded → Transparent" = "Tienený → Transparentný";
 
 /* Explore Dash */
 "Show all locations" = "Zobraziť všetky miesta";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Veľkosť";
+
 /* No comment provided by engineer. */
 "Skip" = "Preskočiť";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Niektoré z vašich masternódov v tomto zozname možno chýbajú — peňaženka nedokázala prečítať celú vašu sadu hlasovacích kľúčov. Dokončite synchronizáciu a otvorte túto obrazovku znova.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Niektoré používateľské mená môžu byť zablokované";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Zoradiť podľa";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Zoradiť kontakty";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Zoradené podľa zľavy";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Zoradené podľa názvu";
+
+/* Raw transaction inspector */
+"Special payload" = "Špeciálny payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Zadať množstvo";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Stávkovanie";
 
+/* Usernames */
+"Starts after you add funds" = "Začne po pridaní prostriedkov";
+
+/* Transaction details */
+"Status" = "Stav";
+
 /* Step 1 */
 "Step %ld" = "Krok %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Uložené ako";
 
 /* Voting */
 "Submit" = "Odoslať";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Prebieha synchronizácia… Výsledky nemusia byť úplné.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informácie o synchronizácii";
+
+/* SPV sync */
+"Sync too slow?" = "Synchronizácia je príliš pomalá?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Urobiť fotografiu z fotoaparátu";
 
+"Take no side" = "Nepridať sa na žiadnu stranu";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Klepnutím na adresu zo schránky ju použijete";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Ťuknutím skopírujete";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Klepnutím skryť zostatok";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Dočasne nedostupné";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Kľúč uzla Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Zmluvné podmienky";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testovacia sieť";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Kód je nesprávny. Skontrolujte a skúste to znova!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash dorazí na adresu príjemcu po tom, ako sieť spracuje výber — môže to trvať až 10 minút.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash dorazí na adresu príjemcu, len čo sieť spracuje výber.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash dorazí na váš transparentný zostatok, len čo sieť spracuje výber.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Sieť Dash musí hlasovať o schválení niektorých používateľských mien pred ich vytvorením";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Odkaz, ktorý odošlete, bude viditeľný iba pre vlastníkov siete";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Hlavnú identitu možno vybrať len z aktívnej peňaženky";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Minimálna suma, ktorú môžete poslať, je %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najsúkromnejšie miesto na uchovávanie vašich Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Uložený záznam peňaženky nemá sieť — opakovanú synchronizáciu nemožno pripraviť.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registrácia bola odoslaná, ale jej výsledok sa nepodarilo potvrdiť. Počkajte minútu, kým sa peňaženka zosynchronizuje, a potom to skúste znova — neodosielajte ju hneď opäť.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Zdieľaný fond súkromia stále rastie (%1$ld z %2$ld vkladov). Súkromná registrácia sa odomkne, keď dosiahne minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Zdieľaný fond súkromia stále rastie (%1$ld z %2$ld vkladov). Skúste to znova, keď dosiahne minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Používateľské meno '%@' bolo zablokované sieťou Dash Network. Skúste to znova a požiadajte o iné používateľské meno.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Výška vytvorenia peňaženky — spodná hranica pre skenovanie filtrov a opakované skenovanie „Od vytvorenia peňaženky“. Nastavte ju na úroveň prvého financovania peňaženky alebo nižšie; importy používajú predvolene 200000 na mainnete a 0 na testnete. Uloženie výšky rovnakej alebo nižšej než aktuálna vymaže pri najbližšom spustení dáta reťazca tejto siete a od tejto výšky znovu prehľadá.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "jeho (načítavajú sa informácie)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nie sú žiadne nové upozornenia";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Žiadne transakcie na zobrazenie";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nie sú žiadni používatelia zodpovedajúci menu %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Vo vašich kontaktoch nie sú žiadni používatelia zodpovedajúci menu %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Pri exporte vašej histórie transakcií do ZenLedger sa vyskytla chyba";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Vyskytla sa chyba, skúste to znova neskôr";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Tieto prostriedky prejdú na váš zostatok Platform a budú pripravené na použitie hneď po dokončení prevodu.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Túto adresu nemožno zaplatiť z vášho zostatku %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Toto pridá k vašej identite dva kľúče, aby vám ostatní používatelia mohli posielať žiadosti o kontakt a aby ste mohli prijímať tie ich. Deje sa to iba raz.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Toto použije jednu voľbu na všetkých %d vybraných používateľských mien.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Tento dodatočný krok potvrdzuje, že ste to skutočne vy kto sa pokúša uskutočniť transakciu.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Tento pozývací odkaz nie je platný.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Toto nie je platná adresa Dash pre túto sieť";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Toto nie je platný pozývací odkaz";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Toto je vaša hlavná identita";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Tento masternód zatiaľ nemá identitu Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Tento obchodník momentálne nie je k dispozícii.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "To predstavuje to aktuálny ročný percentuálny výnos celého Masternódu mínus 15 % poplatok CrowdNode. Nie je to zaručená miera návratnosti a môže stúpať alebo klesať v závislosti od veľkosti fondov CrowdNode a ceny Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Stále sa to počíta ako hlasovanie vašich masternódov v tomto spore.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Surové bajty tejto transakcie nie sú v tomto zariadení uložené.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Toto používateľské meno pripadlo niekomu inému";
+
+"This wallet could not derive the voting key for this node." = "Táto peňaženka nedokázala odvodiť hlasovací kľúč pre tento uzol.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Táto peňaženka neobsahuje aktívne hlasovacie kľúče masternódov, takže nemôže hlasovať. Zaregistrované uzly nájdete v Nástroje → Masternódy.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Toto vyberie celý váš zostatok Platform jedným prevodom. Dash dorazí na adresu príjemcu, len čo sieť spracuje výber.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Toto vyberie celý váš zostatok Platform jedným prevodom. Dash dorazí na váš transparentný zostatok, len čo sieť spracuje výber.";
 
 /* Send Screen: to address */
 "to" = "pre";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "História transakcií";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "História transakcií nie je k dispozícii";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Id transakcie";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcie";
 
 /* A verb, button title. */
 "Transfer" = "Presun";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Prichádzajúce";
 
+/* Balance breakdown */
+"Transfer in" = "Prevod dnu";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Odchádzajúce";
+
+/* Balance breakdown */
+"Transfer out" = "Prevod von";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Prevody trvajú dlhšie — vytváranie dôkazov o súkromí si vyžaduje čas";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Prevody na iné adresy Platform a na tienené adresy sú okamžité a konečné";
+
+/* Balance breakdown */
+"Transparent" = "Transparentný";
+
+/* Send screen destination type */
+"Transparent address" = "Transparentná adresa";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentný zostatok";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentné financovanie verejne spája vaše používateľské meno s týmito prostriedkami.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentný → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentný → Tienený";
 
 /* An action */
 "Try again" = "Skúsiť znova";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nemožno poskytnúť návrhy";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Neznámy zostatok";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Neznámy špeciálny typ %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Netienené";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Nepodporovaná URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Inovujte na DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Prejsť na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Použiť radšej transparentný zostatok";
+
+/* Masternode keys */
+"Used" = "Použitý";
+
+/* Masternode keys */
+"Used at: " = "Použitý dňa: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Používateľ (načítavajú sa informácie)";
 
 /* Voting */
 "Username" = "Používateľské meno";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "O používateľské meno bolo úspešne požiadané";
 
+/* Identities */
+"Usernames" = "Používateľské mená";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Používateľské mená sa ukladajú v normalizovanej podobe, aby sa predišlo zameniteľným menám, takže sa to môže líšiť od toho, čo jednotliví ľudia napísali.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Používateľské mená, nie adresy";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Používatelia zodpovedajúci %@, ktorí momentálne nie sú vo vašich kontaktoch";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Používa jednu z najlepšie auditovaných a otestovaných knižníc s nulovou znalosťou (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Platná pozvánka";
+
 /* CrowdNode Portal */
 "Validating address…" = "Overuje sa adresa…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Vyžaduje sa overenie";
 
+/* Usernames */
+"Verified during registration" = "Overené počas registrácie";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Úspešne overené";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Overte svoju identitu";
 
+/* Raw transaction inspector */
+"Version" = "Verzia";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Veľmi efektívne pri nízkych poplatkoch";
+
 /* adjective, security level */
 "Very High" = "Veľmi vysoké";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Do a z CrowdNode budú odoslané veľmi malé množstvá Dash, aby sme overili, že ste vlastníkom tejto adresy peňaženky.";
+
+/* No comment provided by engineer. */
+"View All" = "Zobraziť všetko";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Zobraziť v prehliadači";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Zobraziť frázu pre obnovenie";
 
+/* Raw transaction inspector */
+"View Transaction" = "Zobraziť transakciu";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Zobraziť podrobnosti transakcie";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Hlasovať";
+
+"Vote cast" = "Hlas odovzdaný";
+
 /* Voting */
 "Vote for All" = "Hlasovať za všetkých";
 
 /* Voting */
+"Vote on contested usernames" = "Hlasovať o sporných používateľských menách";
+
+"Vote on several" = "Hlasovať o viacerých";
+
+/* Voting */
 "Vote to Approve" = "Hlasovanie za schválenie";
+
+"Vote with" = "Hlasovať s";
+
+"Votes that nobody should receive these usernames." = "Hlasuje za to, aby tieto používateľské mená nezískal nikto.";
 
 /* Voting */
 "Votes: High to low" = "Hlasy: od najvyšších";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Adresa pre hlasovanie";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresa pre hlasovanie";
+
+"Voting ended with no winner" = "Hlasovanie sa skončilo bez víťaza";
+
+"Voting ends" = "Hlasovanie končí";
+
 /* Voting */
 "Voting ends in %dd" = "Hlasovanie končí o %d dní";
+
+"Voting in progress" = "Hlasovanie prebieha";
+
+"Voting in progress — lock votes are ahead" = "Hlasovanie prebieha — uzamykacie hlasy vedú";
+
+"Voting in progress — you are ahead" = "Hlasovanie prebieha — vediete";
 
 /* Usernames */
 "Voting is only required in some cases" = "Hlasovanie je potrebné len v niektorých prípadoch";
 
+/* Masternodes */
+"Voting key hash" = "Hash hlasovacieho kľúča";
+
 /* Voting keys */
 "Voting keys" = "Hlasovacie kľúče";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Hlasovanie o tomto používateľskom mene bolo uzavreté. Počty nižšie sú posledné načítané.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Hlasovanie o „%@“ už bolo uzavreté. Obnovte, aby ste videli výsledok.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Na dokončenie transakcie počkajte, kým sa peňaženka zosynchronizuje";
 
+"Waiting for Dash Platform" = "Čaká sa na Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Adresa peňaženky";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Počiatočná výška peňaženky";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Peňaženka neaktívna";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Vitajte v DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "A čo Unstoppable Domains a podobné menné služby?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Koľko to stojí?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Čo je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Čo je to hlasovanie o používateľské mená?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Čo príde ďalej?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kedy budú žiadosti o kontakt súkromné?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Kde minúť";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Kde minúť?";
+
+"Who is requesting this name" = "Kto žiada o toto meno";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Prečo to musím povoliť?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Prečo sa mi zobrazujú všetky tieto transakcie?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Žiadosť o výber podaná";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Vyberie celý zostatok";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funguje s každou peňaženkou, burzou a obchodníkom Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Chcete prijať pozvanie?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Včera";
+
+"You" = "Vy";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Prijali ste žiadosť o kontakt od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Ako používateľské meno ste si zvolili „%@“.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Momentálne nemáte žiadne kontakty";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Na dokončenie tejto transakcie nemáte dostatok prostriedkov ";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Prekročili ste autorizačný limit na Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Zatiaľ máte %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "Máte %1$@ Dashov.\nNiektoré používateľské mená stoja až %2$@ Dashov.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Odoslali ste žiadosť o kontakt používateľovi %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "V Dash peňaženke by ste mali mať kladný zostatok";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Toto používateľské meno ste vyhrali";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Všetko je pripravené. Ostatní používatelia vám teraz môžu posielať žiadosti o kontakt — a vy môžete posielať tie svoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaša identita Dash Platform sa tu zobrazí, keď si zaregistrujete používateľské meno.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Váš email slúži len na zaslanie jednorazového hesla.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaša história, usporiadaná";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vaša identita potrebuje dva ďalšie kľúče, aby sa žiadosti o kontakt dali šifrovať medzi vami a ostatnými používateľmi. Povolenie ich pridá jedinou sieťovou transakciou. Deje sa to iba raz.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Vaša pozvánka od používateľa %@ už bola nárokovaná";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Vaša pozvánka od %@ nie je platná";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaša pozvánka pokryje registračný poplatok za toto používateľské meno.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Vaša poloha sa používa na zobrazenie vašej polohy na mape, bankomatov vo vybranom okruhu a zlepšenie výsledkov vyhľadávania.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Vaša poloha sa používa na zobrazenie vašej pozície na mape, obchodníkov vo vybranom okolí a k zlepšeniu výsledkov vyhľadávania.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Váš hlavný zostatok Dash v blockchaine Core — to, čo posielate a prijímate s ostatnými peňaženkami, burzami a obchodníkmi.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaše zmiešané mince boli presunuté do zostatku peňaženky Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaše zmiešané mince boli presunuté do tieneného zostatku. Pre čo najlepšie súkromie počkajte pred použitím týchto prostriedkov aspoň 2 hodiny.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Váš zostatok Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Vaša primárna Dash adresa, ktorú momentálne používate pre váš CrowdNode účet";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Váš súkromný zostatok. Sumy a adresy sú v reťazci zašifrované, takže vaše prostriedky aj história zostávajú dôverné.";
+
 /* Usernames */
 "Your request was cancelled" = "Vaša žiadosť bola zrušená";
 
 /* DashSpend */
 "Your session expired" = "Platnosť vašej relácie vypršala";
+
+/* Usernames */
+"Your Shielded balance" = "Váš tienený zostatok";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Váš tienený zostatok je takmer pripravený — súkromne sa budete môcť zaregistrovať približne o %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Váš tienený zostatok je pripravený — zaregistrujte si teraz používateľské meno súkromne";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Váš tienený zostatok odpočíva — súkromne sa budete môcť zaregistrovať približne o %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Váš tienený zostatok ešte dozrieva. Pripravený bude približne o %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Váš transparentný zostatok";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Vaše používateľské meno %@ bolo úspešne vytvorené v sieti Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Vaše používateľské meno bolo úspešne vytvorené";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše používateľské meno je viditeľné pre všetkých. Ak ho financujete z tieneného zostatku — po tom, ako prostriedky nechá pár hodín odpočívať —, nikto nedokáže spojiť vaše používateľské meno s ostatnými vašimi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše používateľské meno, profil a kontakty patria k tejto identite.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše používateľské meno, profil a kontakty budú patriť k tejto identite.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Váš hlas bol zrušený";
 
 /* Voting */
 "Your vote was submitted" = "Váš hlas bol odoslaný";
 
+"Your votes" = "Vaše hlasy";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Vaša peňaženka je zabezpečená. Frázu pre obnovenie môžete kedykoľvek použiť na obnovenie svojho účtu na inom zariadení.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaša peňaženka sa ešte synchronizuje so sieťou Dash. Odosielanie bude k dispozícii po dokončení synchronizácie.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaša peňaženka sa ešte synchronizuje. Odosielanie z transparentného zostatku bude k dispozícii po dokončení synchronizácie.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ sa nepodarilo prečítať ako používateľské meno Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ bolo zaregistrované. Poslať žiadosť o kontakt osobe, ktorá vás pozvala?";

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Všetky uzly naraz";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všetky vaše masternódy o tomto používateľskom mene hlasovali. Ak chcete hlas zmeniť, zahlasujte znova od uchádzača, ktorého teraz uprednostňujete.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Všetky vaše masternódy o tomto používateľskom mene hlasovali. Ak chcete hlas zmeniť, zahlasujte znova za uchádzača, ktorého teraz uprednostňujete.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/sk.lproj/Localizable.stringsdict
+++ b/DashWallet/sk.lproj/Localizable.stringsdict
@@ -102,5 +102,305 @@
 			<string>%d kľúče</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ započítaných pre „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u hlas</string>
+			<key>few</key>
+			<string>%1$u hlasy</string>
+			<key>many</key>
+			<string>%1$u hlasu</string>
+			<key>other</key>
+			<string>%1$u hlasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Hlasované o %1$d z %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d používateľského mena</string>
+			<key>few</key>
+			<string>%2$d používateľských mien</string>
+			<key>many</key>
+			<string>%2$d používateľského mena</string>
+			<key>other</key>
+			<string>%2$d používateľských mien</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Odovzdať %u hlas</string>
+			<key>few</key>
+			<string>Odovzdať %u hlasy</string>
+			<key>many</key>
+			<string>Odovzdať %u hlasu</string>
+			<key>other</key>
+			<string>Odovzdať %u hlasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternódu</string>
+			<key>few</key>
+			<string>%2$d masternódy</string>
+			<key>many</key>
+			<string>%2$d masternódu</string>
+			<key>other</key>
+			<string>%2$d masternódov</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uzla</string>
+			<key>few</key>
+			<string>%2$d uzly</string>
+			<key>many</key>
+			<string>%2$d uzla</string>
+			<key>other</key>
+			<string>%2$d uzlov</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonód</string>
+			<key>few</key>
+			<string>%d evonódy</string>
+			<key>many</key>
+			<string>%d evonódu</string>
+			<key>other</key>
+			<string>%d evonódov</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>celkovo %u hlas</string>
+			<key>few</key>
+			<string>celkovo %u hlasy</string>
+			<key>many</key>
+			<string>celkovo %u hlasu</string>
+			<key>other</key>
+			<string>celkovo %u hlasov</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternód</string>
+			<key>few</key>
+			<string>%d masternódy</string>
+			<key>many</key>
+			<string>%d masternódu</string>
+			<key>other</key>
+			<string>%d masternódov</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vybraný</string>
+			<key>few</key>
+			<string>%d vybrané</string>
+			<key>many</key>
+			<string>%d vybraného</string>
+			<key>other</key>
+			<string>%d vybraných</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d váš uzol tu už hlasoval a nie je uvedený.</string>
+			<key>few</key>
+			<string>%d vaše uzly tu už hlasovali a nie sú uvedené.</string>
+			<key>many</key>
+			<string>%d vášho uzla tu už hlasovalo a nie je uvedené.</string>
+			<key>other</key>
+			<string>%d vašich uzlov tu už hlasovalo a nie sú uvedené.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hlas na spor — evonódy sa počítajú ako 4, masternódy ako 1</string>
+			<key>few</key>
+			<string>%u hlasy na spor — evonódy sa počítajú ako 4, masternódy ako 1</string>
+			<key>many</key>
+			<string>%u hlasu na spor — evonódy sa počítajú ako 4, masternódy ako 1</string>
+			<key>other</key>
+			<string>%u hlasov na spor — evonódy sa počítajú ako 4, masternódy ako 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hlasovať o %d používateľskom mene</string>
+			<key>few</key>
+			<string>Hlasovať o %d používateľských menách</string>
+			<key>many</key>
+			<string>Hlasovať o %d používateľských menách</string>
+			<key>other</key>
+			<string>Hlasovať o %d používateľských menách</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u hlas</string>
+			<key>few</key>
+			<string>%u hlasy</string>
+			<key>many</key>
+			<string>%u hlasu</string>
+			<key>other</key>
+			<string>%u hlasov</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Hlasovať ×%d</string>
+			<key>few</key>
+			<string>Hlasovať ×%d</string>
+			<key>many</key>
+			<string>Hlasovať ×%d</string>
+			<key>other</key>
+			<string>Hlasovať ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d žiadosť</string>
+			<key>few</key>
+			<string>%d žiadosti</string>
+			<key>many</key>
+			<string>%d žiadosti</string>
+			<key>other</key>
+			<string>%d žiadostí</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sk.lproj/Localizable.stringsdict
+++ b/DashWallet/sk.lproj/Localizable.stringsdict
@@ -105,7 +105,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ započítaných pre „%2$@“</string>
+		<string>%#@votes@ pre „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -113,13 +113,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u hlas</string>
+			<string>%1$u započítaný hlas</string>
 			<key>few</key>
-			<string>%1$u hlasy</string>
+			<string>%1$u započítané hlasy</string>
 			<key>many</key>
-			<string>%1$u hlasu</string>
+			<string>%1$u započítaného hlasu</string>
 			<key>other</key>
-			<string>%1$u hlasov</string>
+			<string>%1$u započítaných hlasov</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -165,7 +165,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<string>Hlasovanie: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -185,7 +185,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d z %#@nodes@ hlasovalo</string>
+		<string>Hlasovanie: %1$d z %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Vsa vozlišča hkrati";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte pri kandidatu, ki mu zdaj dajete prednost.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte za kandidata, ki mu zdaj dajete prednost.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ali ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ ni bilo mogoče najti v omrežju Dash, da bi mu poslali zahtevo za stik.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash na voljo";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ je sprejel vašo zahtevo za stik";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtov";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld od %ld pologov";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditno stanje na Dash Platform, ki se uporablja za takojšnja plačila med naslovi Platform in za funkcije, kot so uporabniška imena.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Vizitka";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Vzdrži se";
+
+"Abstain on “%@”" = "Vzdrži se pri »%@«";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiven";
+
+/* No comment provided by engineer. */
+"Activity" = "Dejavnost";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Dejavnost je javna, a je ni lahko izslediti";
+
 /* No comment provided by engineer. */
 "Add" = "Dodaj";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Dodaj %@ med stike";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Dodajte %@ med stike, da boste lahko plačevali neposredno na uporabniško ime in ohranili skupno zgodovino transakcij";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Dodajte %@ Dash v zaščiteno stanje in pustite, da nekaj ur počiva, da se registrirate brez povezovanja uporabniškega imena z drugimi sredstvi.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Dodajte vsaj %@ Dash v svoje zaščiteno stanje";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Zdaj napolnite zaščiteno stanje in čez nekaj ur zasebno registrirajte uporabniško ime";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Vsa vozlišča hkrati";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte pri kandidatu, ki mu zdaj dajete prednost.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Skoraj takojšnja sinhronizacija stanj";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Zneski in naslovi so na blockchainu javni";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Račun Ethereum je en sam večkrat uporabljen naslov: celotno stanje in zgodovina plačil sta javno pod njim, ime (na primer domena ENS) pa običajno kaže naravnost na ta naslov, tako da ga lahko kdorkoli razreši. DashPay je zasnovan obratno — ime vodi do identitete, ne do plačilnega naslova, dejanski plačilni naslovi pa ostanejo znotraj šifriranih izmenjav s stiki in so za vsak stik novi.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Kdorkoli pozna naslov, si lahko ogleda njegovo zgodovino";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Odobri";
+
+"Approving a specific request can only be done one username at a time." = "Odobritev določene zahteve je mogoča samo za eno uporabniško ime naenkrat.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Kot besedilo";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Preverjanje pristnosti je bilo preklicano. Vaš glas ni bil oddan.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Preverjanje pristnosti ni uspelo. Vaš glas ni bil oddan.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Dodeli »%@« temu kandidatu";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Stanje";
 
 /* CrowdNode */
+"Balance after" = "Stanje po tem";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Stanja in prenosi niso javno vidni";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Začetna višina je shranjena — dvignjeni prag pregledovanja velja od naslednjega zagona.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vezan na pogodbo";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vezan na pogodbo, vrsta dokumenta »%@«";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Samo pregledovanje";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Zbere nedavne diagnostične dnevnike v datoteko zip, da jih pošljete prek AirDropa, po e-pošti ali shranite v Datoteke";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Oddaj glas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Zamenjaj vozlišča";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Preverjanje…";
+
+"Choice" = "Izbira";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Prevzemite svoje povabilo";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Stanje za prevzem";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Počisti in znova sinhroniziraj";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Ali želite počistiti podatke verige in znova sinhronizirati?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Se zapira";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (novi kovanci)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ni več podprt — izberite, kam premakniti svoje pomešane kovance.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Zavarovanje";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Kmalu";
+
+/* Shielded transfer status */
+"Completed" = "Zaključeno";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potrjena";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potrditev shrani začetno višino %u in ob naslednjem zagonu aplikacije počisti podatke verige za to omrežje, jih znova prenese ter od te višine znova pregleda filtre. Trenutna seja obdrži svoj stari prag pregledovanja — zaprite in znova odprite aplikacijo, da se začne.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Povezana vozlišča";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Slabosti";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Zahteva za stik ni uspela";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Zahteva za stik je bila poslana uporabniku %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Zahteve za stik";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Nadaljujte in izberite svoje uporabniško ime. Povabilo plača pristojbino za registracijo.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiraj surovo transakcijo";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Arhiva dnevnikov ni bilo mogoče ustvariti: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Ne najdem menjalnih tečajev.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Ni bilo mogoče osvežiti %d identitet";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Stanja ni bilo mogoče pridobiti (omrežna napaka). Poskusite osvežiti.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Ustvarite svoje uporabniško ime, poiščite prijatelje in družino po njihovih uporabniških imenih in jih dodajte med stike";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediti";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform tega spora še ni indeksiral. Števila glasov se bodo prikazala tukaj, ko ga bo.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform še ni povezan. Počakajte, da se sinhronizacija zaključi, in poskusite znova.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash, poslan na napačen naslov, ni povrnljiv. Prepričajte se, da je naslov natanko tisti, ki mu želite plačati.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash shranjuje uporabniška imena v obliki, odporni na podobne zapise, zato se shranjeno ime lahko razlikuje od tega, kar je vsak vpisal.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Stanje denarnice Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay je omogočen";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je Dashova družbena plačilna izkušnja, zgrajena na Dash Platform. Registrirate uporabniško ime, druge uporabnike dodate med stike in jim plačujete po imenu — nič več kopiranja naslovov.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay dolge in nerazumljive naslove nadomesti z uporabniškimi imeni. Prijatelje dodajte med stike, denar pošljite na ime in vsako plačilo ohranite urejeno po osebah.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Rok neznan";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Pot izpeljave";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Onemogočen";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Končano — vaše stanje je počivalo dovolj dolgo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Še enkrat preverite naslov";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Vsak masternode ima en veljaven glas na spor. Pozneje ga lahko spremenite, a Dash Platform dovoljuje skupno le 5 glasov na masternode na spor.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Vsak dotik doda h glasovanju še eno vozlišče, tako da sami izberete, koliko jih boste povezali.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Uredi začetno višino";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Omogoči";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Omogoči DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Omogočanje DashPay stane majhno enkratno omrežno provizijo, plačano iz kreditnega stanja vaše identitete. Natančna ocena je prikazana pred potrditvijo. Pošiljanje zahtev za stik in plačil stane običajne omrežne provizije.";
+
+"Ending soonest" = "Se konča najprej";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Ocenjena omrežna provizija";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Vsa vozlišča glasujejo skupaj. Hitreje je, a javno poveže vaše masternode med seboj.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operaterski ključi Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Izvozi dnevnike";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Zunanji naslov";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Neuspešno";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Pridobivanje…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Glave filtrov";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Poiščite uporabnika v omrežju Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Poišči identitete";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Najdenih je %d novih identitet";
+
+/* Identities */
+"Found 1 new identity" = "Najdena je 1 nova identiteta";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Uporabniško ime financirajte iz zaščitenega stanja. Sredstva dodajte nekaj ur vnaprej — kratko počivanje poskrbi, da vašega uporabniškega imena ni mogoče povezati z drugimi vašimi Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financirano iz vašega zaščitenega stanja — vašega uporabniškega imena ni mogoče povezati z drugimi vašimi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Sredstva zaklenjena — prenos se zaključuje";
+
+/* CoinJoin */
+"Funds moved" = "Sredstva premaknjena";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pripravite se na pridružitev DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Razumem";
+
+/* Governance */
+"Governance" = "Upravljanje";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "je zaprosil, da bi bil vaš prijatelj";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Imate povabilo?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Glave";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Višina %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Višje provizije, okoli 7 centov (še vedno nižje kot pri drugih verigah s podobno zasebnostjo)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kako se to glede zasebnosti primerja z Bitcoinom?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kako se to glede zasebnosti primerja z računi Ethereum?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Kako zaseben je DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identitete";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Krediti identitete";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identitete";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registracija identitete";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Polnitev identitete";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktiven";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Vhod %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Vhod %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Vhodi (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Povabilo od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Povabite nekoga v omrežje Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Povabite prijatelje in družino v omrežje Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Ohranite te kovance zasebne. Veljajo omrežne provizije in provizije za zasebnost.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ključ št. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Podatki ključa";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Lastništvo ključa";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ključi";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vodi";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Več o tem";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Nalaganje transakcij";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Samo lokalno";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Zakleni";
+
+"Lock the name" = "Zakleni ime";
+
+"Lock “%@” so nobody gets it" = "Zakleni »%@«, da ga nihče ne dobi";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Zaklenjeno — tega uporabniškega imena ne dobi nihče";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Nizke provizije za vsakdanjo porabo";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Glavna";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Ključavnica masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Seznam masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Glasovi masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode in evonode, registrirani s ključi te denarnice, se bodo prikazali tukaj, ko se denarnica sinhronizira.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode in evonode, ki uporabljajo ključe te denarnice";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode glasujejo o imenih, za katera je zaprosila več kot ena oseba. Ko se glasovanje konča, boste obveščeni.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum je dosežen";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Več predlogov";
+
+"Most lock votes" = "Največ glasov za zaklep";
+
+"Most votes" = "Največ glasov";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Premakni v običajno stanje za porabo.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Premikanje sredstev";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Storitve imen, kot je Unstoppable Domains, povežejo berljivo ime s fiksnim javnim naslovom v verigi. Kdorkoli lahko razreši to ime in vidi vsako plačilo, ki je bilo kdaj nanj poslano. Uporabniško ime DashPay se nikoli javno ne razreši v plačilni naslov — naslovi se razkrijejo samo znotraj šifrirane izmenjave z vsakim stikom, tako da vaše ime in vaš denar za zunanje opazovalce ostaneta nepovezana.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Potrebuje pozornost";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "V tej napravi ni bilo najdenih diagnostičnih dnevnikov. Dnevniki se zapisujejo od naslednjega zagona naprej.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Ni identitet";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Še ni masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Ni ustreznih sporov";
+
+/* Identities */
+"No new identities were found for this wallet" = "Za to denarnico ni bilo najdenih novih identitet";
+
+"No open contest matches that search." = "Nobeden odprt spor se ne ujema s tem iskanjem.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nobeden odprt spor se ne ujema s tem iskanjem. Imena so shranjena v normalizirani obliki, zato je »alice« navedena kot »a11ce«.";
+
+"No open contests" = "Ni odprtih sporov";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Za povezano denarnico ni bilo najdenega shranjenega zapisa.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Za rezervno zaščiteno registracijo še ni na voljo naslova Platform. Poskusite znova, ko denarnica konča sinhronizacijo.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Trenutno ni nobeno uporabniško ime sporno. Spor se odpre, ko dve osebi ali več zaprosita za isto ime.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Noben glas ni bil oddan";
+
+"Nobody gets it" = "Nihče ga ne dobi";
+
+/* SPV sync peer type */
+"Node" = "Vozlišče";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandardno";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Še ni na voljo";
+
+"Not cast" = "Ni oddan";
+
+/* Masternodes */
+"Not checked yet" = "Še ni preverjeno";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Premalo zaščitenega stanja za registracijo identitete";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ni v zgodovini denarnice";
+
+"Not now" = "Ne zdaj";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Trgovci ga ne sprejemajo široko";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Trgovci ga še ne sprejemajo široko";
+
+/* Masternode keys */
+"Not yet used" = "Še ni uporabljen";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Pri Bitcoinu ni plasti imen, zato ljudje naslove odkrito delijo in znova uporabljajo — ko je naslov enkrat znan, je vse, kar je kdaj prejel, mogoče povezati z njegovim lastnikom. Pri DashPay je vaše uporabniško ime javno, a nikoli ne kaže na plačilni naslov: naslovi se zasebno izmenjujejo z vsakim stikom in se menjajo, zato plačilo po imenu ne razkrije, kam gre vaš denar. Obe sta transparentni verigi, zato analiza verige še vedno velja za same kovance.";
+
+/* Identities */
+"On Network" = "V omrežju";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Ko %@ sprejme vašo zahtevo, boste lahko plačevali neposredno na uporabniško ime";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Eno vozlišče naenkrat";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "O uporabniških imenih lahko glasujejo samo masternode in evonode. Ta denarnica ne vsebuje aktivnih ključev za glasovanje masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operater";
+
+/* Masternode keys */
+"Operator keys" = "Operaterski ključi";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Javni ključ operaterja (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ali";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Drugi izidi";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Izhod %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Izhodi (%d)";
+
+/* Masternodes */
+"Owner" = "Lastnik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Naslov lastnika";
+
+/* Masternodes */
+"Owner key hash" = "Zgoščena vrednost ključa lastnika";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Plačano iz kreditnega stanja vaše identitete.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Prilepite povezavo povabila, ki ste jo prejeli, ali skenirajte njeno kodo QR. Povabilo financira registracijo vašega uporabniškega imena.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "plačevali neposredno na uporabniško ime";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plačujte ljudem, ne naslovom";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Plačila so zasebna: naslovi, ki jih izmenjate s stikom, potujejo znotraj šifrirane vsebine, ki jo lahko prebereta samo vidva, in nikoli niso objavljeni — zato vaših plačil ni mogoče preprosto povezati z vašim uporabniškim imenom. Kljub temu gre še vedno za običajna plačila na transparentni verigi: napredna analiza verige lahko razkrije informacije. Shielded DashPay (kmalu) bo to vrzel zaprl. Same zahteve za stik trenutno NISO zasebne: kdorkoli lahko vidi, da sta dve identiteti povezani. Zasebne zahteve za stik so funkcija, ki prihaja kmalu. Vaše uporabniško ime in profil sta na Dash Platform prav tako javna.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Plačila se z InstantSend potrdijo v nekaj sekundah";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Plačila, izvedena neposredno na naslove, se v dejavnosti ne bodo ohranila.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Plačila z vsakim stikom so združena na enem mestu, z imeni in profili namesto surovih transakcij.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Naslov za izplačilo";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Naslov Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Stanje Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Vozlišče Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID vozlišča Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Plačila Platform ne identificirajo pošiljatelja. To plačilo je bilo zabeleženo, ko je denarnica opazila spremembo stanja — morda je prispelo že prej.";
+
+"Platform SDK not ready" = "Platform SDK ni pripravljen";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Sinhronizacija Platform ne teče. Odprite Informacije o sinhronizaciji → Stanje sinhronizacije Platform, da jo zaženete.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Zaščiteno";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Prej uporabljen: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Zaseben po zasnovi";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Zasebne zahteve za stik (da ostane zasebno, s kom se povezujete), Shielded DashPay — plačila stikom iz vašega zasebnega zaščitenega stanja — in plačila uporabnikom, ki jih še nimate med stiki, vse to prihaja kmalu.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Zasebne zahteve za stik so v razvoju in so pričakovane okoli septembra–oktobra 2026. Danes je sama zahteva javna — kdorkoli lahko vidi, da sta dve identiteti povezani, čeprav so podatki o plačilu v njej šifrirani. Ko bodo zasebne zahteve za stik na voljo, boste lahko izbrali, ali naj bo vaše prijateljstvo javno ali zasebno.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Zasebne zahteve za stik, Shielded DashPay in plačevanje ljudem, ki še niso stiki.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Zasebni plačilni naslovi se izmenjujejo med vami in vašimi stiki. Samo vi in vaš stik veste, kdo je prejemnik in kdo pošiljatelj plačil med vama.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Zasebna plačila";
+
+/* Usernames */
+"Private registration" = "Zasebna registracija";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Čas obdelave";
+
+/* Balance info sheet section */
+"Pros" = "Prednosti";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transakcije ponudnika";
+
+/* Masternode keys */
+"Public key" = "Javni ključ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Javni ključ (starejši)";
+
+/* Identities */
+"Public keys" = "Javni ključi";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Namen";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Surova transakcija";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Surova transakcija ni na voljo";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Od izbrane višine znova preveri kompaktne blokovne filtre za transakcije te denarnice, tako da jih znova prenese in primerja. Ponovni pregledi so navzdol omejeni z višino nastanka denarnice in lokalno shranjenimi podatki verige — za obnovitev starejše zgodovine raje znižajte začetno višino denarnice.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Samo za branje";
+
+/* Usernames */
+"Ready around %@" = "Pripravljeno okoli %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Razlog";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Prejeto od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Zabeleži vaše masternode kot da so glasovali, ne da bi se opredelili.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Osveži";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registriran";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Zasebna registracija zahteva vsaj %@ Dash v zaščitenem stanju in nekaj ur počivanja — naslednji zasloni vas bodo vodili skozi postopek.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registracija";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Prosi za to ime";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovljene denarnice ne morejo vedno obnoviti vrste operacije. Ta vnos je bil rekonstruiran iz podatkov zaznamka v verigi.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ponovna sinhronizacija je pripravljena od višine %u — zaprite in znova odprite aplikacijo, da se začne.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "ohranili skupno zgodovino transakcij";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Umaknjen";
 
 /* No comment provided by engineer. */
 "Retry" = "Poskusi ponovno";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Preklic";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skripta";
+
+/* Raw transaction inspector */
+"Script signature" = "Podpis skripte";
+
+/* Raw transaction inspector */
+"Script type" = "Vrsta skripte";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Poišči stik";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Poišči zahtevo za stik";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Poišči uporabnika v omrežju Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Poišči uporabniško ime";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultati iskanja za \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Poišči uporabniška imena";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Iskanje uporabniškega imena %@ v omrežju Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Raven varnosti";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Izberi vse";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Izberite vsaj en masternode, s katerim boste glasovali.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Izbira manj vozlišč razkrije manj o tem, katere masternode upravljate.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Pošlji stiku";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Pošljite na uporabniško ime, ki si ga res lahko zapomnite in ga preverite.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Pošljite svojo prvo zahtevo za stik";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Pošiljanje zahteve za stik";
+
+/* No comment provided by engineer. */
+"Sending to" = "Pošiljanje na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Poslano uporabniku %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Storitev";
+
+/* Identities */
+"Set as Main" = "Nastavi kot glavno";
+
+/* Identities */
+"Set as Main Identity" = "Nastavi kot glavno identiteto";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Skupni bazen zasebnosti je na najmanjši velikosti";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Zaščiten naslov";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Zaščitena poraba";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Zaganjanje zaščitene denarnice…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Zaščiteno → Platform";
+
+"Shielded → Transparent" = "Zaščiteno → Transparentno";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Velikost";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Nekateri vaši masternode morda manjkajo na tem seznamu — denarnica ni mogla prebrati celotnega nabora vaših ključev za glasovanje. Dokončajte sinhronizacijo in znova odprite ta zaslon.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Razvrsti stike";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Poseben payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Začne se, ko dodate sredstva";
+
+/* Transaction details */
+"Status" = "Stanje";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Shranjeno kot";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacije o sinhronizaciji";
+
+/* SPV sync */
+"Sync too slow?" = "Je sinhronizacija prepočasna?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne zavzemi nobene strani";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tapnite za kopiranje";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ključ vozlišča Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash prispe na naslov prejemnika, ko omrežje obdela izplačilo — to lahko traja do 10 minut.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash prispe na naslov prejemnika, takoj ko omrežje obdela izplačilo.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash prispe v vaše transparentno stanje, takoj ko omrežje obdela izplačilo.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Glavno identiteto je mogoče izbrati samo iz aktivne denarnice";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najbolj zasebno mesto za hranjenje vaših Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Shranjen zapis denarnice nima omrežja — ponovne sinhronizacije ni mogoče pripraviti.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registracija je bila poslana, a njenega izida ni bilo mogoče potrditi. Počakajte minuto, da se denarnica sinhronizira, in poskusite znova — ne pošiljajte je takoj ponovno.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Skupni bazen zasebnosti še raste (%1$ld od %2$ld pologov). Zasebna registracija se odklene, ko doseže minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Skupni bazen zasebnosti še raste (%1$ld od %2$ld pologov). Poskusite znova, ko doseže minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Višina nastanka denarnice — spodnja meja za preglede filtrov in za ponovne preglede »Od nastanka denarnice«. Nastavite jo na raven prvega priliva v denarnico ali nižje; uvozi privzeto uporabijo 200000 na mainnetu in 0 na testnetu. Shranjevanje višine, ki je enaka trenutni ali nižja, ob naslednjem zagonu počisti podatke verige tega omrežja in znova pregleda od nje naprej.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "njega (Pridobivanje informacij)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Ni novih obvestil";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Ni uporabnikov, ki bi se ujemali z imenom %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Med vašimi stiki ni uporabnikov, ki bi se ujemali z imenom %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ta sredstva se prenesejo v vaše stanje Platform in so pripravljena za porabo, takoj ko se prenos zaključi.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Tega naslova ni mogoče plačati iz vašega stanja %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "S tem se vaši identiteti dodata dva ključa, da vam lahko drugi uporabniki pošiljajo zahteve za stik in da lahko vi sprejmete njihove. To se zgodi samo enkrat.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "S tem se ena izbira uporabi za vseh %d izbranih uporabniških imen.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ta povezava povabila ni veljavna.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "To ni veljaven naslov Dash za to omrežje";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "To ni veljavna povezava povabila";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "To je vaša glavna identiteta";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ta masternode še nima identitete Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "To se še vedno šteje, kot da so vaši masternode glasovali v tem sporu.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Surovi bajti te transakcije niso shranjeni v tej napravi.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "To uporabniško ime je pripadlo nekomu drugemu";
+
+"This wallet could not derive the voting key for this node." = "Ta denarnica ni mogla izpeljati ključa za glasovanje za to vozlišče.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ta denarnica ne vsebuje aktivnih ključev za glasovanje masternode, zato ne more glasovati. Registrirana vozlišča se prikažejo v Orodja → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "S tem se izplača celotno vaše stanje Platform v enem prenosu. Dash prispe na naslov prejemnika, takoj ko omrežje obdela izplačilo.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "S tem se izplača celotno vaše stanje Platform v enem prenosu. Dash prispe v vaše transparentno stanje, takoj ko omrežje obdela izplačilo.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Zgodovina transakcij ni na voljo";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcije";
 
 /* A verb, button title. */
 "Transfer" = "Prenesi";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Prenos noter";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Prenos ven";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Prenosi trajajo dlje — gradnja dokazov zasebnosti zahteva čas";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Prenosi na druge naslove Platform in na zaščitene naslove so takojšnji in dokončni";
+
+/* Balance breakdown */
+"Transparent" = "Transparentno";
+
+/* Send screen destination type */
+"Transparent address" = "Transparenten naslov";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentno stanje";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentno financiranje javno poveže vaše uporabniško ime s temi sredstvi.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentno → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentno → Zaščiteno";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Predlogov ni mogoče ponuditi";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Neznana posebna vrsta %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nezaščiteno";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Nadgradi na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Namesto tega uporabi transparentno stanje";
+
+/* Masternode keys */
+"Used" = "Uporabljen";
+
+/* Masternode keys */
+"Used at: " = "Uporabljen: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Uporabnik (Pridobivanje informacij)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Uporabniška imena";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Uporabniška imena so shranjena v normalizirani obliki, da se preprečijo podobno videti imena, zato se to lahko razlikuje od tega, kar je vsak vpisal.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Uporabniška imena, ne naslovi";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Uporabniki, ki se ujemajo z %@ in trenutno niso med vašimi stiki";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uporablja eno najbolj revidiranih in preizkušenih knjižnic z ničelnim znanjem (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Veljavno povabilo";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Preverjeno med registracijo";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Različica";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Zelo učinkovito z nizkimi provizijami";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Prikaži vse";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Prikaži transakcijo";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Glasuj";
+
+"Vote cast" = "Glas oddan";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Glasujte o spornih uporabniških imenih";
+
+"Vote on several" = "Glasuj o več";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Glasuj z";
+
+"Votes that nobody should receive these usernames." = "Glasuje, da teh uporabniških imen ne bi smel dobiti nihče.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Naslov za glasovanje";
+
+"Voting ended with no winner" = "Glasovanje se je končalo brez zmagovalca";
+
+"Voting ends" = "Glasovanje se konča";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Glasovanje poteka";
+
+"Voting in progress — lock votes are ahead" = "Glasovanje poteka — glasovi za zaklep vodijo";
+
+"Voting in progress — you are ahead" = "Glasovanje poteka — vi vodite";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Zgoščena vrednost ključa za glasovanje";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Glasovanje o tem uporabniškem imenu je zaprto. Spodnja števila so zadnja prebrana.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Glasovanje o »%@« je že zaprto. Osvežite, da vidite rezultat.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Čakanje na Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Začetna višina denarnice";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Denarnica onemogočena";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Kaj pa Unstoppable Domains in podobne storitve imen?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Koliko stane?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Kaj je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Kaj prihaja naslednje?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kdaj bodo zahteve za stik postale zasebne?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kdo prosi za to ime";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Zakaj ga moram omogočiti?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Izplača celotno stanje";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Deluje z vsako denarnico Dash, borzo in trgovcem";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vi";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Sprejeli ste zahtevo za stik od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Trenutno nimate nobenih stikov";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Doslej imate %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Poslali ste zahtevo za stik uporabniku %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Osvojili ste to uporabniško ime";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Vse je pripravljeno. Drugi uporabniki vam zdaj lahko pošiljajo zahteve za stik — in vi lahko pošiljate svoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaša identiteta Dash Platform se bo prikazala tukaj, ko registrirate uporabniško ime.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaša zgodovina, urejena";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vaša identiteta potrebuje dva dodatna ključa, da je zahteve za stik mogoče šifrirati med vami in drugimi uporabniki. Omogočanje ju doda z eno samo omrežno transakcijo. To se zgodi samo enkrat.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaše povabilo plača pristojbino za registracijo tega uporabniškega imena.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Vaše glavno stanje Dash na verigi Core — tisto, kar pošiljate in prejemate z drugimi denarnicami, borzami in trgovci.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaši pomešani kovanci so bili premaknjeni v stanje vaše denarnice Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaši pomešani kovanci so bili premaknjeni v zaščiteno stanje. Za najboljšo zasebnost počakajte vsaj 2 uri, preden ta sredstva uporabite.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Vaše stanje Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Vaše zasebno stanje. Zneski in naslovi so v verigi šifrirani, zato vaša sredstva in zgodovina ostanejo zaupni.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Vaše zaščiteno stanje";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Vaše zaščiteno stanje je skoraj pripravljeno — zasebno se boste lahko registrirali okoli %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Vaše zaščiteno stanje je pripravljeno — zdaj zasebno registrirajte svoje uporabniško ime";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Vaše zaščiteno stanje počiva — zasebno se boste lahko registrirali okoli %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Vaše zaščiteno stanje še zori. Pripravljeno bo okoli %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Vaše transparentno stanje";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše uporabniško ime vidijo vsi. Če ga financirate iz zaščitenega stanja — potem ko sredstva nekaj ur počivajo — nihče ne bo mogel povezati vašega uporabniškega imena z drugimi vašimi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše uporabniško ime, profil in stiki sledijo tej identiteti.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše uporabniško ime, profil in stiki bodo sledili tej identiteti.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Vaši glasovi";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaša denarnica se še sinhronizira z omrežjem Dash. Pošiljanje bo na voljo, ko se sinhronizacija zaključi.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaša denarnica se še sinhronizira. Pošiljanje iz transparentnega stanja bo na voljo, ko se sinhronizacija zaključi.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "»%@« ni bilo mogoče prebrati kot uporabniško ime Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "»%@« je bilo registrirano. Želite poslati zahtevo za stik osebi, ki vas je povabila?";

--- a/DashWallet/sl.lproj/Localizable.stringsdict
+++ b/DashWallet/sl.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ preštetih za »%2$@«</string>
+		<string>%#@votes@ za »%2$@«</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,13 +93,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u glas</string>
+			<string>%1$u preštet glas</string>
 			<key>two</key>
-			<string>%1$u glasova</string>
+			<string>%1$u prešteta glasova</string>
 			<key>few</key>
-			<string>%1$u glasovi</string>
+			<string>%1$u prešteti glasovi</string>
 			<key>other</key>
-			<string>%1$u glasov</string>
+			<string>%1$u preštetih glasov</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -145,7 +145,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -165,7 +165,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/sl.lproj/Localizable.stringsdict
+++ b/DashWallet/sl.lproj/Localizable.stringsdict
@@ -82,5 +82,305 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ preštetih za »%2$@«</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u glas</string>
+			<key>two</key>
+			<string>%1$u glasova</string>
+			<key>few</key>
+			<string>%1$u glasovi</string>
+			<key>other</key>
+			<string>%1$u glasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Glasovano o %1$d od %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uporabniškega imena</string>
+			<key>two</key>
+			<string>%2$d uporabniških imen</string>
+			<key>few</key>
+			<string>%2$d uporabniških imen</string>
+			<key>other</key>
+			<string>%2$d uporabniških imen</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Oddaj %u glas</string>
+			<key>two</key>
+			<string>Oddaj %u glasova</string>
+			<key>few</key>
+			<string>Oddaj %u glasove</string>
+			<key>other</key>
+			<string>Oddaj %u glasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>two</key>
+			<string>%2$d masternode</string>
+			<key>few</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d vozlišča</string>
+			<key>two</key>
+			<string>%2$d vozlišč</string>
+			<key>few</key>
+			<string>%2$d vozlišč</string>
+			<key>other</key>
+			<string>%2$d vozlišč</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>two</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>skupaj %u glas</string>
+			<key>two</key>
+			<string>skupaj %u glasova</string>
+			<key>few</key>
+			<string>skupaj %u glasovi</string>
+			<key>other</key>
+			<string>skupaj %u glasov</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>two</key>
+			<string>%d masternode</string>
+			<key>few</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d izbran</string>
+			<key>two</key>
+			<string>%d izbrana</string>
+			<key>few</key>
+			<string>%d izbrani</string>
+			<key>other</key>
+			<string>%d izbranih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vaše vozlišče je tu že glasovalo in ni na seznamu.</string>
+			<key>two</key>
+			<string>%d vaši vozlišči sta tu že glasovali in nista na seznamu.</string>
+			<key>few</key>
+			<string>%d vaša vozlišča so tu že glasovala in niso na seznamu.</string>
+			<key>other</key>
+			<string>%d vaših vozlišč je tu že glasovalo in niso na seznamu.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas na spor — evonode šteje 4, masternode 1</string>
+			<key>two</key>
+			<string>%u glasova na spor — evonode šteje 4, masternode 1</string>
+			<key>few</key>
+			<string>%u glasovi na spor — evonode šteje 4, masternode 1</string>
+			<key>other</key>
+			<string>%u glasov na spor — evonode šteje 4, masternode 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasuj o %d uporabniškem imenu</string>
+			<key>two</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+			<key>few</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+			<key>other</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas</string>
+			<key>two</key>
+			<string>%u glasova</string>
+			<key>few</key>
+			<string>%u glasovi</string>
+			<key>other</key>
+			<string>%u glasov</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasuj ×%d</string>
+			<key>two</key>
+			<string>Glasuj ×%d</string>
+			<key>few</key>
+			<string>Glasuj ×%d</string>
+			<key>other</key>
+			<string>Glasuj ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d zahteva</string>
+			<key>two</key>
+			<string>%d zahtevi</string>
+			<key>few</key>
+			<string>%d zahteve</string>
+			<key>other</key>
+			<string>%d zahtev</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Vsa vozlišča hkrati";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte pri kandidatu, ki mu zdaj dajete prednost.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte za kandidata, ki mu zdaj dajete prednost.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ali ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ ni bilo mogoče najti v omrežju Dash, da bi mu poslali zahtevo za stik.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash na voljo";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ je sprejel vašo zahtevo za stik";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtov";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld od %ld pologov";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditno stanje na Dash Platform, ki se uporablja za takojšnja plačila med naslovi Platform in za funkcije, kot so uporabniška imena.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "About";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Vzdrži se";
+
+"Abstain on “%@”" = "Vzdrži se pri »%@«";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiven";
+
+/* No comment provided by engineer. */
+"Activity" = "Dejavnost";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Dejavnost je javna, a je ni lahko izslediti";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Dodaj %@ med stike";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Dodajte %@ med stike, da boste lahko plačevali neposredno na uporabniško ime in ohranili skupno zgodovino transakcij";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Dodajte %@ Dash v zaščiteno stanje in pustite, da nekaj ur počiva, da se registrirate brez povezovanja uporabniškega imena z drugimi sredstvi.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Dodajte vsaj %@ Dash v svoje zaščiteno stanje";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Zdaj napolnite zaščiteno stanje in čez nekaj ur zasebno registrirajte uporabniško ime";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Vsa vozlišča hkrati";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Vsi vaši masternode so glasovali o tem uporabniškem imenu. Če želite spremeniti glas, znova glasujte pri kandidatu, ki mu zdaj dajete prednost.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Skoraj takojšnja sinhronizacija stanj";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Zneski in naslovi so na blockchainu javni";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Račun Ethereum je en sam večkrat uporabljen naslov: celotno stanje in zgodovina plačil sta javno pod njim, ime (na primer domena ENS) pa običajno kaže naravnost na ta naslov, tako da ga lahko kdorkoli razreši. DashPay je zasnovan obratno — ime vodi do identitete, ne do plačilnega naslova, dejanski plačilni naslovi pa ostanejo znotraj šifriranih izmenjav s stiki in so za vsak stik novi.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Kdorkoli pozna naslov, si lahko ogleda njegovo zgodovino";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Odobri";
+
+"Approving a specific request can only be done one username at a time." = "Odobritev določene zahteve je mogoča samo za eno uporabniško ime naenkrat.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Kot besedilo";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Preverjanje pristnosti je bilo preklicano. Vaš glas ni bil oddan.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Preverjanje pristnosti ni uspelo. Vaš glas ni bil oddan.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Dodeli »%@« temu kandidatu";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "Stanje po tem";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Stanja in prenosi niso javno vidni";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Začetna višina je shranjena — dvignjeni prag pregledovanja velja od naslednjega zagona.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vezan na pogodbo";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vezan na pogodbo, vrsta dokumenta »%@«";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Samo pregledovanje";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Zbere nedavne diagnostične dnevnike v datoteko zip, da jih pošljete prek AirDropa, po e-pošti ali shranite v Datoteke";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Oddaj glas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Zamenjaj vozlišča";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Preverjanje…";
+
+"Choice" = "Izbira";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Prevzemite svoje povabilo";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Stanje za prevzem";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Počisti in znova sinhroniziraj";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Ali želite počistiti podatke verige in znova sinhronizirati?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Se zapira";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (novi kovanci)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ni več podprt — izberite, kam premakniti svoje pomešane kovance.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Zavarovanje";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Kmalu";
+
+/* Shielded transfer status */
+"Completed" = "Zaključeno";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potrjena";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potrditev shrani začetno višino %u in ob naslednjem zagonu aplikacije počisti podatke verige za to omrežje, jih znova prenese ter od te višine znova pregleda filtre. Trenutna seja obdrži svoj stari prag pregledovanja — zaprite in znova odprite aplikacijo, da se začne.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Povezana vozlišča";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Slabosti";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Zahteva za stik ni uspela";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Zahteva za stik je bila poslana uporabniku %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Zahteve za stik";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Nadaljujte in izberite svoje uporabniško ime. Povabilo plača pristojbino za registracijo.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiraj surovo transakcijo";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Arhiva dnevnikov ni bilo mogoče ustvariti: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Ni bilo mogoče osvežiti %d identitet";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Stanja ni bilo mogoče pridobiti (omrežna napaka). Poskusite osvežiti.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Ustvarite svoje uporabniško ime, poiščite prijatelje in družino po njihovih uporabniških imenih in jih dodajte med stike";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediti";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform tega spora še ni indeksiral. Števila glasov se bodo prikazala tukaj, ko ga bo.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform še ni povezan. Počakajte, da se sinhronizacija zaključi, in poskusite znova.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash, poslan na napačen naslov, ni povrnljiv. Prepričajte se, da je naslov natanko tisti, ki mu želite plačati.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash shranjuje uporabniška imena v obliki, odporni na podobne zapise, zato se shranjeno ime lahko razlikuje od tega, kar je vsak vpisal.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Stanje denarnice Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay je omogočen";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je Dashova družbena plačilna izkušnja, zgrajena na Dash Platform. Registrirate uporabniško ime, druge uporabnike dodate med stike in jim plačujete po imenu — nič več kopiranja naslovov.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay dolge in nerazumljive naslove nadomesti z uporabniškimi imeni. Prijatelje dodajte med stike, denar pošljite na ime in vsako plačilo ohranite urejeno po osebah.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Rok neznan";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Pot izpeljave";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Onemogočen";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Končano — vaše stanje je počivalo dovolj dolgo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Še enkrat preverite naslov";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Vsak masternode ima en veljaven glas na spor. Pozneje ga lahko spremenite, a Dash Platform dovoljuje skupno le 5 glasov na masternode na spor.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Vsak dotik doda h glasovanju še eno vozlišče, tako da sami izberete, koliko jih boste povezali.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Uredi začetno višino";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Omogoči";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Omogoči DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Omogočanje DashPay stane majhno enkratno omrežno provizijo, plačano iz kreditnega stanja vaše identitete. Natančna ocena je prikazana pred potrditvijo. Pošiljanje zahtev za stik in plačil stane običajne omrežne provizije.";
+
+"Ending soonest" = "Se konča najprej";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Ocenjena omrežna provizija";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Vsa vozlišča glasujejo skupaj. Hitreje je, a javno poveže vaše masternode med seboj.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operaterski ključi Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Izvozi dnevnike";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Zunanji naslov";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Neuspešno";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Pridobivanje…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Glave filtrov";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Poiščite uporabnika v omrežju Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Poišči identitete";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Najdenih je %d novih identitet";
+
+/* Identities */
+"Found 1 new identity" = "Najdena je 1 nova identiteta";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Uporabniško ime financirajte iz zaščitenega stanja. Sredstva dodajte nekaj ur vnaprej — kratko počivanje poskrbi, da vašega uporabniškega imena ni mogoče povezati z drugimi vašimi Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financirano iz vašega zaščitenega stanja — vašega uporabniškega imena ni mogoče povezati z drugimi vašimi Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Sredstva zaklenjena — prenos se zaključuje";
+
+/* CoinJoin */
+"Funds moved" = "Sredstva premaknjena";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pripravite se na pridružitev DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Razumem";
+
+/* Governance */
+"Governance" = "Upravljanje";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "je zaprosil, da bi bil vaš prijatelj";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Imate povabilo?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Glave";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Višina %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Višje provizije, okoli 7 centov (še vedno nižje kot pri drugih verigah s podobno zasebnostjo)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kako se to glede zasebnosti primerja z Bitcoinom?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kako se to glede zasebnosti primerja z računi Ethereum?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Kako zaseben je DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identitete";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Krediti identitete";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identitete";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registracija identitete";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Polnitev identitete";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktiven";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Vhod %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Vhod %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Vhodi (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Povabilo od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Povabite nekoga v omrežje Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Povabite prijatelje in družino v omrežje Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Ohranite te kovance zasebne. Veljajo omrežne provizije in provizije za zasebnost.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ključ št. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Podatki ključa";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Lastništvo ključa";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ključi";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vodi";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Več o tem";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Nalaganje transakcij";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Samo lokalno";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Zakleni";
+
+"Lock the name" = "Zakleni ime";
+
+"Lock “%@” so nobody gets it" = "Zakleni »%@«, da ga nihče ne dobi";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Zaklenjeno — tega uporabniškega imena ne dobi nihče";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Nizke provizije za vsakdanjo porabo";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Glavna";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Ključavnica masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Seznam masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Glasovi masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode in evonode, registrirani s ključi te denarnice, se bodo prikazali tukaj, ko se denarnica sinhronizira.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode in evonode, ki uporabljajo ključe te denarnice";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode glasujejo o imenih, za katera je zaprosila več kot ena oseba. Ko se glasovanje konča, boste obveščeni.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum je dosežen";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Več predlogov";
+
+"Most lock votes" = "Največ glasov za zaklep";
+
+"Most votes" = "Največ glasov";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Premakni v običajno stanje za porabo.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Premikanje sredstev";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Storitve imen, kot je Unstoppable Domains, povežejo berljivo ime s fiksnim javnim naslovom v verigi. Kdorkoli lahko razreši to ime in vidi vsako plačilo, ki je bilo kdaj nanj poslano. Uporabniško ime DashPay se nikoli javno ne razreši v plačilni naslov — naslovi se razkrijejo samo znotraj šifrirane izmenjave z vsakim stikom, tako da vaše ime in vaš denar za zunanje opazovalce ostaneta nepovezana.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Potrebuje pozornost";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "V tej napravi ni bilo najdenih diagnostičnih dnevnikov. Dnevniki se zapisujejo od naslednjega zagona naprej.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Ni identitet";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Še ni masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Ni ustreznih sporov";
+
+/* Identities */
+"No new identities were found for this wallet" = "Za to denarnico ni bilo najdenih novih identitet";
+
+"No open contest matches that search." = "Nobeden odprt spor se ne ujema s tem iskanjem.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nobeden odprt spor se ne ujema s tem iskanjem. Imena so shranjena v normalizirani obliki, zato je »alice« navedena kot »a11ce«.";
+
+"No open contests" = "Ni odprtih sporov";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Za povezano denarnico ni bilo najdenega shranjenega zapisa.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Za rezervno zaščiteno registracijo še ni na voljo naslova Platform. Poskusite znova, ko denarnica konča sinhronizacijo.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Trenutno ni nobeno uporabniško ime sporno. Spor se odpre, ko dve osebi ali več zaprosita za isto ime.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Noben glas ni bil oddan";
+
+"Nobody gets it" = "Nihče ga ne dobi";
+
+/* SPV sync peer type */
+"Node" = "Vozlišče";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandardno";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Še ni na voljo";
+
+"Not cast" = "Ni oddan";
+
+/* Masternodes */
+"Not checked yet" = "Še ni preverjeno";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Premalo zaščitenega stanja za registracijo identitete";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Ni v zgodovini denarnice";
+
+"Not now" = "Ne zdaj";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Trgovci ga ne sprejemajo široko";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Trgovci ga še ne sprejemajo široko";
+
+/* Masternode keys */
+"Not yet used" = "Še ni uporabljen";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Pri Bitcoinu ni plasti imen, zato ljudje naslove odkrito delijo in znova uporabljajo — ko je naslov enkrat znan, je vse, kar je kdaj prejel, mogoče povezati z njegovim lastnikom. Pri DashPay je vaše uporabniško ime javno, a nikoli ne kaže na plačilni naslov: naslovi se zasebno izmenjujejo z vsakim stikom in se menjajo, zato plačilo po imenu ne razkrije, kam gre vaš denar. Obe sta transparentni verigi, zato analiza verige še vedno velja za same kovance.";
+
+/* Identities */
+"On Network" = "V omrežju";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Ko %@ sprejme vašo zahtevo, boste lahko plačevali neposredno na uporabniško ime";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Eno vozlišče naenkrat";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "O uporabniških imenih lahko glasujejo samo masternode in evonode. Ta denarnica ne vsebuje aktivnih ključev za glasovanje masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operater";
+
+/* Masternode keys */
+"Operator keys" = "Operaterski ključi";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Javni ključ operaterja (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ali";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Drugi izidi";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Izhod %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Izhodi (%d)";
+
+/* Masternodes */
+"Owner" = "Lastnik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Naslov lastnika";
+
+/* Masternodes */
+"Owner key hash" = "Zgoščena vrednost ključa lastnika";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Plačano iz kreditnega stanja vaše identitete.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Prilepite povezavo povabila, ki ste jo prejeli, ali skenirajte njeno kodo QR. Povabilo financira registracijo vašega uporabniškega imena.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "plačevali neposredno na uporabniško ime";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plačujte ljudem, ne naslovom";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Plačila so zasebna: naslovi, ki jih izmenjate s stikom, potujejo znotraj šifrirane vsebine, ki jo lahko prebereta samo vidva, in nikoli niso objavljeni — zato vaših plačil ni mogoče preprosto povezati z vašim uporabniškim imenom. Kljub temu gre še vedno za običajna plačila na transparentni verigi: napredna analiza verige lahko razkrije informacije. Shielded DashPay (kmalu) bo to vrzel zaprl. Same zahteve za stik trenutno NISO zasebne: kdorkoli lahko vidi, da sta dve identiteti povezani. Zasebne zahteve za stik so funkcija, ki prihaja kmalu. Vaše uporabniško ime in profil sta na Dash Platform prav tako javna.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Plačila se z InstantSend potrdijo v nekaj sekundah";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Plačila, izvedena neposredno na naslove, se v dejavnosti ne bodo ohranila.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Plačila z vsakim stikom so združena na enem mestu, z imeni in profili namesto surovih transakcij.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Naslov za izplačilo";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Naslov Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Stanje Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Vozlišče Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID vozlišča Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Plačila Platform ne identificirajo pošiljatelja. To plačilo je bilo zabeleženo, ko je denarnica opazila spremembo stanja — morda je prispelo že prej.";
+
+"Platform SDK not ready" = "Platform SDK ni pripravljen";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Sinhronizacija Platform ne teče. Odprite Informacije o sinhronizaciji → Stanje sinhronizacije Platform, da jo zaženete.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Zaščiteno";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Prej uporabljen: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Zaseben po zasnovi";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Zasebne zahteve za stik (da ostane zasebno, s kom se povezujete), Shielded DashPay — plačila stikom iz vašega zasebnega zaščitenega stanja — in plačila uporabnikom, ki jih še nimate med stiki, vse to prihaja kmalu.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Zasebne zahteve za stik so v razvoju in so pričakovane okoli septembra–oktobra 2026. Danes je sama zahteva javna — kdorkoli lahko vidi, da sta dve identiteti povezani, čeprav so podatki o plačilu v njej šifrirani. Ko bodo zasebne zahteve za stik na voljo, boste lahko izbrali, ali naj bo vaše prijateljstvo javno ali zasebno.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Zasebne zahteve za stik, Shielded DashPay in plačevanje ljudem, ki še niso stiki.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Zasebni plačilni naslovi se izmenjujejo med vami in vašimi stiki. Samo vi in vaš stik veste, kdo je prejemnik in kdo pošiljatelj plačil med vama.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Zasebna plačila";
+
+/* Usernames */
+"Private registration" = "Zasebna registracija";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Čas obdelave";
+
+/* Balance info sheet section */
+"Pros" = "Prednosti";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transakcije ponudnika";
+
+/* Masternode keys */
+"Public key" = "Javni ključ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Javni ključ (starejši)";
+
+/* Identities */
+"Public keys" = "Javni ključi";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Namen";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Surova transakcija";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Surova transakcija ni na voljo";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Od izbrane višine znova preveri kompaktne blokovne filtre za transakcije te denarnice, tako da jih znova prenese in primerja. Ponovni pregledi so navzdol omejeni z višino nastanka denarnice in lokalno shranjenimi podatki verige — za obnovitev starejše zgodovine raje znižajte začetno višino denarnice.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Samo za branje";
+
+/* Usernames */
+"Ready around %@" = "Pripravljeno okoli %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Razlog";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Prejeto od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Zabeleži vaše masternode kot da so glasovali, ne da bi se opredelili.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Osveži";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registriran";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Zasebna registracija zahteva vsaj %@ Dash v zaščitenem stanju in nekaj ur počivanja — naslednji zasloni vas bodo vodili skozi postopek.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registracija";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Prosi za to ime";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovljene denarnice ne morejo vedno obnoviti vrste operacije. Ta vnos je bil rekonstruiran iz podatkov zaznamka v verigi.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ponovna sinhronizacija je pripravljena od višine %u — zaprite in znova odprite aplikacijo, da se začne.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "ohranili skupno zgodovino transakcij";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Umaknjen";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Preklic";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret.";
 
+/* Raw transaction inspector */
+"Script" = "Skripta";
+
+/* Raw transaction inspector */
+"Script signature" = "Podpis skripte";
+
+/* Raw transaction inspector */
+"Script type" = "Vrsta skripte";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Poišči stik";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Poišči zahtevo za stik";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Poišči uporabnika v omrežju Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Poišči uporabniško ime";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultati iskanja za \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Poišči uporabniška imena";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Iskanje uporabniškega imena %@ v omrežju Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Raven varnosti";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Izberi vse";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Izberite vsaj en masternode, s katerim boste glasovali.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Izbira manj vozlišč razkrije manj o tem, katere masternode upravljate.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Pošlji stiku";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Pošljite na uporabniško ime, ki si ga res lahko zapomnite in ga preverite.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Pošljite svojo prvo zahtevo za stik";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Pošiljanje zahteve za stik";
+
+/* No comment provided by engineer. */
+"Sending to" = "Pošiljanje na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Poslano uporabniku %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Storitev";
+
+/* Identities */
+"Set as Main" = "Nastavi kot glavno";
+
+/* Identities */
+"Set as Main Identity" = "Nastavi kot glavno identiteto";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Skupni bazen zasebnosti je na najmanjši velikosti";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Zaščiten naslov";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Zaščitena poraba";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Zaganjanje zaščitene denarnice…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Zaščiteno → Platform";
+
+"Shielded → Transparent" = "Zaščiteno → Transparentno";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Velikost";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Nekateri vaši masternode morda manjkajo na tem seznamu — denarnica ni mogla prebrati celotnega nabora vaših ključev za glasovanje. Dokončajte sinhronizacijo in znova odprite ta zaslon.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Razvrsti stike";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Poseben payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Začne se, ko dodate sredstva";
+
+/* Transaction details */
+"Status" = "Stanje";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Shranjeno kot";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacije o sinhronizaciji";
+
+/* SPV sync */
+"Sync too slow?" = "Je sinhronizacija prepočasna?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne zavzemi nobene strani";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tapnite za kopiranje";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ključ vozlišča Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash prispe na naslov prejemnika, ko omrežje obdela izplačilo — to lahko traja do 10 minut.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash prispe na naslov prejemnika, takoj ko omrežje obdela izplačilo.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash prispe v vaše transparentno stanje, takoj ko omrežje obdela izplačilo.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Glavno identiteto je mogoče izbrati samo iz aktivne denarnice";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najbolj zasebno mesto za hranjenje vaših Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Shranjen zapis denarnice nima omrežja — ponovne sinhronizacije ni mogoče pripraviti.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registracija je bila poslana, a njenega izida ni bilo mogoče potrditi. Počakajte minuto, da se denarnica sinhronizira, in poskusite znova — ne pošiljajte je takoj ponovno.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Skupni bazen zasebnosti še raste (%1$ld od %2$ld pologov). Zasebna registracija se odklene, ko doseže minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Skupni bazen zasebnosti še raste (%1$ld od %2$ld pologov). Poskusite znova, ko doseže minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Višina nastanka denarnice — spodnja meja za preglede filtrov in za ponovne preglede »Od nastanka denarnice«. Nastavite jo na raven prvega priliva v denarnico ali nižje; uvozi privzeto uporabijo 200000 na mainnetu in 0 na testnetu. Shranjevanje višine, ki je enaka trenutni ali nižja, ob naslednjem zagonu počisti podatke verige tega omrežja in znova pregleda od nje naprej.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "njega (Pridobivanje informacij)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Ni novih obvestil";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Ni uporabnikov, ki bi se ujemali z imenom %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Med vašimi stiki ni uporabnikov, ki bi se ujemali z imenom %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ta sredstva se prenesejo v vaše stanje Platform in so pripravljena za porabo, takoj ko se prenos zaključi.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Tega naslova ni mogoče plačati iz vašega stanja %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "S tem se vaši identiteti dodata dva ključa, da vam lahko drugi uporabniki pošiljajo zahteve za stik in da lahko vi sprejmete njihove. To se zgodi samo enkrat.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "S tem se ena izbira uporabi za vseh %d izbranih uporabniških imen.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ta povezava povabila ni veljavna.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "To ni veljaven naslov Dash za to omrežje";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "To ni veljavna povezava povabila";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "To je vaša glavna identiteta";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ta masternode še nima identitete Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "To se še vedno šteje, kot da so vaši masternode glasovali v tem sporu.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Surovi bajti te transakcije niso shranjeni v tej napravi.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "To uporabniško ime je pripadlo nekomu drugemu";
+
+"This wallet could not derive the voting key for this node." = "Ta denarnica ni mogla izpeljati ključa za glasovanje za to vozlišče.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ta denarnica ne vsebuje aktivnih ključev za glasovanje masternode, zato ne more glasovati. Registrirana vozlišča se prikažejo v Orodja → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "S tem se izplača celotno vaše stanje Platform v enem prenosu. Dash prispe na naslov prejemnika, takoj ko omrežje obdela izplačilo.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "S tem se izplača celotno vaše stanje Platform v enem prenosu. Dash prispe v vaše transparentno stanje, takoj ko omrežje obdela izplačilo.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Zgodovina transakcij ni na voljo";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcije";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Prenos noter";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Prenos ven";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Prenosi trajajo dlje — gradnja dokazov zasebnosti zahteva čas";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Prenosi na druge naslove Platform in na zaščitene naslove so takojšnji in dokončni";
+
+/* Balance breakdown */
+"Transparent" = "Transparentno";
+
+/* Send screen destination type */
+"Transparent address" = "Transparenten naslov";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentno stanje";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentno financiranje javno poveže vaše uporabniško ime s temi sredstvi.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentno → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentno → Zaščiteno";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Predlogov ni mogoče ponuditi";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Neznana posebna vrsta %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nezaščiteno";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Nadgradi na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Namesto tega uporabi transparentno stanje";
+
+/* Masternode keys */
+"Used" = "Uporabljen";
+
+/* Masternode keys */
+"Used at: " = "Uporabljen: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Uporabnik (Pridobivanje informacij)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Uporabniška imena";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Uporabniška imena so shranjena v normalizirani obliki, da se preprečijo podobno videti imena, zato se to lahko razlikuje od tega, kar je vsak vpisal.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Uporabniška imena, ne naslovi";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Uporabniki, ki se ujemajo z %@ in trenutno niso med vašimi stiki";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Uporablja eno najbolj revidiranih in preizkušenih knjižnic z ničelnim znanjem (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Veljavno povabilo";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Preverjeno med registracijo";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Različica";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Zelo učinkovito z nizkimi provizijami";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Prikaži vse";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Preveri seznam skrivnih besed za obnovo denarnice";
 
+/* Raw transaction inspector */
+"View Transaction" = "Prikaži transakcijo";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Glasuj";
+
+"Vote cast" = "Glas oddan";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Glasujte o spornih uporabniških imenih";
+
+"Vote on several" = "Glasuj o več";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Glasuj z";
+
+"Votes that nobody should receive these usernames." = "Glasuje, da teh uporabniških imen ne bi smel dobiti nihče.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Naslov za glasovanje";
+
+"Voting ended with no winner" = "Glasovanje se je končalo brez zmagovalca";
+
+"Voting ends" = "Glasovanje se konča";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Glasovanje poteka";
+
+"Voting in progress — lock votes are ahead" = "Glasovanje poteka — glasovi za zaklep vodijo";
+
+"Voting in progress — you are ahead" = "Glasovanje poteka — vi vodite";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Zgoščena vrednost ključa za glasovanje";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Glasovanje o tem uporabniškem imenu je zaprto. Spodnja števila so zadnja prebrana.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Glasovanje o »%@« je že zaprto. Osvežite, da vidite rezultat.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Čakanje na Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Začetna višina denarnice";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Denarnica onemogočena";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Kaj pa Unstoppable Domains in podobne storitve imen?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Koliko stane?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Kaj je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Kaj prihaja naslednje?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kdaj bodo zahteve za stik postale zasebne?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kdo prosi za to ime";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Zakaj ga moram omogočiti?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Izplača celotno stanje";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Deluje z vsako denarnico Dash, borzo in trgovcem";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vi";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Sprejeli ste zahtevo za stik od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Trenutno nimate nobenih stikov";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Doslej imate %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Poslali ste zahtevo za stik uporabniku %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Osvojili ste to uporabniško ime";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Vse je pripravljeno. Drugi uporabniki vam zdaj lahko pošiljajo zahteve za stik — in vi lahko pošiljate svoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaša identiteta Dash Platform se bo prikazala tukaj, ko registrirate uporabniško ime.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaša zgodovina, urejena";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vaša identiteta potrebuje dva dodatna ključa, da je zahteve za stik mogoče šifrirati med vami in drugimi uporabniki. Omogočanje ju doda z eno samo omrežno transakcijo. To se zgodi samo enkrat.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaše povabilo plača pristojbino za registracijo tega uporabniškega imena.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Vaše glavno stanje Dash na verigi Core — tisto, kar pošiljate in prejemate z drugimi denarnicami, borzami in trgovci.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaši pomešani kovanci so bili premaknjeni v stanje vaše denarnice Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaši pomešani kovanci so bili premaknjeni v zaščiteno stanje. Za najboljšo zasebnost počakajte vsaj 2 uri, preden ta sredstva uporabite.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Vaše stanje Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Vaše zasebno stanje. Zneski in naslovi so v verigi šifrirani, zato vaša sredstva in zgodovina ostanejo zaupni.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Vaše zaščiteno stanje";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Vaše zaščiteno stanje je skoraj pripravljeno — zasebno se boste lahko registrirali okoli %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Vaše zaščiteno stanje je pripravljeno — zdaj zasebno registrirajte svoje uporabniško ime";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Vaše zaščiteno stanje počiva — zasebno se boste lahko registrirali okoli %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Vaše zaščiteno stanje še zori. Pripravljeno bo okoli %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Vaše transparentno stanje";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše uporabniško ime vidijo vsi. Če ga financirate iz zaščitenega stanja — potem ko sredstva nekaj ur počivajo — nihče ne bo mogel povezati vašega uporabniškega imena z drugimi vašimi Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše uporabniško ime, profil in stiki sledijo tej identiteti.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše uporabniško ime, profil in stiki bodo sledili tej identiteti.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Vaši glasovi";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaša denarnica se še sinhronizira z omrežjem Dash. Pošiljanje bo na voljo, ko se sinhronizacija zaključi.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaša denarnica se še sinhronizira. Pošiljanje iz transparentnega stanja bo na voljo, ko se sinhronizacija zaključi.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "»%@« ni bilo mogoče prebrati kot uporabniško ime Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "»%@« je bilo registrirano. Želite poslati zahtevo za stik osebi, ki vas je povabila?";

--- a/DashWallet/sl_SI.lproj/Localizable.stringsdict
+++ b/DashWallet/sl_SI.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ preštetih za »%2$@«</string>
+		<string>%#@votes@ za »%2$@«</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,13 +93,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u glas</string>
+			<string>%1$u preštet glas</string>
 			<key>two</key>
-			<string>%1$u glasova</string>
+			<string>%1$u prešteta glasova</string>
 			<key>few</key>
-			<string>%1$u glasovi</string>
+			<string>%1$u prešteti glasovi</string>
 			<key>other</key>
-			<string>%1$u glasov</string>
+			<string>%1$u preštetih glasov</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -145,7 +145,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -165,7 +165,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<string>Glasovanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/sl_SI.lproj/Localizable.stringsdict
+++ b/DashWallet/sl_SI.lproj/Localizable.stringsdict
@@ -82,5 +82,305 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ preštetih za »%2$@«</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u glas</string>
+			<key>two</key>
+			<string>%1$u glasova</string>
+			<key>few</key>
+			<string>%1$u glasovi</string>
+			<key>other</key>
+			<string>%1$u glasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Glasovano o %1$d od %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d uporabniškega imena</string>
+			<key>two</key>
+			<string>%2$d uporabniških imen</string>
+			<key>few</key>
+			<string>%2$d uporabniških imen</string>
+			<key>other</key>
+			<string>%2$d uporabniških imen</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Oddaj %u glas</string>
+			<key>two</key>
+			<string>Oddaj %u glasova</string>
+			<key>few</key>
+			<string>Oddaj %u glasove</string>
+			<key>other</key>
+			<string>Oddaj %u glasov</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>two</key>
+			<string>%2$d masternode</string>
+			<key>few</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasovalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d vozlišča</string>
+			<key>two</key>
+			<string>%2$d vozlišč</string>
+			<key>few</key>
+			<string>%2$d vozlišč</string>
+			<key>other</key>
+			<string>%2$d vozlišč</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>two</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>skupaj %u glas</string>
+			<key>two</key>
+			<string>skupaj %u glasova</string>
+			<key>few</key>
+			<string>skupaj %u glasovi</string>
+			<key>other</key>
+			<string>skupaj %u glasov</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>two</key>
+			<string>%d masternode</string>
+			<key>few</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d izbran</string>
+			<key>two</key>
+			<string>%d izbrana</string>
+			<key>few</key>
+			<string>%d izbrani</string>
+			<key>other</key>
+			<string>%d izbranih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vaše vozlišče je tu že glasovalo in ni na seznamu.</string>
+			<key>two</key>
+			<string>%d vaši vozlišči sta tu že glasovali in nista na seznamu.</string>
+			<key>few</key>
+			<string>%d vaša vozlišča so tu že glasovala in niso na seznamu.</string>
+			<key>other</key>
+			<string>%d vaših vozlišč je tu že glasovalo in niso na seznamu.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas na spor — evonode šteje 4, masternode 1</string>
+			<key>two</key>
+			<string>%u glasova na spor — evonode šteje 4, masternode 1</string>
+			<key>few</key>
+			<string>%u glasovi na spor — evonode šteje 4, masternode 1</string>
+			<key>other</key>
+			<string>%u glasov na spor — evonode šteje 4, masternode 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasuj o %d uporabniškem imenu</string>
+			<key>two</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+			<key>few</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+			<key>other</key>
+			<string>Glasuj o %d uporabniških imenih</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas</string>
+			<key>two</key>
+			<string>%u glasova</string>
+			<key>few</key>
+			<string>%u glasovi</string>
+			<key>other</key>
+			<string>%u glasov</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasuj ×%d</string>
+			<key>two</key>
+			<string>Glasuj ×%d</string>
+			<key>few</key>
+			<string>Glasuj ×%d</string>
+			<key>other</key>
+			<string>Glasuj ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d zahteva</string>
+			<key>two</key>
+			<string>%d zahtevi</string>
+			<key>few</key>
+			<string>%d zahteve</string>
+			<key>other</key>
+			<string>%d zahtev</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ose ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ nuk u gjet në rrjetin Dash për t'i dërguar një kërkesë kontakti.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash në dispozicion";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ pranoi kërkesën tuaj për kontakt";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajt";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld nga %ld depozita";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Një balancë krediti në Dash Platform që përdoret për pagesa të menjëhershme mes adresave Platform dhe për veçori si emrat e përdoruesve.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Një kodkalim është i nevojshëm për sigurinë e kuletës suaj. Shko në konfigurimet dhe aktivizo kodkalimin dhe vazhdo.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Rreth";
 
+/* DashPay FAQ title */
+"About DashPay" = "Rreth DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Abstenoni";
+
+"Abstain on “%@”" = "Absteno për „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiv";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktiviteti";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktiviteti është publik, por nuk gjurmohet lehtë";
+
 /* No comment provided by engineer. */
 "Add" = "Shto";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Shto %@ si kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Shtoni %@ si kontakt për të paguar drejtpërdrejt te emri i përdoruesit dhe për të ruajtur historikun e përbashkët të transaksioneve";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Shtoni %@ Dash në balancën tuaj të mbrojtur dhe lëreni të prehet disa orë, që të regjistroheni pa e lidhur emrin tuaj të përdoruesit me fondet e tjera.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Shtoni të paktën %@ Dash në balancën tuaj të mbrojtur";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Shtoni fonde në balancën e mbrojtur tani dhe regjistrojeni emrin e përdoruesit privatisht pas disa orësh";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Të gjitha nyjet njëherësh";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Të gjithë masternode-t tuaj kanë votuar për këtë emër përdoruesi. Për të ndryshuar një votë, votoni sërish nga kandidati që tani preferoni.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Sinkronizim i balancave gati i menjëhershëm";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Shumat dhe adresat janë publike në blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Një llogari Ethereum është një adresë e vetme e ripërdorur: e gjithë balanca dhe historiku juaj i pagesave qëndrojnë publikisht nën të, dhe një emër (për shembull një domen ENS) zakonisht tregon drejt te ajo adresë, kështu që kushdo mund ta zbërthejë. DashPay ka formën e kundërt — emri zbërthehet te një identitet, jo te një adresë pagese, dhe adresat reale të pagesës mbeten brenda shkëmbimeve të fshehtëzuara me kontaktet, të reja për çdo kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Kushdo që di një adresë mund të shohë historikun e saj";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Mirato";
+
+"Approving a specific request can only be done one username at a time." = "Miratimi i një kërkese të caktuar mund të bëhet vetëm për një emër përdoruesi në një kohë.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Si tekst";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Vërtetimi u anulua. Vota juaj nuk u dha.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Vërtetimi dështoi. Vota juaj nuk u dha.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Jepja „%@“ këtij kandidati";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balanca";
 
 /* CrowdNode */
+"Balance after" = "Balanca më pas";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Balancat dhe transferimet nuk janë publikisht të dukshme";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Lartësia fillestare u ruajt — kufiri i ngritur i skanimit vlen që nga nisja e ardhshme.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "E lidhur me kontratë";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "E lidhur me kontratë, lloji i dokumentit „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Vetëm shfletim";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Mbledh regjistrat e fundit diagnostikues në një skedar zip për t'i dërguar me AirDrop, me e-mail ose për t'i ruajtur te Skedarët";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Jep votën";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Ndrysho nyjet";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Po kontrollohet…";
+
+"Choice" = "Zgjedhja";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Merrni ftesën tuaj";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Balancë e kërkueshme";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Pastro dhe risinkronizo";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Të pastrohen të dhënat e zinxhirit dhe të risinkronizohet?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Po mbyllet";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (monedha të reja)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin nuk mbështetet më — zgjidhni ku t'i zhvendosni monedhat tuaja të përziera.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolateral";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Së shpejti";
+
+/* Shielded transfer status */
+"Completed" = "Përfunduar";
 
 /* No comment provided by engineer. */
 "Confirm" = "Confirm";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "E konfirmuar";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Konfirmimi ruan lartësinë fillestare %u dhe pastron të dhënat e zinxhirit të këtij rrjeti në nisjen e ardhshme të aplikacionit, i shkarkon sërish dhe i riskanon filtrat nga ajo lartësi. Sesioni aktual e mban kufirin e vjetër të skanimit — mbyllni dhe rihapni aplikacionin që të fillojë.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Nyjet e lidhura";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Të metat";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kërkesa për kontakt dështoi";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kërkesa për kontakt u dërgua te %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kërkesa për kontakt";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidati %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Vazhdoni për të zgjedhur emrin tuaj të përdoruesit. Ftesa e paguan tarifën e regjistrimit.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopjo transaksionin e papërpunuar";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Arkivi i regjistrave nuk u krijua dot: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Nuk mund të gjej kursin e këmbimit.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nuk u rifreskuan dot %d identitete";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Balanca nuk u mor dot (gabim rrjeti). Provoni të rifreskoni.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Krijoni emrin tuaj të përdoruesit, gjeni miq e familjarë me emrat e tyre të përdoruesit dhe shtojini te kontaktet tuaja";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Kredite";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ende nuk e ka indeksuar këtë kontest. Numrat e votave do të shfaqen këtu sapo ta bëjë.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ende nuk është e lidhur. Prisni të përfundojë sinkronizimi dhe provoni sërish.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash i dërguar në një adresë të gabuar nuk mund të rikthehet. Sigurohuni që adresa të jetë saktësisht ajo së cilës doni t'i paguani.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash i ruan emrat e përdoruesve në një formë të mbrojtur nga ngjashmëritë, prandaj emri i ruajtur mund të ndryshojë nga ajo që shkroi secili person.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Balanca e kuletës Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay u aktivizua";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay është përvoja sociale e pagesave e Dash, e ndërtuar mbi Dash Platform. Regjistroni një emër përdoruesi, shtoni përdorues të tjerë si kontakte dhe u paguani me emër — pa kopjuar më adresa.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay i zëvendëson adresat e gjata e të pakuptueshme me emra përdoruesish. Shtoni miqtë si kontakte, dërgoni para te një emër dhe mbajeni çdo pagesë të organizuar sipas personit.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Afati i panjohur";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Shtegu i derivimit";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "I çaktivizuar";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "U krye — balanca juaj u pre mjaftueshëm gjatë";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Kontrolloni edhe një herë adresën";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Çdo masternode ka një votë të vlefshme për çdo kontest. Mund ta ndryshoni më vonë, por Dash Platform lejon gjithsej vetëm 5 vota për çdo masternode për çdo kontest.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Çdo prekje voton me një nyje më shumë, kështu që ju zgjidhni sa prej tyre t'i lidhni bashkë.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Ndrysho lartësinë fillestare";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktivizo";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Aktivizo DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Aktivizimi i DashPay kushton një tarifë të vogël rrjeti një herë të vetme, e paguar nga balanca e kreditit të identitetit tuaj. Vlerësimi i saktë shfaqet para se të konfirmoni. Dërgimi i kërkesave për kontakt dhe i pagesave kushton tarifat e zakonshme të rrjetit.";
+
+"Ending soonest" = "Përfundon më së pari";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Tarifa e vlerësuar e rrjetit";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Të gjitha nyjet votojnë bashkë. Më shpejt, por i lidh publikisht masternode-t tuaj me njëri-tjetrin.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Çelësat e operatorit të Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Eksporto regjistrat";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Adresë e jashtme";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Dështoi";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Po merret…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtro";
+
+/* SPV sync phase */
+"Filter headers" = "Kokat e filtrave";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Gjeni një përdorues në rrjetin Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Gjej identitete";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "U gjetën %d identitete të reja";
+
+/* Identities */
+"Found 1 new identity" = "U gjet 1 identitet i ri";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Financojeni emrin tuaj të përdoruesit nga balanca e mbrojtur. Shtoni fondet disa orë më parë — prehja e shkurtër bën që emri juaj i përdoruesit të mos lidhet me Dash-in tuaj tjetër.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Financuar nga balanca juaj e mbrojtur — emri juaj i përdoruesit nuk mund të lidhet me Dash-in tuaj tjetër.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fondet janë të kyçura — transferimi po përfundon";
+
+/* CoinJoin */
+"Funds moved" = "Fondet u zhvendosën";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Përgatituni t'i bashkoheni DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "E kuptova";
+
+/* Governance */
+"Governance" = "Qeverisja";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ka kërkuar të jetë miku juaj";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Keni një ftesë?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Kokat";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Lartësia %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Tarifa më të larta rreth 7 centësh (prapëseprapë më të ulëta se blockchain-e të tjerë me privatësi të ngjashme)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Si krahasohet kjo me Bitcoin sa i përket privatësisë?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Si krahasohet kjo me llogaritë Ethereum sa i përket privatësisë?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Sa privat është DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "Identitetet";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kreditet e identitetit";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeksi i identitetit";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Regjistrimi i identitetit";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Rimbushja e identitetit";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Joaktiv";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Hyrja %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Hyrja %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Hyrjet (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Ftesë nga %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Ftoni dikë t'i bashkohet rrjetit Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Ftoni miqtë dhe familjen tuaj në rrjetin Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Mbaji këto monedha private. Zbatohen tarifa rrjeti dhe privatësie.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Çelësi nr. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Të dhënat e çelësit";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Pronësia e çelësit";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Çelësat";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Në krye";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Mëso më shumë";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Po ngarkohen transaksionet";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Vetëm lokal";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Kyç";
+
+"Lock the name" = "Kyç emrin";
+
+"Lock “%@” so nobody gets it" = "Kyç „%@“ që të mos e marrë askush";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "I kyçur — askush nuk e merr këtë emër përdoruesi";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Tarifa të ulëta për shpenzimet e përditshme";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Kryesor";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Vargu i çelësave të masternode-it";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Lista e masternode-ve";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Votat e masternode-ve";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode-t";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternode-t dhe evonode-t e regjistruar me çelësat e kësaj kuletë do të shfaqen këtu pasi kuleta të sinkronizohet.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode-t dhe evonode-t që përdorin çelësat e kësaj kuletë";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode-t votojnë për emra që i ka kërkuar më shumë se një person. Do të njoftoheni kur të përfundojë votimi.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimumi u arrit";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Më shumë sugjerime";
+
+"Most lock votes" = "Më shumë vota kyçjeje";
+
+"Most votes" = "Më shumë vota";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Zhvendos te balanca jote e zakonshme e shpenzueshme.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Po zhvendosen fondet";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Shërbimet e emrave si Unstoppable Domains e lidhin një emër të lexueshëm me një adresë publike fikse në zinxhir. Kushdo mund ta zbërthejë emrin dhe të shohë çdo pagesë të bërë ndonjëherë ndaj tij. Një emër përdoruesi DashPay nuk zbërthehet kurrë publikisht në një adresë pagese — adresat zbulohen vetëm brenda shkëmbimit të fshehtëzuar me çdo kontakt, kështu që emri dhe paratë tuaja mbeten të palidhura për vëzhguesit e jashtëm.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Kërkon vëmendje";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Në këtë pajisje nuk u gjet asnjë regjistër diagnostikues. Regjistrat shkruhen nga nisja e ardhshme e tutje.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Asnjë identitet";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Ende asnjë masternode";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Asnjë kontest që përputhet";
+
+/* Identities */
+"No new identities were found for this wallet" = "Nuk u gjet asnjë identitet i ri për këtë kuletë";
+
+"No open contest matches that search." = "Asnjë kontest i hapur nuk përputhet me atë kërkim.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Asnjë kontest i hapur nuk përputhet me atë kërkim. Emrat ruhen në formë të normalizuar, prandaj „alice“ renditet si „a11ce“.";
+
+"No open contests" = "Asnjë kontest i hapur";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Nuk u gjet asnjë rresht i ruajtur kuletë për kuletën e lidhur.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Ende nuk ka asnjë adresë Platform të disponueshme për regjistrimin rezervë të mbrojtur. Provoni sërish pasi kuleta të përfundojë sinkronizimin.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Aktualisht asnjë emër përdoruesi nuk është i kontestuar. Kontestet hapen kur dy a më shumë veta kërkojnë të njëjtin emër.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nuk u dha asnjë votë";
+
+"Nobody gets it" = "Askush nuk e merr";
+
+/* SPV sync peer type */
+"Node" = "Nyje";
+
+/* Raw transaction inspector */
+"Non-standard" = "Jostandard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Ende i padisponueshëm";
+
+"Not cast" = "E padhënë";
+
+/* Masternodes */
+"Not checked yet" = "Ende i pakontrolluar";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Balanca e mbrojtur nuk mjafton për të regjistruar një identitet";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nuk është në historikun e kuletës";
+
+"Not now" = "Jo tani";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Nuk pranohet gjerësisht nga tregtarët";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Ende nuk pranohet gjerësisht nga tregtarët";
+
+/* Masternode keys */
+"Not yet used" = "Ende i papërdorur";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Në Bitcoin nuk ka një shtresë emrash, prandaj njerëzit i ndajnë dhe i ripërdorin adresat haptazi — sapo një adresë njihet, gjithçka që ka marrë ndonjëherë mund të lidhet me pronarin e saj. Me DashPay emri juaj i përdoruesit është publik, por nuk tregon kurrë te një adresë pagese: adresat shkëmbehen privatisht me çdo kontakt dhe ndërrohen, kështu që pagesa me emër nuk e bën publike se ku shkojnë paratë tuaja. Të dyja janë zinxhirë transparentë, prandaj analiza e zinxhirit vlen ende për vetë monedhat.";
+
+/* Identities */
+"On Network" = "Në rrjet";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Sapo %@ ta pranojë kërkesën tuaj, do të mund të paguani drejtpërdrejt te emri i përdoruesit";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Një nyje në një kohë";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Vetëm masternode-t dhe evonode-t mund të votojnë për emrat e përdoruesve. Kjo kuletë nuk përmban çelësa aktivë votimi masternode.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operatori";
+
+/* Masternode keys */
+"Operator keys" = "Çelësat e operatorit";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Çelësi publik i operatorit (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ose";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Rezultate të tjera";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Dalja %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Daljet (%d)";
+
+/* Masternodes */
+"Owner" = "Pronari";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adresa e pronarit";
+
+/* Masternodes */
+"Owner key hash" = "Hash-i i çelësit të pronarit";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Paguar nga balanca e kreditit të identitetit tuaj.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Ngjitni lidhjen e ftesës që morët, ose skanoni kodin e saj QR. Ajo financon regjistrimin e emrit tuaj të përdoruesit.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "paguani drejtpërdrejt te emri i përdoruesit";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Paguani njerëz, jo adresa";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Ngarkesa (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Pagesat janë private: adresat që shkëmbeni me një kontakt udhëtojnë brenda një përmbajtjeje të fshehtëzuar që vetëm ju të dy mund ta lexoni dhe nuk botohen kurrë — prandaj pagesat tuaja nuk lidhen lehtë me emrin tuaj të përdoruesit. Megjithatë ato mbeten pagesa të zakonshme në një zinxhir transparent: një analizë e sofistikuar e zinxhirit mund të nxjerrë informacion. Shielded DashPay (së shpejti) do ta mbyllë atë boshllëk. Vetë kërkesat për kontakt aktualisht NUK janë private: kushdo mund të shohë se dy identitete janë të lidhura. Kërkesat private për kontakt janë një veçori që vjen së shpejti. Emri juaj i përdoruesit dhe profili janë gjithashtu publikë në Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Pagesat konfirmohen brenda sekondash me InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Pagesat e bëra drejtpërdrejt te adresat nuk do të ruhen në aktivitet.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Pagesat me çdo kontakt grupohen në një vend, me emra dhe profile në vend të transaksioneve të papërpunuara.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adresa e pagesës";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Adresë Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Balanca Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nyje Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID-ja e nyjes Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Pagesat Platform nuk e identifikojnë dërguesin. Kjo pagesë u regjistrua kur kuleta vuri re ndryshimin e balancës — mund të ketë mbërritur më herët.";
+
+"Platform SDK not ready" = "SDK-ja e Platform nuk është gati";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Sinkronizimi i Platform nuk po ekzekutohet. Hapni Informacioni i sinkronizimit → Statusi i sinkronizimit të Platform për ta nisur.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → I mbrojtur";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Përdorur më parë më: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat nga vetë dizajni";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Kërkesat private për kontakt (që të mbetet private se me kë lidheni), Shielded DashPay — pagesa për kontaktet nga balanca juaj private e mbrojtur — dhe pagesat për përdorues që ende nuk janë te kontaktet tuaja, të gjitha vijnë së shpejti.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Kërkesat private për kontakt janë në zhvillim dhe priten rreth shtatorit–tetorit 2026. Sot vetë kërkesa është publike — kushdo mund të shohë se dy identitete janë të lidhura, edhe pse të dhënat e pagesës brenda saj janë të fshehtëzuara. Sapo të dalin kërkesat private për kontakt, do të mund të zgjidhni nëse miqësia juaj do të jetë publike apo private.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Kërkesa private për kontakt, Shielded DashPay dhe pagesa për njerëz që ende nuk janë kontakte.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Adresat private të pagesës shkëmbehen mes jush dhe kontakteve tuaja. Vetëm ju dhe kontakti juaj e dini marrësin dhe dërguesin e pagesave mes jush.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Pagesa private";
+
+/* Usernames */
+"Private registration" = "Regjistrim privat";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Koha e përpunimit";
+
+/* Balance info sheet section */
+"Pros" = "Përparësitë";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transaksionet e ofruesit";
+
+/* Masternode keys */
+"Public key" = "Çelës publik";
+
+/* Masternode keys */
+"Public key (legacy)" = "Çelës publik (i vjetër)";
+
+/* Identities */
+"Public keys" = "Çelësa publikë";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Qëllimi";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Transaksion i papërpunuar";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Transaksioni i papërpunuar nuk është i disponueshëm";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Rikontrollon filtrat kompaktë të blloqeve nga lartësia e zgjedhur për transaksionet e kësaj kuletë, duke i shkarkuar dhe përputhur sërish. Riskanimet kufizohen poshtë nga lartësia e krijimit të kuletës dhe nga të dhënat e zinxhirit të ruajtura lokalisht — për të rikthyer historikun më të hershëm, ulni më mirë lartësinë fillestare të kuletës.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Vetëm për lexim";
+
+/* Usernames */
+"Ready around %@" = "Gati rreth %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Arsyeja";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Marrë nga %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "I regjistron masternode-t tuaj si të votuar, pa mbajtur anë.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Rifresko";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Regjistruar më";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Regjistrimi privat kërkon të paktën %@ Dash në balancën tuaj të mbrojtur plus disa orë prehje — ekranet e ardhshme do t'ju udhëheqin.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Regjistrimi";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Po kërkon këtë emër";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Kuletat e rikthyera nuk mund ta rikuperojnë gjithmonë llojin e veprimit. Ky zë u rindërtua nga të dhënat e shënimit në zinxhir.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Risinkronizimi u përgatit nga lartësia %u — mbyllni dhe rihapni aplikacionin që të fillojë.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "të ruani historikun e përbashkët të transaksioneve";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "I tërhequr";
 
 /* No comment provided by engineer. */
 "Retry" = "Provo prapë";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Revokimi";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshot mund të shihen nga aplikacionet dhe pajisjet tjera. Gjenero një frazë tjetër rikthyese dhe mbaje sekret.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Nënshkrimi i skriptit";
+
+/* Raw transaction inspector */
+"Script type" = "Lloji i skriptit";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Kërko një kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Kërko një kërkesë kontakti";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Kërko një përdorues në rrjetin Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Kërko një emër përdoruesi";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultatet e kërkimit për \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Kërko emra përdoruesish";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Po kërkohet emri i përdoruesit %@ në rrjetin Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Niveli i sigurisë";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Zgjidh të gjitha";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Zgjidhni të paktën një masternode me të cilin të votoni.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Zgjedhja e më pak nyjeve zbulon më pak se cilët masternode-t drejtoni.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Dërgo te një kontakt";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Dërgoni te një emër përdoruesi që vërtet mund ta mbani mend dhe ta verifikoni.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Dërgoni kërkesën tuaj të parë për kontakt";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Po dërgohet kërkesa për kontakt";
+
+/* No comment provided by engineer. */
+"Sending to" = "Po dërgohet te";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Dërguar te %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Shërbimi";
+
+/* Identities */
+"Set as Main" = "Vendos si kryesor";
+
+/* Identities */
+"Set as Main Identity" = "Vendos si identitet kryesor";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Pishina e përbashkët e privatësisë është në madhësinë minimale";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Adresë e mbrojtur";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Shpenzim i mbrojtur";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Po niset kuleta e mbrojtur…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "I mbrojtur → Platform";
+
+"Shielded → Transparent" = "I mbrojtur → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Madhësia";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Disa nga masternode-t tuaj mund të mungojnë në këtë listë — kuleta nuk e lexoi dot të gjithë grupin e çelësave tuaj të votimit. Përfundoni sinkronizimin dhe rihapni këtë ekran.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Rendit kontaktet";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Ngarkesë e veçantë";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Fillon pasi të shtoni fonde";
+
+/* Transaction details */
+"Status" = "Statusi";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Ruajtur si";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacioni i sinkronizimit";
+
+/* SPV sync */
+"Sync too slow?" = "Sinkronizimi është shumë i ngadaltë?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Mos mbani anë";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Prekni për të kopjuar";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Çelësi i nyjes Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash mbërrin te adresa e marrësit pasi rrjeti të përpunojë tërheqjen — kjo mund të zgjasë deri në 10 minuta.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash mbërrin te adresa e marrësit sapo rrjeti të përpunojë tërheqjen.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash mbërrin te balanca juaj transparente sapo rrjeti të përpunojë tërheqjen.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Identiteti kryesor mund të zgjidhet vetëm nga kuleta aktive";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Vendi më privat për të mbajtur Dash-in tuaj";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Rreshti i ruajtur i kuletës nuk ka rrjet — nuk mund të përgatitet një risinkronizim.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Regjistrimi u dërgua, por rezultati i tij nuk u konfirmua dot. Prisni një minutë që kuleta të sinkronizohet, pastaj provoni sërish — mos e ridërgoni menjëherë.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Pishina e përbashkët e privatësisë ende po rritet (%1$ld nga %2$ld depozita). Regjistrimi privat zhbllokohet sapo të arrijë minimumin.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Pishina e përbashkët e privatësisë ende po rritet (%1$ld nga %2$ld depozita). Provoni sërish sapo të arrijë minimumin.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Lartësia e krijimit të kuletës — kufiri i poshtëm për skanimet e filtrave dhe për riskanimet „Nga krijimi i kuletës“. Vendoseni në nivelin e financimit të parë të kuletës ose më poshtë; importet përdorin si parazgjedhje 200000 në mainnet dhe 0 në testnet. Ruajtja e një lartësie të barabartë ose më të ulët se aktualja i pastron të dhënat e zinxhirit të këtij rrjeti në nisjen e ardhshme dhe riskanon që nga ajo.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "atë (po merret informacioni)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nuk ka njoftime të reja";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nuk ka përdorues që përputhen me emrin %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Te kontaktet tuaja nuk ka përdorues që përputhen me emrin %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Këto fonde kalojnë te balanca juaj Platform dhe janë gati për t'u shpenzuar sapo transferimi të përfundojë.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Kjo adresë nuk mund të paguhet nga balanca juaj %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Kjo i shton identitetit tuaj dy çelësa që përdoruesit e tjerë t'ju dërgojnë kërkesa për kontakt dhe që ju të pranoni të tyret. Kjo ndodh vetëm një herë.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Kjo zbaton një zgjedhje të vetme për të gjithë %d emrat e përzgjedhur të përdoruesve.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Kjo lidhje ftese nuk është e vlefshme.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Kjo nuk është adresë e vlefshme Dash për këtë rrjet";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Kjo nuk është lidhje e vlefshme ftese";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ky është identiteti juaj kryesor";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ky masternode ende nuk ka identitet Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Kjo prapë llogaritet sikur masternode-t tuaj kanë votuar në këtë kontest.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Bajtat e papërpunuar të këtij transaksioni nuk janë ruajtur në këtë pajisje.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ky emër përdoruesi i shkoi dikujt tjetër";
+
+"This wallet could not derive the voting key for this node." = "Kjo kuletë nuk e derivoi dot çelësin e votimit për këtë nyje.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Kjo kuletë nuk përmban çelësa aktivë votimi masternode, prandaj nuk mund të votojë. Nyjet e regjistruara shfaqen te Mjetet → Masternode-t.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Kjo tërheq të gjithë balancën tuaj Platform në një transferim të vetëm. Dash mbërrin te adresa e marrësit sapo rrjeti të përpunojë tërheqjen.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Kjo tërheq të gjithë balancën tuaj Platform në një transferim të vetëm. Dash mbërrin te balanca juaj transparente sapo rrjeti të përpunojë tërheqjen.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Historiku i transaksioneve nuk është i disponueshëm";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID-ja e transaksionit";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Transferim hyrës";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Transferim dalës";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transferimet zgjasin më shumë — ndërtimi i provave të privatësisë kërkon kohë";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Transferimet te adresa të tjera Platform dhe te adresa të mbrojtura janë të menjëhershme dhe përfundimtare";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Adresë transparente";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Balancë transparente";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Financimi transparent e lidh publikisht emrin tuaj të përdoruesit me këto fonde.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → I mbrojtur";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nuk mund të jepen sugjerime";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Lloj i veçantë i panjohur %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "I pambrojtur";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Përmirëso në Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Përdor më mirë balancën transparente";
+
+/* Masternode keys */
+"Used" = "I përdorur";
+
+/* Masternode keys */
+"Used at: " = "Përdorur më: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Përdoruesi (po merret informacioni)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Emrat e përdoruesve";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Emrat e përdoruesve ruhen në formë të normalizuar për të parandaluar emrat e ngjashëm, prandaj kjo mund të ndryshojë nga ajo që shkroi secili person.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Emra përdoruesish, jo adresa";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Përdorues që përputhen me %@ dhe që aktualisht nuk janë te kontaktet tuaja";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Përdor një nga bibliotekat me njohuri zero më të audituara dhe të testuara (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Ftesë e vlefshme";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Verifikuar gjatë regjistrimit";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Versioni";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Shumë efikas me tarifa të ulëta";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Shiko të gjitha";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Shiko transaksionin";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Voto";
+
+"Vote cast" = "Vota u dha";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Votoni për emra përdoruesish të kontestuar";
+
+"Vote on several" = "Voto për disa";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Voto me";
+
+"Votes that nobody should receive these usernames." = "Voton që askush të mos i marrë këta emra përdoruesish.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresa e votimit";
+
+"Voting ended with no winner" = "Votimi përfundoi pa fitues";
+
+"Voting ends" = "Votimi përfundon";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Votimi është në vazhdim";
+
+"Voting in progress — lock votes are ahead" = "Votimi është në vazhdim — votat e kyçjes janë përpara";
+
+"Voting in progress — you are ahead" = "Votimi është në vazhdim — ju jeni përpara";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash-i i çelësit të votimit";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Votimi për këtë emër përdoruesi është mbyllur. Numrat më poshtë janë të fundit të lexuar.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Votimi për „%@“ tashmë është mbyllur. Rifreskoni për të parë rezultatin.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Po pritet Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Lartësia fillestare e kuletës";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Po Unstoppable Domains dhe shërbimet e ngjashme të emrave?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Sa kushton?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Çfarë është DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Çfarë vjen më pas?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kur do të bëhen private kërkesat për kontakt?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Kush po e kërkon këtë emër";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Pse duhet ta aktivizoj?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Tërheq të gjithë balancën";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Funksionon me çdo kuletë, këmbim dhe tregtar Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Ju";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Pranuat kërkesën për kontakt nga %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Aktualisht nuk keni asnjë kontakt";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Deri tani keni %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Dërguat kërkesën për kontakt te %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "E fituat këtë emër përdoruesi";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Gjithçka është gati. Përdoruesit e tjerë tani mund t'ju dërgojnë kërkesa për kontakt — dhe ju mund të dërgoni tuajat.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Identiteti juaj Dash Platform shfaqet këtu sapo të regjistroni një emër përdoruesi.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Historiku juaj, i organizuar";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Identiteti juaj ka nevojë për dy çelësa shtesë që kërkesat për kontakt të mund të fshehtëzohen mes jush dhe përdoruesve të tjerë. Aktivizimi i shton ata me një transaksion të vetëm rrjeti. Kjo ndodh vetëm një herë.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Ftesa juaj e paguan tarifën e regjistrimit për këtë emër përdoruesi.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Balanca juaj kryesore Dash në blockchain-in Core — ajo që dërgoni dhe merrni me kuleta, këmbime dhe tregtarë të tjerë.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Monedhat tuaja të përziera u zhvendosën te balanca e kuletës suaj Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Monedhat tuaja të përziera u zhvendosën te balanca juaj e mbrojtur. Për privatësinë më të mirë, prisni të paktën 2 orë para se t'i përdorni këto fonde.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Balanca juaj Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Balanca juaj private. Shumat dhe adresat janë të fshehtëzuara në zinxhir, kështu që zotërimet dhe historiku juaj mbeten konfidenciale.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Balanca juaj e mbrojtur";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Balanca juaj e mbrojtur është gati — do të mund të regjistroheni privatisht rreth %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Balanca juaj e mbrojtur është gati — regjistroni emrin tuaj të përdoruesit privatisht tani";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Balanca juaj e mbrojtur po prehet — do të mund të regjistroheni privatisht rreth %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Balanca juaj e mbrojtur ende po piqet. Do të jetë gati rreth %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Balanca juaj transparente";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Emri juaj i përdoruesit është i dukshëm për të gjithë. Financimi i tij nga balanca juaj e mbrojtur — pasi t'i lini fondet të prehen disa orë — do të thotë se askush nuk mund ta lidhë emrin tuaj të përdoruesit me Dash-in tuaj tjetër.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Emri juaj i përdoruesit, profili dhe kontaktet ndjekin këtë identitet.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Emri juaj i përdoruesit, profili dhe kontaktet do të ndjekin këtë identitet.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Votat tuaja";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Kuleta juaj ende po sinkronizohet me rrjetin Dash. Dërgimi do të jetë i disponueshëm pasi të përfundojë sinkronizimi.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Kuleta juaj ende po sinkronizohet. Dërgimi nga balanca juaj transparente do të jetë i disponueshëm pasi të përfundojë sinkronizimi.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ nuk u lexua dot si emër përdoruesi Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ u regjistrua. Të dërgohet një kërkesë kontakti te personi që ju ftoi?";

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Të gjitha nyjet njëherësh";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Të gjithë masternode-t tuaj kanë votuar për këtë emër përdoruesi. Për të ndryshuar një votë, votoni sërish nga kandidati që tani preferoni.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Të gjithë masternode-t tuaj kanë votuar për këtë emër përdoruesi. Për të ndryshuar një votë, votoni sërish për kandidatin që tani preferoni.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/sq.lproj/Localizable.stringsdict
+++ b/DashWallet/sq.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ të numëruara për „%2$@“</string>
+		<string>%#@votes@ për „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u votë</string>
+			<string>%1$u votë e numëruar</string>
 			<key>other</key>
-			<string>%1$u vota</string>
+			<string>%1$u vota të numëruara</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -133,7 +133,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d nga %#@nodes@ votuan</string>
+		<string>Votim: %1$d nga %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -149,7 +149,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d nga %#@nodes@ votuan</string>
+		<string>Votim: %1$d nga %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/sq.lproj/Localizable.stringsdict
+++ b/DashWallet/sq.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ të numëruara për „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u votë</string>
+			<key>other</key>
+			<string>%1$u vota</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>U votua për %1$d nga %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d emër përdoruesi</string>
+			<key>other</key>
+			<string>%2$d emra përdoruesish</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Jep %u votë</string>
+			<key>other</key>
+			<string>Jep %u vota</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d nga %#@nodes@ votuan</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternode</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d nga %#@nodes@ votuan</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nyje</string>
+			<key>other</key>
+			<string>%2$d nyje</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u votë gjithsej</string>
+			<key>other</key>
+			<string>%u vota gjithsej</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternode</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d i zgjedhur</string>
+			<key>other</key>
+			<string>%d të zgjedhur</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d nga nyjet tuaja ka votuar tashmë këtu dhe nuk është në listë.</string>
+			<key>other</key>
+			<string>%d nga nyjet tuaja kanë votuar tashmë këtu dhe nuk janë në listë.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u votë për çdo kontest — evonode-t numërohen si 4, masternode-t si 1</string>
+			<key>other</key>
+			<string>%u vota për çdo kontest — evonode-t numërohen si 4, masternode-t si 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voto për %d emër përdoruesi</string>
+			<key>other</key>
+			<string>Voto për %d emra përdoruesish</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u votë</string>
+			<key>other</key>
+			<string>%u vota</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Voto ×%d</string>
+			<key>other</key>
+			<string>Voto ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d kërkesë</string>
+			<key>other</key>
+			<string>%d kërkesa</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Svi čvorovi odjednom";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodovi glasali su o ovom korisničkom imenu. Da biste promenili glas, glasajte ponovo od kandidata kojeg sada preferirate.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodovi glasali su o ovom korisničkom imenu. Da biste promenili glas, glasajte ponovo za kandidata kojeg sada preferirate.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
@@ -3069,7 +3069,7 @@
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
 
-"Records your masternodes as having voted, without taking a side." = "Beleži vaše masternodove kao da su glasali, bez staja na nečiju stranu.";
+"Records your masternodes as having voted, without taking a side." = "Beleži vaše masternodove kao da su glasali, bez zauzimanja strane.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " ili ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ nije pronađen na Dash mreži da bi mu se poslao zahtev za kontakt.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash dostupno";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ je prihvatio vaš zahtev za kontakt";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bajtova";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld od %ld depozita";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Kreditno stanje na Dash Platform koje se koristi za trenutna plaćanja između Platform adresa i za funkcije poput korisničkih imena.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Opis";
 
+/* DashPay FAQ title */
+"About DashPay" = "O DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Uzdrži se";
+
+"Abstain on “%@”" = "Uzdrži se povodom „%@“";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktivan";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivnost";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktivnost je javna, ali je nije lako pratiti";
+
 /* No comment provided by engineer. */
 "Add" = "Dodaj";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Dodaj %@ kao kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Dodajte %@ kao kontakt da biste plaćali direktno na korisničko ime i zadržali zajedničku istoriju transakcija";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Dodajte %@ Dash u svoje zaštićeno stanje i pustite ga da odstoji nekoliko sati kako biste se registrovali bez povezivanja korisničkog imena sa ostalim sredstvima.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Dodajte najmanje %@ Dash u svoje zaštićeno stanje";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Dopunite zaštićeno stanje sada i registrujte korisničko ime privatno nekoliko sati kasnije";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "Svi čvorovi odjednom";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Svi vaši masternodovi glasali su o ovom korisničkom imenu. Da biste promenili glas, glasajte ponovo od kandidata kojeg sada preferirate.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Gotovo trenutna sinhronizacija stanja";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Iznosi i adrese su javni na blokčejnu";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ethereum nalog je jedna adresa koja se ponovo koristi: celo vaše stanje i istorija plaćanja javno stoje pod njom, a ime (na primer ENS domen) obično pokazuje pravo na tu adresu, tako da je svako može razrešiti. DashPay je suprotno postavljen — ime vodi do identiteta, a ne do adrese za plaćanje, a stvarne adrese za plaćanje ostaju unutar šifrovanih razmena sa kontaktima, nove za svaki kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Svako ko zna adresu može pogledati njenu istoriju";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Odobri";
+
+"Approving a specific request can only be done one username at a time." = "Odobravanje konkretnog zahteva moguće je samo za jedno korisničko ime odjednom.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Kao tekst";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Provera identiteta je otkazana. Vaš glas nije predat.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Provera identiteta nije uspela. Vaš glas nije predat.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Dodeli „%@“ ovom kandidatu";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Stanje";
 
 /* CrowdNode */
+"Balance after" = "Stanje nakon toga";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Stanja i prenosi nisu javno vidljivi";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Početna visina je sačuvana — povišeni prag skeniranja važi od sledećeg pokretanja.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Vezan za ugovor";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Vezan za ugovor, tip dokumenta „%@“";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Samo pregled";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Pakuje nedavne dijagnostičke zapise u zip da biste ih poslali preko AirDrop-a, mejlom ili sačuvali u Datoteke";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Predaj glas";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Promeni čvorove";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Provera…";
+
+"Choice" = "Izbor";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Preuzmite svoju pozivnicu";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Stanje koje se može preuzeti";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Obriši i ponovo sinhronizuj";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Obrisati podatke lanca i ponovo sinhronizovati?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Zatvara se";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (novi novčići)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin više nije podržan — izaberite gde da premestite svoje pomešane novčiće.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Kolateral";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Uskoro";
+
+/* Shielded transfer status */
+"Completed" = "Završeno";
 
 /* No comment provided by engineer. */
 "Confirm" = "Potvrdi";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Potvrđena";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Potvrda čuva početnu visinu %u i briše podatke lanca ove mreže pri sledećem pokretanju aplikacije, ponovo ih preuzima i skenira filtere od te visine. Aktuelna sesija zadržava stari prag skeniranja — zatvorite i ponovo otvorite aplikaciju da biste počeli.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Povezani čvorovi";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Mane";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Zahtev za kontakt nije uspeo";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Zahtev za kontakt poslat korisniku %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Zahtevi za kontakt";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Kandidat %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Nastavite da izaberete svoje korisničko ime. Pozivnica plaća naknadu za registraciju.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiraj sirovu transakciju";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Nije moguće napraviti arhivu zapisa: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Ne može da se pronadje kurs za razmenu.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Nije moguće osvežiti %d identiteta";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Nije moguće preuzeti stanje (mrežna greška). Pokušajte da osvežite.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Napravite svoje korisničko ime, pronađite prijatelje i porodicu po njihovim korisničkim imenima i dodajte ih u kontakte";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediti";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform još nije indeksirao ovaj spor. Broj glasova pojaviće se ovde kada to uradi.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform još nije povezan. Sačekajte da se sinhronizacija završi i pokušajte ponovo.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash poslat na pogrešnu adresu ne može se povratiti. Uverite se da je adresa tačno ona kojoj želite da platite.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash čuva korisnička imena u obliku otpornom na slične zapise, pa se sačuvano ime može razlikovati od onoga što je svako ukucao.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Stanje Dash novčanika";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay je omogućen";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay je Dash-ov društveni doživljaj plaćanja, izgrađen na Dash Platform. Registrujete korisničko ime, dodajete druge korisnike kao kontakte i plaćate im po imenu — nema više kopiranja adresa.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay zamenjuje duge i nerazumljive adrese korisničkim imenima. Dodajte prijatelje kao kontakte, pošaljite novac na ime i držite svako plaćanje uredno po osobi.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Rok nepoznat";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Putanja izvođenja";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Onemogućen";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Gotovo";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Gotovo — vaše stanje je odstajalo dovoljno dugo";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Proverite adresu još jednom";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Svaki masternod ima jedan važeći glas po sporu. Možete ga kasnije promeniti, ali Dash Platform dozvoljava ukupno samo 5 glasova po masternodu po sporu.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Svaki dodir dodaje još jedan čvor u glasanje, pa vi birate koliko će ih biti povezano.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Izmeni početnu visinu";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Omogući";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Omogući DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Omogućavanje DashPay-a košta malu jednokratnu mrežnu naknadu, plaćenu iz kreditnog stanja vašeg identiteta. Tačna procena se prikazuje pre nego što potvrdite. Slanje zahteva za kontakt i plaćanja košta uobičajene mrežne naknade.";
+
+"Ending soonest" = "Najranije se završava";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Procenjena mrežna provizija";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Svi čvorovi glasaju zajedno. Brže je, ali javno povezuje vaše masternodove međusobno.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operaterski ključevi Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Izvezi zapise";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Spoljna adresa";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Limit u prepoznavanju lica";
+
+/* No comment provided by engineer. */
+"Failed" = "Neuspešno";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Preuzimanje…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtriraj";
+
+/* SPV sync phase */
+"Filter headers" = "Zaglavlja filtera";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Pronađite korisnika na Dash mreži";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Pronađi identitete";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Pronađeno je %d novih identiteta";
+
+/* Identities */
+"Found 1 new identity" = "Pronađen je 1 novi identitet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finansirajte svoje korisničko ime iz zaštićenog stanja. Dodajte sredstva nekoliko sati unapred — kratko odstajavanje čini da se vaše korisničko ime ne može povezati sa ostalim vašim Dash sredstvima.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finansirano iz vašeg zaštićenog stanja — vaše korisničko ime ne može se povezati sa ostalim vašim Dash sredstvima.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Sredstva zaključana — prenos se završava";
+
+/* CoinJoin */
+"Funds moved" = "Sredstva premeštena";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Pripremite se da se pridružite DashPay-u";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Razumem";
+
+/* Governance */
+"Governance" = "Upravljanje";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "je zatražio da vam bude prijatelj";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Imate pozivnicu?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Zaglavlja";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Visina %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Više naknade, oko 7 centi (i dalje niže nego kod drugih blokčejnova sa sličnom privatnošću)";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Kako se ovo poredi sa Bitcoin-om po pitanju privatnosti?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Kako se ovo poredi sa Ethereum nalozima po pitanju privatnosti?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Koliko je DashPay privatan?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Zapisao sam";
 
+/* Identities */
+"Identities" = "Identiteti";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Krediti identiteta";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Indeks identiteta";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Registracija identiteta";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Dopuna identiteta";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Neaktivan";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Ulaz %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Ulaz %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Ulazi (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Pozivnica od %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Pozovite nekoga da se pridruži Dash mreži";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Pozovite prijatelje i porodicu na Dash mrežu";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Zadržite ove novčiće privatnim. Primenjuju se mrežne naknade i naknade za privatnost.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ključ br. %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Podaci ključa";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Vlasništvo nad ključem";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Ključevi";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Vodi";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Saznaj više";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Učitavanje transakcija";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Lokalna valuta";
 
+/* Identities */
+"Local Only" = "Samo lokalno";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Zaključaj";
+
+"Lock the name" = "Zaključaj ime";
+
+"Lock “%@” so nobody gets it" = "Zaključaj „%@“ da ga niko ne dobije";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "Zaključano — niko ne dobija ovo korisničko ime";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Niske naknade za svakodnevnu potrošnju";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Glavni";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Privezak ključeva masternoda";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Lista masternodova";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Glasovi masternodova";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternodovi";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternodovi i evonodovi registrovani ključevima ovog novčanika pojaviće se ovde nakon što se novčanik sinhronizuje.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternodovi i evonodovi koji koriste ključeve ovog novčanika";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternodovi glasaju o imenima koja je zatražilo više od jedne osobe. Bićete obavešteni kada se glasanje završi.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Minimum je dostignut";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Još predloga";
+
+"Most lock votes" = "Najviše glasova za zaključavanje";
+
+"Most votes" = "Najviše glasova";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Premestite u svoje uobičajeno raspoloživo stanje.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Premeštanje sredstava";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Servisi imena poput Unstoppable Domains povezuju čitljivo ime sa fiksnom javnom adresom na lancu. Svako može razrešiti to ime i videti svako plaćanje koje mu je ikada poslato. DashPay korisničko ime nikada se javno ne razrešava do adrese za plaćanje — adrese se otkrivaju samo unutar šifrovane razmene sa svakim kontaktom, pa vaše ime i vaš novac za spoljne posmatrače ostaju nepovezani.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Zahteva pažnju";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Na ovom uređaju nisu pronađeni dijagnostički zapisi. Zapisi se beleže od sledećeg pokretanja.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Nema identiteta";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Još nema masternodova";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Nema odgovarajućih sporova";
+
+/* Identities */
+"No new identities were found for this wallet" = "Za ovaj novčanik nisu pronađeni novi identiteti";
+
+"No open contest matches that search." = "Nijedan otvoren spor ne odgovara toj pretrazi.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Nijedan otvoren spor ne odgovara toj pretrazi. Imena se čuvaju u normalizovanom obliku, pa se „alice“ navodi kao „a11ce“.";
+
+"No open contests" = "Nema otvorenih sporova";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Za povezani novčanik nije pronađen sačuvan zapis.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Još nema dostupne Platform adrese za rezervnu zaštićenu registraciju. Pokušajte ponovo nakon što se novčanik sinhronizuje.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Trenutno nijedno korisničko ime nije sporno. Spor se otvara kada dve ili više osoba zatraže isto ime.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Nijedan glas nije predat";
+
+"Nobody gets it" = "Niko ga ne dobija";
+
+/* SPV sync peer type */
+"Node" = "Čvor";
+
+/* Raw transaction inspector */
+"Non-standard" = "Nestandardan";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Još nije dostupno";
+
+"Not cast" = "Nije predat";
+
+/* Masternodes */
+"Not checked yet" = "Još nije provereno";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Nedovoljno zaštićenog stanja za registraciju identiteta";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Nije u istoriji novčanika";
+
+"Not now" = "Ne sada";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Trgovci ga ne prihvataju široko";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Trgovci ga još ne prihvataju široko";
+
+/* Masternode keys */
+"Not yet used" = "Još nije korišćen";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Na Bitcoin-u ne postoji sloj imena, pa ljudi otvoreno dele i ponovo koriste adrese — čim je adresa poznata, sve što je ikada primila može se povezati sa njenim vlasnikom. Uz DashPay vaše korisničko ime je javno, ali nikada ne pokazuje na adresu za plaćanje: adrese se privatno razmenjuju sa svakim kontaktom i smenjuju se, pa plaćanje po imenu ne objavljuje kuda vaš novac ide. Oba su transparentni lanci, pa se analiza lanca i dalje odnosi na same novčiće.";
+
+/* Identities */
+"On Network" = "Na mreži";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Kada %@ prihvati vaš zahtev, moći ćete da plaćate direktno na korisničko ime";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Jedan po jedan čvor";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Samo masternodovi i evonodovi mogu da glasaju o korisničkim imenima. Ovaj novčanik ne sadrži aktivne ključeve za glasanje masternodova.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operater";
+
+/* Masternode keys */
+"Operator keys" = "Operaterski ključevi";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Javni ključ operatera (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "ili";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Drugi ishodi";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Izlaz %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Izlazi (%d)";
+
+/* Masternodes */
+"Owner" = "Vlasnik";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Adresa vlasnika";
+
+/* Masternodes */
+"Owner key hash" = "Heš ključa vlasnika";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Plaćeno iz kreditnog stanja vašeg identiteta.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Nalepite link pozivnice koji ste dobili ili skenirajte njegov QR kod. On finansira registraciju vašeg korisničkog imena.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "plaćate direktno na korisničko ime";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Plaćajte ljudima, a ne adresama";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload heks";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Plaćanja su privatna: adrese koje razmenjujete sa kontaktom putuju unutar šifrovanog sadržaja koji možete pročitati samo vas dvoje i nikada se ne objavljuju — pa se vaša plaćanja ne mogu lako povezati sa vašim korisničkim imenom. Ipak, i dalje su to obična plaćanja na transparentnom lancu: napredna analiza lanca može otkriti informacije. Shielded DashPay (uskoro) zatvoriće taj procep. Sami zahtevi za kontakt trenutno NISU privatni: svako može videti da su dva identiteta povezana. Privatni zahtevi za kontakt su funkcija koja stiže uskoro. Vaše korisničko ime i profil su takođe javni na Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Plaćanja se potvrđuju za nekoliko sekundi uz InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Plaćanja izvršena direktno na adrese neće se čuvati u aktivnosti.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Plaćanja sa svakim kontaktom grupisana su na jednom mestu, sa imenima i profilima umesto sirovih transakcija.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Adresa isplate";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform adresa";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform stanje";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform čvor";
+
+/* Masternode keys */
+"Platform Node ID" = "ID Platform čvora";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform plaćanja ne identifikuju pošiljaoca. Ovo plaćanje je zabeleženo kada je novčanik primetio promenu stanja — možda je stiglo i ranije.";
+
+"Platform SDK not ready" = "Platform SDK nije spreman";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform sinhronizacija nije pokrenuta. Otvorite Informacije o sinhronizaciji → Status Platform sinhronizacije da biste je pokrenuli.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Zaštićeno";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Prethodno korišćen: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privatan po dizajnu";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privatni zahtevi za kontakt (da ostane privatno sa kim se povezujete), Shielded DashPay — plaćanja kontaktima iz vašeg privatnog zaštićenog stanja — i plaćanja korisnicima koji još nisu u vašim kontaktima, sve to stiže uskoro.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privatni zahtevi za kontakt su u izradi i očekuju se oko septembra–oktobra 2026. Danas je sam zahtev javan — svako može videti da su dva identiteta povezana, iako su podaci o plaćanju u njemu šifrovani. Kada privatni zahtevi za kontakt budu dostupni, moći ćete da birate da li će vaše prijateljstvo biti javno ili privatno.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privatni zahtevi za kontakt, Shielded DashPay i plaćanje ljudima koji još nisu kontakti.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privatne adrese za plaćanje razmenjuju se između vas i vaših kontakata. Samo vi i vaš kontakt znate primaoca i pošiljaoca plaćanja između vas.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privatna plaćanja";
+
+/* Usernames */
+"Private registration" = "Privatna registracija";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Vreme obrade";
+
+/* Balance info sheet section */
+"Pros" = "Prednosti";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Transakcije provajdera";
+
+/* Masternode keys */
+"Public key" = "Javni ključ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Javni ključ (stari)";
+
+/* Identities */
+"Public keys" = "Javni ključevi";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Svrha";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Sirova transakcija";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Sirova transakcija nije dostupna";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Ponovo proverava kompaktne blok filtere od izabrane visine radi transakcija ovog novčanika, tako što ih ponovo preuzima i uparuje. Ponovna skeniranja su odozdo ograničena visinom kreiranja novčanika i lokalno sačuvanim podacima lanca — da biste povratili stariju istoriju, umesto toga smanjite početnu visinu novčanika.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Samo za čitanje";
+
+/* Usernames */
+"Ready around %@" = "Spremno oko %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Razlog";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Primljeno od %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Beleži vaše masternodove kao da su glasali, bez staja na nečiju stranu.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Osveži";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrovan";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privatna registracija zahteva najmanje %@ Dash u zaštićenom stanju i nekoliko sati odstajavanja — sledeći ekrani će vas voditi kroz postupak.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registracija";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Traži ovo ime";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Obnovljeni novčanici ne mogu uvek da povrate tip operacije. Ovaj unos je rekonstruisan iz podataka beleške na lancu.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Ponovna sinhronizacija pripremljena od visine %u — zatvorite i ponovo otvorite aplikaciju da biste počeli.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "zadržali zajedničku istoriju transakcija";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Povučen";
 
 /* No comment provided by engineer. */
 "Retry" = "Pokušaj opet";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Opoziv";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Screenshot-ovi su vidljivi drugim aplikacijama i uređajima. Generišite novu frazu za oporavak i čuvajte je u tajnosti.";
 
+/* Raw transaction inspector */
+"Script" = "Skripta";
+
+/* Raw transaction inspector */
+"Script signature" = "Potpis skripte";
+
+/* Raw transaction inspector */
+"Script type" = "Tip skripte";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Pretraži kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Pretraži zahtev za kontakt";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Pretraži korisnika na Dash mreži";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Pretraži korisničko ime";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Rezultati pretrage za \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Pretraži korisnička imena";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Traženje korisničkog imena %@ na Dash mreži";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Nivo bezbednosti";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Izaberi sve";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Izaberite bar jedan masternod sa kojim ćete glasati.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Izbor manjeg broja čvorova otkriva manje o tome koje masternodove držite.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Pošalji kontaktu";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Pošaljite na korisničko ime koje zaista možete da zapamtite i proverite.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Pošaljite svoj prvi zahtev za kontakt";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Slanje zahteva za kontakt";
+
+/* No comment provided by engineer. */
+"Sending to" = "Slanje na";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Poslato korisniku %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Servis";
+
+/* Identities */
+"Set as Main" = "Postavi kao glavni";
+
+/* Identities */
+"Set as Main Identity" = "Postavi kao glavni identitet";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Zajednički skup privatnosti na minimalnoj veličini";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Zaštićena adresa";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Zaštićena potrošnja";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Pokretanje zaštićenog novčanika…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Zaštićeno → Platform";
+
+"Shielded → Transparent" = "Zaštićeno → Transparentno";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Veličina";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Neki od vaših masternodova možda nedostaju na ovoj listi — novčanik nije mogao da pročita ceo vaš skup ključeva za glasanje. Završite sinhronizaciju i ponovo otvorite ovaj ekran.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortiraj kontakte";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Poseban payload";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Počinje nakon što dodate sredstva";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Sačuvano kao";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Informacije o sinhronizaciji";
+
+/* SPV sync */
+"Sync too slow?" = "Sinhronizacija je prespora?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ne staj ni na čiju stranu";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Dodirnite da kopirate";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ključ Tenderdash čvora (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash stiže na adresu primaoca nakon što mreža obradi isplatu — to može potrajati do 10 minuta.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash stiže na adresu primaoca čim mreža obradi isplatu.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash stiže na vaše transparentno stanje čim mreža obradi isplatu.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Glavni identitet može se izabrati samo iz aktivnog novčanika";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Najprivatnije mesto za čuvanje vaših Dash sredstava";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Sačuvani zapis novčanika nema mrežu — nije moguće pripremiti ponovnu sinhronizaciju.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registracija je poslata, ali njen ishod nije mogao da se potvrdi. Sačekajte minut da se novčanik sinhronizuje, pa pokušajte ponovo — nemojte odmah ponovo slati.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Zajednički skup privatnosti još raste (%1$ld od %2$ld depozita). Privatna registracija se otključava kada dostigne minimum.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Zajednički skup privatnosti još raste (%1$ld od %2$ld depozita). Pokušajte ponovo kada dostigne minimum.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Visina kreiranja novčanika — donja granica za skeniranja filtera i za ponovna skeniranja „Od kreiranja novčanika“. Postavite je na nivo prvog priliva u novčanik ili ispod njega; uvozi podrazumevano koriste 200000 na mainnet-u i 0 na testnet-u. Čuvanje visine jednake trenutnoj ili niže briše podatke lanca ove mreže pri sledećem pokretanju i ponovo skenira od nje.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "njega (Preuzimanje informacija)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Nema novih obaveštenja";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Nema korisnika koji odgovaraju imenu %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "U vašim kontaktima nema korisnika koji odgovaraju imenu %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ova sredstva prelaze na vaše Platform stanje i spremna su za trošenje čim se prenos završi.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Ova adresa ne može da se plati iz vašeg stanja %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Ovo dodaje dva ključa vašem identitetu kako bi vam drugi korisnici mogli slati zahteve za kontakt i kako biste vi mogli da prihvatite njihove. Ovo se dešava samo jednom.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Ovo primenjuje jedan izbor na svih %d izabranih korisničkih imena.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Ovaj link pozivnice nije važeći.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Ovo nije važeća Dash adresa za ovu mrežu";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Ovo nije važeći link pozivnice";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Ovo je vaš glavni identitet";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Ovaj masternod još nema Platform identitet.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Ovo se i dalje računa kao da su vaši masternodovi glasali u ovom sporu.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Sirovi bajtovi ove transakcije nisu sačuvani na ovom uređaju.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Ovo korisničko ime pripalo je nekom drugom";
+
+"This wallet could not derive the voting key for this node." = "Ovaj novčanik nije mogao da izvede ključ za glasanje za ovaj čvor.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ovaj novčanik ne sadrži aktivne ključeve za glasanje masternodova, pa ne može da glasa. Registrovani čvorovi prikazuju se u Alatke → Masternodovi.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ovo isplaćuje celokupno vaše Platform stanje u jednom prenosu. Dash stiže na adresu primaoca čim mreža obradi isplatu.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ovo isplaćuje celokupno vaše Platform stanje u jednom prenosu. Dash stiže na vaše transparentno stanje čim mreža obradi isplatu.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Istorija transakcija nije dostupna";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID transakcije";
 
 /* A verb, button title. */
 "Transfer" = "Prebaci";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Prenos u";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Prenos iz";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Prenosi traju duže — izgradnja dokaza privatnosti zahteva vreme";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Prenosi na druge Platform adrese i na zaštićene adrese su trenutni i konačni";
+
+/* Balance breakdown */
+"Transparent" = "Transparentno";
+
+/* Send screen destination type */
+"Transparent address" = "Transparentna adresa";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparentno stanje";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparentno finansiranje javno povezuje vaše korisničko ime sa ovim sredstvima.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparentno → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparentno → Zaštićeno";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Nije moguće ponuditi predloge";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Nepoznat poseban tip %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Nezaštićeno";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Nadogradi na Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Umesto toga koristi transparentno stanje";
+
+/* Masternode keys */
+"Used" = "Korišćen";
+
+/* Masternode keys */
+"Used at: " = "Korišćen: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Korisnik (Preuzimanje informacija)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Korisnička imena";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Korisnička imena se čuvaju u normalizovanom obliku kako bi se sprečila slična imena, pa se ovo može razlikovati od onoga što je svako ukucao.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Korisnička imena, a ne adrese";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Korisnici koji odgovaraju %@, a trenutno nisu u vašim kontaktima";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Koristi jednu od najviše revidiranih i testiranih biblioteka sa nultim znanjem (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Važeća pozivnica";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Provereno tokom registracije";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Verzija";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Vrlo efikasno uz niske naknade";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Prikaži sve";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Prikaži transakciju";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Glasaj";
+
+"Vote cast" = "Glas je predat";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Glasajte o spornim korisničkim imenima";
+
+"Vote on several" = "Glasaj o više njih";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Glasaj sa";
+
+"Votes that nobody should receive these usernames." = "Glasa da niko ne treba da dobije ova korisnička imena.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Adresa za glasanje";
+
+"Voting ended with no winner" = "Glasanje je završeno bez pobednika";
+
+"Voting ends" = "Glasanje se završava";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Glasanje je u toku";
+
+"Voting in progress — lock votes are ahead" = "Glasanje je u toku — glasovi za zaključavanje vode";
+
+"Voting in progress — you are ahead" = "Glasanje je u toku — vi vodite";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Heš ključa za glasanje";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Glasanje o ovom korisničkom imenu je zatvoreno. Brojevi ispod su poslednji očitani.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Glasanje o „%@“ je već zatvoreno. Osvežite da biste videli rezultat.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Čeka se Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Početna visina novčanika";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Novčanik je onesposobljen";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Šta je sa Unstoppable Domains i sličnim servisima imena?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Koliko košta?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Šta je DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Šta sledi?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Kada će zahtevi za kontakt postati privatni?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Ko traži ovo ime";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Zašto moram da ga omogućim?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Isplaćuje celokupno stanje";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Radi sa svakim Dash novčanikom, menjačnicom i trgovcem";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Vi";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Prihvatili ste zahtev za kontakt od %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Trenutno nemate nijedan kontakt";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Do sada imate %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Poslali ste zahtev za kontakt korisniku %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Osvojili ste ovo korisničko ime";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Sve je spremno. Drugi korisnici sada mogu da vam šalju zahteve za kontakt — a i vi možete da šaljete svoje.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Vaš Dash Platform identitet pojaviće se ovde kada registrujete korisničko ime.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Vaša istorija, sređena";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Vašem identitetu su potrebna dva dodatna ključa kako bi zahtevi za kontakt mogli da se šifruju između vas i drugih korisnika. Omogućavanje ih dodaje jednom jedinom mrežnom transakcijom. Ovo se dešava samo jednom.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Vaša pozivnica plaća naknadu za registraciju ovog korisničkog imena.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Vaše glavno Dash stanje na Core blokčejnu — ono što šaljete i primate sa drugim novčanicima, menjačnicama i trgovcima.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Vaši pomešani novčići premešteni su u stanje vašeg Dash novčanika.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Vaši pomešani novčići premešteni su u zaštićeno stanje. Radi najbolje privatnosti, sačekajte najmanje 2 sata pre nego što upotrebite ova sredstva.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Vaše Platform stanje";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Vaše privatno stanje. Iznosi i adrese su šifrovani na lancu, pa vaša sredstva i istorija ostaju poverljivi.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Vaše zaštićeno stanje";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Vaše zaštićeno stanje je skoro spremno — moći ćete da se registrujete privatno oko %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Vaše zaštićeno stanje je spremno — registrujte svoje korisničko ime privatno sada";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Vaše zaštićeno stanje odstoji — moći ćete da se registrujete privatno oko %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Vaše zaštićeno stanje još sazreva. Biće spremno oko %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Vaše transparentno stanje";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Vaše korisničko ime vide svi. Ako ga finansirate iz zaštićenog stanja — nakon što sredstva odstoje nekoliko sati — niko neće moći da poveže vaše korisničko ime sa ostalim vašim Dash sredstvima.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Vaše korisničko ime, profil i kontakti prate ovaj identitet.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Vaše korisničko ime, profil i kontakti pratiće ovaj identitet.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Vaši glasovi";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Vaš novčanik se još sinhronizuje sa Dash mrežom. Slanje će biti dostupno kada se sinhronizacija završi.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Vaš novčanik se još sinhronizuje. Slanje iz transparentnog stanja biće dostupno kada se sinhronizacija završi.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "„%@“ nije moglo da se pročita kao Dash korisničko ime.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "„%@“ je registrovano. Poslati zahtev za kontakt osobi koja vas je pozvala?";

--- a/DashWallet/sr.lproj/Localizable.stringsdict
+++ b/DashWallet/sr.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ izbrojano za „%2$@“</string>
+		<string>%#@votes@ za „%2$@“</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,11 +93,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u glas</string>
+			<string>%1$u izbrojan glas</string>
 			<key>few</key>
-			<string>%1$u glasa</string>
+			<string>%1$u izbrojana glasa</string>
 			<key>other</key>
-			<string>%1$u glasova</string>
+			<string>%1$u izbrojanih glasova</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>
@@ -139,7 +139,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasalo</string>
+		<string>Glasanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -157,7 +157,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d od %#@nodes@ je glasalo</string>
+		<string>Glasanje: %1$d od %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/sr.lproj/Localizable.stringsdict
+++ b/DashWallet/sr.lproj/Localizable.stringsdict
@@ -82,5 +82,275 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ izbrojano za „%2$@“</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u glas</string>
+			<key>few</key>
+			<string>%1$u glasa</string>
+			<key>other</key>
+			<string>%1$u glasova</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Glasano o %1$d od %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d korisničko ime</string>
+			<key>few</key>
+			<string>%2$d korisnička imena</string>
+			<key>other</key>
+			<string>%2$d korisničkih imena</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Predaj %u glas</string>
+			<key>few</key>
+			<string>Predaj %u glasa</string>
+			<key>other</key>
+			<string>Predaj %u glasova</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternod</string>
+			<key>few</key>
+			<string>%2$d masternoda</string>
+			<key>other</key>
+			<string>%2$d masternodova</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d od %#@nodes@ je glasalo</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d čvor</string>
+			<key>few</key>
+			<string>%2$d čvora</string>
+			<key>other</key>
+			<string>%2$d čvorova</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonod</string>
+			<key>few</key>
+			<string>%d evonoda</string>
+			<key>other</key>
+			<string>%d evonodova</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>ukupno %u glas</string>
+			<key>few</key>
+			<string>ukupno %u glasa</string>
+			<key>other</key>
+			<string>ukupno %u glasova</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternod</string>
+			<key>few</key>
+			<string>%d masternoda</string>
+			<key>other</key>
+			<string>%d masternodova</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d izabran</string>
+			<key>few</key>
+			<string>%d izabrana</string>
+			<key>other</key>
+			<string>%d izabranih</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d vaš čvor je već glasao ovde i nije naveden.</string>
+			<key>few</key>
+			<string>%d vaša čvora su već glasala ovde i nisu navedena.</string>
+			<key>other</key>
+			<string>%d vaših čvorova je već glasalo ovde i nisu navedeni.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas po sporu — evonodovi se broje kao 4, masternodovi kao 1</string>
+			<key>few</key>
+			<string>%u glasa po sporu — evonodovi se broje kao 4, masternodovi kao 1</string>
+			<key>other</key>
+			<string>%u glasova po sporu — evonodovi se broje kao 4, masternodovi kao 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasaj o %d korisničkom imenu</string>
+			<key>few</key>
+			<string>Glasaj o %d korisnička imena</string>
+			<key>other</key>
+			<string>Glasaj o %d korisničkih imena</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u glas</string>
+			<key>few</key>
+			<string>%u glasa</string>
+			<key>other</key>
+			<string>%u glasova</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Glasaj ×%d</string>
+			<key>few</key>
+			<string>Glasaj ×%d</string>
+			<key>other</key>
+			<string>Glasaj ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d zahtev</string>
+			<key>few</key>
+			<string>%d zahteva</string>
+			<key>other</key>
+			<string>%d zahteva</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/sr.lproj/Localizable.stringsdict
+++ b/DashWallet/sr.lproj/Localizable.stringsdict
@@ -111,7 +111,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d korisničko ime</string>
+			<string>%2$d korisničkog imena</string>
 			<key>few</key>
 			<string>%2$d korisnička imena</string>
 			<key>other</key>
@@ -147,7 +147,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d masternod</string>
+			<string>%2$d masternoda</string>
 			<key>few</key>
 			<string>%2$d masternoda</string>
 			<key>other</key>
@@ -165,7 +165,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%2$d čvor</string>
+			<string>%2$d čvora</string>
 			<key>few</key>
 			<string>%2$d čvora</string>
 			<key>other</key>

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Alla noder på en gång";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alla dina masternoder har röstat om det här användarnamnet. Rösta igen från den sökande du nu föredrar för att ändra en röst.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alla dina masternoder har röstat om det här användarnamnet. Rösta igen på den sökande du nu föredrar för att ändra en röst.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " eller ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "%@ kunde inte hittas på Dash-nätverket för att skicka en kontaktförfrågan.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash tillgängligt";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ har accepterat din kontaktförfrågan";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld av %ld insättningar";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Ett kreditsaldo på Dash Platform som används för direktbetalningar mellan Platform-adresser och för funktioner som användarnamn.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Om";
 
+/* DashPay FAQ title */
+"About DashPay" = "Om DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Avstå";
+
+"Abstain on “%@”" = "Avstå om ”%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Aktiv";
+
+/* No comment provided by engineer. */
+"Activity" = "Aktivitet";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Aktiviteten är offentlig men inte lätt att spåra";
+
 /* No comment provided by engineer. */
 "Add" = "Lägg till";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Lägg till %@ som kontakt";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Lägg till %@ som kontakt för att betala direkt till användarnamnet och behålla den gemensamma transaktionshistoriken";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Lägg till %@ Dash i ditt skyddade saldo och låt det vila några timmar, så att registreringen inte kopplar ditt användarnamn till dina övriga medel.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Lägg till minst %@ Dash i ditt skyddade saldo";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Fyll på ditt skyddade saldo nu och registrera ditt användarnamn privat om några timmar";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Alla";
 
+"All nodes at once" = "Alla noder på en gång";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Alla dina masternoder har röstat om det här användarnamnet. Rösta igen från den sökande du nu föredrar för att ändra en röst.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Nästan omedelbar synkronisering av saldon";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Belopp och adresser är offentliga på blockkedjan";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Ett Ethereum-konto är en enda återanvänd adress: hela ditt saldo och din betalningshistorik ligger offentligt under den, och ett namn (till exempel en ENS-domän) pekar oftast rakt på den adressen så att vem som helst kan slå upp den. DashPay är precis tvärtom — namnet leder till en identitet, inte till en betalningsadress, och de faktiska betalningsadresserna stannar inuti krypterade kontaktutbyten, nya för varje kontakt.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Alla som känner till en adress kan se dess historik";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Godkänn";
+
+"Approving a specific request can only be done one username at a time." = "Att godkänna en specifik begäran går bara att göra för ett användarnamn i taget.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Som text";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Autentiseringen avbröts. Din röst lades inte.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Autentiseringen misslyckades. Din röst lades inte.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Tilldela ”%@” till den här sökanden";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Saldo";
 
 /* CrowdNode */
+"Balance after" = "Saldo efteråt";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Saldon och överföringar syns inte offentligt";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Starthöjd sparad — den höjda skanningsgränsen gäller från nästa start.";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Bunden till kontrakt";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Bunden till kontrakt, dokumenttyp ”%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Endast visning";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Samlar de senaste diagnostikloggarna i en zip-fil så att du kan AirDroppa, mejla eller spara dem i Filer";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Lägg din röst";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Byt noder";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrollerar…";
+
+"Choice" = "Val";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Lös in din inbjudan";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Saldo att hämta";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Rensa och synka om";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Rensa kedjedata och synka om?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "Stänger";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (nya mynt)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin stöds inte längre — välj vart dina blandade mynt ska flyttas.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Säkerhet";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Kommer snart";
+
+/* Shielded transfer status */
+"Completed" = "Slutförd";
 
 /* No comment provided by engineer. */
 "Confirm" = "Bekräfta";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Bekräftad";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Bekräftelsen sparar starthöjden %u och rensar den här nätverkets kedjedata vid nästa appstart, laddar ner dem igen och skannar om filtren från den höjden. Den pågående sessionen behåller sin gamla skanningsgräns — avsluta och öppna appen igen för att börja.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Anslutna noder";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nackdelar";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Kontaktförfrågan misslyckades";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Kontaktförfrågan skickad till %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Kontaktförfrågningar";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "Sökande %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Fortsätt";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Fortsätt för att välja ditt användarnamn. Inbjudan betalar registreringsavgiften.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Kopiera rå transaktion";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Kunde inte skapa loggarkivet: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Kunde inte hitta växlingskurs";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Kunde inte uppdatera %d identiteter";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Kunde inte hämta saldot (nätverksfel). Prova att uppdatera.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Skapa ditt användarnamn, hitta vänner och familj via deras användarnamn och lägg till dem bland dina kontakter";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Krediter";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform har inte indexerat den här tvisten ännu. Rösträkningen visas här när det sker.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform är inte ansluten ännu. Vänta tills synkroniseringen är klar och försök igen.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash som skickats till fel adress går inte att få tillbaka. Se till att adressen är exakt den du tänker betala till.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash lagrar användarnamn i en förväxlingssäker form, så det lagrade namnet kan skilja sig från det var och en skrev.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Saldo i Dash-plånboken";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay aktiverat";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay är Dashs sociala betalningsupplevelse, byggd på Dash Platform. Du registrerar ett användarnamn, lägger till andra användare som kontakter och betalar dem med namn — inget mer kopierande av adresser.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay ersätter långa kryptiska adresser med användarnamn. Lägg till vänner som kontakter, skicka pengar till ett namn och håll varje betalning ordnad per person.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Okänd tidsfrist";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Härledningsväg";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Inaktiverad";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Done";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Klart — ditt saldo har vilat tillräckligt länge";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Dubbelkolla adressen";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Varje masternod har en giltig röst per tvist. Du kan ändra den senare, men Dash Platform tillåter bara 5 röster totalt per masternod och tvist.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Varje tryck röstar med ytterligare en nod, så du väljer hur många du kopplar ihop.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Redigera starthöjd";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Aktivera";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Aktivera DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Att aktivera DashPay kostar en liten engångsavgift till nätverket, som betalas från din identitets kreditsaldo. Den exakta uppskattningen visas innan du bekräftar. Att skicka kontaktförfrågningar och betalningar kostar de vanliga nätverksavgifterna.";
+
+"Ending soonest" = "Avslutas först";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Uppskattad nätverksavgift";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Alla noder röstar tillsammans. Snabbare, men det kopplar offentligt ihop dina masternoder med varandra.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Operatörsnycklar för Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Exportera loggar";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Extern adress";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limit";
+
+/* No comment provided by engineer. */
+"Failed" = "Misslyckades";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Hämtar…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "Filterhuvuden";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Hitta en användare på Dash-nätverket";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Hitta identiteter";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "Hittade %d nya identiteter";
+
+/* Identities */
+"Found 1 new identity" = "Hittade 1 ny identitet";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Finansiera ditt användarnamn från ditt skyddade saldo. Lägg till medlen några timmar i förväg — den korta vilan gör att ditt användarnamn inte kan kopplas till dina övriga Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Finansierat från ditt skyddade saldo — ditt användarnamn kan inte kopplas till dina övriga Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Medlen är låsta — överföringen slutförs";
+
+/* CoinJoin */
+"Funds moved" = "Medlen har flyttats";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Gör dig redo att gå med i DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Uppfattat";
+
+/* Governance */
+"Governance" = "Styrning";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "har bett om att bli din vän";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Har du en inbjudan?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "Blockhuvuden";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Höjd %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Högre avgifter runt 7 cent (fortfarande lägre än andra blockkedjor med liknande integritet)";
+
 /* No comment provided by engineer. */
 "History" = "Historik";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Hur står sig detta mot Bitcoin när det gäller integritet?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Hur står sig detta mot Ethereum-konton när det gäller integritet?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Hur privat är DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Jag har skrivit ned den";
 
+/* Identities */
+"Identities" = "Identiteter";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Identitetskrediter";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Identitetsindex";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Identitetsregistrering";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Påfyllning av identitet";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Inaktiv";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Indata %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Indata %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Indata (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Inbjudan från %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Bjud in någon att gå med i Dash-nätverket";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Bjud in dina vänner och din familj till Dash-nätverket";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Håll de här mynten privata. Nätverks- och integritetsavgifter tillkommer.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Nyckel nr %d";
+
+/* Identities: the public key bytes */
+"Key data" = "Nyckeldata";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Nyckelägarskap";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Nycklar";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Leder";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Läs mer";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Läser in transaktioner";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "Endast lokalt";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Lås";
+
+"Lock the name" = "Lås namnet";
+
+"Lock “%@” so nobody gets it" = "Lås ”%@” så att ingen får det";
+
 /* No comment provided by engineer. */
 "Locked" = "Låst";
 
+"Locked — nobody receives this username" = "Låst — ingen får det här användarnamnet";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Låg";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Låga avgifter för vardagliga utgifter";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Huvud";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Nyckelknippa för masternod";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Masternodlista";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "Masternodröster";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternoder";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Masternoder och evonoder som registrerats med den här plånbokens nycklar visas här när plånboken har synkroniserats.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternoder och evonoder som använder den här plånbokens nycklar";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternoder röstar om namn som fler än en person har begärt. Du meddelas när röstningen avslutas.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Miniminivån är uppnådd";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Fler förslag";
+
+"Most lock votes" = "Flest låsröster";
+
+"Most votes" = "Flest röster";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Flytta till ditt vanliga disponibla saldo.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "Flyttar medel";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Namntjänster som Unstoppable Domains kopplar ett läsbart namn till en fast offentlig adress på kedjan. Vem som helst kan slå upp namnet och se varje betalning som någonsin gjorts till det. Ett DashPay-användarnamn leder aldrig offentligt till en betalningsadress — adresser avslöjas bara inuti det krypterade utbytet med varje kontakt, så ditt namn och dina pengar förblir oförknippade för utomstående.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Kräver åtgärd";
 
 /* No comment provided by engineer. */
 "Network" = "Nätverk";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Inga diagnostikloggar hittades på den här enheten. Loggar skrivs från och med nästa start.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Inga identiteter";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Inga masternoder ännu";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Inga matchande tvister";
+
+/* Identities */
+"No new identities were found for this wallet" = "Inga nya identiteter hittades för den här plånboken";
+
+"No open contest matches that search." = "Ingen öppen tvist matchar den sökningen.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Ingen öppen tvist matchar den sökningen. Namn lagras i normaliserad form, så ”alice” listas som ”a11ce”.";
+
+"No open contests" = "Inga öppna tvister";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Ingen sparad plånboksrad hittades för den bundna plånboken.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Ingen Platform-adress är ännu tillgänglig för den skyddade reservregistreringen. Försök igen när plånboken har synkroniserat klart.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Inget användarnamn är omtvistat just nu. Tvister öppnas när två eller fler personer begär samma namn.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Inga röster lades";
+
+"Nobody gets it" = "Ingen får det";
+
+/* SPV sync peer type */
+"Node" = "Nod";
+
+/* Raw transaction inspector */
+"Non-standard" = "Icke-standard";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "Inte tillgängligt ännu";
+
+"Not cast" = "Ej lagd";
+
+/* Masternodes */
+"Not checked yet" = "Ännu inte kontrollerad";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Otillräckligt skyddat saldo för att registrera en identitet";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Finns inte i plånbokshistoriken";
+
+"Not now" = "Inte nu";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Accepteras inte allmänt av handlare";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Accepteras ännu inte allmänt av handlare";
+
+/* Masternode keys */
+"Not yet used" = "Ännu inte använd";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "På Bitcoin finns inget namnlager, så folk delar och återanvänder adresser helt öppet — när en adress väl är känd kan allt den någonsin tagit emot kopplas till ägaren. Med DashPay är ditt användarnamn offentligt, men det pekar aldrig på en betalningsadress: adresser utbyts privat per kontakt och roterar, så att betala till ett namn avslöjar inte vart dina pengar går. Båda är transparenta kedjor, så kedjeanalys gäller fortfarande själva mynten.";
+
+/* Identities */
+"On Network" = "På nätverket";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "När %@ accepterar din förfrågan kan du betala direkt till användarnamnet";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "En nod i taget";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Bara masternoder och evonoder kan rösta om användarnamn. Den här plånboken har inga aktiva röstningsnycklar för masternoder.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Operatör";
+
+/* Masternode keys */
+"Operator keys" = "Operatörsnycklar";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operatörens publika nyckel (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "eller";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Andra utfall";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Utdata %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Utdata (%d)";
+
+/* Masternodes */
+"Owner" = "Ägare";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "Ägarens adress";
+
+/* Masternodes */
+"Owner key hash" = "Hash för ägarnyckel";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Betalas från din identitets kreditsaldo.";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Klistra in inbjudningslänken du fick, eller skanna dess QR-kod. Den betalar registreringen av ditt användarnamn.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "betala direkt till användarnamnet";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Betala människor, inte adresser";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Nyttolast (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Betalningarna är privata: adresserna du utbyter med en kontakt färdas i en krypterad nyttolast som bara ni två kan läsa, och publiceras aldrig — därför går dina betalningar inte att enkelt koppla till ditt användarnamn. De är ändå vanliga betalningar på en transparent kedja: avancerad kedjeanalys kan läcka information. Shielded DashPay (kommer snart) täpper till den luckan. Själva kontaktförfrågningarna är för närvarande INTE privata: vem som helst kan se att två identiteter är kopplade. Privata kontaktförfrågningar är en funktion som kommer snart. Ditt användarnamn och din profil är också offentliga på Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Betalningar bekräftas på några sekunder med InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Betalningar som görs direkt till adresser sparas inte i aktiviteten.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Betalningarna med varje kontakt samlas på ett ställe, med namn och profiler i stället för råa transaktioner.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Utbetalningsadress";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform-adress";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform-saldo";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform-nod";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform-nod-ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform-betalningar identifierar inte avsändaren. Den här betalningen registrerades när plånboken märkte saldoändringen — den kan ha kommit tidigare.";
+
+"Platform SDK not ready" = "Platform-SDK:n är inte redo";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform-synkroniseringen körs inte. Öppna Synkinfo → Platform-synkstatus för att starta den.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Skyddat";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Tidigare använd den: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Privat i grunden";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Privata kontaktförfrågningar (så att vem du kopplar upp dig mot förblir privat), Shielded DashPay — kontaktbetalningar från ditt privata skyddade saldo — och betalningar till användare som ännu inte finns bland dina kontakter kommer alla snart.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Privata kontaktförfrågningar är under utveckling och väntas omkring september–oktober 2026. I dag är själva förfrågan offentlig — vem som helst kan se att två identiteter är kopplade, även om betalningsuppgifterna i den är krypterade. När privata kontaktförfrågningar lanseras kan du välja om din vänskap ska vara offentlig eller privat.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Privata kontaktförfrågningar, Shielded DashPay och betalningar till personer som ännu inte är kontakter.";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Privata betalningsadresser utbyts mellan dig och dina kontakter. Bara du och din kontakt vet vem som är mottagare och avsändare av betalningarna er emellan.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Privata betalningar";
+
+/* Usernames */
+"Private registration" = "Privat registrering";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Behandlingstid";
+
+/* Balance info sheet section */
+"Pros" = "Fördelar";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "Leverantörstransaktioner";
+
+/* Masternode keys */
+"Public key" = "Publik nyckel";
+
+/* Masternode keys */
+"Public key (legacy)" = "Publik nyckel (äldre)";
+
+/* Identities */
+"Public keys" = "Publika nycklar";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Ändamål";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Rå transaktion";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Rå transaktion är inte tillgänglig";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Kontrollerar om de kompakta blockfiltren från den valda höjden innehåller den här plånbokens transaktioner, genom att ladda ner och matcha om dem. Omskanningar begränsas nedåt av plånbokens skapelsehöjd och av lokalt lagrad kedjedata — sänk i stället plånbokens starthöjd för att återställa historik under den nivån.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Skrivskyddad";
+
+/* Usernames */
+"Ready around %@" = "Klart omkring %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Orsak";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Mottaget från %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Registrerar att dina masternoder har röstat, utan att ta ställning.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Uppdatera";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Registrerad den";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Privat registrering kräver minst %@ Dash i ditt skyddade saldo plus några timmars vila — nästa skärmar guidar dig igenom.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Registrering";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Begär det här namnet";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Återställda plånböcker kan inte alltid återskapa operationstypen. Den här posten rekonstruerades från anteckningsdata på kedjan.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Omsynkronisering förberedd från höjd %u — avsluta och öppna appen igen för att börja.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "behålla den gemensamma transaktionshistoriken";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Avvecklad";
 
 /* No comment provided by engineer. */
 "Retry" = "Försök igen";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Återkallande";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Skärmbilder är synliga för andra appar och enheter. Skapa en ny återställningsfras och håll den hemlig.";
 
+/* Raw transaction inspector */
+"Script" = "Skript";
+
+/* Raw transaction inspector */
+"Script signature" = "Skriptsignatur";
+
+/* Raw transaction inspector */
+"Script type" = "Skripttyp";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Sök efter en kontakt";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Sök efter en kontaktförfrågan";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Sök efter en användare på Dash-nätverket";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Sök efter ett användarnamn";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Sökresultat för \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Sök användarnamn";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Söker efter användarnamnet %@ på Dash-nätverket";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Säkerhetsnivå";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Markera alla";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Välj minst en masternod att rösta med.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Att välja färre noder avslöjar mindre om vilka masternoder du driver.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Skicka till en kontakt";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Skicka till ett användarnamn du faktiskt kan minnas och verifiera.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Skicka din första kontaktförfrågan";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Skickar kontaktförfrågan";
+
+/* No comment provided by engineer. */
+"Sending to" = "Skickar till";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Skickat till %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Tjänst";
+
+/* Identities */
+"Set as Main" = "Ange som huvud";
+
+/* Identities */
+"Set as Main Identity" = "Ange som huvudidentitet";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Den delade integritetspoolen har minsta storlek";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Skyddad adress";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Skyddad utbetalning";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Startar den skyddade plånboken…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Skyddat → Platform";
+
+"Shielded → Transparent" = "Skyddat → Transparent";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Storlek";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Några av dina masternoder kan saknas i den här listan — plånboken kunde inte läsa hela din uppsättning röstningsnycklar. Slutför synkroniseringen och öppna den här skärmen igen.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sortera kontakter";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Särskild nyttolast";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Startar när du lägger till medel";
+
+/* Transaction details */
+"Status" = "Status";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Lagrat som";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Synkinfo";
+
+/* SPV sync */
+"Sync too slow?" = "Går synkroniseringen för långsamt?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Ta inte ställning";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Tryck för att kopiera";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash-nodnyckel (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash når mottagarens adress efter att nätverket har behandlat uttaget — det kan ta upp till 10 minuter.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash når mottagarens adress så snart nätverket behandlar uttaget.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash når ditt transparenta saldo så snart nätverket behandlar uttaget.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Huvudidentiteten kan bara väljas från den aktiva plånboken";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Den mest privata platsen att förvara dina Dash på";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Den sparade plånboksraden saknar nätverk — kan inte förbereda en omsynkronisering.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Registreringen skickades in men resultatet kunde inte bekräftas. Vänta en minut tills plånboken synkroniserar och försök sedan igen — skicka inte in på nytt direkt.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Den delade integritetspoolen växer fortfarande (%1$ld av %2$ld insättningar). Privat registrering låses upp när den når miniminivån.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Den delade integritetspoolen växer fortfarande (%1$ld av %2$ld insättningar). Försök igen när den når miniminivån.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Plånbokens skapelsehöjd — nedre gräns för filterskanningar och för omskanningar av typen ”Från plånbokens skapande”. Ställ in den på eller under plånbokens första insättning; importer använder som standard 200000 på mainnet och 0 på testnet. Att spara en höjd som är lika med eller lägre än den nuvarande rensar den här nätverkets kedjedata vid nästa start och skannar om därifrån.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "honom (hämtar info)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Det finns inga nya aviseringar";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Det finns inga användare som matchar namnet %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Det finns inga användare bland dina kontakter som matchar namnet %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "De här medlen flyttas till ditt Platform-saldo och är redo att användas så snart överföringen är klar.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Den här adressen kan inte betalas från ditt %@-saldo";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Detta lägger till två nycklar i din identitet så att andra användare kan skicka kontaktförfrågningar till dig, och så att du kan acceptera deras. Det sker bara en gång.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Detta tillämpar ett val på alla %d markerade användarnamn.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Den här inbjudningslänken är inte giltig.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Detta är inte en giltig Dash-adress för det här nätverket";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Detta är inte en giltig inbjudningslänk";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Detta är din huvudidentitet";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Den här masternoden har ännu ingen Platform-identitet.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Detta räknas ändå som att dina masternoder har röstat i den här tvisten.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Den här transaktionens råa byte lagras inte på den här enheten.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Det här användarnamnet gick till någon annan";
+
+"This wallet could not derive the voting key for this node." = "Den här plånboken kunde inte härleda röstningsnyckeln för den här noden.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Den här plånboken har inga aktiva röstningsnycklar för masternoder och kan därför inte rösta. Registrerade noder visas under Verktyg → Masternoder.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Detta tar ut hela ditt Platform-saldo i en enda överföring. Dash når mottagarens adress så snart nätverket behandlar uttaget.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Detta tar ut hela ditt Platform-saldo i en enda överföring. Dash når ditt transparenta saldo så snart nätverket behandlar uttaget.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Transaktionshistoriken är inte tillgänglig";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Transaktions-ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Överföring in";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Överföring ut";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Överföringar tar längre tid — att bygga integritetsbevis tar tid";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Överföringar till andra Platform-adresser och till skyddade adresser är omedelbara och slutgiltiga";
+
+/* Balance breakdown */
+"Transparent" = "Transparent";
+
+/* Send screen destination type */
+"Transparent address" = "Transparent adress";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Transparent saldo";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Transparent finansiering kopplar offentligt ditt användarnamn till de här medlen.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Transparent → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Transparent → Skyddat";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Kan inte ge förslag";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Okänd specialtyp %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Oskyddad";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Uppgradera till Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Använd det transparenta saldot i stället";
+
+/* Masternode keys */
+"Used" = "Använd";
+
+/* Masternode keys */
+"Used at: " = "Använd den: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Användare (hämtar info)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Användarnamn";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Användarnamn lagras i normaliserad form för att förhindra förväxlingsbara namn, så detta kan skilja sig från det var och en skrev.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Användarnamn, inte adresser";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Användare som matchar %@ och som för närvarande inte finns bland dina kontakter";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Använder ett av de mest granskade och testade nollkunskapsbiblioteken (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Giltig inbjudan";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Verifierad vid registreringen";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Version";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Mycket effektivt med låga avgifter";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Visa alla";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "Visa transaktion";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Rösta";
+
+"Vote cast" = "Röst lagd";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Rösta om omtvistade användarnamn";
+
+"Vote on several" = "Rösta om flera";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Rösta med";
+
+"Votes that nobody should receive these usernames." = "Röstar för att ingen ska få de här användarnamnen.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Röstningsadress";
+
+"Voting ended with no winner" = "Röstningen avslutades utan vinnare";
+
+"Voting ends" = "Röstningen avslutas";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Röstning pågår";
+
+"Voting in progress — lock votes are ahead" = "Röstning pågår — låsrösterna leder";
+
+"Voting in progress — you are ahead" = "Röstning pågår — du leder";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash för röstningsnyckel";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Röstningen om det här användarnamnet är stängd. Siffrorna nedan är de senast avlästa.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Röstningen om ”%@” är redan stängd. Uppdatera för att se resultatet.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Väntar på Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Plånbokens starthöjd";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Hur är det med Unstoppable Domains och liknande namntjänster?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Vad kostar det?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Vad är DashPay?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Vad kommer härnäst?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "När blir kontaktförfrågningar privata?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Vem som begär det här namnet";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Varför måste jag aktivera det?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Tar ut hela saldot";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Fungerar med alla Dash-plånböcker, börser och handlare";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Du";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Du accepterade kontaktförfrågan från %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Du har inga kontakter just nu";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Du har %@ Dash hittills";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Du skickade kontaktförfrågan till %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Du vann det här användarnamnet";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Allt är klart. Andra användare kan nu skicka kontaktförfrågningar till dig — och du kan skicka dina.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Din Dash Platform-identitet visas här när du registrerar ett användarnamn.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Din historik, ordnad";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Din identitet behöver två extra nycklar för att kontaktförfrågningar ska kunna krypteras mellan dig och andra användare. Aktiveringen lägger till dem med en enda nätverkstransaktion. Det sker bara en gång.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Din inbjudan betalar registreringsavgiften för det här användarnamnet.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Ditt huvudsakliga Dash-saldo på Core-blockkedjan — det du skickar och tar emot med andra plånböcker, börser och handlare.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Dina blandade mynt har flyttats till saldot i din Dash-plånbok.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Dina blandade mynt har flyttats till ditt skyddade saldo. För bästa integritet, vänta minst 2 timmar innan du använder de här medlen.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Ditt Platform-saldo";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Ditt privata saldo. Belopp och adresser är krypterade på kedjan, så ditt innehav och din historik förblir konfidentiella.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Ditt skyddade saldo";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Ditt skyddade saldo är nästan klart — du kan registrera dig privat omkring %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Ditt skyddade saldo är klart — registrera ditt användarnamn privat nu";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Ditt skyddade saldo vilar — du kan registrera dig privat omkring %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Ditt skyddade saldo mognar fortfarande. Det är klart omkring %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Ditt transparenta saldo";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Ditt användarnamn syns för alla. Att finansiera det från ditt skyddade saldo — efter att medlen fått vila några timmar — gör att ingen kan koppla ditt användarnamn till dina övriga Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Ditt användarnamn, din profil och dina kontakter följer den här identiteten.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Ditt användarnamn, din profil och dina kontakter kommer att följa den här identiteten.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Dina röster";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Din plånbok synkroniserar fortfarande med Dash-nätverket. Det går att skicka när synkroniseringen är klar.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Din plånbok synkroniserar fortfarande. Det går att skicka från ditt transparenta saldo när synkroniseringen är klar.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "”%@” kunde inte läsas som ett Dash-användarnamn.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "”%@” har registrerats. Vill du skicka en kontaktförfrågan till personen som bjöd in dig?";

--- a/DashWallet/sv.lproj/Localizable.stringsdict
+++ b/DashWallet/sv.lproj/Localizable.stringsdict
@@ -85,7 +85,7 @@
 	<key>%u votes counted for “%@”</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@votes@ räknade för ”%2$@”</string>
+		<string>%#@votes@ för ”%2$@”</string>
 		<key>votes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -93,9 +93,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>u</string>
 			<key>one</key>
-			<string>%1$u röst</string>
+			<string>%1$u räknad röst</string>
 			<key>other</key>
-			<string>%1$u röster</string>
+			<string>%1$u räknade röster</string>
 		</dict>
 	</dict>
 	<key>%d of %d usernames voted on</key>

--- a/DashWallet/sv.lproj/Localizable.stringsdict
+++ b/DashWallet/sv.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ räknade för ”%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u röst</string>
+			<key>other</key>
+			<string>%1$u röster</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Röstat på %1$d av %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d användarnamn</string>
+			<key>other</key>
+			<string>%2$d användarnamn</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Lägg %u röst</string>
+			<key>other</key>
+			<string>Lägg %u röster</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d av %#@nodes@ har röstat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d masternod</string>
+			<key>other</key>
+			<string>%2$d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d av %#@nodes@ har röstat</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d nod</string>
+			<key>other</key>
+			<string>%2$d noder</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonod</string>
+			<key>other</key>
+			<string>%d evonoder</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u röst totalt</string>
+			<key>other</key>
+			<string>%u röster totalt</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d masternod</string>
+			<key>other</key>
+			<string>%d masternoder</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d markerad</string>
+			<key>other</key>
+			<string>%d markerade</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d av dina noder har redan röstat här och visas inte.</string>
+			<key>other</key>
+			<string>%d av dina noder har redan röstat här och visas inte.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u röst per tvist — evonoder räknas som 4, masternoder som 1</string>
+			<key>other</key>
+			<string>%u röster per tvist — evonoder räknas som 4, masternoder som 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Rösta om %d användarnamn</string>
+			<key>other</key>
+			<string>Rösta om %d användarnamn</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u röst</string>
+			<key>other</key>
+			<string>%u röster</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Rösta ×%d</string>
+			<key>other</key>
+			<string>Rösta ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d förfrågan</string>
+			<key>other</key>
+			<string>%d förfrågningar</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "ทุกโหนดพร้อมกัน";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "มาสเตอร์โหนดทั้งหมดของคุณได้โหวตชื่อผู้ใช้นี้แล้ว หากต้องการเปลี่ยนคะแนน ให้โหวตอีกครั้งจากผู้ขอที่คุณต้องการตอนนี้";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "มาสเตอร์โหนดทั้งหมดของคุณได้โหวตชื่อผู้ใช้นี้แล้ว หากต้องการเปลี่ยนคะแนน ให้โหวตให้ผู้ขอที่คุณต้องการตอนนี้อีกครั้ง";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " หรือ ";
+
 /* CrowdNode */
 " Privacy Policy " = "นโยบายความเป็นส่วนตัว";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "ไม่พบ %@ บนเครือข่าย Dash จึงส่งคำขอการติดต่อไม่ได้";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash พร้อมใช้งาน";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ ยอมรับคำขอการติดต่อของคุณแล้ว";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d ไบต์";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld ซ้ำ";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld จาก %ld รายการฝาก";
 
 /* Voting */
 "%ld requests" = "%ld คำขอ";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" ไม่ใช่คำวลีการกู้คืน คุณต้องการที่จะพยายามกู้คืนคำที่ถูกต้องที่ควรเป็นที่ของมันหรือไม่";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "ยอดเครดิตบน Dash Platform ใช้สำหรับการชำระเงินทันทีระหว่างที่อยู่ Platform และสำหรับฟีเจอร์ต่าง ๆ เช่น ชื่อผู้ใช้";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "รหัสผ่านอุปกรณ์นั้นจำเป็นในการปกป้องกระเป๋าสตางค์ของคุณ ไปที่การตั้งค่าและเปิดรหัสผ่านเพื่อดำเนินการต่อ";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "เกี่ยวกับ";
 
+/* DashPay FAQ title */
+"About DashPay" = "เกี่ยวกับ DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "เกี่ยวกับฉัน";
+
+"Abstain" = "งดออกเสียง";
+
+"Abstain on “%@”" = "งดออกเสียงเรื่อง “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "ยอมรับ";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "การกู้คืนบัญชี";
 
+/* Masternode status */
+"Active" = "ใช้งานอยู่";
+
+/* No comment provided by engineer. */
+"Activity" = "กิจกรรม";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "กิจกรรมเป็นสาธารณะแต่ติดตามได้ไม่ง่าย";
+
 /* No comment provided by engineer. */
 "Add" = "เพิ่ม";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "เพิ่ม %@ เป็นผู้ติดต่อ";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "เพิ่ม %@ เป็นผู้ติดต่อเพื่อจ่ายตรงไปยังชื่อผู้ใช้และเก็บประวัติธุรกรรมร่วมกันไว้";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "เพิ่ม %@ Dash เข้าไปในยอดคงเหลือแบบปกปิดของคุณ แล้วปล่อยพักไว้สองสามชั่วโมงเพื่อลงทะเบียนโดยไม่เชื่อมโยงชื่อผู้ใช้กับเงินส่วนอื่นของคุณ";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "เพิ่มรายชื่อใหม่";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "เพิ่มอย่างน้อย %@ Dash เข้าไปในยอดคงเหลือแบบปกปิดของคุณ";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "เพิ่มเงินเข้ายอดคงเหลือแบบปกปิดตอนนี้ แล้วลงทะเบียนชื่อผู้ใช้แบบส่วนตัวในอีกสองสามชั่วโมง";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "ทั้งหมด";
 
+"All nodes at once" = "ทุกโหนดพร้อมกัน";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "มาสเตอร์โหนดทั้งหมดของคุณได้โหวตชื่อผู้ใช้นี้แล้ว หากต้องการเปลี่ยนคะแนน ให้โหวตอีกครั้งจากผู้ขอที่คุณต้องการตอนนี้";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "ซิงค์ยอดคงเหลือได้เกือบจะทันที";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "จำนวนเงินและที่อยู่เป็นสาธารณะบนบล็อกเชน";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "บัญชี Ethereum คือที่อยู่เดียวที่ใช้ซ้ำได้ ยอดคงเหลือทั้งหมดและประวัติการชำระเงินของคุณอยู่ใต้ที่อยู่นั้นอย่างเปิดเผย และชื่อ (เช่นโดเมน ENS) มักชี้ตรงไปยังที่อยู่นั้นให้ใครก็ตามค้นหาได้ DashPay เป็นตรงกันข้าม — ชื่อจะชี้ไปยังตัวตน ไม่ใช่ที่อยู่ชำระเงิน และที่อยู่ชำระเงินจริงจะอยู่ภายในการแลกเปลี่ยนผู้ติดต่อที่เข้ารหัส ใหม่สำหรับผู้ติดต่อแต่ละราย";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "ประสบการณ์ที่ใช้งานง่ายและคุ้นเคย";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "ใครก็ตามที่รู้ที่อยู่ย่อมดูประวัติของที่อยู่นั้นได้";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "นำมาใช้";
 
+"Approve" = "อนุมัติ";
+
+"Approving a specific request can only be done one username at a time." = "การอนุมัติคำขอเฉพาะรายทำได้ครั้งละหนึ่งชื่อผู้ใช้เท่านั้น";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "แน่ใจหรือว่าต้องการยกเลิกคำสั่งซื้อนี้?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "เป็นข้อความ";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "ยกเลิกการยืนยันตัวตน คะแนนของคุณไม่ได้ถูกลง";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "ยืนยันตัวตนไม่สำเร็จ คะแนนของคุณไม่ได้ถูกลง";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "ไม่สามารตรวจสอบสิทธิ์ได้";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "มอบ “%@” ให้ผู้ขอรายนี้";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "ยอดคงเหลือ";
 
 /* CrowdNode */
+"Balance after" = "ยอดคงเหลือหลังจากนี้";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "ยอดคงเหลือบน CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "ยอดคงเหลือ: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "ยอดคงเหลือและการโอนไม่ปรากฏต่อสาธารณะ";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "บัญชีธนาคาร";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "บันทึกความสูงเริ่มต้นแล้ว — ขอบล่างการสแกนที่ยกขึ้นจะมีผลตั้งแต่การเปิดแอปครั้งถัดไป";
+
 /* Voting */
 "Block" = "บล็อก";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "ผูกกับสัญญา";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "ผูกกับสัญญา ประเภทเอกสาร “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "ดูอย่างเดียว";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "รวมบันทึกการวินิจฉัยล่าสุดเป็นไฟล์ zip เพื่อส่งผ่าน AirDrop อีเมล หรือบันทึกลงไฟล์";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "ลงคะแนน";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "เปลี่ยนพีร์";
 
 /* No comment provided by engineer. */
 "Change PIN" = "เปลี่ยนแปลง PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "กำลังตรวจสอบ…";
+
+"Choice" = "ตัวเลือก";
+
 /* Choose your Dash username */
 "Choose your" = "เลือกของคุณ";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "เลือกชื่อผู้ใช้ของคุณ";
 
+/* DashPay Invitations */
+"Claim your invitation" = "รับคำเชิญของคุณ";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "ยอดคงเหลือที่ขอรับได้";
+
 /* No comment provided by engineer. */
 "Claimed" = "เคลม";
+
+/* SPV diagnostics */
+"Clear & resync" = "ล้างและซิงค์ใหม่";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "ล้างข้อมูลเชนและซิงค์ใหม่หรือไม่";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "ปิดแอพพลิเคชั่น";
 
+"Closing" = "กำลังจะปิด";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (เหรียญใหม่)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "รหัส 2FA ของ Coinbase ";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin ไม่รองรับอีกต่อไป — เลือกว่าจะย้ายเหรียญที่ผสมแล้วของคุณไปที่ใด";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "หลักประกัน";
+
+/* DashPay intro: feature title */
+"Coming soon" = "เร็ว ๆ นี้";
+
+/* Shielded transfer status */
+"Completed" = "เสร็จสมบูรณ์";
 
 /* No comment provided by engineer. */
 "Confirm" = "ยืนยัน";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "ยืนยันแล้ว";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "การยืนยันจะบันทึกความสูงเริ่มต้น %u และล้างข้อมูลเชนของเครือข่ายนี้เมื่อเปิดแอปครั้งถัดไป แล้วดาวน์โหลดใหม่และสแกนตัวกรองใหม่จากความสูงนั้น เซสชันที่กำลังทำงานอยู่จะยังใช้ขอบล่างการสแกนเดิม — ปิดแล้วเปิดแอปใหม่เพื่อเริ่ม";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "ที่อยู่ Dash ที่เชื่อมต่อ";
 
+/* SPV sync */
+"Connected peers" = "พีร์ที่เชื่อมต่ออยู่";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "ข้อเสีย";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "คำขอการติดต่อล้มเหลว";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "ส่งคำขอการติดต่อไปยัง %@ แล้ว";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "คำขอการติดต่อ";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "ติดต่อ";
 
+"Contender %@" = "ผู้ขอ %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "ดำเนินการต่อ";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "ดำเนินการต่อเพื่อเลือกชื่อผู้ใช้ของคุณ คำเชิญจะจ่ายค่าธรรมเนียมการลงทะเบียนให้";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "คัดลอกลิงค์คำเชิญ";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "คัดลอกธุรกรรมดิบ";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "ไม่สามารถกู้คืนคำที่หายไปหรือไม่ถูกต้อง";
 
+/* Log export */
+"Could not create the log archive: %@" = "สร้างไฟล์บันทึกไม่สำเร็จ: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "ไม่พบอัตราแลกเปลี่ยน";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "รีเฟรช %d ตัวตนไม่สำเร็จ";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "ดึงยอดคงเหลือไม่สำเร็จ (ข้อผิดพลาดเครือข่าย) ลองรีเฟรชดู";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "ไม่สามารถชำระเงินได้";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "สร้างชื่อผู้ใช้ของคุณ ค้นหาเพื่อนและครอบครัวด้วยชื่อผู้ใช้ของพวกเขา แล้วเพิ่มเข้าในผู้ติดต่อ";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "บัตรเครดิต";
+
+/* Masternodes */
+"Credits" = "เครดิต";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "การชำระเงิน Dash ไม่สามารถจะน้อยกว่า %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ยังไม่ได้จัดทำดัชนีการชิงชื่อครั้งนี้ จำนวนคะแนนจะปรากฏที่นี่เมื่อจัดทำแล้ว";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "ยังไม่ได้เชื่อมต่อ Dash Platform รอให้ซิงค์เสร็จแล้วลองอีกครั้ง";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash ที่ส่งไปยังที่อยู่ผิดจะเรียกคืนไม่ได้ ตรวจสอบให้แน่ใจว่าที่อยู่ตรงกับที่คุณตั้งใจจะจ่ายทุกประการ";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash เก็บชื่อผู้ใช้ในรูปแบบที่ป้องกันชื่อดูคล้ายกัน ชื่อที่เก็บไว้จึงอาจต่างจากที่แต่ละคนพิมพ์";
+
 /* No comment provided by engineer. */
 "Dash username" = "ชื่อผู้ใช้ Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "กระเป๋าเงิน Dash ";
+
+/* CoinJoin */
+"Dash Wallet balance" = "ยอดคงเหลือกระเป๋าเงิน Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "กระเป๋าเงิน Dash บนอุปกรณ์นี้";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "เปิดใช้ DashPay แล้ว";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "คำเชิญ DashPay ";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay คือประสบการณ์การชำระเงินเชิงสังคมของ Dash สร้างอยู่บน Dash Platform คุณลงทะเบียนชื่อผู้ใช้ เพิ่มผู้ใช้คนอื่นเป็นผู้ติดต่อ และจ่ายเงินให้พวกเขาด้วยชื่อ — ไม่ต้องคัดลอกที่อยู่อีกต่อไป";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay แทนที่ที่อยู่ยาว ๆ ที่อ่านไม่รู้เรื่องด้วยชื่อผู้ใช้ เพิ่มเพื่อนเป็นผู้ติดต่อ ส่งเงินไปยังชื่อ และจัดระเบียบทุกการชำระเงินตามรายบุคคล";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay อัพเกรดค่าบริการ";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "วันที่: เก่าไปใหม่";
+
+"Deadline unknown" = "ไม่ทราบกำหนดเวลา";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "ส่งเงินฝากแล้ว";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "เส้นทางการอนุพันธ์";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "อุปกรณ์รักษาความปลอดภัยที่ถูกบุกรุก\n'jailbreak' แอพพลิเคชั่นต่าง ๆ สามารถเข้าถึงข้อมูลของแอพพลิเคชั่นอื่นได้ (และสามารถขโมย dash ของคุณได้) กำจัดกระเป๋าสตางค์นี้โดยทันที และกู้คืนบนอุปกรณ์ที่ปลอดภัย";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "ปิดใช้งาน";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "ตัดการเชื่อมต่อบัญชี Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "เสร็จแล้ว";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "เสร็จแล้ว — ยอดคงเหลือของคุณพักไว้นานพอแล้ว";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "ตรวจสอบที่อยู่อีกครั้ง";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "คำเชิญแต่ละครั้งจะได้รับเงินทุนด้วยจำนวนเงินนี้เพื่อให้ผู้รับสามารถสร้างชื่อผู้ใช้ของพวกเขาได้อย่างรวดเร็วบนเครือข่าย Dash";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "มาสเตอร์โหนดแต่ละตัวมีคะแนนที่ใช้ได้หนึ่งเสียงต่อการชิงชื่อหนึ่งครั้ง คุณเปลี่ยนได้ภายหลัง แต่ Dash Platform อนุญาตรวมเพียง 5 เสียงต่อมาสเตอร์โหนดต่อการชิงชื่อหนึ่งครั้ง";
+
+"Each tap votes with one more node, so you choose how many to link together." = "การแตะแต่ละครั้งจะเพิ่มโหนดอีกหนึ่งตัวเข้ามาโหวต คุณจึงเลือกได้ว่าจะเชื่อมโยงกี่ตัว";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "ก่อน";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = " Stake Dash ได้อย่างง่ายดายและได้รับรายได้แบบ passive income ด้วยการคลิกง่ายๆ";
+
+/* SPV diagnostics */
+"Edit birth height" = "แก้ไขความสูงเริ่มต้น";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "แก้ไขโปรไฟล์";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "อีเมล";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "เปิดใช้";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "เปิดใช้ DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "เชื่อมต่อ Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "เชื่อมต่อ touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "การเปิดใช้ DashPay มีค่าธรรมเนียมเครือข่ายเล็กน้อยครั้งเดียว หักจากยอดเครดิตของตัวตนคุณ ค่าประมาณที่แน่นอนจะแสดงก่อนที่คุณยืนยัน ส่วนการส่งคำขอการติดต่อและการชำระเงินจะเสียค่าธรรมเนียมเครือข่ายตามปกติ";
+
+"Ending soonest" = "สิ้นสุดเร็วที่สุด";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "ข้อผิดพลาดในการอัปเดตโปรไฟล์ของคุณ";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "ค่าธรรมเนียมเครือข่ายโดยประมาณ";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "ทุกโหนดโหวตพร้อมกัน เร็วกว่า แต่จะเชื่อมโยงมาสเตอร์โหนดของคุณเข้าด้วยกันอย่างเปิดเผย";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "คีย์ผู้ดำเนินการ Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "ส่งออกบันทึก";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "ที่อยู่ภายนอก";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "ขีดจำกัด Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "ล้มเหลว";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "กำลังดึงข้อมูล…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "บัญชีเงินสด";
 
 /* No comment provided by engineer. */
 "Filter" = "กรอง";
+
+/* SPV sync phase */
+"Filter headers" = "ส่วนหัวตัวกรอง";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "ค้นหาผู้ใช้บนเครือข่าย Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "ค้นหาตัวตน";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "ลืม PIN ใช่หรือไม่";
 
+/* Identities */
+"Found %d new identities" = "พบตัวตนใหม่ %d รายการ";
+
+/* Identities */
+"Found 1 new identity" = "พบตัวตนใหม่ 1 รายการ";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "พบคำที่หายไป:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "จ่ายค่าชื่อผู้ใช้จากยอดคงเหลือแบบปกปิดของคุณ เติมเงินล่วงหน้าสองสามชั่วโมง — การพักสั้น ๆ นี้ทำให้ชื่อผู้ใช้ของคุณเชื่อมโยงกับ Dash ส่วนอื่นไม่ได้";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "จ่ายจากยอดคงเหลือแบบปกปิดของคุณ — ชื่อผู้ใช้ของคุณเชื่อมโยงกับ Dash ส่วนอื่นไม่ได้";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "เงินถูกล็อก — กำลังทำการโอนให้เสร็จ";
+
+/* CoinJoin */
+"Funds moved" = "ย้ายเงินแล้ว";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "รับรางวัลจากเงินฝากใน Dash มาสเตอร์โหนดที่มีเพียง 0.5 Dash";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "รับใบเสนอราคา";
+
+/* Usernames */
+"Get ready to join DashPay" = "เตรียมพร้อมเข้าร่วม DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "รับรางวัลทันที";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "เข้าใจแล้ว";
+
+/* Governance */
+"Governance" = "ธรรมาภิบาล";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "ให้สิทธิ์ GPS เพื่อให้เราสามารถแสดงสถานที่ใกล้คุณ";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "ได้ขอเป็นเพื่อนกับคุณ";
+
+/* DashPay Invitations */
+"Have an invitation?" = "มีคำเชิญไหม";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "มีการควบคุมที่สมบูรณ์และปรับแต่งกระเป๋าสตางค์ของคุณขึ้นอยู่กับความต้องการของคุณ";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "หัวข้อ #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "ส่วนหัว";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "ความสูง %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "นี่คือที่อยู่ Dash ที่กำหนดไว้สำหรับบัญชี CrowdNode ของคุณในกระเป๋าเงิน Dash บนอุปกรณ์นี้";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "สูงไปต่ำ";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "ค่าธรรมเนียมสูงกว่าราว 7 เซนต์ (ยังต่ำกว่าบล็อกเชนอื่นที่ให้ความเป็นส่วนตัวใกล้เคียงกัน)";
+
 /* No comment provided by engineer. */
 "History" = "ประวัติ";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "ฉันจะรับ Test Dash ได้อย่างไร?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "เมื่อเทียบกับ Bitcoin ในแง่ความเป็นส่วนตัวเป็นอย่างไร";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "เมื่อเทียบกับบัญชี Ethereum ในแง่ความเป็นส่วนตัวเป็นอย่างไร";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay เป็นส่วนตัวแค่ไหน";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "วิธียืนยันที่อยู่ API Dash ของคุณ";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "ฉันได้เขียนลงไปแล้ว";
 
+/* Identities */
+"Identities" = "ตัวตน";
+
 /* Voting */
 "Identity" = "ตัวตน";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "เครดิตของตัวตน";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "ดัชนีตัวตน";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "การลงทะเบียนตัวตน";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "การเติมเครดิตตัวตน";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "ไม่ได้ใช้งาน";
+
+/* No comment provided by engineer. */
 "Income" = "รายได้";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "อินพุต %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "อินพุต %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "อินพุต (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "ยอดเงินไม่เพียงพอ";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "ค่าธรรมเนียมการเชิญ";
 
+/* DashPay Invitations */
+"Invitation from %@" = "คำเชิญจาก %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "คำเชิญใช้โดย";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "การเชิญ";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "เชิญใครสักคนให้เข้าร่วมเครือข่าย Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "เชิญครอบครัวของคุณค้นหาเพื่อนของคุณโดยค้นหาชื่อผู้ใช้ของพวกเขา";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "เชิญเพื่อนและครอบครัวของคุณเข้าร่วมเครือข่าย Dash";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "เชิญเพื่อนและครอบครัวของคุณเข้าสู่เครือข่าย Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "เข้าร่วม pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "เก็บเหรียญเหล่านี้ไว้เป็นส่วนตัว มีค่าธรรมเนียมเครือข่ายและค่าธรรมเนียมความเป็นส่วนตัว";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "รักษาข้อความรหัสผ่านของคุณให้ปลอดภัย";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "คีย์ #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "ข้อมูลคีย์";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "ความเป็นเจ้าของคีย์";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "คีย์";
 
 /* Explore Dash */
 "Last device sync" = "การซิงค์อุปกรณ์ล่าสุด";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "นำอยู่";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "เรียนรู้เพิ่มเติม";
 
 /* Info Screen */
 "Learn More..." = "เรียนรู้เพิ่มเติม...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "กำลังโหลดธุรกรรม";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "สกุลเงินท้องถิ่น";
 
+/* Identities */
+"Local Only" = "เฉพาะในเครื่อง";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "จำนวนเงินที่ต้องการท้องถิ่น: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "ตำแหน่ง";
 
+"Lock" = "ล็อก";
+
+"Lock the name" = "ล็อกชื่อนี้";
+
+"Lock “%@” so nobody gets it" = "ล็อก “%@” ไม่ให้ใครได้ไป";
+
 /* No comment provided by engineer. */
 "Locked" = "ล็อค";
 
+"Locked — nobody receives this username" = "ล็อกแล้ว — ไม่มีใครได้ชื่อผู้ใช้นี้";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "ต่ำ";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "ค่าธรรมเนียมต่ำสำหรับการใช้จ่ายประจำวัน";
+
 /* Voting */
 "Low to high" = "ต่ำไปสูง";
+
+/* Identities — the wallet's main identity */
+"Main" = "หลัก";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "ที่อยู่ IP มาสเตอร์โหนด";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "พวงกุญแจมาสเตอร์โหนด";
+
+/* Masternode keys */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "รายการมาสเตอร์โหนด";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "รายการมาสเตอร์โหนด #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "อัพเดตมาสเตอร์โหนด";
 
+"Masternode votes" = "คะแนนจากมาสเตอร์โหนด";
+
 /* Voting */
 "Masternode Voting Key" = "รหัสการลงคะแนน Masternode";
+
+/* Tools menu */
+"Masternodes" = "มาสเตอร์โหนด";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "มาสเตอร์โหนดและ Evonode ที่ลงทะเบียนด้วยคีย์ของกระเป๋าเงินนี้จะปรากฏที่นี่หลังจากกระเป๋าเงินซิงค์เสร็จ";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "มาสเตอร์โหนดและ Evonode ที่ใช้คีย์ของกระเป๋าเงินนี้";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "มาสเตอร์โหนดจะโหวตชื่อที่มีคนขอมากกว่าหนึ่งคน เราจะแจ้งคุณเมื่อการโหวตสิ้นสุด";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "สูงสุด";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "ถึงขั้นต่ำแล้ว";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "ควบคุมมากขึ้น";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "คำแนะนำเพิ่มเติม";
+
+"Most lock votes" = "คะแนนล็อกมากที่สุด";
+
+"Most votes" = "คะแนนมากที่สุด";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "ย้ายและซูมรูปภาพของคุณเพื่อค้นหาความพอดีที่สมบูรณ์แบบ";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "ย้ายไปยังยอดคงเหลือที่ใช้จ่ายได้ตามปกติ";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "ย้ายไปยังที่อยู่";
+
+/* CoinJoin */
+"Moving funds" = "กำลังย้ายเงิน";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "ชื่อ";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "บริการชื่ออย่าง Unstoppable Domains จับคู่ชื่อที่อ่านออกกับที่อยู่สาธารณะแบบตายตัวบนเชน ใครก็ตามสามารถค้นหาชื่อนั้นและเห็นทุกการชำระเงินที่เคยส่งไป ส่วนชื่อผู้ใช้ DashPay จะไม่ชี้ไปยังที่อยู่ชำระเงินอย่างเปิดเผยเลย — ที่อยู่จะถูกเปิดเผยเฉพาะภายในการแลกเปลี่ยนที่เข้ารหัสกับผู้ติดต่อแต่ละราย ชื่อและเงินของคุณจึงไม่ถูกเชื่อมโยงในสายตาผู้สังเกตภายนอก";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "ต้องการความช่วยเหลือ?";
+
+"Needs attention" = "ต้องดำเนินการ";
 
 /* No comment provided by engineer. */
 "Network" = "เครือข่าย";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "ไม่พบบันทึกการวินิจฉัยบนอุปกรณ์นี้ บันทึกจะถูกเขียนตั้งแต่การเปิดแอปครั้งถัดไปเป็นต้นไป";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "ไม่มีตัวตน";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "ยังไม่มีมาสเตอร์โหนด";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "ไม่มีการชิงชื่อที่ตรงกัน";
+
+/* Identities */
+"No new identities were found for this wallet" = "ไม่พบตัวตนใหม่สำหรับกระเป๋าเงินนี้";
+
+"No open contest matches that search." = "ไม่มีการชิงชื่อที่เปิดอยู่ตรงกับการค้นหานั้น";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "ไม่มีการชิงชื่อที่เปิดอยู่ตรงกับการค้นหานั้น ชื่อจะถูกเก็บในรูปแบบมาตรฐาน ดังนั้น “alice” จึงแสดงเป็น “a11ce”";
+
+"No open contests" = "ไม่มีการชิงชื่อที่เปิดอยู่";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "ไม่มีวิธีการชำระเงิน";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "ไม่พบระเบียนกระเป๋าเงินที่บันทึกไว้สำหรับกระเป๋าเงินที่ผูกอยู่";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "ยังไม่มีที่อยู่ Platform สำหรับการลงทะเบียนแบบปกปิดสำรอง ลองอีกครั้งหลังกระเป๋าเงินซิงค์เสร็จ";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "ไม่พบผลลัพธ์";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "ขณะนี้ไม่มีชื่อผู้ใช้ที่ถูกชิง การชิงชื่อจะเริ่มเมื่อมีคนสองคนขึ้นไปขอชื่อเดียวกัน";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "ไม่มีการลงคะแนน";
+
+"Nobody gets it" = "ไม่มีใครได้ไป";
+
+/* SPV sync peer type */
+"Node" = "โหนด";
+
+/* Raw transaction inspector */
+"Non-standard" = "ไม่มาตรฐาน";
 
 /* adjective, security level */
 "None" = "ไม่มี";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "ไม่สามารถใช้ได้";
 
+"Not available yet" = "ยังใช้งานไม่ได้";
+
+"Not cast" = "ยังไม่ได้ลงคะแนน";
+
+/* Masternodes */
+"Not checked yet" = "ยังไม่ได้ตรวจสอบ";
+
 /* Location Service Status */
 "Not Determined" = "ไม่ได้กำหนด";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "ยอดคงเหลือแบบปกปิดไม่พอสำหรับลงทะเบียนตัวตน";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "ไม่อยู่ในประวัติกระเป๋าเงิน";
+
+"Not now" = "ไว้ทีหลัง";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "ร้านค้ายังรับไม่แพร่หลาย";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "ร้านค้ายังรับไม่แพร่หลาย";
+
+/* Masternode keys */
+"Not yet used" = "ยังไม่ได้ใช้";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "เก่าไปใหม่";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "บน Bitcoin ไม่มีชั้นของชื่อ ผู้คนจึงแบ่งปันและใช้ที่อยู่ซ้ำอย่างเปิดเผย เมื่อรู้ที่อยู่หนึ่งแล้ว ทุกอย่างที่ที่อยู่นั้นเคยได้รับก็เชื่อมโยงกับเจ้าของได้ ส่วน DashPay ชื่อผู้ใช้ของคุณเป็นสาธารณะ แต่ไม่เคยชี้ไปยังที่อยู่ชำระเงิน ที่อยู่จะถูกแลกเปลี่ยนเป็นการส่วนตัวกับผู้ติดต่อแต่ละรายและหมุนเวียนไป การจ่ายด้วยชื่อจึงไม่เปิดเผยว่าเงินของคุณไปที่ใด ทั้งสองเป็นเชนแบบโปร่งใส การวิเคราะห์เชนจึงยังใช้กับตัวเหรียญได้อยู่";
+
+/* Identities */
+"On Network" = "บนเครือข่าย";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "เมื่อ %@ ยอมรับคำขอของคุณแล้ว คุณจะจ่ายตรงไปยังชื่อผู้ใช้ได้";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "ทีละโหนด";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "ซ้ำกันเท่านั้น";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "มีเพียงมาสเตอร์โหนดและ Evonode เท่านั้นที่โหวตชื่อผู้ใช้ได้ กระเป๋าเงินนี้ไม่มีคีย์โหวตมาสเตอร์โหนดที่ใช้งานอยู่";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "คำขอที่มีลิงก์เท่านั้น";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "แค่ลิงก์เท่านั้น";
+
+/* Masternodes */
+"Operator" = "ผู้ดำเนินการ";
+
+/* Masternode keys */
+"Operator keys" = "คีย์ผู้ดำเนินการ";
+
+/* Masternodes */
+"Operator public key (BLS)" = "คีย์สาธารณะของผู้ดำเนินการ (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "หรือ";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "คำสั่งซื้อตัวอย่าง";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "ผลลัพธ์อื่น";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "เอาต์พุต %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "เอาต์พุต (%d)";
+
+/* Masternodes */
+"Owner" = "เจ้าของ";
+
 /* No comment provided by engineer. */
 "Owner Address" = "ที่อยู่เจ้าของ";
+
+/* Masternodes */
+"Owner address" = "ที่อยู่เจ้าของ";
+
+/* Masternodes */
+"Owner key hash" = "แฮชคีย์เจ้าของ";
 
 /* Owner keys */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "หักจากยอดเครดิตของตัวตนคุณ";
 
 /* DashSpend */
 "Password" = "รหัสผ่าน";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "วางลิงก์คำเชิญที่คุณได้รับ หรือสแกนคิวอาร์โค้ดของลิงก์นั้น ลิงก์จะจ่ายค่าลงทะเบียนชื่อผู้ใช้ของคุณ";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "วาง URL ภาพของคุณ";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "ชำระเงินและรับเงินทันทีด้วยกระบวนการชำระเงินที่ใช้งานง่าย";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "จ่ายตรงไปยังชื่อผู้ใช้";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "จ่ายให้คน ไม่ใช่จ่ายให้ที่อยู่";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "จ่ายให้กับชื่อผู้ใช้  ไม่มีที่อยู่ตัวอักษรและตัวเลขอีกต่อไป";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "กำลังชำระเงิน";
 
+/* Raw transaction inspector */
+"Payload hex" = "เพย์โหลด hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "วิธีการชำระเงิน";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "การชำระเงินเป็นส่วนตัว: ที่อยู่ที่คุณแลกเปลี่ยนกับผู้ติดต่อจะเดินทางอยู่ในข้อมูลที่เข้ารหัสซึ่งมีเพียงคุณสองคนอ่านได้ และไม่เคยถูกเผยแพร่ การชำระเงินของคุณจึงไม่ถูกเชื่อมโยงกับชื่อผู้ใช้ได้ง่าย ๆ อย่างไรก็ตาม สิ่งเหล่านี้ยังเป็นการชำระเงินปกติบนเชนแบบโปร่งใส การวิเคราะห์เชนขั้นสูงอาจทำให้ข้อมูลรั่วไหลได้ Shielded DashPay (เร็ว ๆ นี้) จะปิดช่องว่างนั้น ส่วนคำขอการติดต่อเองในตอนนี้ยังไม่เป็นส่วนตัว ใครก็ตามเห็นได้ว่าสองตัวตนเชื่อมโยงกันอยู่ คำขอการติดต่อแบบส่วนตัวเป็นฟีเจอร์ที่จะมาเร็ว ๆ นี้ ชื่อผู้ใช้และโปรไฟล์ของคุณก็เป็นสาธารณะบน Dash Platform เช่นกัน";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "การชำระเงินยืนยันได้ในไม่กี่วินาทีด้วย InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "การชำระเงินที่ทำตรงไปยังที่อยู่จะไม่ถูกเก็บไว้ในกิจกรรม";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "การชำระเงินกับผู้ติดต่อแต่ละรายจะถูกจัดรวมไว้ที่เดียว พร้อมชื่อและโปรไฟล์แทนธุรกรรมดิบ";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "ที่อยู่รับเงิน";
 
 /* CrowdNode */
 "Payout Options" = "ตัวเลือกการจ่ายเงิน";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "ที่อยู่ Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "ยอดคงเหลือ Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "โหนด Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "รหัสโหนด Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "การชำระเงินบน Platform ไม่ระบุตัวผู้ส่ง รายการนี้ถูกบันทึกเมื่อกระเป๋าเงินสังเกตเห็นยอดคงเหลือเปลี่ยนไป — อาจมาถึงก่อนหน้านั้นแล้วก็ได้";
+
+"Platform SDK not ready" = "Platform SDK ยังไม่พร้อม";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "การซิงค์ Platform ไม่ได้ทำงานอยู่ เปิดข้อมูลการซิงค์ → สถานะการซิงค์ Platform เพื่อเริ่ม";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → ปกปิด";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "โปรดเพิ่มวิธีการชำระเงินบน Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "คำเชิญดูตัวอย่าง";
 
+/* Masternode keys */
+"Previously used at: " = "ใช้ครั้งก่อนเมื่อ: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "เป็นส่วนตัวโดยการออกแบบ";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "คำขอการติดต่อแบบส่วนตัว (เพื่อให้การเชื่อมโยงกับใครยังคงเป็นส่วนตัว) Shielded DashPay — การชำระเงินให้ผู้ติดต่อจากยอดคงเหลือแบบปกปิดส่วนตัวของคุณ — และการจ่ายเงินให้ผู้ใช้ที่ยังไม่อยู่ในผู้ติดต่อของคุณ ทั้งหมดกำลังจะมาเร็ว ๆ นี้";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "คำขอการติดต่อแบบส่วนตัวอยู่ระหว่างการพัฒนา คาดว่าราวเดือนกันยายน–ตุลาคม 2026 ปัจจุบันตัวคำขอเองเป็นสาธารณะ — ใครก็ตามเห็นได้ว่าสองตัวตนเชื่อมโยงกันอยู่ แม้รายละเอียดการชำระเงินภายในจะถูกเข้ารหัสก็ตาม เมื่อคำขอการติดต่อแบบส่วนตัวพร้อมใช้งาน คุณจะเลือกได้ว่าจะให้มิตรภาพของคุณเป็นสาธารณะหรือส่วนตัว";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "คำขอการติดต่อแบบส่วนตัว Shielded DashPay และการจ่ายเงินให้คนที่ยังไม่ได้เป็นผู้ติดต่อ";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "ที่อยู่ชำระเงินแบบส่วนตัวจะถูกแลกเปลี่ยนระหว่างคุณกับผู้ติดต่อของคุณ มีเพียงคุณกับผู้ติดต่อเท่านั้นที่รู้ว่าใครเป็นผู้รับและผู้ส่งของการชำระเงินระหว่างกัน";
+
+/* DashPay intro: feature title */
+"Private payments" = "การชำระเงินแบบส่วนตัว";
+
+/* Usernames */
+"Private registration" = "การลงทะเบียนแบบส่วนตัว";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "เวลาดำเนินการ";
+
+/* Balance info sheet section */
+"Pros" = "ข้อดี";
 
 /* CrowdNode Portal */
 "Protect your savings" = "ปกป้องเงินทุนของคุณ";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "ที่อยู่ผู้จัดหา";
 
+/* Masternodes */
+"Provider transactions" = "ธุรกรรมของผู้ให้บริการ";
+
+/* Masternode keys */
+"Public key" = "คีย์สาธารณะ";
+
+/* Masternode keys */
+"Public key (legacy)" = "คีย์สาธารณะ (รุ่นเก่า)";
+
+/* Identities */
+"Public keys" = "คีย์สาธารณะ";
+
 /* No comment provided by engineer. */
 "Public URL" = "URL สาธารณะ";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "การซื้อไม่สำเร็จ";
+
+/* Identities: what a public key is used for */
+"Purpose" = "วัตถุประสงค์";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "ราคา: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "ธุรกรรมดิบ";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "ไม่มีธุรกรรมดิบให้ใช้งาน";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "ตรวจสอบตัวกรองบล็อกแบบกะทัดรัดอีกครั้งตั้งแต่ความสูงที่เลือก เพื่อหาธุรกรรมของกระเป๋าเงินนี้ โดยดาวน์โหลดและจับคู่ใหม่ การสแกนใหม่มีขอบล่างอยู่ที่ความสูงตอนสร้างกระเป๋าเงินและข้อมูลเชนที่เก็บไว้ในเครื่อง — หากต้องการกู้ประวัติที่ต่ำกว่านั้น ให้ลดความสูงเริ่มต้นของกระเป๋าเงินแทน";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "โปรดอ่านนโยบายการถอนเงิน";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "อ่านอย่างเดียว";
+
+/* Usernames */
+"Ready around %@" = "พร้อมราว %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "เหตุผล";
 
 /* No comment provided by engineer. */
 "Receive" = "ได้รับ";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "ได้รับจาก";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "ได้รับจาก %@";
+
 /* CrowdNode */
 "Receiving rewards" = "การรับรีวอร์ด";
+
+"Records your masternodes as having voted, without taking a side." = "บันทึกว่ามาสเตอร์โหนดของคุณได้โหวตแล้ว โดยไม่เข้าข้างฝ่ายใด";
 
 /* No comment provided by engineer. */
 "Recover" = "กู้คืน";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "วลีการกู้คืนต้องมี 12, 15, 18, 21 หรือ 24 ค";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "รีเฟรช";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "ลงทะเบียนหรือไม่";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "ลงทะเบียนเมื่อ";
+
+/* No comment provided by engineer. */
 "Registered from" = "ลงทะเบียนจาก";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternodes ที่ลงทะเบียน";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "การลงทะเบียนแบบส่วนตัวต้องมีอย่างน้อย %@ Dash ในยอดคงเหลือแบบปกปิด บวกกับเวลาพักอีกสองสามชั่วโมง — หน้าจอถัดไปจะพาคุณทำทีละขั้น";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "การลงทะเบียน";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "กำลังขอชื่อนี้";
+
 /* An action */
 "Rescan" = "สแกนอีกครั้ง";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "กระเป๋าเงินที่กู้คืนมาอาจกู้ประเภทการดำเนินการไม่ได้เสมอไป รายการนี้ถูกสร้างขึ้นใหม่จากข้อมูลบันทึกบนเชน";
+
+/* Location Service Status */
 "Restricted" = "ถูกจำกัด";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "เตรียมซิงค์ใหม่จากความสูง %u แล้ว — ปิดแล้วเปิดแอปใหม่เพื่อเริ่ม";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "เก็บประวัติธุรกรรมร่วมกันไว้";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "ปลดระวางแล้ว";
 
 /* No comment provided by engineer. */
 "Retry" = "ลองอีกครั้ง";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "ตรวจสอบการโพสต์ด้านล่างเพื่อยืนยันความเป็นเจ้าของชื่อผู้ใช้นี้";
+
+/* Masternodes */
+"Revocation" = "การเพิกถอน";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "การบันทึกภาพจะปรากฏแก่แอพพลิเคชันและอุปกรณ์อื่น ๆ สร้างวลีกู้คืนใหม่และเก็บไว้เป็นความลับ";
 
+/* Raw transaction inspector */
+"Script" = "สคริปต์";
+
+/* Raw transaction inspector */
+"Script signature" = "ลายเซ็นสคริปต์";
+
+/* Raw transaction inspector */
+"Script type" = "ประเภทสคริปต์";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "ค้นหาผู้ติดต่อ";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "ค้นหาคำขอการติดต่อ";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "ค้นหาผู้ใช้บนเครือข่าย Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "ค้นหาชื่อผู้ใช้";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "ผลการค้นหาสำหรับ \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "ค้นหาชื่อผู้ใช้";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "กำลังค้นหาชื่อผู้ใช้ %@ บนเครือข่าย Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "รักษาความปลอดภัยให้กระเป๋าเงินของคุณ";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "เลเวลความปลอดภัย";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "ระดับความปลอดภัย";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "เลือกบริการที่จะซื้อ ขาย แปลงและโอน Dash";
 
+"Select all" = "เลือกทั้งหมด";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "เลือกมาสเตอร์โหนดอย่างน้อยหนึ่งตัวเพื่อใช้โหวต";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "เลือกเหรียญ";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "การเลือกโหนดน้อยลงจะเปิดเผยน้อยลงว่าคุณดูแลมาสเตอร์โหนดใดบ้าง";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "ส่งไปยัง";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "ส่งให้ผู้ติดต่อ";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "ส่งไปยังชื่อผู้ใช้ที่คุณจดจำและตรวจสอบได้จริง";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "ส่งไปยังที่อยู่";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "ส่งคำขอการติดต่อครั้งแรกของคุณ";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "กำลังส่ง";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "กำลังส่งคำขอการติดต่อ";
+
+/* No comment provided by engineer. */
+"Sending to" = "กำลังส่งไปยัง";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "ส่งไปยังบัญชี CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "ส่งไปยัง";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "ส่งให้ %@ แล้ว";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "บริการ";
+
+/* Identities */
+"Set as Main" = "ตั้งเป็นหลัก";
+
+/* Identities */
+"Set as Main Identity" = "ตั้งเป็นตัวตนหลัก";
 
 /* No comment provided by engineer. */
 "Set PIN" = "ตั้งค่า PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "กลุ่มความเป็นส่วนตัวร่วมอยู่ที่ขนาดขั้นต่ำ";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "ที่อยู่แบบปกปิด";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "การใช้จ่ายแบบปกปิด";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "กำลังเริ่มกระเป๋าเงินแบบปกปิด…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "ปกปิด → Platform";
+
+"Shielded → Transparent" = "ปกปิด → โปร่งใส";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "ขนาด";
+
 /* No comment provided by engineer. */
 "Skip" = "ข้าม";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "มาสเตอร์โหนดบางตัวของคุณอาจไม่อยู่ในรายการนี้ — กระเป๋าเงินอ่านชุดคีย์โหวตของคุณไม่ครบ ซิงค์ให้เสร็จแล้วเปิดหน้านี้ใหม่";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "เรียงลำดับตาม";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "เรียงลำดับผู้ติดต่อ";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "จัดเรียงตามชื่อ";
+
+/* Raw transaction inspector */
+"Special payload" = "เพย์โหลดพิเศษ";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "ระบุจำนวน";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "เริ่มหลังจากคุณเติมเงิน";
+
+/* Transaction details */
+"Status" = "สถานะ";
+
 /* Step 1 */
 "Step %ld" = "ขั้นตอน %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "เก็บไว้เป็น";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "กำลังซิงค์... ผลลัพธ์อาจไม่สมบูรณ์";
 
+/* No comment provided by engineer. */
+"Sync Info" = "ข้อมูลการซิงค์";
+
+/* SPV sync */
+"Sync too slow?" = "ซิงค์ช้าเกินไปไหม";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "ถ่ายภาพจากกล้อง";
 
+"Take no side" = "ไม่เข้าข้างฝ่ายใด";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "แตะที่อยู่จากคลิปบอร์ดเพื่อวาง";
+
+/* Raw transaction inspector */
+"Tap to copy" = "แตะเพื่อคัดลอก";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "กดเพื่อซ่อนยอดคงเหลือ";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "คีย์โหนด Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "รหัสไม่ถูกต้อง กรุณาตรวจสอบและลองอีกครั้ง!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash จะไปถึงที่อยู่ของผู้รับหลังจากเครือข่ายประมวลผลการถอนแล้ว — อาจใช้เวลาถึง 10 นาที";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash จะไปถึงที่อยู่ของผู้รับทันทีที่เครือข่ายประมวลผลการถอน";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash จะไปถึงยอดคงเหลือแบบโปร่งใสของคุณทันทีที่เครือข่ายประมวลผลการถอน";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "เลือกตัวตนหลักได้จากกระเป๋าเงินที่ใช้งานอยู่เท่านั้น";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "จำนวนเงินขั้นต่ำที่คุณสามารถส่งได้คือ %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "ที่ที่เป็นส่วนตัวที่สุดสำหรับเก็บ Dash ของคุณ";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "ระเบียนกระเป๋าเงินที่บันทึกไว้ไม่มีเครือข่าย — เตรียมการซิงค์ใหม่ไม่ได้";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "ส่งการลงทะเบียนแล้วแต่ยืนยันผลลัพธ์ไม่ได้ รอสักหนึ่งนาทีให้กระเป๋าเงินซิงค์ แล้วลองอีกครั้ง — อย่าส่งซ้ำทันที";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "กลุ่มความเป็นส่วนตัวร่วมยังเติบโตอยู่ (%1$ld จาก %2$ld รายการฝาก) การลงทะเบียนแบบส่วนตัวจะปลดล็อกเมื่อถึงขั้นต่ำ";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "กลุ่มความเป็นส่วนตัวร่วมยังเติบโตอยู่ (%1$ld จาก %2$ld รายการฝาก) ลองอีกครั้งเมื่อถึงขั้นต่ำ";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "ความสูงตอนสร้างกระเป๋าเงิน — ขอบล่างสำหรับการสแกนตัวกรองและการสแกนใหม่แบบ “จากตอนสร้างกระเป๋าเงิน” ตั้งค่าให้เท่ากับหรือต่ำกว่าการเติมเงินครั้งแรกของกระเป๋าเงิน การนำเข้าจะใช้ค่าเริ่มต้น 200000 บน mainnet และ 0 บน testnet การบันทึกความสูงที่เท่ากับหรือต่ำกว่าค่าปัจจุบันจะล้างข้อมูลเชนของเครือข่ายนี้ในการเปิดแอปครั้งถัดไปและสแกนใหม่จากความสูงนั้น";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "เขา (กำลังดึงข้อมูล)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "ไม่มีการแจ้งเตือนใหม่";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "ไม่มีธุรกรรมเพื่อแสดง";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "ไม่มีผู้ใช้ที่ตรงกับชื่อ %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "ไม่มีผู้ใช้ที่ตรงกับชื่อ %@ ในผู้ติดต่อของคุณ";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "มีข้อผิดพลาดโปรดลองอีกครั้งในภายหลัง";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "เงินนี้จะย้ายไปยังยอดคงเหลือ Platform ของคุณ และพร้อมใช้จ่ายทันทีที่การโอนเสร็จสมบูรณ์";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "จ่ายไปยังที่อยู่นี้จากยอดคงเหลือ %@ ของคุณไม่ได้";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "การทำเช่นนี้จะเพิ่มคีย์สองตัวให้กับตัวตนของคุณ เพื่อให้ผู้ใช้คนอื่นส่งคำขอการติดต่อมาหาคุณได้ และคุณก็ยอมรับคำขอของพวกเขาได้ เกิดขึ้นเพียงครั้งเดียว";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "การทำเช่นนี้จะใช้ตัวเลือกเดียวกับชื่อผู้ใช้ที่เลือกไว้ทั้ง %d รายการ";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "ขั้นตอนพิเศษนี้แสดงให้เห็นว่าคุณพยายามทำธุรกรรม";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "ลิงก์คำเชิญนี้ไม่ถูกต้อง";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "นี่ไม่ใช่ที่อยู่ Dash ที่ถูกต้องสำหรับเครือข่ายนี้";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "นี่ไม่ใช่ลิงก์คำเชิญที่ถูกต้อง";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "นี่คือตัวตนหลักของคุณ";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "มาสเตอร์โหนดนี้ยังไม่มีตัวตนบน Platform";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "สิ่งนี้แสดงถึงอัตราผลตอบแทนร้อยละต่อปีปัจจุบันของมาสเตอรืโหนด เต็มน้อยกว่าค่าธรรมเนียม CrowdNode 15% แต่มันไม่ได้เป็นอัตราผลตอบแทนที่รับประกันได้และอาจเพิ่มขึ้นหรือลงตามขนาดของกลุ่ม CrowdNode และราคา Dash";
 
+"This still counts as your masternodes having voted in this contest." = "กรณีนี้ยังนับว่ามาสเตอร์โหนดของคุณได้โหวตในการชิงชื่อครั้งนี้แล้ว";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "ไบต์ดิบของธุรกรรมนี้ไม่ได้เก็บไว้บนอุปกรณ์นี้";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "ชื่อผู้ใช้นี้ตกเป็นของคนอื่น";
+
+"This wallet could not derive the voting key for this node." = "กระเป๋าเงินนี้สร้างคีย์โหวตสำหรับโหนดนี้ไม่ได้";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "กระเป๋าเงินนี้ไม่มีคีย์โหวตมาสเตอร์โหนดที่ใช้งานอยู่ จึงโหวตไม่ได้ โหนดที่ลงทะเบียนไว้จะแสดงใน เครื่องมือ → มาสเตอร์โหนด";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "การทำเช่นนี้จะถอนยอดคงเหลือ Platform ทั้งหมดของคุณในการโอนครั้งเดียว Dash จะไปถึงที่อยู่ของผู้รับทันทีที่เครือข่ายประมวลผลการถอน";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "การทำเช่นนี้จะถอนยอดคงเหลือ Platform ทั้งหมดของคุณในการโอนครั้งเดียว Dash จะไปถึงยอดคงเหลือแบบโปร่งใสของคุณทันทีที่เครือข่ายประมวลผลการถอน";
 
 /* Send Screen: to address */
 "to" = "ถึง";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "ประวัติการทำรายการ";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "ไม่มีประวัติธุรกรรมให้ใช้งาน";
+
 /* No comment provided by engineer. */
 "Transaction id" = "id ธุรกรรม";
+
+/* Raw transaction inspector */
+"Transaction ID" = "รหัสธุรกรรม";
 
 /* A verb, button title. */
 "Transfer" = "โอน";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "โอนเข้า";
 
+/* Balance breakdown */
+"Transfer in" = "โอนเข้า";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "โอนออก";
+
+/* Balance breakdown */
+"Transfer out" = "โอนออก";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "การโอนใช้เวลานานกว่า — การสร้างหลักฐานความเป็นส่วนตัวต้องใช้เวลา";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "การโอนไปยังที่อยู่ Platform อื่นและที่อยู่แบบปกปิดเกิดขึ้นทันทีและสิ้นสุด";
+
+/* Balance breakdown */
+"Transparent" = "โปร่งใส";
+
+/* Send screen destination type */
+"Transparent address" = "ที่อยู่แบบโปร่งใส";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "ยอดคงเหลือแบบโปร่งใส";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "การใช้เงินแบบโปร่งใสจะเชื่อมโยงชื่อผู้ใช้ของคุณกับเงินนั้นอย่างเปิดเผย";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "โปร่งใส → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "โปร่งใส → ปกปิด";
 
 /* An action */
 "Try again" = "ลองอีกครั้ง";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "ให้คำแนะนำไม่ได้";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "ไม่ทราบยอดคงเหลือ";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "ประเภทพิเศษที่ไม่รู้จัก %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "ไม่ปกปิด";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "ไม่รับรองแหล่งที่มาของทรัพยากร URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "อัปเกรดเป็น Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "ใช้ยอดคงเหลือแบบโปร่งใสแทน";
+
+/* Masternode keys */
+"Used" = "ใช้แล้ว";
+
+/* Masternode keys */
+"Used at: " = "ใช้เมื่อ: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "ผู้ใช้ (กำลังดึงข้อมูล)";
 
 /* Voting */
 "Username" = "ชื่อผู้ใช้";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "ชื่อผู้ใช้";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "ชื่อผู้ใช้ถูกเก็บในรูปแบบมาตรฐานเพื่อป้องกันชื่อที่ดูคล้ายกัน จึงอาจต่างจากที่แต่ละคนพิมพ์ไว้";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "ชื่อผู้ใช้ ไม่ใช่ที่อยู่";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "ผู้ใช้ที่ตรงกับ %@ ซึ่งขณะนี้ยังไม่อยู่ในผู้ติดต่อของคุณ";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "ใช้หนึ่งในไลบรารีความรู้เป็นศูนย์ที่ผ่านการตรวจสอบและทดสอบมากที่สุด (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "คำเชิญถูกต้อง";
+
 /* CrowdNode Portal */
 "Validating address…" = "ตรวจสอบที่อยู่...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "จำเป็นต้องมีการตรวจสอบ";
 
+/* Usernames */
+"Verified during registration" = "ยืนยันแล้วระหว่างการลงทะเบียน";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "ตรวจสอบสำเร็จ";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "เวอร์ชัน";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "มีประสิทธิภาพสูงมากและค่าธรรมเนียมต่ำ";
+
 /* adjective, security level */
 "Very High" = "สูงมาก";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Dash จำนวนน้อยมากจะถูกส่งไปและกลับจาก CrowdNode เพื่อตรวจสอบว่าคุณเป็นเจ้าของที่อยู่กระเป๋าเงินนี้";
+
+/* No comment provided by engineer. */
+"View All" = "ดูทั้งหมด";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "ดูใน Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "ดูวลีกู้คืน";
 
+/* Raw transaction inspector */
+"View Transaction" = "ดูธุรกรรม";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "โหวต";
+
+"Vote cast" = "ลงคะแนนแล้ว";
+
 /* Voting */
 "Vote for All" = "โหวตให้ทุกคน";
 
 /* Voting */
+"Vote on contested usernames" = "โหวตชื่อผู้ใช้ที่มีการแข่งขัน";
+
+"Vote on several" = "โหวตหลายรายการ";
+
+/* Voting */
 "Vote to Approve" = "ลงคะแนนเพื่ออนุมัติ";
+
+"Vote with" = "โหวตด้วย";
+
+"Votes that nobody should receive these usernames." = "โหวตว่าไม่ควรมีใครได้ชื่อผู้ใช้เหล่านี้";
 
 /* Voting */
 "Votes: High to low" = "โหวต: สูงไปต่ำ";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "ที่อยู่ซึ่งใช้ในการออกเสียงลงคะแนน";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "ที่อยู่ซึ่งใช้ในการออกเสียงลงคะแนน";
+
+"Voting ended with no winner" = "การโหวตสิ้นสุดโดยไม่มีผู้ชนะ";
+
+"Voting ends" = "การโหวตสิ้นสุด";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "การโหวตดำเนินอยู่";
+
+"Voting in progress — lock votes are ahead" = "การโหวตดำเนินอยู่ — คะแนนล็อกนำอยู่";
+
+"Voting in progress — you are ahead" = "การโหวตดำเนินอยู่ — คุณนำอยู่";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "แฮชคีย์การโหวต";
+
 /* Voting keys */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "การโหวตชื่อผู้ใช้นี้ปิดแล้ว จำนวนด้านล่างคือค่าที่อ่านได้ล่าสุด";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "การโหวต “%@” ปิดไปแล้ว รีเฟรชเพื่อดูผล";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "รอจนกว่ากระเป๋าเงินจะถูกซิงค์เพื่อทำธุรกรรมให้เสร็จสมบูรณ์";
 
+"Waiting for Dash Platform" = "กำลังรอ Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "ที่อยู่กระเป๋าเงิน";
+
+/* SPV diagnostics */
+"Wallet birth height" = "ความสูงเริ่มต้นของกระเป๋าเงิน";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "wallet ถูกปิดการใช้งาน";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "ยินดีต้อนรับสู่ DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "แล้ว Unstoppable Domains และบริการชื่อที่คล้ายกันล่ะ";
+
+/* DashPay FAQ */
+"What does it cost?" = "มีค่าใช้จ่ายเท่าไร";
+
+/* DashPay FAQ */
+"What is DashPay?" = "DashPay คืออะไร";
+
 /* Usernames */
 "What is username voting?" = "การโหวตชื่อผู้ใช้คืออะไร?";
+
+/* DashPay FAQ */
+"What's coming next?" = "อะไรจะมาต่อไป";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "คำขอการติดต่อจะเป็นส่วนตัวเมื่อใด";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "จะใช้จ่ายที่ไหน";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "จะใช้จ่ายที่ไหน?";
+
+"Who is requesting this name" = "ใครกำลังขอชื่อนี้";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "ทำไมฉันต้องเปิดใช้";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "ทำไมฉันถึงเห็นธุรกรรมเหล่านี้ทั้งหมด?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "ขอถอนเงิน";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "ถอนยอดคงเหลือทั้งหมด";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "ใช้ได้กับกระเป๋าเงิน Dash ทุกใบ ทุกกระดานเทรด และทุกร้านค้า";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "คุณต้องการยอมรับคำเชิญหรือไม่?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "เมื่อวาน";
+
+"You" = "คุณ";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "คุณยอมรับคำขอการติดต่อจาก %@ แล้ว";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "ขณะนี้คุณยังไม่มีผู้ติดต่อ";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "คุณมีเงินทุนไม่เพียงพอที่จะดำเนินการทางธุรกรรมได้สำเร็จ";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "คุณทำรายการเกินขีดจำกัดการอนุญาตของ Coinbase";
+
+/* Usernames */
+"You have %@ Dash so far" = "ตอนนี้คุณมี %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "คุณส่งคำขอการติดต่อไปยัง %@ แล้ว";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "คุณควรมียอดเงินคงเหลือบนกระเป๋าเงิน Dash มากกว่านี้";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "คุณได้ชื่อผู้ใช้นี้";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "พร้อมแล้ว ผู้ใช้คนอื่นส่งคำขอการติดต่อมาหาคุณได้แล้ว — และคุณก็ส่งของคุณได้เช่นกัน";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "ตัวตน Dash Platform ของคุณจะปรากฏที่นี่เมื่อคุณลงทะเบียนชื่อผู้ใช้";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "ประวัติของคุณ จัดระเบียบไว้แล้ว";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "ตัวตนของคุณต้องมีคีย์เพิ่มอีกสองตัวเพื่อให้คำขอการติดต่อเข้ารหัสระหว่างคุณกับผู้ใช้คนอื่นได้ การเปิดใช้จะเพิ่มคีย์เหล่านั้นด้วยธุรกรรมเครือข่ายเพียงรายการเดียว เกิดขึ้นเพียงครั้งเดียว";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "คำเชิญของคุณจาก %@ ได้รับการเคลมแล้ว ";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "คำเชิญของคุณจาก %@ ไม่ถูกต้อง";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "คำเชิญของคุณจะจ่ายค่าธรรมเนียมการลงทะเบียนสำหรับชื่อผู้ใช้นี้";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "ตำแหน่งของคุณใช้เพื่อแสดงตำแหน่งของคุณบนแผนที่ตู้เอทีเอ็มในขอบเขตที่เลือกและปรับปรุงผลการค้นหา";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "ตำแหน่งของคุณใช้เพื่อแสดงตำแหน่งของคุณบนแผนที่ร้านค้าใน redius ที่เลือกและปรับปรุงผลการค้นหา";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "ยอดคงเหลือ Dash หลักของคุณบนบล็อกเชน Core — ยอดที่คุณส่งและรับกับกระเป๋าเงิน กระดานเทรด และร้านค้าอื่น ๆ";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "เหรียญที่ผสมแล้วของคุณถูกย้ายไปยังยอดคงเหลือกระเป๋าเงิน Dash";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "เหรียญที่ผสมแล้วของคุณถูกย้ายไปยังยอดคงเหลือแบบปกปิด เพื่อความเป็นส่วนตัวสูงสุด โปรดรออย่างน้อย 2 ชั่วโมงก่อนใช้เงินนี้";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "ยอดคงเหลือ Platform ของคุณ";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "ที่อยู่หลัก Dash ของคุณที่คุณใช้สำหรับบัญชี CrowdNode ของคุณในปัจจุบัน";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "ยอดคงเหลือส่วนตัวของคุณ จำนวนเงินและที่อยู่ถูกเข้ารหัสบนเชน สินทรัพย์และประวัติของคุณจึงเป็นความลับ";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "ยอดคงเหลือแบบปกปิดของคุณ";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "ยอดคงเหลือแบบปกปิดของคุณเกือบพร้อมแล้ว — คุณจะลงทะเบียนแบบส่วนตัวได้ราว %@";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "ยอดคงเหลือแบบปกปิดของคุณพร้อมแล้ว — ลงทะเบียนชื่อผู้ใช้แบบส่วนตัวได้เลย";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "ยอดคงเหลือแบบปกปิดของคุณกำลังพักอยู่ — คุณจะลงทะเบียนแบบส่วนตัวได้ราว %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "ยอดคงเหลือแบบปกปิดของคุณยังบ่มอยู่ จะพร้อมราว %@";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "ยอดคงเหลือแบบโปร่งใสของคุณ";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "ชื่อผู้ใช้ของคุณ %@ ได้รับการสร้างที่ประสบความสำเร็จบนเครือข่าย Dash";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "ชื่อผู้ใช้ของคุณทุกคนมองเห็นได้ การจ่ายค่าชื่อจากยอดคงเหลือแบบปกปิด — หลังปล่อยเงินพักไว้สองสามชั่วโมง — หมายความว่าไม่มีใครเชื่อมโยงชื่อผู้ใช้ของคุณกับ Dash ส่วนอื่นได้";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "ชื่อผู้ใช้ โปรไฟล์ และผู้ติดต่อของคุณผูกอยู่กับตัวตนนี้";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "ชื่อผู้ใช้ โปรไฟล์ และผู้ติดต่อของคุณจะผูกอยู่กับตัวตนนี้";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "การลงคะแนนของคุณถูกยกเลิก";
 
 /* Voting */
 "Your vote was submitted" = "การลงคะแนนของคุณถูกยกเลิก";
 
+"Your votes" = "คะแนนของคุณ";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "กระเป๋าเงินของคุณปลอดภัยแล้ว คุณสามารถใช้วลีกู้คืนได้ทุกเวลาเพื่อกู้คืนบัญชีของคุณบนอุปกรณ์อื่น";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "กระเป๋าเงินของคุณยังซิงค์กับเครือข่าย Dash อยู่ จะส่งได้เมื่อซิงค์เสร็จ";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "กระเป๋าเงินของคุณยังซิงค์อยู่ จะส่งจากยอดคงเหลือแบบโปร่งใสได้เมื่อซิงค์เสร็จ";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "อ่าน “%@” เป็นชื่อผู้ใช้ Dash ไม่ได้";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "ลงทะเบียน “%@” แล้ว ต้องการส่งคำขอการติดต่อไปยังคนที่เชิญคุณไหม";

--- a/DashWallet/th.lproj/Localizable.stringsdict
+++ b/DashWallet/th.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d คีย์</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>นับ %#@votes@ ให้ “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u คะแนน</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>ลงคะแนนแล้ว %1$d จาก %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d ชื่อผู้ใช้</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>ลงคะแนน %u เสียง</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d จาก %#@nodes@ ลงคะแนนแล้ว</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d มาสเตอร์โหนด</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d จาก %#@nodes@ ลงคะแนนแล้ว</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d โหนด</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>รวม %u คะแนน</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d มาสเตอร์โหนด</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>เลือกแล้ว %d รายการ</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>โหนดของคุณ %d โหนดลงคะแนนที่นี่แล้วและไม่แสดงในรายการ</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u คะแนนต่อการชิงชื่อหนึ่งครั้ง — Evonode นับเป็น 4 มาสเตอร์โหนดนับเป็น 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>โหวตชื่อผู้ใช้ %d รายการ</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u คะแนน</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>โหวต ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d คำขอ</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " veya ";
+
 /* CrowdNode */
 " Privacy Policy " = "Gizlilik Politikası";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "İletişim isteği göndermek için %@ Dash ağında bulunamadı.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash kullanılabilir";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ iletişim isteğinizi kabul etti";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d bayt";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duff";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "Cüzdanınızda birden fazla oylama anahtarı saklandığı için %d oy kullanılacak";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld kopyalar";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld yatırma";
 
 /* Voting */
 "%ld requests" = "%ld istekler";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" bir kurtarma sözcüğü değildir. Yerine gelmesi gereken doğru sözcüğü denemek ister misiniz?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Platform adresleri arasındaki anlık ödemelerde ve kullanıcı adı gibi özelliklerde kullanılan, Dash Platform üzerindeki kredi bakiyesi.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Cüzdanınızın korunması için bir cihaz şifresi gerekmektedir. Devam etmek için Ayarlar'dan şifreyi etkinleştirin.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Hakkında";
 
+/* DashPay FAQ title */
+"About DashPay" = "DashPay hakkında";
+
 /* No comment provided by engineer. */
 "About me" = "Hakkımda";
+
+"Abstain" = "Çekimser kal";
+
+"Abstain on “%@”" = "“%@” konusunda çekimser kal";
 
 /* No comment provided by engineer. */
 "Accept" = "Kabul et";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Hesap Kurtarma";
 
+/* Masternode status */
+"Active" = "Etkin";
+
+/* No comment provided by engineer. */
+"Activity" = "Etkinlik";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Etkinlik herkese açıktır ama izlenmesi kolay değildir";
+
 /* No comment provided by engineer. */
 "Add" = "Ekle";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "%@ kişisini kişi olarak ekle";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Kullanıcı adına doğrudan ödeme yapmak ve karşılıklı işlem geçmişini saklamak için %@ kişisini kişilerinize ekleyin";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Korumalı bakiyenize %@ Dash ekleyin ve kullanıcı adınızın diğer fonlarınızla ilişkilendirilmeden kaydolması için birkaç saat bekletin.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Yeni Kişi Ekle";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Korumalı bakiyenize en az %@ Dash ekleyin";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Şimdi korumalı bakiyenize fon ekleyin ve birkaç saat sonra kullanıcı adınızı gizlice kaydedin";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Hepsi";
 
+"All nodes at once" = "Tüm düğümler birden";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tüm anadüğümleriniz bu kullanıcı adı için oy verdi. Bir oyu değiştirmek için şimdi tercih ettiğiniz adaydan yeniden oy verin.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Tüm işlemlerin Dash Cüzdanından Zenledger'a gönderilmesine izin verilsin mi?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Bakiye eşitlemesi neredeyse anında";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Tutarlar ve adresler blok zincirinde herkese açıktır";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Bir Ethereum hesabı tek ve yeniden kullanılan bir adrestir: tüm bakiyeniz ve ödeme geçmişiniz herkese açık şekilde onun altında yer alır ve bir ad (örneğin bir ENS alan adı) genellikle doğrudan o adresi gösterir, herkes çözümleyebilir. DashPay bunun tam tersidir — ad, bir ödeme adresine değil bir kimliğe çözümlenir ve gerçek ödeme adresleri şifreli kişi değişimlerinin içinde kalır, her kişi için yeniden oluşturulur.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Tüm cihazlarınızda tanıdık sezgisel bir deneyim";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Bir adresi bilen herkes onun geçmişini görüntüleyebilir";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Uygula";
 
+"Approve" = "Onayla";
+
+"Approving a specific request can only be done one username at a time." = "Belirli bir isteğin onaylanması yalnızca tek seferde bir kullanıcı adı için yapılabilir.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Bu siparişi iptal etmek istediğinizden emin misiniz?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Metin olarak";
 
 /* DashSpend */
 "at" = "de";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Kimlik doğrulama iptal edildi. Oyunuz kullanılmadı.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Kimlik doğrulama başarısız. Oyunuz kullanılmadı.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Kimlik doğrulaması yapılamıyor";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "“%@” adını bu adaya ver";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Bakiye";
 
 /* CrowdNode */
+"Balance after" = "Sonraki bakiye";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "CrowdNode'daki Bakiye";
 
 /* CrowdNode */
 "Balance: " = "Bakiye:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Bakiyeler ve transferler herkese açık değildir";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Banka Hesabı";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Başlangıç yüksekliği kaydedildi — yükseltilen tarama alt sınırı bir sonraki açılıştan itibaren geçerlidir.";
+
 /* Voting */
 "Block" = "Blok";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Sözleşmeye bağlı";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Sözleşmeye bağlı, belge türü “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Yalnızca göz atma";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Son tanılama günlüklerini AirDrop ile göndermek, e-postalamak veya Dosyalar'a kaydetmek üzere bir zip dosyasında toplar";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Oyu kullan";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Eşleri değiştir";
 
 /* No comment provided by engineer. */
 "Change PIN" = "PİN Değiştir";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Kontrol ediliyor…";
+
+"Choice" = "Seçim";
+
 /* Choose your Dash username */
 "Choose your" = "Seçin";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Kullanıcı adınızı seçin";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Davetiyenizi alın";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Talep edilebilir bakiye";
+
 /* No comment provided by engineer. */
 "Claimed" = "Talep Edildi";
+
+/* SPV diagnostics */
+"Clear & resync" = "Temizle ve yeniden eşitle";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Zincir verileri temizlenip yeniden eşitlensin mi?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Uygulamayı kapat";
 
+"Closing" = "Kapanıyor";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (yeni coinler)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA kodu";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin artık desteklenmiyor — karıştırılmış coinlerinizi nereye taşıyacağınızı seçin.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Teminat";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Yakında";
+
+/* Shielded transfer status */
+"Completed" = "Tamamlandı";
 
 /* No comment provided by engineer. */
 "Confirm" = "Onayla";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Onaylandı";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Onaylamak, %u başlangıç yüksekliğini kaydeder ve bu ağın zincir verilerini uygulamanın bir sonraki açılışında temizleyerek yeniden indirir ve filtreleri o yükseklikten yeniden tarar. Çalışan oturum eski tarama alt sınırını korur — başlatmak için uygulamadan çıkıp yeniden açın.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Kripto cüzdanlarınızı ZenLedger platformuna bağlayın. Daha fazlasını öğrenin ve Dash Cüzdan işlemlerinize başlayın.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Bağlantılı Dash adresleri";
 
+/* SPV sync */
+"Connected peers" = "Bağlı eşler";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Eksileri";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "İletişim isteği başarısız";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "%@ kişisine iletişim isteği gönderildi";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "İletişim İstekleri";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Kişiler";
 
+"Contender %@" = "Aday %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Devam";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Kullanıcı adınızı seçmek için devam edin. Davetiye kayıt ücretini karşılar.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Davet Linkini Kopyala";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Ham işlemi kopyala";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Otomatik olarak eksik veya hatalı sözcükleri yedekleyememektedir";
 
+/* Log export */
+"Could not create the log archive: %@" = "Günlük arşivi oluşturulamadı: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Döviz kuru bulunamadı.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "%d kimlik yenilenemedi";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Bakiye alınamadı (ağ hatası). Yenilemeyi deneyin.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Ödeme yapılamadı";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Kullanıcı adınızı oluşturun";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Kullanıcı adınızı oluşturun, arkadaşlarınızı ve ailenizi kullanıcı adlarıyla bulun ve kişilerinize ekleyin";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Kredi Kartı";
+
+/* Masternodes */
+"Credits" = "Krediler";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash ödemesi %@ altında olamaz";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform bu çekişmeyi henüz dizinlemedi. Dizinlendiğinde oy sayıları burada görünecek.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform henüz bağlı değil. Eşitlemenin bitmesini bekleyip tekrar deneyin.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Yanlış bir adrese gönderilen Dash geri alınamaz. Adresin tam olarak ödeme yapmak istediğiniz adres olduğundan emin olun.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash, kullanıcı adlarını benzer görünüme karşı güvenli bir biçimde saklar, bu yüzden saklanan ad her kişinin yazdığından farklı olabilir.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash kullanıcı adı";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Cüzdanı";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash Cüzdanı bakiyesi";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Bu cihazdaki Dash Cüzdanı";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay etkinleştirildi";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Davetiyesi";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay, Dash Platform üzerine kurulu, Dash'in sosyal ödeme deneyimidir. Bir kullanıcı adı kaydedersiniz, diğer kullanıcıları kişi olarak eklersiniz ve onlara adlarıyla ödeme yaparsınız — artık adres kopyalamak yok.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay, uzun ve anlaşılmaz adreslerin yerine kullanıcı adlarını koyar. Arkadaşlarınızı kişi olarak ekleyin, bir ada para gönderin ve her ödemeyi kişiye göre düzenli tutun.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Yükseltme Ücreti";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Tarih: Eskiden yeniye";
+
+"Deadline unknown" = "Son tarih bilinmiyor";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Para yatırma işleminiz gönderildi";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Türetme yolu";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "CİHAZ GÜVENLİĞİ ZAYIFLADI\nHerhangi bir 'jailbreak' uygulaması diğer uygulamaların verilerine erişebilir (ve Dashlerinizi çalabilir). Bu cüzdanı hemen silin ve güvenli bir cihaza yükleyin.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Devre dışı";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Coinbase Hesabının Bağlantısını Kes";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Bitti";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Bitti — bakiyeniz yeterince uzun süre bekledi";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Adresi iki kez kontrol edin";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Her davetiye, alıcının Dash Ağında kullanıcı adını hızlı bir şekilde oluşturabilmesi için bu tutarla finanse edilecektir.";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Her anadüğümün her çekişmede bir geçerli oyu vardır. Bunu daha sonra değiştirebilirsiniz ama Dash Platform çekişme başına anadüğüm başına toplamda yalnızca 5 oya izin verir.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Her dokunuş bir düğüm daha ekleyerek oy verir, böylece kaç tanesini birbirine bağlayacağınızı siz seçersiniz.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Önceki";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Dash'i kolayca stake edin ve birkaç basit tıklamayla pasif gelir elde edin.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Başlangıç yüksekliğini düzenle";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Profili Düzenle";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "E-Posta";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Etkinleştir";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "DashPay'i etkinleştir";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Yüz Kimliğini Etkinleştir";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Dokunmatik Kimliği Etkinleştir";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "DashPay'i etkinleştirmek, kimliğinizin kredi bakiyesinden ödenen küçük ve bir defalık bir ağ ücretine mal olur. Kesin tahmin, onaylamanızdan önce gösterilir. İletişim isteği ve ödeme göndermek olağan ağ ücretlerine tabidir.";
+
+"Ending soonest" = "En erken bitiyor";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Profiliniz güncellenirken hata oluştu";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Tahmini ağ ücreti";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Her düğüm birlikte oy verir. Daha hızlıdır ama anadüğümlerinizi herkese açık şekilde birbirine bağlar.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode operatör anahtarları";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Günlükleri dışa aktar";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Harici adres";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID limiti";
+
+/* No comment provided by engineer. */
+"Failed" = "Başarısız";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fiyatlar getiriliyor…";
 
+/* Masternodes */
+"Fetching…" = "Alınıyor…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Hesabı";
 
 /* No comment provided by engineer. */
 "Filter" = "Filtre";
+
+/* SPV sync phase */
+"Filter headers" = "Filtre başlıkları";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Dash Ağında bir kullanıcı bul";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Kimlikleri bul";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "PİN'inizi unuttunuz mu?";
 
+/* Identities */
+"Found %d new identities" = "%d yeni kimlik bulundu";
+
+/* Identities */
+"Found 1 new identity" = "1 yeni kimlik bulundu";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Eksik sözcük bulundu:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Kullanıcı adınızı korumalı bakiyenizden karşılayın. Fonları birkaç saat önceden ekleyin — kısa bekleme, kullanıcı adınızın diğer Dash'lerinizle ilişkilendirilmesini engeller.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Korumalı bakiyenizden karşılandı — kullanıcı adınız diğer Dash'lerinizle ilişkilendirilemez.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Fonlar kilitli — transfer tamamlanıyor";
+
+/* CoinJoin */
+"Funds moved" = "Fonlar taşındı";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "0,5 Dash gibi küçük bir miktar ile Dash Masternode'da para yatırma işlemlerinden ödüller kazanın.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Teklif Al";
+
+/* Usernames */
+"Get ready to join DashPay" = "DashPay'e katılmaya hazırlanın";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Anında Ödül Kazanın";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Play";
 
 /* No comment provided by engineer. */
+"Got it" = "Anladım";
+
+/* Governance */
+"Governance" = "Yönetişim";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Size yakın konumları gösterebilmemiz için GPS izinleri verin.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "arkadaşınız olmak istedi";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Davetiyeniz var mı?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Tam kontrol sahibi olun ve cüzdanınızı ihtiyacınıza göre özelleştirin";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "başlık #%1$d / %2$d";
+
+/* SPV sync phase */
+"Headers" = "Başlıklar";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Yükseklik %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Bu cihazdaki Dash Cüzdanında CrowdNode hesabınız için belirlenmiş bir Dash adresi";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Yüksekten alçağa";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Yaklaşık 7 sent civarında daha yüksek ücretler (benzer gizlilik sunan diğer blok zincirlerden yine de düşük)";
+
 /* No comment provided by engineer. */
 "History" = "Geçmiş";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Test Dash'ı nasıl edinebilirim?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Gizlilik açısından Bitcoin ile karşılaştırıldığında nasıl?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Gizlilik açısından Ethereum hesaplarıyla karşılaştırıldığında nasıl?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay ne kadar özel?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "API Dash adresinizi nasıl onaylarsınız?";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Not aldım";
 
+/* Identities */
+"Identities" = "Kimlikler";
+
 /* Voting */
 "Identity" = "Kimlik";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Kimlik kredileri";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Kimlik dizini";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Kimlik kaydı";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Kimlik yükleme";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Etkin değil";
+
+/* No comment provided by engineer. */
 "Income" = "Gelir";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Başlatılıyor";
+
+/* Raw transaction inspector */
+"Input %d" = "Girdi %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Girdi %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Girdiler (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Yetersiz bakiye";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Davet Ücreti";
 
+/* DashPay Invitations */
+"Invitation from %@" = "%@ kişisinden davetiye";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Davetiyeyi kullanan kişi";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Davet etmek";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Birini Dash Ağına davet edin";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Ailenizi davet edin, kullanıcı adlarını aratarak arkadaşlarınızı bulun";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Arkadaşlarınızı ve ailenizi Dash Ağı'na katılmaya davet edin.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Arkadaşlarınızı ve ailenizi Dash Ağına davet edin";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Havuza katılmak";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Bu coinleri özel tutun. Ağ ve gizlilik ücretleri geçerlidir.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Parolanızı güvende tutun";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Anahtar #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Anahtar verisi";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Anahtar sahipliği";
+
 /* No comment provided by engineer. */
 "Keypair" = "Anahtar Çifti";
+
+/* Masternodes */
+"Keys" = "Anahtarlar";
 
 /* Explore Dash */
 "Last device sync" = "Son cihaz senkronizasyonu";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Önde";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Daha fazla bilgi";
 
 /* Info Screen */
 "Learn More..." = "Daha fazla bilgi edin...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "İşlemler yükleniyor";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Yerel Para Birimi";
 
+/* Identities */
+"Local Only" = "Yalnızca yerel";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Yerel istenilen miktar: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Konum";
 
+"Lock" = "Kilitle";
+
+"Lock the name" = "Adı kilitle";
+
+"Lock “%@” so nobody gets it" = "Kimse alamasın diye “%@” adını kilitle";
+
 /* No comment provided by engineer. */
 "Locked" = "Kilitlendi";
 
+"Locked — nobody receives this username" = "Kilitlendi — bu kullanıcı adını kimse alamaz";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Düşük";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Günlük harcamalar için düşük ücretler";
+
 /* Voting */
 "Low to high" = "Alçaktan yükseğe";
+
+/* Identities — the wallet's main identity */
+"Main" = "Ana";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Ananet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "Ana düğüm IP adresi";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Anadüğüm Anahtarlığı";
+
+/* Masternode keys */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Anadüğüm listesi";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "Anadüğüm listesi #%1$d / %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Anadüğüm Güncellemesi";
 
+"Masternode votes" = "Anadüğüm oyları";
+
 /* Voting */
 "Masternode Voting Key" = "Ana düğüm Oylama Anahtarı";
+
+/* Tools menu */
+"Masternodes" = "Anadüğümler";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Bu cüzdanın anahtarlarıyla kaydedilmiş anadüğümler ve evonode'lar, cüzdan eşitlendikten sonra burada görünecek.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Bu cüzdanın anahtarlarını kullanan anadüğümler ve evonode'lar";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Anadüğümler, birden fazla kişinin istediği adlar için oy verir. Oylama bittiğinde size bildirilecek.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Maksimum";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Asgari tutara ulaşıldı";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Daha Fazla Kontrol";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Daha fazla öneri";
+
+"Most lock votes" = "En çok kilitleme oyu";
+
+"Most votes" = "En çok oy";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Mükemmel uyumu bulmak için fotoğrafınızı hareket ettirin ve yakınlaştırın";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Olağan harcanabilir bakiyenize taşıyın.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Adrese Taşındı";
+
+/* CoinJoin */
+"Moving funds" = "Fonlar taşınıyor";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "İsim";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains gibi ad hizmetleri, okunabilir bir adı zincir üzerindeki sabit ve herkese açık bir adrese eşler. Herkes bu adı çözümleyip ona yapılmış her ödemeyi görebilir. Bir DashPay kullanıcı adı hiçbir zaman herkese açık şekilde bir ödeme adresine çözümlenmez — adresler yalnızca her kişiyle yapılan şifreli değişimin içinde açığa çıkar, böylece adınız ve paranız dışarıdan bakanlar için ilişkisiz kalır.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Yardıma mı ihtiyacınız var?";
+
+"Needs attention" = "İlgi gerekiyor";
 
 /* No comment provided by engineer. */
 "Network" = "Ağ";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Bu cihazda tanılama günlüğü bulunamadı. Günlükler bir sonraki açılıştan itibaren yazılır.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Kimlik Yok";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Henüz anadüğüm yok";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Eşleşen çekişme yok";
+
+/* Identities */
+"No new identities were found for this wallet" = "Bu cüzdan için yeni kimlik bulunamadı";
+
+"No open contest matches that search." = "Bu aramayla eşleşen açık çekişme yok.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Bu aramayla eşleşen açık çekişme yok. Adlar normalleştirilmiş biçimde saklanır, bu yüzden “alice”, “a11ce” olarak listelenir.";
+
+"No open contests" = "Açık çekişme yok";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Ödeme yöntemi yok";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Bağlı cüzdan için kayıtlı cüzdan satırı bulunamadı.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Korumalı kayıt yedeği için henüz kullanılabilir bir Platform adresi yok. Cüzdan eşitlemeyi bitirdikten sonra tekrar deneyin.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Sonuç bulunamadı";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Şu anda çekişmeli bir kullanıcı adı yok. İki veya daha fazla kişi aynı adı istediğinde çekişme başlar.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Hiç oy kullanılmadı";
+
+"Nobody gets it" = "Kimse alamasın";
+
+/* SPV sync peer type */
+"Node" = "Düğüm";
+
+/* Raw transaction inspector */
+"Non-standard" = "Standart dışı";
 
 /* adjective, security level */
 "None" = "Hiçbiri";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Mevcut değil";
 
+"Not available yet" = "Henüz kullanılamıyor";
+
+"Not cast" = "Kullanılmadı";
+
+/* Masternodes */
+"Not checked yet" = "Henüz kontrol edilmedi";
+
 /* Location Service Status */
 "Not Determined" = "Belirlenmedi";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Bir kimlik kaydetmek için yeterli korumalı bakiye yok";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Cüzdan geçmişinde yok";
+
+"Not now" = "Şimdi değil";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Satıcılar tarafından yaygın olarak kabul edilmiyor";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Satıcılar tarafından henüz yaygın olarak kabul edilmiyor";
+
+/* Masternode keys */
+"Not yet used" = "Henüz kullanılmadı";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Eskiden yeniye";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoin'de bir ad katmanı yoktur, bu yüzden insanlar adresleri açıkça paylaşır ve yeniden kullanır — bir adres bir kez bilindiğinde, o adrese gelmiş her şey sahibiyle ilişkilendirilebilir. DashPay'de kullanıcı adınız herkese açıktır ama hiçbir zaman bir ödeme adresini göstermez: adresler her kişiyle özel olarak değiştirilir ve döner, bu yüzden adla ödeme yapmak paranızın nereye gittiğini yayımlamaz. Her ikisi de şeffaf zincirlerdir, dolayısıyla zincir analizi coinlerin kendisi için hâlâ geçerlidir.";
+
+/* Identities */
+"On Network" = "Ağda";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "%@ isteğinizi kabul ettiğinde kullanıcı adına doğrudan ödeme yapabilirsiniz";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Her seferinde bir düğüm";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Yalnızca kopyalar";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Kullanıcı adları için yalnızca anadüğümler ve evonode'lar oy verebilir. Bu cüzdanda etkin anadüğüm oy verme anahtarı yok.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Yalnızca bağlantı içeren istekler";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Yalnızca bağlantılarla";
+
+/* Masternodes */
+"Operator" = "Operatör";
+
+/* Masternode keys */
+"Operator keys" = "Operatör anahtarları";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Operatör açık anahtarı (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "veya";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Sipariş Önizleme";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Diğer sonuçlar";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Çıktı %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Çıktılar (%d)";
+
+/* Masternodes */
+"Owner" = "Sahip";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Sahip Adresi";
+
+/* Masternodes */
+"Owner address" = "Sahip adresi";
+
+/* Masternodes */
+"Owner key hash" = "Sahip anahtarı özeti";
 
 /* Owner keys */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Kimliğinizin kredi bakiyesinden ödendi.";
 
 /* DashSpend */
 "Password" = "Şifre";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Aldığınız davet bağlantısını yapıştırın veya QR kodunu tarayın. Kullanıcı adı kaydınızı karşılar.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Resim URL'nizi yapıştırın";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Kullanımı kolay ödeme akımlarıyla anında ödeme yapın ve alın";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "kullanıcı adına doğrudan ödeme yapmak";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Adreslere değil, kişilere ödeme yapın";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Kullanıcı adlarına ödeme yapın. Artık alfanümerik adres yok";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Ödeniyor...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Yük (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Ödeme şekli";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Ödemeler özeldir: bir kişiyle değiş tokuş ettiğiniz adresler yalnızca ikinizin okuyabildiği şifreli bir yük içinde taşınır ve asla yayımlanmaz — bu yüzden ödemeleriniz kullanıcı adınızla kolayca ilişkilendirilemez. Yine de bunlar şeffaf zincir üzerindeki normal ödemelerdir: gelişmiş zincir analizi bilgi sızdırabilir. Shielded DashPay (yakında) bu boşluğu kapatacak. İletişim isteklerinin kendisi şu anda özel DEĞİLDİR: iki kimliğin bağlantılı olduğunu herkes görebilir. Özel iletişim istekleri yakında gelecek bir özelliktir. Kullanıcı adınız ve profiliniz de Dash Platform üzerinde herkese açıktır.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Ödemeler InstantSend ile saniyeler içinde onaylanır";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Doğrudan adreslere yapılan ödemeler etkinlikte saklanmayacak.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Her kişiyle yapılan ödemeler tek bir yerde toplanır; ham işlemler yerine adlar ve profiller görünür.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Ödeme adresi";
 
 /* CrowdNode */
 "Payout Options" = "Ödeme Seçenekleri";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform adresi";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform bakiyesi";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform düğümü";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform Düğüm Kimliği";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform ödemeleri göndericiyi tanımlamaz. Bu ödeme, cüzdan bakiye değişimini fark ettiğinde kaydedildi — daha erken ulaşmış olabilir.";
+
+"Platform SDK not ready" = "Platform SDK hazır değil";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform eşitlemesi çalışmıyor. Başlatmak için Eşitleme Bilgisi → Platform Eşitleme Durumu'nu açın.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Korumalı";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Lütfen Coinbase'de bir ödeme yöntemi ekleyin";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Önizleme Davetiyesi";
 
+/* Masternode keys */
+"Previously used at: " = "Daha önce kullanıldı: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Fiyatlar en az 30 dakikalıktır. Fiat değerleri yanlış olabilir.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Tasarımı gereği özel";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Özel iletişim istekleri (kiminle bağlantı kurduğunuz özel kalsın diye), Shielded DashPay — özel korumalı bakiyenizden kişilere ödeme — ve henüz kişilerinizde olmayan kullanıcılara ödeme yapma, hepsi yakında geliyor.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Özel iletişim istekleri geliştirilme aşamasındadır ve yaklaşık Eylül–Ekim 2026'da bekleniyor. Bugün isteğin kendisi herkese açıktır — içindeki ödeme ayrıntıları şifreli olsa bile iki kimliğin bağlantılı olduğunu herkes görebilir. Özel iletişim istekleri geldiğinde, arkadaşlığınızın herkese açık mı yoksa özel mi olacağını seçebileceksiniz.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Özel iletişim istekleri, Shielded DashPay ve henüz kişiniz olmayan kişilere ödeme yapma.";
+
 /* No comment provided by engineer. */
 "Private key" = "Özel anahtar";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Özel ödeme adresleri sizinle kişileriniz arasında değiş tokuş edilir. Aranızdaki ödemelerin alıcısını ve göndericisini yalnızca siz ve kişiniz bilir.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Özel ödemeler";
+
+/* Usernames */
+"Private registration" = "Özel kayıt";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "İşlem süresi";
+
+/* Balance info sheet section */
+"Pros" = "Artıları";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Birikimlerinizi koruyun";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Sağlayıcının Adresi";
 
+/* Masternodes */
+"Provider transactions" = "Sağlayıcı işlemleri";
+
+/* Masternode keys */
+"Public key" = "Açık anahtar";
+
+/* Masternode keys */
+"Public key (legacy)" = "Açık anahtar (eski)";
+
+/* Identities */
+"Public keys" = "Açık anahtarlar";
+
 /* No comment provided by engineer. */
 "Public URL" = "Genel URL";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Satın Alma Başarısız";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Amaç";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Oran: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Ham işlem";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Ham işlem kullanılamıyor";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Bu cüzdanın işlemleri için, seçilen yükseklikten itibaren sıkıştırılmış blok filtrelerini yeniden indirip yeniden eşleştirerek denetler. Yeniden taramalar, cüzdanın oluşturulma yüksekliği ve yerel olarak saklanan zincir verileriyle sınırlıdır — bunun altındaki geçmişi kurtarmak için bunun yerine cüzdanın başlangıç yüksekliğini düşürün.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Para Çekme Politikasını Okuyun";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Salt okunur";
+
+/* Usernames */
+"Ready around %@" = "Yaklaşık %@ civarında hazır";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Neden";
 
 /* No comment provided by engineer. */
 "Receive" = "Al";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Gönderen";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "%@ kişisinden alındı";
+
 /* CrowdNode */
 "Receiving rewards" = "Ödüller alınıyor";
+
+"Records your masternodes as having voted, without taking a side." = "Taraf tutmadan, anadüğümlerinizi oy vermiş olarak kaydeder.";
 
 /* No comment provided by engineer. */
 "Recover" = "Kurtar";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Kurtarma ifadesi 12, 15, 18, 21 veya 24 sözcükten oluşmalıdır";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Yenile";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Kayıt ol?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Kayıt tarihi";
+
+/* No comment provided by engineer. */
 "Registered from" = "Tarafından kaydedildi";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Kayıtlı Anadüğüm";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Özel kayıt, korumalı bakiyenizde en az %@ Dash ve birkaç saatlik bekleme süresi gerektirir — sonraki ekranlar size yol gösterecek.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Kayıt";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Bu adı istiyor";
+
 /* An action */
 "Rescan" = "Yeniden tara";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Geri yüklenen cüzdanlar işlem türünü her zaman kurtaramaz. Bu kayıt, zincir üzerindeki not verilerinden yeniden oluşturuldu.";
+
+/* Location Service Status */
 "Restricted" = "Sınırlı";
 
 /* Usernames */
 "Results" = "Sonuçlar";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "%u yüksekliğinden yeniden eşitleme hazırlandı — başlatmak için uygulamadan çıkıp yeniden açın.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "karşılıklı işlem geçmişini saklamak";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Emekli";
 
 /* No comment provided by engineer. */
 "Retry" = "Tekrar dene";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Bu kullanıcı adının size ait olduğunu doğrulamak için aşağıdaki gönderiyi inceleyin";
+
+/* Masternodes */
+"Revocation" = "İptal";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Ekran görüntüleri diğer uygulamalar ve cihazlar tarafından görülebilir. Yeni bir kurtarma metni oluşturun ve gizli tutun.";
 
+/* Raw transaction inspector */
+"Script" = "Betik";
+
+/* Raw transaction inspector */
+"Script signature" = "Betik imzası";
+
+/* Raw transaction inspector */
+"Script type" = "Betik türü";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Bir kişi ara";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Bir iletişim isteği ara";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Dash Ağında bir kullanıcı ara";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Bir kullanıcı adı ara";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Şunun arama sonuçları: \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Kullanıcı adı ara";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "%@ kullanıcı adı Dash Ağında aranıyor";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Cüzdanınızı Güvende Tutun";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Güvenlik Seviyesi";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Güvenlik düzeyi";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Dash alıp, satıp, dönüştürebileceğiniz ve aktarım yapabileceğiniz bir hizmet seçin";
 
+"Select all" = "Tümünü seç";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Oy vermek için en az bir anadüğüm seçin.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Koin seçin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Daha az düğüm seçmek, hangi anadüğümleri işlettiğiniz hakkında daha az bilgi verir.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Otomatik ödeme";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Gönder";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Bir kişiye gönder";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Gerçekten hatırlayıp doğrulayabileceğiniz bir kullanıcı adına gönderin.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Adrese Gönder";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "İlk iletişim isteğinizi gönderin";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Gönderiliyor";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "İletişim İsteği Gönderiliyor";
+
+/* No comment provided by engineer. */
+"Sending to" = "Şuraya gönderiliyor";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "CrowdNode hesabına gönderme";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Gönderildi";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "%@ kişisine gönderildi";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Servis";
+
+/* Identities */
+"Set as Main" = "Ana olarak ayarla";
+
+/* Identities */
+"Set as Main Identity" = "Ana kimlik olarak ayarla";
 
 /* No comment provided by engineer. */
 "Set PIN" = "PİN Oluştur";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Paylaşılan gizlilik havuzu asgari boyutta";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Korumalı adres";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Korumalı harcama";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Korumalı cüzdan başlatılıyor…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Korumalı → Platform";
+
+"Shielded → Transparent" = "Korumalı → Şeffaf";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Boyut";
+
 /* No comment provided by engineer. */
 "Skip" = "Atla";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Anadüğümlerinizden bazıları bu listede eksik olabilir — cüzdan oy verme anahtarlarınızın tamamını okuyamadı. Eşitlemeyi bitirip bu ekranı yeniden açın.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Bazı kullanıcı adları engellenebilir";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Göre sırala";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Kişileri Sırala";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "İsme göre sıralanmış";
+
+/* Raw transaction inspector */
+"Special payload" = "Özel yük";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Tutarı Belirleyin";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Fon ekledikten sonra başlar";
+
+/* Transaction details */
+"Status" = "Durum";
+
 /* Step 1 */
 "Step %ld" = "Adım %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Şu şekilde saklanıyor";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Senkronizasyon devam ediyor... Sonuçlar tamamlanmayabilir.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Eşitleme Bilgisi";
+
+/* SPV sync */
+"Sync too slow?" = "Eşitleme çok mu yavaş?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Kameradan Fotoğraf Çek";
 
+"Take no side" = "Taraf tutma";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Yapıştırmak için panodaki adresi seçin";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Kopyalamak için dokunun";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Bakiyeyi gizlemek için tıkla";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash düğüm anahtarı (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Kod yanlış. Lütfen kontrol edip tekrar deneyin!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Ağ çekimi işledikten sonra Dash alıcının adresine ulaşır — bu 10 dakikaya kadar sürebilir.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Ağ çekimi işler işlemez Dash alıcının adresine ulaşır.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Ağ çekimi işler işlemez Dash şeffaf bakiyenize ulaşır.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Gönderdiğiniz bağlantı yalnızca ağ sahipleri tarafından görülebilecektir";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Ana kimlik yalnızca etkin cüzdandan seçilebilir";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Gönderebileceğiniz minimum miktar %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Dash'lerinizi tutmak için en özel yer";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Kayıtlı cüzdan satırının ağı yok — yeniden eşitleme hazırlanamaz.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Kayıt gönderildi ancak sonucu doğrulanamadı. Cüzdanın eşitlenmesi için bir dakika bekleyin, sonra tekrar deneyin — hemen yeniden göndermeyin.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Paylaşılan gizlilik havuzu hâlâ büyüyor (%1$ld / %2$ld yatırma). Asgari boyuta ulaştığında özel kayıt açılır.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Paylaşılan gizlilik havuzu hâlâ büyüyor (%1$ld / %2$ld yatırma). Asgari boyuta ulaştığında tekrar deneyin.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Cüzdanın oluşturulma yüksekliği — filtre taramaları ve “Cüzdan oluşturulmasından itibaren” yeniden taramaları için alt sınır. Bunu cüzdana ilk para girişinin yüksekliğine ya da altına ayarlayın; içe aktarmalarda varsayılan mainnet'te 200000, testnet'te 0'dır. Mevcut değere eşit veya ondan düşük bir yükseklik kaydetmek, bir sonraki açılışta bu ağın zincir verilerini temizler ve oradan yeniden tarar.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "onu (Bilgi Alınıyor)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Yeni bildirim yok";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Görüntülenecek işlem yok";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "%@ adıyla eşleşen kullanıcı yok";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Kişilerinizde %@ adıyla eşleşen kullanıcı yok";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "İşlem geçmişinizi ZenLedger'a aktarırken bir hata oluştu";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Bir hata oluştu, lütfen daha sonra tekrar deneyin";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Bu fonlar Platform bakiyenize geçer ve transfer tamamlanır tamamlanmaz harcanmaya hazır olur.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Bu adrese %@ bakiyenizden ödeme yapılamaz";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Bu, diğer kullanıcıların size iletişim isteği gönderebilmesi ve sizin de onlarınkini kabul edebilmeniz için kimliğinize iki anahtar ekler. Bu yalnızca bir kez gerçekleşir.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Bu, seçili %d kullanıcı adının tümüne tek bir seçimi uygular.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Bu ekstra adım, gerçekten bir işlem yapmaya çalıştığınızı gösterir.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Bu davet bağlantısı geçerli değil.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Bu, bu ağ için geçerli bir Dash adresi değil";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Bu geçerli bir davet bağlantısı değil";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Bu sizin ana kimliğiniz";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Bu anadüğümün henüz bir Platform kimliği yok.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Bu, tam bir Ana Düğümün mevcut Yıllık Faiz Getirisini CrowdNode ücretinden %15 daha az temsil eder. Garantili bir getiri oranı değildir ve CrowdNode havuzlarının boyutuna ve Dash fiyatına bağlı olarak yukarı veya aşağı yönlü değişebilir.";
 
+"This still counts as your masternodes having voted in this contest." = "Bu yine de anadüğümlerinizin bu çekişmede oy vermiş olması sayılır.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Bu işlemin ham baytları bu cihazda saklanmıyor.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Bu kullanıcı adı başkasına gitti";
+
+"This wallet could not derive the voting key for this node." = "Bu cüzdan bu düğüm için oy verme anahtarını türetemedi.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Bu cüzdanda etkin anadüğüm oy verme anahtarı yok, bu yüzden oy veremez. Kayıtlı düğümler Araçlar → Anadüğümler altında görünür.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Bu, tüm Platform bakiyenizi tek bir transferde çeker. Ağ çekimi işler işlemez Dash alıcının adresine ulaşır.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Bu, tüm Platform bakiyenizi tek bir transferde çeker. Ağ çekimi işler işlemez Dash şeffaf bakiyenize ulaşır.";
 
 /* Send Screen: to address */
 "to" = "giden";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "İşlem Geçmişi";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "İşlem geçmişi kullanılamıyor";
+
 /* No comment provided by engineer. */
 "Transaction id" = "İşlem kimliği";
+
+/* Raw transaction inspector */
+"Transaction ID" = "İşlem Kimliği";
 
 /* A verb, button title. */
 "Transfer" = "Aktarma";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "İçeriye transfer et";
 
+/* Balance breakdown */
+"Transfer in" = "Gelen transfer";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Dışarıya transfer et";
+
+/* Balance breakdown */
+"Transfer out" = "Giden transfer";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Transferler daha uzun sürer — gizlilik kanıtlarının oluşturulması zaman alır";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Diğer Platform adreslerine ve korumalı adreslere yapılan transferler anlık ve kesindir";
+
+/* Balance breakdown */
+"Transparent" = "Şeffaf";
+
+/* Send screen destination type */
+"Transparent address" = "Şeffaf adres";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Şeffaf bakiye";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Şeffaf finansman, kullanıcı adınızı bu fonlarla herkese açık şekilde ilişkilendirir.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Şeffaf → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Şeffaf → Korumalı";
 
 /* An action */
 "Try again" = "Tekrar dene";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Öneri sunulamıyor";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Bilinmeyen Bakiye";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Bilinmeyen özel tür %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Korumasız";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Desteklenmeyen bağlantı";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Evolution'a yükselt";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Bunun yerine şeffaf bakiyeyi kullan";
+
+/* Masternode keys */
+"Used" = "Kullanıldı";
+
+/* Masternode keys */
+"Used at: " = "Kullanıldı: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Kullanıcı (Bilgi Alınıyor)";
 
 /* Voting */
 "Username" = "Kullanıcı Adı";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Kullanıcı adı başarıyla istendi";
 
+/* Identities */
+"Usernames" = "Kullanıcı Adları";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Kullanıcı adları, birbirine benzeyen adları önlemek için normalleştirilmiş biçimde saklanır, bu yüzden bu, her kişinin yazdığından farklı olabilir.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Adresler değil, kullanıcı adları";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "%@ ile eşleşen ve şu anda kişilerinizde olmayan kullanıcılar";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "En çok denetlenmiş ve test edilmiş sıfır bilgi kütüphanelerinden birini (Orchard) kullanır";
+
+/* DashPay Invitations */
+"Valid invitation" = "Geçerli davetiye";
+
 /* CrowdNode Portal */
 "Validating address…" = "Adres doğrulanıyor…";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Doğrulama Gerekli";
 
+/* Usernames */
+"Verified during registration" = "Kayıt sırasında doğrulandı";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Başarıyla Doğrulandı";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Kimliğinizi doğrulayın";
 
+/* Raw transaction inspector */
+"Version" = "Sürüm";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Çok verimli ve düşük ücretli";
+
 /* adjective, security level */
 "Very High" = "Çok Yüksek";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Bu cüzdan adresinin sahibi olduğunuzu doğrulamak için CrowdNode'a ve CrowdNode'dan çok küçük miktarlarda Dash gönderilecektir.";
+
+/* No comment provided by engineer. */
+"View All" = "Tümünü Gör";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Gezginde görüntüle";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Kurtarma Sözcük Grubunu Göster";
 
+/* Raw transaction inspector */
+"View Transaction" = "İşlemi Görüntüle";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Oy ver";
+
+"Vote cast" = "Oy kullanıldı";
+
 /* Voting */
 "Vote for All" = "Herkese Oy Ver";
 
 /* Voting */
+"Vote on contested usernames" = "Çekişmeli kullanıcı adları için oy verin";
+
+"Vote on several" = "Birkaçı için oy ver";
+
+/* Voting */
 "Vote to Approve" = "Onaylamak için oy verin";
+
+"Vote with" = "Şununla oy ver";
+
+"Votes that nobody should receive these usernames." = "Bu kullanıcı adlarını kimsenin almaması yönünde oy verir.";
 
 /* Voting */
 "Votes: High to low" = "Oylar: Yüksekten düşüğe";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Oy Verme Adresi";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Oy Verme Adresi";
+
+"Voting ended with no winner" = "Oylama kazanansız bitti";
+
+"Voting ends" = "Oylama bitiyor";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Oylama sürüyor";
+
+"Voting in progress — lock votes are ahead" = "Oylama sürüyor — kilitleme oyları önde";
+
+"Voting in progress — you are ahead" = "Oylama sürüyor — siz öndesiniz";
 
 /* Usernames */
 "Voting is only required in some cases" = "Oylama sadece bazı durumlarda gereklidir";
 
+/* Masternodes */
+"Voting key hash" = "Oy verme anahtarı özeti";
+
 /* Voting keys */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Bu kullanıcı adı için oylama kapandı. Aşağıdaki sayımlar en son okunanlardır.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "“%@” için oylama zaten kapandı. Sonucu görmek için yenileyin.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "İşlemi tamamlamak için cüzdan senkronize edilene kadar bekleyin";
 
+"Waiting for Dash Platform" = "Dash Platform bekleniyor";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Cüzdan Adresi";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Cüzdan başlangıç yüksekliği";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Cüzdan devredışı";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "DashPay'e hoş geldiniz";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains ve benzeri ad hizmetleri ne olacak?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Maliyeti nedir?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "DashPay nedir?";
+
 /* Usernames */
 "What is username voting?" = "Kullanıcı adı oylaması nedir?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Sırada ne var?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "İletişim istekleri ne zaman özel olacak?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Nerede Harcamalı";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Nerede Harcamalı?";
+
+"Who is requesting this name" = "Bu adı kim istiyor";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Neden etkinleştirmem gerekiyor?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Neden tüm bu işlemleri görüyorum?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Para çekme isteği gönderildi";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Tüm bakiyeyi çeker";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Her Dash cüzdanı, borsası ve satıcısıyla çalışır";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Daveti kabul etmek ister misiniz?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Dün";
+
+"You" = "Siz";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "%@ kişisinden gelen iletişim isteğini kabul ettiniz";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Şu anda hiç kişiniz yok";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Bu işlemi gerçekleştirmek için yeterli bakiyeniz yoktur";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Coinbase'deki yetki sınırını aştınız.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Şu ana kadar %@ Dash'iniz var";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "%@ kişisine iletişim isteği gönderdiniz";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "Dash Cüzdan'da pozitif bir bakiyeniz olmalıdır";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Bu kullanıcı adını kazandınız";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Her şey hazır. Diğer kullanıcılar artık size iletişim isteği gönderebilir — siz de kendi isteklerinizi gönderebilirsiniz.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Bir kullanıcı adı kaydettiğinizde Dash Platform kimliğiniz burada görünür.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "E-postanız yalnızca tek kullanımlık şifre göndermek için kullanılır.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Geçmişiniz, düzenli";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "İletişim isteklerinin sizinle diğer kullanıcılar arasında şifrelenebilmesi için kimliğinizin iki ek anahtara ihtiyacı var. Etkinleştirmek, bunları tek bir ağ işlemiyle ekler. Bu yalnızca bir kez gerçekleşir.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "%@ tarafından gönderilen davetiniz zaten talep edildi";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "%@'dan gelen davetiniz geçerli değil";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Davetiyeniz bu kullanıcı adının kayıt ücretini karşılar.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Konumunuz, haritada konumunuzu ve seçilen yarıçaptaki ATMleri gösterip arama sonuçlarını iyileştirmek için kullanılır.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Konumunuz, haritada konumunuzu ve seçilen yarıçaptaki tüccarları gösterip arama sonuçlarını iyileştirmek için kullanılır.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Core blok zincirindeki ana Dash bakiyeniz — diğer cüzdanlar, borsalar ve satıcılarla gönderip aldığınız tutar.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Karıştırılmış coinleriniz Dash Cüzdanı bakiyenize taşındı.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Karıştırılmış coinleriniz korumalı bakiyenize taşındı. En iyi gizlilik için bu fonları kullanmadan önce en az 2 saat bekleyin.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Platform bakiyeniz";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Şu anda CrowdNode hesabınız için kullandığınız birincil Dash adresiniz";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Özel bakiyeniz. Tutarlar ve adresler zincir üzerinde şifrelenir, böylece varlıklarınız ve geçmişiniz gizli kalır.";
+
 /* Usernames */
 "Your request was cancelled" = "İsteğiniz iptal edildi";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Korumalı bakiyeniz";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Korumalı bakiyeniz neredeyse hazır — yaklaşık %@ civarında gizlice kaydolabilirsiniz.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Korumalı bakiyeniz hazır — kullanıcı adınızı şimdi gizlice kaydedin";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Korumalı bakiyeniz bekletiliyor — yaklaşık %@ civarında gizlice kaydolabilirsiniz";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Korumalı bakiyeniz hâlâ olgunlaşıyor. Yaklaşık %@ civarında hazır olacak.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Şeffaf bakiyeniz";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Kullanıcı adınız %@ Dash Ağında başarıyla oluşturuldu";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Kullanıcı adınızı herkes görebilir. Fonları birkaç saat beklettikten sonra korumalı bakiyenizden karşılamanız, kimsenin kullanıcı adınızı diğer Dash'lerinizle ilişkilendirememesi anlamına gelir.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Kullanıcı adınız, profiliniz ve kişileriniz bu kimliğe bağlıdır.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Kullanıcı adınız, profiliniz ve kişileriniz bu kimliğe bağlı olacak.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Oyunuz iptal edildi";
 
 /* Voting */
 "Your vote was submitted" = "Oyunuz gönderildi";
 
+"Your votes" = "Oylarınız";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Cüzdanınız artık güvende. Hesabınızı başka bir cihaza aktarmak için kurtarma sözcük grubunuzu istediğiniz zaman kullanabilirsiniz.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Cüzdanınız hâlâ Dash ağıyla eşitleniyor. Eşitleme tamamlandığında gönderim kullanılabilir olacak.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Cüzdanınız hâlâ eşitleniyor. Eşitleme tamamlandığında şeffaf bakiyenizden gönderim kullanılabilir olacak.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "“%@” bir Dash kullanıcı adı olarak okunamadı.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” kaydedildi. Sizi davet eden kişiye bir iletişim isteği gönderilsin mi?";

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Tüm düğümler birden";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tüm anadüğümleriniz bu kullanıcı adı için oy verdi. Bir oyu değiştirmek için şimdi tercih ettiğiniz adaydan yeniden oy verin.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tüm anadüğümleriniz bu kullanıcı adı için oy verdi. Bir oyu değiştirmek için şimdi tercih ettiğiniz adaya yeniden oy verin.";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/tr.lproj/Localizable.stringsdict
+++ b/DashWallet/tr.lproj/Localizable.stringsdict
@@ -82,5 +82,245 @@
 			<string>%d anahtarlar</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>“%2$@” için %#@votes@ sayıldı</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u oy</string>
+			<key>other</key>
+			<string>%1$u oy</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@ içinden %1$d oylandı</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d kullanıcı adı</string>
+			<key>other</key>
+			<string>%2$d kullanıcı adı</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u oy kullan</string>
+			<key>other</key>
+			<string>%u oy kullan</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ içinden %1$d oy kullandı</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d anadüğüm</string>
+			<key>other</key>
+			<string>%2$d anadüğüm</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@ içinden %1$d oy kullandı</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d düğüm</string>
+			<key>other</key>
+			<string>%2$d düğüm</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>toplam %u oy</string>
+			<key>other</key>
+			<string>toplam %u oy</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d anadüğüm</string>
+			<key>other</key>
+			<string>%d anadüğüm</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d seçildi</string>
+			<key>other</key>
+			<string>%d seçildi</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Düğümlerinizden %d tanesi burada zaten oy kullandı ve listelenmiyor.</string>
+			<key>other</key>
+			<string>Düğümlerinizden %d tanesi burada zaten oy kullandı ve listelenmiyor.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Çekişme başına %u oy — evonode'lar 4, anadüğümler 1 sayılır</string>
+			<key>other</key>
+			<string>Çekişme başına %u oy — evonode'lar 4, anadüğümler 1 sayılır</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d kullanıcı adı için oy ver</string>
+			<key>other</key>
+			<string>%d kullanıcı adı için oy ver</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u oy</string>
+			<key>other</key>
+			<string>%u oy</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Oy ver ×%d</string>
+			<key>other</key>
+			<string>Oy ver ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d istek</string>
+			<key>other</key>
+			<string>%d istek</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " або ";
+
 /* CrowdNode */
 " Privacy Policy " = "Політика конфіденційності";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Не вдалося знайти %@ у мережі Dash, щоб надіслати запит на додавання до контактів.";
+
+/* Usernames */
+"%@ Dash available" = "Доступно %@ Dash";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ прийняв ваш запит на додавання до контактів";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@  ~ %2$lu контактів / %3$lu оновлень профілю";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d байтів";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d даффів";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d голоси будуть віддані, оскільки у вас є кілька ключів для голосування, які зберігаються в гаманці";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%Ід дублікатів";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld з %ld депозитів";
 
 /* Voting */
 "%ld requests" = "%Ід запитів";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" не є словом з фрази для відновлення. Чи бажаєте ви спробувати відновити правильне слово, що має бути на цьому місці?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Баланс кредитів на Dash Platform, який використовується для миттєвих платежів між адресами Platform і для функцій на кшталт імен користувачів.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Пароль пристрою потрібен для захисту вашого гаманця. Щоб продовжити, перейдіть до налаштувань і ввімкніть пароль.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Про програму";
 
+/* DashPay FAQ title */
+"About DashPay" = "Про DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "Про мене";
+
+"Abstain" = "Утриматися";
+
+"Abstain on “%@”" = "Утриматися щодо «%@»";
 
 /* No comment provided by engineer. */
 "Accept" = "Прийняти";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Відновлення Акаунта";
 
+/* Masternode status */
+"Active" = "Активна";
+
+/* No comment provided by engineer. */
+"Activity" = "Активність";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Активність публічна, але її нелегко відстежити";
+
 /* No comment provided by engineer. */
 "Add" = "Додати";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Додати %@ до контактів";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Додайте %@ до контактів, щоб платити безпосередньо на ім'я користувача та зберігати спільну історію транзакцій";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Додайте %@ Dash до екранованого балансу й дайте їм відлежатися кілька годин, щоб зареєструватися, не пов'язуючи ім'я користувача з рештою ваших коштів.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Додати новий контакт";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Додайте щонайменше %@ Dash до екранованого балансу";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Поповніть екранований баланс зараз і приватно зареєструйте ім'я користувача за кілька годин";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Все";
 
+"All nodes at once" = "Усі вузли одразу";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Усі ваші мастерноди проголосували за це ім'я користувача. Щоб змінити голос, проголосуйте ще раз за того претендента, якому ви тепер віддаєте перевагу.";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Дозволити надсилати всі транзакції з Dash Wallet до Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Майже миттєва синхронізація балансів";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Суми й адреси є публічними в блокчейні";
+
 /* No comment provided by engineer. */
 "An error occurred" = "Сталася помилка";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Обліковий запис Ethereum — це одна багаторазова адреса: увесь ваш баланс та історія платежів публічно перебувають під нею, а ім'я (наприклад, домен ENS) зазвичай указує прямо на цю адресу, і будь-хто може її розв'язати. DashPay влаштований навпаки — ім'я розв'язується в ідентифікатор, а не в платіжну адресу, а справжні платіжні адреси залишаються всередині зашифрованих обмінів із контактами, нові для кожного контакту.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Інтуїтивний та звичний інтерфейс на всіх ваших пристроях";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Будь-яке ім’я користувача, яке містить цифру від 2-9, має понад 20 символів або містить дефіс, буде автоматично схвалене";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Будь-хто, хто знає адресу, може переглянути її історію";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Застосувати";
 
+"Approve" = "Схвалити";
+
+"Approving a specific request can only be done one username at a time." = "Схвалити конкретний запит можна лише для одного імені користувача за раз.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Ви впевнені, що хочете скасувати замовлення?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Як текст";
 
 /* DashSpend */
 "at" = "в";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Автентифікацію скасовано. Ваш голос не було віддано.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Автентифікація не вдалася. Ваш голос не було віддано.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Автентифікація недоступна";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Присудити «%@» цьому претенденту";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Баланс";
 
 /* CrowdNode */
+"Balance after" = "Баланс після";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Баланс на CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Баланс:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Баланси й перекази не видно публічно";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Банківський рахунок";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Потрібен доступ до біометричних даних";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Початкову висоту збережено — підвищену межу сканування застосовано з наступного запуску.";
+
 /* Voting */
 "Block" = "Блок";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Ім'я користувача '%@' заблоковане";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Прив'язаний до контракту";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Прив'язаний до контракту, тип документа «%@»";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Лише перегляд";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Зібрати останні діагностичні журнали в zip-архів, щоб надіслати через AirDrop, поштою або зберегти у Файли";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Віддати голос";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Змінити піри";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Змінити PIN-код";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Перевірка…";
+
+"Choice" = "Вибір";
+
 /* Choose your Dash username */
 "Choose your" = "Виберіть свій";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Виберіть своє ім'я користувача";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Активуйте своє запрошення";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Баланс до отримання";
+
 /* No comment provided by engineer. */
 "Claimed" = "Заявлено";
+
+/* SPV diagnostics */
+"Clear & resync" = "Очистити й пересинхронізувати";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Очистити дані ланцюжка й пересинхронізувати?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Закрити додаток";
 
+"Closing" = "Закривається";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (нові монети)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Код 2FA від Coinbase";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin більше не підтримується — оберіть, куди перемістити змішані монети.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Застава";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Незабаром";
+
+/* Shielded transfer status */
+"Completed" = "Завершено";
 
 /* No comment provided by engineer. */
 "Confirm" = "Підтверджую";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Підтверджено";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Підтвердження збереже початкову висоту %u та очистить дані ланцюжка цієї мережі під час наступного запуску застосунку, після чого їх буде завантажено заново, а фільтри пересканує з цієї висоти. Поточний сеанс збереже стару межу сканування — закрийте та знову відкрийте застосунок, щоб почати.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Підключіть свої криптогаманці до платформи ZenLedger. Дізнайтеся більше та розпочніть роботу з транзакціями Dash Wallet.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Підключена адреса Dash";
 
+/* SPV sync */
+"Connected peers" = "Підключені піри";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Мінуси";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Не вдалося надіслати запит на додавання до контактів";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Запит на додавання до контактів надіслано %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Запити на додавання до контактів";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Контакти";
 
+"Contender %@" = "Претендент %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Продовжити";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Продовжіть, щоб обрати ім'я користувача. Запрошення оплачує комісію за реєстрацію.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Копіювати посилання на запрошення";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Скопіювати необроблену транзакцію";
+
 /* No comment provided by engineer. */
 "Copy text" = "Скопіювати текст";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Не вдалося автоматично відновити пропущені або неправильні слова";
 
+/* Log export */
+"Could not create the log archive: %@" = "Не вдалося створити архів журналів: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Не вдалося знайти обмінний курс.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Не вдалося оновити %d ідентифікаторів";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Не вдалося отримати баланс (помилка мережі). Спробуйте оновити.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Не вдалося здійснити платіж";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Створити ім'я користувача";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Створіть своє ім'я користувача, знайдіть друзів і родину за їхніми іменами користувачів і додайте їх до контактів";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Кредитна картка";
+
+/* Masternodes */
+"Credits" = "Кредити";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Платежі Dash не можуть бути меншими ніж %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform ще не проіндексувала цей спір. Кількість голосів з'явиться тут, коли це станеться.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform ще не підключено. Дочекайтеся завершення синхронізації та спробуйте ще раз.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash, надіслані на неправильну адресу, повернути неможливо. Переконайтеся, що адреса саме та, на яку ви маєте намір платити.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash зберігає імена користувачів у захищеному від схожих написань вигляді, тож збережене ім'я може відрізнятися від того, що ввела кожна людина.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Ім'я користувача Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Баланс гаманця Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet на цьому пристрої";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay увімкнено";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "Запрошення DashPay";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay — це соціальні платежі Dash, побудовані на Dash Platform. Ви реєструєте ім'я користувача, додаєте інших користувачів до контактів і платите їм за іменем — більше не потрібно копіювати адреси.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay замінює довгі незрозумілі адреси іменами користувачів. Додавайте друзів до контактів, надсилайте гроші на ім'я й тримайте кожен платіж упорядкованим за людьми.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Комісія за оновлення DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Дата: від старої до нової";
+
+"Deadline unknown" = "Термін невідомий";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Депозит відправлено";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Шлях деривації";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "БЕЗПЕКА ПРИСТРОЮ ПІД ЗАГРОЗОЮ\nБудь-який «jailbreak» додаток може отримати доступ до ваших приватних ключів (і вкрасти ваші Dash). Негайно видаліть цей гаманець та відновіть його на довіреному пристрої.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Вимкнено";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "ВІдключити обліковий запис Coinbase";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Готово";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Готово — ваш баланс відлежався достатньо довго";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Ще раз перевірте адресу";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Кожне запрошення фінансуватиметься цією сумою, щоб одержувач міг швидко створити своє ім’я користувача в Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Кожна мастернода має один чинний голос у спорі. Ви можете змінити його пізніше, але Dash Platform дозволяє загалом лише 5 голосів на мастерноду в одному спорі.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Кожне торкання додає до голосування ще один вузол, тож ви обираєте, скільки їх пов'язати разом.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Раніше";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Застейкайте Dash і отримайте пасивний дохід за кілька кліків.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Змінити початкову висоту";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Редагувати профіль";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Електронна адреса";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Увімкнути";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Увімкнути DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Увімкнути Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Увімкнути Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Увімкнення DashPay коштує невелику одноразову комісію мережі, яку сплачують із балансу кредитів вашого ідентифікатора. Точну оцінку показано перед підтвердженням. Надсилання запитів на додавання до контактів і платежів коштує звичайних комісій мережі.";
+
+"Ending soonest" = "Завершується найраніше";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Помилка оновлення профіля";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Орієнтовна комісія мережі";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Усі вузли голосують разом. Швидше, але публічно пов'язує ваші мастерноди між собою.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Ключі оператора Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Експорт CSV";
 
+/* Log export */
+"Export Logs" = "Експортувати журнали";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Зовнішня адреса";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Ліміт Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Не вдалося";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Не вдалося завантажити штрих-код";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Отримання ставок…";
 
+/* Masternodes */
+"Fetching…" = "Отримання…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Фіатний рахунок";
 
 /* No comment provided by engineer. */
 "Filter" = "Фільтр";
+
+/* SPV sync phase */
+"Filter headers" = "Заголовки фільтрів";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Фільтрувати транзакції";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Знайти користувача в мережі Dash";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Знайдіть банкомати, де можна купити або продати Dash.";
+
+/* Identities */
+"Find identities" = "Знайти ідентифікатори";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Забули PIN-код?";
 
+/* Identities */
+"Found %d new identities" = "Знайдено %d нових ідентифікаторів";
+
+/* Identities */
+"Found 1 new identity" = "Знайдено 1 новий ідентифікатор";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Знайдено пропущене слово:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Профінансуйте ім'я користувача з екранованого балансу. Додайте кошти за кілька годин наперед — коротка витримка не дасть пов'язати ваше ім'я користувача з рештою ваших Dash.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Профінансовано з екранованого балансу — ваше ім'я користувача неможливо пов'язати з рештою ваших Dash.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Кошти заблоковано — завершення переказу";
+
+/* CoinJoin */
+"Funds moved" = "Кошти переміщено";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Отримуйте нагороди від депозитів у Dash Мастерноди лише за 0,5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Отримати пропозицію";
+
+/* Usernames */
+"Get ready to join DashPay" = "Готуйтеся приєднатися до DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Отримуйте винагороди миттєво";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Зрозуміло";
+
+/* Governance */
+"Governance" = "Управління";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Надайте дозволи GPS, щоб ми могли відображати точки поблизу вас.";
 
 /* Voting */
 "Has blocked votes" = "Має заблоковані голоси";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "хоче додати вас у друзі";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Маєте запрошення?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Отримайте повний контроль і налаштуйте свій гаманець для своїх потреб";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "заголовок #%1$d з %2$d";
+
+/* SPV sync phase */
+"Headers" = "Заголовки";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Висота %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Ось адреса Dash, призначена для вашого облікового запису CrowdNode у Dash Wallet на цьому пристрої.";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "Від високого до низького";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Вищі комісії, близько 7 центів (усе одно нижчі, ніж в інших блокчейнах із подібною приватністю)";
+
 /* No comment provided by engineer. */
 "History" = "Історія";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "Як мені отримати тестові Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "Як це порівняти з Bitcoin щодо приватності?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "Як це порівняти з обліковими записами Ethereum щодо приватності?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "Наскільки приватний DashPay?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "Як підтвердити свою API Dash адресу";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Я записав її";
 
+/* Identities */
+"Identities" = "Ідентифікатори";
+
 /* Voting */
 "Identity" = "Ідентично";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Кредити ідентифікатора";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Індекс ідентифікатора";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Реєстрація ідентифікатора";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Поповнення ідентифікатора";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "У розділі оплати під час оформлення замовлення виберіть «подарункова картка» та введіть номер картки й PIN-код.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Неактивна";
+
+/* No comment provided by engineer. */
 "Income" = "Дохід";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Ініціалізація";
+
+/* Raw transaction inspector */
+"Input %d" = "Вхід %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Вхід %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Входи (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Недостатньо коштів";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Комісія за запрошення";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Запрошення від %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Запрошення використовував";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Запросити";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Запросіть когось приєднатися до мережі Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Запросіть свою родину, знайдіть друзів, ввівши в пошук їхні імена користувачів";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Запросіть своїх друзів і родину приєднатися до Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Запросіть друзів і родину до мережі Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Повідомлено про проблему";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Приєднання до пула";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Зберегти ці монети приватними. Стягуються комісії мережі та за приватність.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Зберігайте свою парольну фразу в безпеці";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Ключ №%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Дані ключа";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Володіння ключем";
+
 /* No comment provided by engineer. */
 "Keypair" = "Ключі";
+
+/* Masternodes */
+"Keys" = "Ключі";
 
 /* Explore Dash */
 "Last device sync" = "Останній пристрій який було синхронізовано";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Лідирує";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Дізнатися більше";
 
 /* Info Screen */
 "Learn More..." = "Дізнатися більше...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Завантаження транзакцій";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Локальна валюта";
 
+/* Identities */
+"Local Only" = "Лише локально";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Сума у ​​місцевій валюті: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Місцезнаходження";
 
+"Lock" = "Заблокувати";
+
+"Lock the name" = "Заблокувати ім'я";
+
+"Lock “%@” so nobody gets it" = "Заблокувати «%@», щоб ніхто його не отримав";
+
 /* No comment provided by engineer. */
 "Locked" = "Заблоковано";
 
+"Locked — nobody receives this username" = "Заблоковано — ніхто не отримає це ім'я користувача";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Вхід";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Низький";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Низькі комісії для щоденних витрат";
+
 /* Voting */
 "Low to high" = "Від низького до високого";
+
+/* Identities — the wallet's main identity */
+"Main" = "Основний";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "IP-адреса Мастернод";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Зв'язка ключів мастерноди";
+
+/* Masternode keys */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Список мастернод";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "список Мастернод #%1$d з %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Оновлення Мастерноди";
 
+"Masternode votes" = "Голоси мастернод";
+
 /* Voting */
 "Masternode Voting Key" = "Ключі голосування Мастернод";
+
+/* Tools menu */
+"Masternodes" = "Мастерноди";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Мастерноди та evonode, зареєстровані ключами цього гаманця, з'являться тут після синхронізації гаманця.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Мастерноди та evonode, що використовують ключі цього гаманця";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Мастерноди голосують за імена, які запитала більш ніж одна людина. Ви отримаєте сповіщення, коли голосування завершиться.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Макс";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Мін: %@";
 
+/* Usernames */
+"Minimum met" = "Мінімум досягнуто";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Більше контролю";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Більше пропозицій";
+
+"Most lock votes" = "Найбільше голосів за блокування";
+
+"Most votes" = "Найбільше голосів";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Переміщуйте та масштабуйте свою фотографію, щоб знайти ідеальну форму";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Перемістити на звичайний доступний баланс.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Переміщено на адресу";
+
+/* CoinJoin */
+"Moving funds" = "Переміщення коштів";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Назва";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Сервіси імен на кшталт Unstoppable Domains зіставляють зрозуміле людині ім'я з фіксованою публічною адресою в ланцюжку. Будь-хто може розв'язати це ім'я й побачити кожен платіж, коли-небудь зроблений на нього. Ім'я користувача DashPay ніколи не розв'язується публічно в платіжну адресу — адреси розкриваються лише всередині зашифрованого обміну з кожним контактом, тож ваше ім'я та ваші гроші залишаються непов'язаними для сторонніх спостерігачів.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Потрібна допомога?";
+
+"Needs attention" = "Потребує уваги";
 
 /* No comment provided by engineer. */
 "Network" = "Мережа";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "На цьому пристрої діагностичних журналів не знайдено. Журнали записуються, починаючи з наступного запуску.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Немає ідентифікаторів";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Мастернод поки немає";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Немає відповідних спорів";
+
+/* Identities */
+"No new identities were found for this wallet" = "Для цього гаманця нових ідентифікаторів не знайдено";
+
+"No open contest matches that search." = "Жоден відкритий спір не відповідає цьому пошуку.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Жоден відкритий спір не відповідає цьому пошуку. Імена зберігаються в нормалізованому вигляді, тож «alice» відображається як «a11ce».";
+
+"No open contests" = "Немає відкритих спорів";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "Немає способів оплати";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Для прив'язаного гаманця не знайдено збереженого запису.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Для резервної екранованої реєстрації поки немає доступної адреси Platform. Спробуйте ще раз після того, як гаманець завершить синхронізацію.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "Нічого не знайдено";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Наразі жодне ім'я користувача не оспорюється. Спір відкривається, коли двоє або більше людей запитують одне й те саме ім'я.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "Голосів немає";
+
+"No votes were cast" = "Голосів не було віддано";
+
+"Nobody gets it" = "Ніхто його не отримає";
+
+/* SPV sync peer type */
+"Node" = "Вузол";
+
+/* Raw transaction inspector */
+"Non-standard" = "Нестандартний";
 
 /* adjective, security level */
 "None" = "Відсутній";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Недоступний";
 
+"Not available yet" = "Поки недоступно";
+
+"Not cast" = "Не віддано";
+
+/* Masternodes */
+"Not checked yet" = "Ще не перевірено";
+
 /* Location Service Status */
 "Not Determined" = "Не визначено";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Недостатньо екранованого балансу для реєстрації ідентифікатора";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Відсутнє в історії гаманця";
+
+"Not now" = "Не зараз";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Не надто широко приймається продавцями";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Поки не надто широко приймається продавцями";
+
+/* Masternode keys */
+"Not yet used" = "Ще не використовувався";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Від старого до нового";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "У Bitcoin немає рівня імен, тому люди відкрито діляться адресами й повторно їх використовують — щойно адреса стає відомою, усе, що вона будь-коли отримала, можна пов'язати з її власником. У DashPay ваше ім'я користувача публічне, але воно ніколи не вказує на платіжну адресу: адреси обмінюються приватно з кожним контактом і змінюються, тож платіж за іменем не оприлюднює, куди йдуть ваші гроші. Обидві мережі — прозорі ланцюжки, тож аналіз ланцюжка й далі застосовний до самих монет.";
+
+/* Identities */
+"On Network" = "У мережі";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Щойно %@ прийме ваш запит, ви зможете платити безпосередньо на ім'я користувача";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "По одному вузлу";
 
 /* Voting */
 "One vote left" = "Залишився один голос";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Тільки дублікати";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Голосувати за імена користувачів можуть лише мастерноди та evonode. У цьому гаманці немає активних ключів голосування мастернод.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Тільки запити з посиланнями";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Тільки з посиланнями";
+
+/* Masternodes */
+"Operator" = "Оператор";
+
+/* Masternode keys */
+"Operator keys" = "Ключі оператора";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Публічний ключ оператора (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "або";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Попередній перегляд замовлення";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Інші результати";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Вихід %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Виходи (%d)";
+
+/* Masternodes */
+"Owner" = "Власник";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Адреса власника";
+
+/* Masternodes */
+"Owner address" = "Адреса власника";
+
+/* Masternodes */
+"Owner key hash" = "Хеш ключа власника";
 
 /* Owner keys */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Сплачено з балансу кредитів вашого ідентифікатора.";
 
 /* DashSpend */
 "Password" = "Пароль";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Вставте посилання тут";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Вставте отримане посилання-запрошення або відскануйте його QR-код. Воно оплачує реєстрацію вашого імені користувача.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Вставте URL-адресу зображення";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Платіть і отримуйте гроші миттєво за допомогою простих у використанні платіжних потоків";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "платити безпосередньо на ім'я користувача";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Платіть людям, а не адресам";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Оплата іменам користувачів. Більше немає буквено-цифрових адрес";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Оплата...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Корисне навантаження (hex)";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Спосіб оплати";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Платежі приватні: адреси, якими ви обмінюєтеся з контактом, передаються всередині зашифрованих даних, які можете прочитати лише ви двоє, і ніколи не публікуються — тож ваші платежі нелегко пов'язати з вашим іменем користувача. Утім, це і далі звичайні платежі у прозорому ланцюжку: досконалий аналіз ланцюжка може розкрити інформацію. Shielded DashPay (незабаром) закриє цю прогалину. Самі запити на додавання до контактів наразі НЕ приватні: будь-хто може побачити, що два ідентифікатори пов'язані. Приватні запити на додавання до контактів з'являться незабаром. Ваше ім'я користувача та профіль також публічні в Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Платежі підтверджуються за секунди завдяки InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Платежі, зроблені безпосередньо на адреси, не зберігатимуться в активності.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Платежі з кожним контактом зібрані в одному місці — з іменами та профілями замість необроблених транзакцій.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Адреса виплати";
 
 /* CrowdNode */
 "Payout Options" = "Варіанти Виплат";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Адреса Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Баланс Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Вузол Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID вузла Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Платежі Platform не ідентифікують відправника. Цей платіж записано тоді, коли гаманець помітив зміну балансу — він міг надійти раніше.";
+
+"Platform SDK not ready" = "SDK Platform не готовий";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Синхронізація Platform не працює. Відкрийте Інформація про синхронізацію → Стан синхронізації Platform, щоб її запустити.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Екранований";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Додайте спосіб оплати на Coinbase";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Попередній перегляд запрошення";
 
+/* Masternode keys */
+"Previously used at: " = "Раніше використано: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Цінам що найменше 30 хвилин. Фіатні значення можуть бути неправильними.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Приватність за задумом";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Приватні запити на додавання до контактів (щоб те, з ким ви пов'язані, залишалося приватним), Shielded DashPay — платежі контактам із вашого приватного екранованого балансу — і платежі користувачам, яких ще немає у ваших контактах, з'являться незабаром.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Приватні запити на додавання до контактів розробляються й очікуються приблизно у вересні–жовтні 2026 року. Сьогодні сам запит публічний — будь-хто може побачити, що два ідентифікатори пов'язані, навіть якщо платіжні дані всередині зашифровані. Коли з'являться приватні запити, ви зможете обирати, чи буде ваш зв'язок публічним або приватним.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Приватні запити на додавання до контактів, Shielded DashPay і платежі людям, яких ще немає у ваших контактах.";
+
 /* No comment provided by engineer. */
 "Private key" = "Приватний ключ";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Приватними платіжними адресами обмінюєтеся ви та ваші контакти. Лише ви й ваш контакт знаєте отримувача та відправника платежів між вами.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Приватні платежі";
+
+/* Usernames */
+"Private registration" = "Приватна реєстрація";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Час обробки";
+
+/* Balance info sheet section */
+"Pros" = "Плюси";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Захистіть свої заощадження";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Адреса провайдера";
 
+/* Masternodes */
+"Provider transactions" = "Транзакції провайдера";
+
+/* Masternode keys */
+"Public key" = "Публічний ключ";
+
+/* Masternode keys */
+"Public key (legacy)" = "Публічний ключ (застарілий)";
+
+/* Identities */
+"Public keys" = "Публічні ключі";
+
 /* No comment provided by engineer. */
 "Public URL" = "Публічна URL-адреса";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Покупка не вдалася";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Призначення";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Курс: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Необроблена транзакція";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Необроблена транзакція недоступна";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Повторно перевіряє компактні блокові фільтри з обраної висоти на предмет транзакцій цього гаманця, завантажуючи та зіставляючи їх заново. Пересканування обмежене висотою створення гаманця та локально збереженими даними ланцюжка — щоб відновити історію нижче, натомість знизьте початкову висоту гаманця.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Прочитати Політику виведення коштів";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Лише для читання";
+
+/* Usernames */
+"Ready around %@" = "Готово приблизно о %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Причина";
 
 /* No comment provided by engineer. */
 "Receive" = "Отримати";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Отримано з";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Отримано від %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Отримання нагород";
+
+"Records your masternodes as having voted, without taking a side." = "Позначає ваші мастерноди як такі, що проголосували, не стаючи на чийсь бік.";
 
 /* No comment provided by engineer. */
 "Recover" = "Відновити";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Фраза для відновлення повинна містити 12, 15, 18, 21 або 24 слова";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Оновити";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "Зареєструватись?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Зареєстровано";
+
+/* No comment provided by engineer. */
 "Registered from" = "Зареєстровано з";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Зареєстрована Мастернода";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Приватна реєстрація потребує щонайменше %@ Dash на екранованому балансі та кількох годин витримки — наступні екрани проведуть вас по кроках.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Реєстрація";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Запитує це ім'я";
+
 /* An action */
 "Rescan" = "Повторне сканування";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Відновлені гаманці не завжди можуть визначити тип операції. Цей запис відтворено з даних нотатки в ланцюжку.";
+
+/* Location Service Status */
 "Restricted" = "Обмежено";
 
 /* Usernames */
 "Results" = "Результати";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Пересинхронізацію підготовлено з висоти %u — закрийте та знову відкрийте застосунок, щоб почати.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "зберігати спільну історію транзакцій";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Виведено з експлуатації";
 
 /* No comment provided by engineer. */
 "Retry" = "Повторити";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Перегляньте публікацію нижче, щоб підтвердити право власності на це ім’я користувача";
+
+/* Masternodes */
+"Revocation" = "Відкликання";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Знімки екрана доступні для інших програм і пристроїв. Створіть нову фразу відновлення та збережіть її в секреті.";
 
+/* Raw transaction inspector */
+"Script" = "Скрипт";
+
+/* Raw transaction inspector */
+"Script signature" = "Підпис скрипта";
+
+/* Raw transaction inspector */
+"Script type" = "Тип скрипта";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Пошук контакту";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Пошук запиту на додавання до контактів";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Пошук користувача в мережі Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Пошук імені користувача";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Результати пошуку за \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Шукати території";
+
+"Search usernames" = "Пошук імен користувачів";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Пошук імені користувача %@ в мережі Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Захистіть свій гаманець";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Рівень безпеки";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Рівень безпеки";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "Виберіть сервіс для покупки, продажу, конвертації та передачі Dash";
 
+"Select all" = "Обрати все";
+
 /* DashSpend denomination selection */
 "Select amount" = "Виберіть суму";
+
+"Select at least one masternode to vote with." = "Оберіть щонайменше одну мастерноду для голосування.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "Виберіть монету";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Чим менше вузлів обрано, тим менше розкривається про те, які мастерноди ви тримаєте.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Самообслуговування";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Відправити";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Надіслати контакту";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Надсилайте на ім'я користувача, яке ви справді можете запам'ятати й перевірити.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Відправити на адресу";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Надішліть свій перший запит на додавання до контактів";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Відправка";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Надсилання запиту на додавання до контактів";
+
+/* No comment provided by engineer. */
+"Sending to" = "Надсилання на";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Відправляється на акаунт CrowdNode";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Відправити";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Надіслано %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Виникла помилка серверу. Спробуйте ще раз пізніше.";
+
+/* Masternodes */
+"Service" = "Сервіс";
+
+/* Identities */
+"Set as Main" = "Зробити основним";
+
+/* Identities */
+"Set as Main Identity" = "Зробити основним ідентифікатором";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Встановіть PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Спільний пул приватності досяг мінімального розміру";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Екранована адреса";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Екранована витрата";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Запуск екранованого гаманця…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Екранований → Platform";
+
+"Shielded → Transparent" = "Екранований → Прозорий";
 
 /* Explore Dash */
 "Show all locations" = "Показати всі точки";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Розмір";
+
 /* No comment provided by engineer. */
 "Skip" = "Пропустити";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Деяких із ваших мастернод може не бути в цьому списку — гаманець не зміг прочитати повний набір ваших ключів голосування. Завершіть синхронізацію та знову відкрийте цей екран.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Деякі імена користувачів можуть бути заблоковані";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Сортувати зв";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Сортувати контакти";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Відсортовано за знижкою";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Відсортовано за назвою";
+
+/* Raw transaction inspector */
+"Special payload" = "Спеціальне корисне навантаження";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Вкажіть суму";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Стейкінг";
 
+/* Usernames */
+"Starts after you add funds" = "Почнеться після поповнення";
+
+/* Transaction details */
+"Status" = "Статус";
+
 /* Step 1 */
 "Step %ld" = "Крок %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Зберігається як";
 
 /* Voting */
 "Submit" = "Надіслати";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Триває синхронізація... Результати можуть бути неповними.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Інформація про синхронізацію";
+
+/* SPV sync */
+"Sync too slow?" = "Синхронізація надто повільна?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Зробити фото з камери";
 
+"Take no side" = "Не ставати на бік";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Натисніть на адресу з буфера обміну, щоб вставити її";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Торкніться, щоб скопіювати";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Торкніться, щоб приховати баланс";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Тимчасово недоступно";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Ключ вузла Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Терміни і умови";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "Код не правильний. Перевірте та повторіть спробу!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash надійдуть на адресу отримувача після того, як мережа обробить виведення — це може зайняти до 10 хвилин.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash надійдуть на адресу отримувача, щойно мережа обробить виведення.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash надійдуть на ваш прозорий баланс, щойно мережа обробить виведення.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "Мережа Dash повинна проголосувати за схвалення деяких імен користувачів перед їх створенням";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "Посилання, яке ви надішлете, буде видно лише власникам мережі";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Основний ідентифікатор можна обрати лише з активного гаманця";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "Мінімальна сума, яку ви можете надіслати, становить %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Найприватніше місце для зберігання ваших Dash";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "У збереженого запису гаманця немає мережі — неможливо підготувати пересинхронізацію.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Реєстрацію надіслано, але підтвердити її результат не вдалося. Зачекайте хвилину, доки гаманець синхронізується, а потім спробуйте ще раз — не надсилайте повторно одразу.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Спільний пул приватності ще зростає (%1$ld з %2$ld депозитів). Приватна реєстрація розблокується, коли він досягне мінімуму.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Спільний пул приватності ще зростає (%1$ld з %2$ld депозитів). Спробуйте ще раз, коли він досягне мінімуму.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "Ім’я користувача '%@' заблоковано Dash Network. Спробуйте ще раз, попросивши інше ім’я користувача.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Висота створення гаманця — нижня межа для сканування фільтрів і пересканувань «Від створення гаманця». Установіть її на рівні першого поповнення гаманця або нижче; під час імпорту типово використовується 200000 у mainnet і 0 у testnet. Збереження висоти, що дорівнює поточній або менша за неї, очистить дані ланцюжка цієї мережі під час наступного запуску й пересканує з неї.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "його (отримання інформації)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Нових сповіщень немає";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Немає транзакцій для відображення";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Немає користувачів, що відповідають імені %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "У ваших контактах немає користувачів, що відповідають імені %@";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "Сталася помилка під час експорту вашої історії транзакцій до ZenLedger";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "Сталася помилка, спробуйте пізніше";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Ці кошти переходять на ваш баланс Platform і готові до витрачання, щойно переказ завершиться.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "На цю адресу не можна платити з вашого балансу %@";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Це додасть до вашого ідентифікатора два ключі, щоб інші користувачі могли надсилати вам запити на додавання до контактів, а ви — приймати їхні. Це відбувається один раз.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Це застосує один вибір до всіх %d обраних імен користувачів.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "Цей додатковий крок показує, що справді ви намагаєтеся здійснити транзакцію.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Це посилання-запрошення недійсне.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Це недійсна адреса Dash для цієї мережі";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Це недійсне посилання-запрошення";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Це ваш основний ідентифікатор";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "У цієї мастерноди поки немає ідентифікатора Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "Цей торговець наразі недоступний.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "Це поточний річний відсоток прибутку повної Мастерноди мінус комісія CrowdNode у розмірі 15%. Це не гарантована норма прибутку, і вона може зростати або знижуватися залежно від розміру пулів CrowdNode і ціни Dash.";
 
+"This still counts as your masternodes having voted in this contest." = "Це все одно зараховується як участь ваших мастернод у голосуванні в цьому спорі.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Необроблені байти цієї транзакції не зберігаються на цьому пристрої.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Це ім'я користувача дісталося комусь іншому";
+
+"This wallet could not derive the voting key for this node." = "Цей гаманець не зміг отримати ключ голосування для цього вузла.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "У цьому гаманці немає активних ключів голосування мастернод, тож голосувати неможливо. Зареєстровані вузли з'являються в Інструменти → Мастерноди.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Це виведе весь ваш баланс Platform одним переказом. Dash надійдуть на адресу отримувача, щойно мережа обробить виведення.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Це виведе весь ваш баланс Platform одним переказом. Dash надійдуть на ваш прозорий баланс, щойно мережа обробить виведення.";
 
 /* Send Screen: to address */
 "to" = "до";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "Історія Транзакцій";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Історія транзакцій недоступна";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Id транзакції";
+
+/* Raw transaction inspector */
+"Transaction ID" = "ID транзакції";
 
 /* A verb, button title. */
 "Transfer" = "Переказати";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Трансфер в";
 
+/* Balance breakdown */
+"Transfer in" = "Переказ вхідний";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Трансфер з";
+
+/* Balance breakdown */
+"Transfer out" = "Переказ вихідний";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Перекази тривають довше — побудова доказів приватності потребує часу";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Перекази на інші адреси Platform та екрановані адреси миттєві й остаточні";
+
+/* Balance breakdown */
+"Transparent" = "Прозорий";
+
+/* Send screen destination type */
+"Transparent address" = "Прозора адреса";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Прозорий баланс";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Прозоре фінансування публічно пов'язує ваше ім'я користувача з цими коштами.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Прозорий → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Прозорий → Екранований";
 
 /* An action */
 "Try again" = "Спробуйте ще раз";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Не вдалося надати пропозиції";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "Баланс невідомо";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Невідомий спеціальний тип %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Не екрановано";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Непідтримувана URL-адреса";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "Оновіть до DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Перейти на Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Використати прозорий баланс";
+
+/* Masternode keys */
+"Used" = "Використано";
+
+/* Masternode keys */
+"Used at: " = "Використано: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Користувач (отримання інформації)";
 
 /* Voting */
 "Username" = "Ім'я користувача";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "Запит на ім’я користувача успішно виконано";
 
+/* Identities */
+"Usernames" = "Імена користувачів";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Імена користувачів зберігаються в нормалізованому вигляді, щоб уникнути схожих імен, тож це може відрізнятися від того, що ввела кожна людина.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Імена користувачів, а не адреси";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Користувачі, що відповідають %@, яких зараз немає у ваших контактах";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Використовує одну з найбільш перевірених і протестованих бібліотек із нульовим розголошенням (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Дійсне запрошення";
+
 /* CrowdNode Portal */
 "Validating address…" = "Підтвердження адреси...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Потрібна Верифікація";
 
+/* Usernames */
+"Verified during registration" = "Перевірено під час реєстрації";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Успішно верифіковано";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "Підтвердьте свою особу";
 
+/* Raw transaction inspector */
+"Version" = "Версія";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Дуже ефективно й із низькими комісіями";
+
 /* adjective, security level */
 "Very High" = "Дуже високий";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Щоб переконатися, що ви дійсно власник цього гаманця, на рахунок CrowdNode будуть зараховані і списані невелика кількість Dash.";
+
+/* No comment provided by engineer. */
+"View All" = "Показати всі";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Переглянути в Explorer";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Переглянути фразу відновлення";
 
+/* Raw transaction inspector */
+"View Transaction" = "Переглянути транзакцію";
+
 /* No comment provided by engineer. */
 "View transaction details" = "Переглянути деталі транзакції";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Голосувати";
+
+"Vote cast" = "Голос віддано";
+
 /* Voting */
 "Vote for All" = "Голосувати за всіх";
 
 /* Voting */
+"Vote on contested usernames" = "Голосувати за оспорювані імена користувачів";
+
+"Vote on several" = "Голосувати за кілька";
+
+/* Voting */
 "Vote to Approve" = "Голосувати за схвалення";
+
+"Vote with" = "Голосувати з";
+
+"Votes that nobody should receive these usernames." = "Голосує за те, щоб ніхто не отримав ці імена користувачів.";
 
 /* Voting */
 "Votes: High to low" = "Голоси: від високого до низького";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Адреса голосування";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Адреса голосування";
+
+"Voting ended with no winner" = "Голосування завершилося без переможця";
+
+"Voting ends" = "Голосування завершується";
+
 /* Voting */
 "Voting ends in %dd" = "Голосування закінчується через %dднів";
+
+"Voting in progress" = "Голосування триває";
+
+"Voting in progress — lock votes are ahead" = "Голосування триває — голоси за блокування попереду";
+
+"Voting in progress — you are ahead" = "Голосування триває — ви попереду";
 
 /* Usernames */
 "Voting is only required in some cases" = "Голосування потрібне лише в деяких випадках";
 
+/* Masternodes */
+"Voting key hash" = "Хеш ключа голосування";
+
 /* Voting keys */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Голосування за це ім'я користувача закрито. Значення нижче — останні зчитані.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Голосування за «%@» вже закрито. Оновіть, щоб побачити результат.";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Зачекайте, поки гаманець синхронізується, щоб завершити транзакцію";
 
+"Waiting for Dash Platform" = "Очікування Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Адреса гаманця";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Початкова висота гаманця";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Гаманець вимкнено";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Ласкаво просимо до DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "А як щодо Unstoppable Domains і подібних сервісів імен?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Скільки це коштує?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "Що таке DashPay?";
+
 /* Usernames */
 "What is username voting?" = "Що таке голосування за імʼя користувача?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Що буде далі?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Коли запити на додавання до контактів стануть приватними?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Де витратити";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Де витратити?";
+
+"Who is requesting this name" = "Хто запитує це ім'я";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Навіщо мені це вмикати?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Чому я бачу всі ці транзакціїї?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Запит на вивід коштів відправлено";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Виводить увесь баланс";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Працює з будь-яким гаманцем Dash, біржею та продавцем";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Хочете прийняти запрошення?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Вчора";
+
+"You" = "Ви";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Ви прийняли запит на додавання до контактів від %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "Ви обрали “%@” як своє ім’я користувача.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Наразі у вас немає контактів";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "У вас недостатньо коштів для завершення цієї операції";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "Ви перевищили ліміт авторизації на Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Наразі у вас %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "У вас є %1$@ Dash. \nДеякі імена користувачів коштують до %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Ви надіслали запит на додавання до контактів %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "У вас повинен бути додатній баланс Dash Wallet";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Ви виграли це ім'я користувача";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Усе готово. Інші користувачі тепер можуть надсилати вам запити на додавання до контактів — і ви можете надсилати свої.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Ваш ідентифікатор Dash Platform з'явиться тут, щойно ви зареєструєте ім'я користувача.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Ваша електронна адреса використовується лише для надсилання одноразового пароля.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Ваша історія, упорядкована";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Вашому ідентифікатору потрібні два додаткові ключі, щоб запити на додавання до контактів можна було шифрувати між вами та іншими користувачами. Під час увімкнення їх додають однією транзакцією в мережі. Це відбувається один раз.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Ваше запрошення від %@ уже отримано";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Ваше запрошення від %@ недійсне";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Ваше запрошення оплачує комісію за реєстрацію цього імені користувача.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Ваше місцезнаходження використовується для відображення вашого положення на карті, банкоматів у вибраному радіусі та покращення результатів пошуку.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Ваше місцезнаходження використовується для відображення вашого положення на карті, продавців у вибраному радіусі та покращення результатів пошуку.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Ваш основний баланс Dash у блокчейні Core — те, що ви надсилаєте й отримуєте з іншими гаманцями, біржами та продавцями.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Ваші змішані монети переміщено на баланс гаманця Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Ваші змішані монети переміщено на екранований баланс. Для найкращої приватності зачекайте щонайменше 2 години, перш ніж використовувати ці кошти.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Ваш баланс Platform";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Ваша основна адреса Dash, яку ви зараз використовуєте для свого облікового запису CrowdNode";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Ваш приватний баланс. Суми й адреси зашифровано в ланцюжку, тож ваші кошти та історія залишаються конфіденційними.";
+
 /* Usernames */
 "Your request was cancelled" = "Ваш запит скасовано";
 
 /* DashSpend */
 "Your session expired" = "Ваш сеанс закінчився";
+
+/* Usernames */
+"Your Shielded balance" = "Ваш екранований баланс";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Ваш екранований баланс майже готовий — ви зможете приватно зареєструватися приблизно о %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Ваш екранований баланс готовий — зареєструйте ім'я користувача приватно просто зараз";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Ваш екранований баланс відлежується — ви зможете приватно зареєструватися приблизно о %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Ваш екранований баланс ще дозріває. Він буде готовий приблизно о %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Ваш прозорий баланс";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Ваше ім’я користувача %@ було успішно створено в Dash Network";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Ваше ім’я користувача було успішно створено";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Ваше ім'я користувача бачать усі. Якщо профінансувати його з екранованого балансу — давши коштам відлежатися кілька годин, — ніхто не зможе пов'язати ваше ім'я користувача з рештою ваших Dash.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Ваше ім'я користувача, профіль і контакти прив'язані до цього ідентифікатора.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Ваше ім'я користувача, профіль і контакти будуть прив'язані до цього ідентифікатора.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Ваш голос скасовано";
 
 /* Voting */
 "Your vote was submitted" = "Ваш голос подано";
 
+"Your votes" = "Ваші голоси";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Тепер ваш гаманець у безпеці. Ви можете будь-коли використати свою фразу відновлення, щоб відновити обліковий запис на іншому пристрої.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Ваш гаманець ще синхронізується з мережею Dash. Надсилання стане доступним після завершення синхронізації.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Ваш гаманець ще синхронізується. Надсилання з прозорого балансу стане доступним після завершення синхронізації.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Не вдалося прочитати «%@» як ім'я користувача Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "«%@» зареєстровано. Надіслати запит на додавання до контактів людині, яка вас запросила?";

--- a/DashWallet/uk.lproj/Localizable.stringsdict
+++ b/DashWallet/uk.lproj/Localizable.stringsdict
@@ -102,5 +102,305 @@
 			<string>%d ключів</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ за «%2$@»</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%1$u голос</string>
+			<key>few</key>
+			<string>%1$u голоси</string>
+			<key>many</key>
+			<string>%1$u голосів</string>
+			<key>other</key>
+			<string>%1$u голоса</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Проголосовано за %1$d із %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d імені користувача</string>
+			<key>few</key>
+			<string>%2$d імен користувачів</string>
+			<key>many</key>
+			<string>%2$d імен користувачів</string>
+			<key>other</key>
+			<string>%2$d імен користувачів</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>Віддати %u голос</string>
+			<key>few</key>
+			<string>Віддати %u голоси</string>
+			<key>many</key>
+			<string>Віддати %u голосів</string>
+			<key>other</key>
+			<string>Віддати %u голоса</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d із %#@nodes@ проголосували</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d мастерноди</string>
+			<key>few</key>
+			<string>%2$d мастернод</string>
+			<key>many</key>
+			<string>%2$d мастернод</string>
+			<key>other</key>
+			<string>%2$d мастернод</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d із %#@nodes@ проголосували</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$d вузла</string>
+			<key>few</key>
+			<string>%2$d вузлів</string>
+			<key>many</key>
+			<string>%2$d вузлів</string>
+			<key>other</key>
+			<string>%2$d вузлів</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d evonode</string>
+			<key>few</key>
+			<string>%d evonode</string>
+			<key>many</key>
+			<string>%d evonode</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>усього %u голос</string>
+			<key>few</key>
+			<string>усього %u голоси</string>
+			<key>many</key>
+			<string>усього %u голосів</string>
+			<key>other</key>
+			<string>усього %u голоса</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d мастернода</string>
+			<key>few</key>
+			<string>%d мастерноди</string>
+			<key>many</key>
+			<string>%d мастернод</string>
+			<key>other</key>
+			<string>%d мастерноди</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d вибрано</string>
+			<key>few</key>
+			<string>%d вибрано</string>
+			<key>many</key>
+			<string>%d вибрано</string>
+			<key>other</key>
+			<string>%d вибрано</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ваш вузол уже проголосував тут і не показаний.</string>
+			<key>few</key>
+			<string>%d ваші вузли вже проголосували тут і не показані.</string>
+			<key>many</key>
+			<string>%d ваших вузлів уже проголосували тут і не показані.</string>
+			<key>other</key>
+			<string>%d ваших вузлів уже проголосували тут і не показані.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u голос за спір — evonode рахуються як 4, мастерноди як 1</string>
+			<key>few</key>
+			<string>%u голоси за спір — evonode рахуються як 4, мастерноди як 1</string>
+			<key>many</key>
+			<string>%u голосів за спір — evonode рахуються як 4, мастерноди як 1</string>
+			<key>other</key>
+			<string>%u голосів за спір — evonode рахуються як 4, мастерноди як 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Голосувати за %d ім'я користувача</string>
+			<key>few</key>
+			<string>Голосувати за %d імені користувача</string>
+			<key>many</key>
+			<string>Голосувати за %d імен користувачів</string>
+			<key>other</key>
+			<string>Голосувати за %d імен користувачів</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>one</key>
+			<string>%u голос</string>
+			<key>few</key>
+			<string>%u голоси</string>
+			<key>many</key>
+			<string>%u голосів</string>
+			<key>other</key>
+			<string>%u голоса</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>Голосувати ×%d</string>
+			<key>few</key>
+			<string>Голосувати ×%d</string>
+			<key>many</key>
+			<string>Голосувати ×%d</string>
+			<key>other</key>
+			<string>Голосувати ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d запит</string>
+			<key>few</key>
+			<string>%d запити</string>
+			<key>many</key>
+			<string>%d запитів</string>
+			<key>other</key>
+			<string>%d запиту</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/uk.lproj/Localizable.stringsdict
+++ b/DashWallet/uk.lproj/Localizable.stringsdict
@@ -165,7 +165,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d із %#@nodes@ проголосували</string>
+		<string>Голосування: %1$d із %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -185,7 +185,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%1$d із %#@nodes@ проголосували</string>
+		<string>Голосування: %1$d із %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " hoặc ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "Không tìm thấy %@ trên mạng Dash để gửi yêu cầu liên hệ.";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash khả dụng";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ đã chấp nhận yêu cầu liên hệ của bạn";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d byte";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld trên %ld lần nạp";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Số dư tín dụng trên Dash Platform, dùng cho thanh toán tức thì giữa các địa chỉ Platform và cho các tính năng như tên người dùng.";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "Một mật khẩu cho thiết bị là cần thiết để bảo vệ ví của bạn. Hãy vào phần Settings và bật chế độ mật khẩu và tiếp tục.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "Giới thiệu";
 
+/* DashPay FAQ title */
+"About DashPay" = "Giới thiệu về DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "Bỏ phiếu trắng";
+
+"Abstain on “%@”" = "Bỏ phiếu trắng cho “%@”";
 
 /* No comment provided by engineer. */
 "Accept" = "Chấp nhận";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "Đang hoạt động";
+
+/* No comment provided by engineer. */
+"Activity" = "Hoạt động";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "Hoạt động là công khai nhưng không dễ truy vết";
+
 /* No comment provided by engineer. */
 "Add" = "Thêm";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "Thêm %@ làm liên hệ";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "Thêm %@ làm liên hệ để thanh toán trực tiếp đến tên người dùng và giữ lại lịch sử giao dịch chung";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "Thêm %@ Dash vào số dư được che chắn và để yên vài giờ, nhờ đó bạn đăng ký mà không liên kết tên người dùng với số tiền còn lại.";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Thêm một liên hệ";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "Thêm ít nhất %@ Dash vào số dư được che chắn của bạn";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "Nạp vào số dư được che chắn ngay bây giờ và đăng ký tên người dùng một cách riêng tư sau vài giờ";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "Tất cả";
 
+"All nodes at once" = "Tất cả các nút cùng lúc";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tất cả masternode của bạn đã bỏ phiếu cho tên người dùng này. Để đổi phiếu, hãy bỏ phiếu lại từ người xin mà bạn ủng hộ bây giờ.";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "Đồng bộ số dư gần như tức thì";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "Số tiền và địa chỉ là công khai trên blockchain";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "Tài khoản Ethereum là một địa chỉ dùng lại nhiều lần: toàn bộ số dư và lịch sử thanh toán của bạn nằm công khai dưới địa chỉ đó, và một cái tên (chẳng hạn tên miền ENS) thường trỏ thẳng đến địa chỉ ấy để ai cũng phân giải được. DashPay thì ngược lại — tên phân giải thành một danh tính chứ không phải địa chỉ thanh toán, còn địa chỉ thanh toán thật nằm bên trong các trao đổi liên hệ đã mã hoá, mới cho từng liên hệ.";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "Một giao diện trực quan và quen thuộc trên tất cả các thiết bị của bạn";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "Bất cứ ai biết một địa chỉ đều có thể xem lịch sử của địa chỉ đó";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "Chấp thuận";
+
+"Approving a specific request can only be done one username at a time." = "Chấp thuận một yêu cầu cụ thể chỉ thực hiện được cho từng tên người dùng một.";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "Dạng văn bản";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "Đã huỷ xác thực. Phiếu của bạn chưa được gửi.";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "Xác thực thất bại. Phiếu của bạn chưa được gửi.";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Xác thực không sẵn sàng";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "Trao “%@” cho người xin này";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Số dư";
 
 /* CrowdNode */
+"Balance after" = "Số dư sau đó";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "Số dư và các lần chuyển không hiển thị công khai";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "Đã lưu độ cao khởi đầu — mức sàn quét được nâng lên sẽ áp dụng từ lần khởi động sau.";
+
 /* Voting */
 "Block" = "Khối";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "Gắn với hợp đồng";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "Gắn với hợp đồng, loại tài liệu “%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "Chỉ xem";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "Gom các nhật ký chẩn đoán gần đây thành tệp zip để gửi qua AirDrop, email hoặc lưu vào Tệp";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "Gửi phiếu";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "Đổi peer";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Đổi mã PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "Đang kiểm tra…";
+
+"Choice" = "Lựa chọn";
+
 /* Choose your Dash username */
 "Choose your" = "Chọn của bạn";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "Nhận lời mời của bạn";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "Số dư có thể nhận";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "Xoá & đồng bộ lại";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "Xoá dữ liệu chuỗi và đồng bộ lại?";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Đóng ứng dụng";
 
+"Closing" = "Sắp đóng";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase (đồng mới)";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin không còn được hỗ trợ — hãy chọn nơi chuyển số coin đã trộn của bạn.";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "Tài sản thế chấp";
+
+/* DashPay intro: feature title */
+"Coming soon" = "Sắp ra mắt";
+
+/* Shielded transfer status */
+"Completed" = "Đã hoàn tất";
 
 /* No comment provided by engineer. */
 "Confirm" = "Xác thực";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "Đã xác nhận";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "Việc xác nhận sẽ lưu độ cao khởi đầu %u và xoá dữ liệu chuỗi của mạng này ở lần mở ứng dụng sau, tải lại rồi quét lại các bộ lọc từ độ cao đó. Phiên đang chạy vẫn giữ mức sàn quét cũ — hãy thoát và mở lại ứng dụng để bắt đầu.";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "Peer đã kết nối";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "Nhược điểm";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "Yêu cầu liên hệ thất bại";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "Đã gửi yêu cầu liên hệ tới %@";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "Yêu cầu liên hệ";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Các liên hệ";
 
+"Contender %@" = "Người xin %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Tiếp tục";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "Tiếp tục để chọn tên người dùng của bạn. Lời mời sẽ trả phí đăng ký.";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "Sao chép giao dịch thô";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "Không tạo được tệp lưu trữ nhật ký: %@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Không thể tìm thấy tỷ giáo giao dịch.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "Không thể làm mới %d danh tính";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "Không lấy được số dư (lỗi mạng). Hãy thử làm mới.";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Không thể thực hiện giao dịch";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "Tạo Tên người dùng, tìm bạn bè & người thân qua tên người dùng của họ và thêm họ vào danh bạ";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "Tín dụng";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Số Dash cho giao dịch không thể nhỏ hơn %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform chưa lập chỉ mục cuộc tranh chấp này. Số phiếu sẽ hiện ở đây khi việc đó hoàn tất.";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform chưa kết nối. Hãy đợi đồng bộ xong rồi thử lại.";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "Dash gửi nhầm địa chỉ sẽ không lấy lại được. Hãy chắc chắn địa chỉ đúng chính xác là nơi bạn muốn thanh toán.";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash lưu tên người dùng ở dạng chống trông-giống-nhau, nên tên đã lưu có thể khác với những gì mỗi người đã gõ.";
+
 /* No comment provided by engineer. */
 "Dash username" = "Tên người dùng Dash";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Số dư ví Dash";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "Đã bật DashPay";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay là trải nghiệm thanh toán mang tính xã hội của Dash, xây dựng trên Dash Platform. Bạn đăng ký một tên người dùng, thêm người dùng khác làm liên hệ và trả tiền cho họ theo tên — không còn phải sao chép địa chỉ.";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay thay các địa chỉ dài khó hiểu bằng tên người dùng. Thêm bạn bè làm liên hệ, gửi tiền tới một cái tên và giữ mọi khoản thanh toán được sắp xếp theo từng người.";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "Chi phí nâng cấp DashPay";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "Không rõ hạn chót";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "Đường dẫn dẫn xuất";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "THIẾT BỊ NÀY KHÔNG CÒN BẢO MẬT\nBất kỳ ứng dụng 'jailbreak' nào đều có thể truy cập vào dữ liệu chìa khoá của tất cả các ứng dụng khác (và đánh cắp Dash của bạn). Hãy xoá sạch ví ngày ngay lập trức và khôi phục tính năng bảo mật của thiết bị.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "Đã vô hiệu hoá";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "Xong";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "Xong — số dư của bạn đã để yên đủ lâu";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "Kiểm tra lại địa chỉ";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "Mỗi masternode có một phiếu còn hiệu lực cho mỗi cuộc tranh chấp. Bạn có thể đổi sau, nhưng Dash Platform chỉ cho phép tổng cộng 5 phiếu cho mỗi masternode trong mỗi cuộc tranh chấp.";
+
+"Each tap votes with one more node, so you choose how many to link together." = "Mỗi lần chạm sẽ thêm một nút vào bỏ phiếu, nên bạn chọn được số nút muốn liên kết với nhau.";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Trước đó";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "Sửa độ cao khởi đầu";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "Bật";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "Bật DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Cho phép Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Cho phép Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "Bật DashPay tốn một khoản phí mạng nhỏ, chỉ một lần, trả từ số dư tín dụng của danh tính bạn. Ước tính chính xác sẽ hiện ra trước khi bạn xác nhận. Việc gửi yêu cầu liên hệ và thanh toán chịu phí mạng thông thường.";
+
+"Ending soonest" = "Kết thúc sớm nhất";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "Phí mạng ước tính";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "Mọi nút bỏ phiếu cùng nhau. Nhanh hơn, nhưng liên kết công khai các masternode của bạn với nhau.";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Khoá vận hành Evonode";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "Xuất nhật ký";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "Địa chỉ bên ngoài";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Giới hạn Face ID";
+
+/* No comment provided by engineer. */
+"Failed" = "Thất bại";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "Đang lấy…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Lọc";
+
+/* SPV sync phase */
+"Filter headers" = "Tiêu đề bộ lọc";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "Tìm một người dùng trên Mạng Dash";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "Tìm danh tính";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Quên mã PIN";
 
+/* Identities */
+"Found %d new identities" = "Đã tìm thấy %d danh tính mới";
+
+/* Identities */
+"Found 1 new identity" = "Đã tìm thấy 1 danh tính mới";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "Chi trả cho tên người dùng từ số dư được che chắn. Hãy nạp tiền trước vài giờ — khoảng nghỉ ngắn đó giúp tên người dùng của bạn không liên kết được với số Dash còn lại.";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "Chi trả từ số dư được che chắn — tên người dùng của bạn không liên kết được với số Dash còn lại.";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "Đã khoá tiền — đang hoàn tất chuyển";
+
+/* CoinJoin */
+"Funds moved" = "Đã chuyển tiền";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "Sẵn sàng tham gia DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "Đã hiểu";
+
+/* Governance */
+"Governance" = "Quản trị";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "đã yêu cầu kết bạn với bạn";
+
+/* DashPay Invitations */
+"Have an invitation?" = "Bạn có lời mời không?";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Bạn có toàn quyền kiểm soát và tuỳ chỉnh ví dựa trên nhu cầu của mình";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "phần đầu # %1$d của %2$d";
+
+/* SPV sync phase */
+"Headers" = "Tiêu đề khối";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "Độ cao %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "Phí cao hơn, khoảng 7 xu (vẫn thấp hơn các blockchain khác có mức riêng tư tương tự)";
+
 /* No comment provided by engineer. */
 "History" = "Lịch sử";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "So với Bitcoin thì về quyền riêng tư thế nào?";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "So với tài khoản Ethereum thì về quyền riêng tư thế nào?";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay riêng tư đến mức nào?";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "Tôi đã viết xuống";
 
+/* Identities */
+"Identities" = "Danh tính";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "Tín dụng danh tính";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "Chỉ mục danh tính";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "Đăng ký danh tính";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "Nạp thêm cho danh tính";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "Không hoạt động";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "Đầu vào %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "Đầu vào %d — outpoint";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "Đầu vào (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Không đủ tiền";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "Lời mời từ %@";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "Mời ai đó tham gia Mạng Dash";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "Mời bạn bè và người thân của bạn vào Mạng Dash";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "Giữ số coin này ở dạng riêng tư. Có áp dụng phí mạng và phí riêng tư.";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "Khoá #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "Dữ liệu khoá";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "Quyền sở hữu khoá";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "Khoá";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "Dẫn đầu";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "Tìm hiểu thêm";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "Đang tải giao dịch";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Tiền địa phương";
 
+/* Identities */
+"Local Only" = "Chỉ cục bộ";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Số lượng được yêu cầu: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "Khoá";
+
+"Lock the name" = "Khoá cái tên";
+
+"Lock “%@” so nobody gets it" = "Khoá “%@” để không ai nhận được";
+
 /* No comment provided by engineer. */
 "Locked" = "Đã khoá";
 
+"Locked — nobody receives this username" = "Đã khoá — không ai nhận được tên người dùng này";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "Locktime";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Thấp";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "Phí thấp cho chi tiêu hằng ngày";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "Chính";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mạng chính";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "Chùm khoá Masternode";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "Danh sách masternode";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Cập nhật Masternode";
 
+"Masternode votes" = "Phiếu từ masternode";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "Masternode";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "Các masternode và evonode đã đăng ký bằng khoá của ví này sẽ xuất hiện ở đây sau khi ví đồng bộ xong.";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "Masternode và evonode dùng khoá của ví này";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "Masternode bỏ phiếu cho những cái tên có nhiều hơn một người xin. Bạn sẽ được thông báo khi bỏ phiếu kết thúc.";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Tối đa";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "Đã đạt mức tối thiểu";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "Kiểm soát nhiều hơn";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "Thêm gợi ý";
+
+"Most lock votes" = "Nhiều phiếu khoá nhất";
+
+"Most votes" = "Nhiều phiếu nhất";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "Chuyển sang số dư chi tiêu thông thường của bạn.";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Được chuyển đến Địa chỉ";
+
+/* CoinJoin */
+"Moving funds" = "Đang chuyển tiền";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Tên";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Các dịch vụ tên như Unstoppable Domains ánh xạ một cái tên dễ đọc tới một địa chỉ công khai cố định trên chuỗi. Ai cũng có thể phân giải cái tên đó và thấy mọi khoản thanh toán từng gửi tới nó. Tên người dùng DashPay không bao giờ phân giải công khai thành địa chỉ thanh toán — địa chỉ chỉ được tiết lộ bên trong trao đổi đã mã hoá với từng liên hệ, nên tên và tiền của bạn vẫn không liên kết được với nhau dưới mắt người ngoài.";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "Cần chú ý";
 
 /* No comment provided by engineer. */
 "Network" = "Mạng";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "Không tìm thấy nhật ký chẩn đoán nào trên thiết bị này. Nhật ký được ghi từ lần khởi động sau trở đi.";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "Không có danh tính";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "Chưa có masternode nào";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "Không có cuộc tranh chấp nào khớp";
+
+/* Identities */
+"No new identities were found for this wallet" = "Không tìm thấy danh tính mới nào cho ví này";
+
+"No open contest matches that search." = "Không có cuộc tranh chấp đang mở nào khớp với tìm kiếm đó.";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "Không có cuộc tranh chấp đang mở nào khớp với tìm kiếm đó. Tên được lưu ở dạng chuẩn hoá, nên “alice” hiển thị là “a11ce”.";
+
+"No open contests" = "Không có cuộc tranh chấp nào đang mở";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "Không tìm thấy bản ghi ví đã lưu cho ví đang gắn kết.";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "Chưa có địa chỉ Platform nào khả dụng cho phương án đăng ký che chắn dự phòng. Hãy thử lại sau khi ví đồng bộ xong.";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "Hiện không có tên người dùng nào đang tranh chấp. Tranh chấp mở ra khi hai người trở lên cùng xin một cái tên.";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "Không có phiếu nào được gửi";
+
+"Nobody gets it" = "Không ai nhận được";
+
+/* SPV sync peer type */
+"Node" = "Nút";
+
+/* Raw transaction inspector */
+"Non-standard" = "Không chuẩn";
 
 /* adjective, security level */
 "None" = "Không có";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Không sẵn sàng";
 
+"Not available yet" = "Chưa khả dụng";
+
+"Not cast" = "Chưa gửi";
+
+/* Masternodes */
+"Not checked yet" = "Chưa kiểm tra";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "Số dư được che chắn không đủ để đăng ký một danh tính";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "Không có trong lịch sử ví";
+
+"Not now" = "Để sau";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "Chưa được nhiều người bán chấp nhận";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "Chưa được nhiều người bán chấp nhận";
+
+/* Masternode keys */
+"Not yet used" = "Chưa dùng";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "Bitcoin không có lớp tên, nên người ta chia sẻ và dùng lại địa chỉ một cách công khai — một khi địa chỉ đã bị biết, mọi thứ nó từng nhận đều có thể liên kết với chủ sở hữu. Với DashPay, tên người dùng của bạn là công khai nhưng không bao giờ trỏ tới địa chỉ thanh toán: địa chỉ được trao đổi riêng tư theo từng liên hệ và luân phiên thay đổi, nên trả tiền theo tên không công bố tiền của bạn đi đâu. Cả hai đều là chuỗi minh bạch, nên phân tích chuỗi vẫn áp dụng cho chính các đồng coin.";
+
+/* Identities */
+"On Network" = "Trên mạng";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "Khi %@ chấp nhận yêu cầu của bạn, bạn sẽ thanh toán trực tiếp đến tên người dùng được";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "Mỗi lần một nút";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "Chỉ masternode và evonode mới bỏ phiếu cho tên người dùng được. Ví này không có khoá bỏ phiếu masternode nào đang hoạt động.";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "Người vận hành";
+
+/* Masternode keys */
+"Operator keys" = "Khoá vận hành";
+
+/* Masternodes */
+"Operator public key (BLS)" = "Khoá công khai của người vận hành (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "hoặc";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "Kết quả khác";
+
+/* Masternodes */
+"Outpoint" = "Outpoint";
+
+/* Raw transaction inspector */
+"Output %d" = "Đầu ra %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "Đầu ra (%d)";
+
+/* Masternodes */
+"Owner" = "Chủ sở hữu";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Địa chỉ của chủ sở hữu";
+
+/* Masternodes */
+"Owner address" = "Địa chỉ chủ sở hữu";
+
+/* Masternodes */
+"Owner key hash" = "Hash khoá chủ sở hữu";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Khoá của chủ sở hữu";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "Trả từ số dư tín dụng của danh tính bạn.";
 
 /* DashSpend */
 "Password" = "Mật khẩu";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "Dán liên kết lời mời bạn nhận được, hoặc quét mã QR của nó. Nó sẽ trả phí đăng ký tên người dùng cho bạn.";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Trả và nhận một cách tức thời một cách dễ dàng bằng cách sử dụng các quy trình thanh toán";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "thanh toán trực tiếp đến tên người dùng";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "Trả cho con người, không phải cho địa chỉ";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Đang gửi...";
 
+/* Raw transaction inspector */
+"Payload hex" = "Payload hex";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Thanh toán là riêng tư: các địa chỉ bạn trao đổi với một liên hệ đi trong phần dữ liệu đã mã hoá mà chỉ hai người đọc được và không bao giờ được công bố — nên thanh toán của bạn không dễ liên kết với tên người dùng. Dù vậy, đây vẫn là những khoản thanh toán thông thường trên chuỗi minh bạch: phân tích chuỗi tinh vi vẫn có thể làm lộ thông tin. Shielded DashPay (sắp ra mắt) sẽ khép lại khoảng trống đó. Bản thân các yêu cầu liên hệ hiện KHÔNG riêng tư: ai cũng thấy được hai danh tính có kết nối với nhau. Yêu cầu liên hệ riêng tư là tính năng sắp ra mắt. Tên người dùng và hồ sơ của bạn cũng công khai trên Dash Platform.";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "Thanh toán được xác nhận trong vài giây nhờ InstantSend";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "Các khoản thanh toán gửi thẳng tới địa chỉ sẽ không được giữ lại trong hoạt động.";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "Thanh toán với từng liên hệ được gom về một chỗ, hiển thị tên và hồ sơ thay vì giao dịch thô.";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "Địa chỉ nhận tiền";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Địa chỉ Platform";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Số dư Platform";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Nút Platform";
+
+/* Masternode keys */
+"Platform Node ID" = "ID nút Platform";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Thanh toán trên Platform không xác định người gửi. Khoản này được ghi nhận khi ví nhận thấy số dư thay đổi — nó có thể đã đến sớm hơn.";
+
+"Platform SDK not ready" = "Platform SDK chưa sẵn sàng";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Đồng bộ Platform chưa chạy. Mở Thông tin đồng bộ → Trạng thái đồng bộ Platform để khởi động.";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → Che chắn";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "Đã dùng trước đó vào: ";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "Riêng tư ngay từ thiết kế";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "Yêu cầu liên hệ riêng tư (để việc bạn kết nối với ai vẫn riêng tư), Shielded DashPay — thanh toán cho liên hệ từ số dư được che chắn riêng tư của bạn — và thanh toán cho người dùng chưa có trong danh bạ, tất cả đều sắp ra mắt.";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Yêu cầu liên hệ riêng tư đang được phát triển và dự kiến vào khoảng tháng 9–10 năm 2026. Hiện tại bản thân yêu cầu là công khai — ai cũng thấy được hai danh tính có kết nối, dù chi tiết thanh toán bên trong đã được mã hoá. Khi yêu cầu liên hệ riêng tư ra mắt, bạn sẽ được chọn để tình bạn của mình là công khai hay riêng tư.";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "Yêu cầu liên hệ riêng tư, Shielded DashPay và thanh toán cho những người chưa phải liên hệ.";
+
 /* No comment provided by engineer. */
 "Private key" = "Khoá riêng";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "Các địa chỉ thanh toán riêng tư được trao đổi giữa bạn và các liên hệ. Chỉ bạn và liên hệ của mình biết người nhận và người gửi của những khoản thanh toán giữa hai bên.";
+
+/* DashPay intro: feature title */
+"Private payments" = "Thanh toán riêng tư";
+
+/* Usernames */
+"Private registration" = "Đăng ký riêng tư";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "Thời gian xử lý";
+
+/* Balance info sheet section */
+"Pros" = "Ưu điểm";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Địa chỉ nhà cung cấp";
 
+/* Masternodes */
+"Provider transactions" = "Giao dịch nhà cung cấp";
+
+/* Masternode keys */
+"Public key" = "Khoá công khai";
+
+/* Masternode keys */
+"Public key (legacy)" = "Khoá công khai (kiểu cũ)";
+
+/* Identities */
+"Public keys" = "Khoá công khai";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "Mục đích";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Tỷ giá: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "Giao dịch thô";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "Không có giao dịch thô";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "Kiểm tra lại các bộ lọc khối rút gọn từ độ cao đã chọn để tìm giao dịch của ví này, bằng cách tải lại và đối chiếu lại. Việc quét lại bị giới hạn dưới bởi độ cao tạo ví và dữ liệu chuỗi lưu cục bộ — để khôi phục lịch sử thấp hơn mức đó, hãy hạ độ cao khởi đầu của ví.";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "Chỉ đọc";
+
+/* Usernames */
+"Ready around %@" = "Sẵn sàng khoảng %@";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "Lý do";
 
 /* No comment provided by engineer. */
 "Receive" = "Nhận";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Nhận được từ";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "Nhận từ %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "Ghi nhận masternode của bạn đã bỏ phiếu, mà không nghiêng về bên nào.";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "Làm mới";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Đăng ký?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "Đăng ký vào";
+
+/* No comment provided by engineer. */
 "Registered from" = "Đã đăng ký từ";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Masternode đã đăng ký";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "Đăng ký riêng tư cần ít nhất %@ Dash trong số dư được che chắn cộng thêm vài giờ nghỉ — các màn hình tiếp theo sẽ hướng dẫn bạn.";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "Đăng ký";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "Đang xin cái tên này";
+
 /* An action */
 "Rescan" = "Quét lại";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "Ví khôi phục không phải lúc nào cũng lấy lại được loại thao tác. Mục này được dựng lại từ dữ liệu ghi chú trên chuỗi.";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "Đã chuẩn bị đồng bộ lại từ độ cao %u — hãy thoát và mở lại ứng dụng để bắt đầu.";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "giữ lại lịch sử giao dịch chung";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "Đã ngừng hoạt động";
 
 /* No comment provided by engineer. */
 "Retry" = "Thử lại";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "Thu hồi";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "Chụp ảnh màn hình có thể nhìn thấy bởi các ứng dụng và thiết bị khác. Hãy sinh ra một cụm từ phục hồi mới và giữ nó bí mật.";
 
+/* Raw transaction inspector */
+"Script" = "Script";
+
+/* Raw transaction inspector */
+"Script signature" = "Chữ ký script";
+
+/* Raw transaction inspector */
+"Script type" = "Loại script";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "Tìm một liên hệ";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "Tìm một yêu cầu liên hệ";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "Tìm một Người dùng trên Mạng Dash";
+
+/* No comment provided by engineer. */
+"Search for a username" = "Tìm một tên người dùng";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "Kết quả tìm kiếm cho \"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "Tìm tên người dùng";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "Đang tìm tên người dùng %@ trên Mạng Dash";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Mức độ bảo mật";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "Mức bảo mật";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "Chọn tất cả";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "Hãy chọn ít nhất một masternode để bỏ phiếu.";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "Chọn ít nút hơn sẽ để lộ ít hơn về việc bạn đang vận hành những masternode nào.";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Gửi đến";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "Gửi tới một Liên hệ";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "Gửi tới một tên người dùng mà bạn thật sự nhớ và xác minh được.";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "Gửi yêu cầu liên hệ đầu tiên của bạn";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Đang gửi";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "Đang gửi yêu cầu liên hệ";
+
+/* No comment provided by engineer. */
+"Sending to" = "Đang gửi tới";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Gửi đến";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "Đã gửi tới %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "Sequence";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "Dịch vụ";
+
+/* Identities */
+"Set as Main" = "Đặt làm chính";
+
+/* Identities */
+"Set as Main Identity" = "Đặt làm danh tính chính";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Đặt mã PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "Nhóm riêng tư dùng chung ở kích thước tối thiểu";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "Địa chỉ được che chắn";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "Chi tiêu được che chắn";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "Đang khởi động ví được che chắn…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "Che chắn → Platform";
+
+"Shielded → Transparent" = "Che chắn → Minh bạch";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "Kích thước";
+
 /* No comment provided by engineer. */
 "Skip" = "Bỏ qua";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "Một số masternode của bạn có thể thiếu trong danh sách này — ví không đọc được toàn bộ tập khoá bỏ phiếu của bạn. Hãy đồng bộ xong rồi mở lại màn hình này.";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sắp xếp theo";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "Sắp xếp liên hệ";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "Payload đặc biệt";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Xác định số lượng";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "Bắt đầu sau khi bạn nạp tiền";
+
+/* Transaction details */
+"Status" = "Trạng thái";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "Lưu dưới dạng";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "Thông tin đồng bộ";
+
+/* SPV sync */
+"Sync too slow?" = "Đồng bộ quá chậm?";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "Không nghiêng về bên nào";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "Chạm để sao chép";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Bấm để ẩn số dư";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Khoá nút Tenderdash (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Mạng thử nghiệm";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "Dash sẽ tới địa chỉ người nhận sau khi mạng xử lý lệnh rút — việc này có thể mất tới 10 phút.";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "Dash sẽ tới địa chỉ người nhận ngay khi mạng xử lý lệnh rút.";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Dash sẽ tới số dư minh bạch của bạn ngay khi mạng xử lý lệnh rút.";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "Chỉ có thể chọn danh tính chính từ ví đang hoạt động";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "Nơi riêng tư nhất để giữ Dash của bạn";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "Bản ghi ví đã lưu không có mạng — không thể chuẩn bị đồng bộ lại.";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "Đăng ký đã được gửi nhưng chưa xác nhận được kết quả. Hãy đợi một phút để ví đồng bộ, rồi thử lại — đừng gửi lại ngay.";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "Nhóm riêng tư dùng chung vẫn đang lớn dần (%1$ld trên %2$ld lần nạp). Đăng ký riêng tư sẽ mở khi đạt mức tối thiểu.";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "Nhóm riêng tư dùng chung vẫn đang lớn dần (%1$ld trên %2$ld lần nạp). Hãy thử lại khi đạt mức tối thiểu.";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "Độ cao tạo ví — mức sàn cho việc quét bộ lọc và quét lại “Từ khi tạo ví”. Hãy đặt bằng hoặc thấp hơn lần nạp tiền đầu tiên của ví; khi nhập ví, mặc định là 200000 trên mainnet và 0 trên testnet. Lưu một độ cao bằng hoặc thấp hơn hiện tại sẽ xoá dữ liệu chuỗi của mạng này ở lần khởi động sau và quét lại từ đó.";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "anh ấy (Đang lấy thông tin)";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "Không có thông báo mới";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "Không có giao dịch nào để hiển thị";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "Không có người dùng nào khớp với tên %@";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "Không có người dùng nào khớp với tên %@ trong danh bạ của bạn";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "Số tiền này chuyển vào số dư Platform của bạn và sẵn sàng để chi tiêu ngay khi việc chuyển hoàn tất.";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "Không thể thanh toán địa chỉ này từ số dư %@ của bạn";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "Thao tác này thêm hai khoá vào danh tính của bạn để người dùng khác gửi được yêu cầu liên hệ tới bạn, và để bạn chấp nhận yêu cầu của họ. Việc này chỉ diễn ra một lần.";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "Thao tác này áp dụng một lựa chọn cho toàn bộ %d tên người dùng đã chọn.";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "Liên kết lời mời này không hợp lệ.";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "Đây không phải địa chỉ Dash hợp lệ cho mạng này";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "Đây không phải liên kết lời mời hợp lệ";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "Đây là danh tính chính của bạn";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "Masternode này chưa có danh tính Platform.";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "Điều này vẫn được tính là masternode của bạn đã bỏ phiếu trong cuộc tranh chấp này.";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "Các byte thô của giao dịch này không được lưu trên thiết bị này.";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "Tên người dùng này thuộc về người khác";
+
+"This wallet could not derive the voting key for this node." = "Ví này không dẫn xuất được khoá bỏ phiếu cho nút này.";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "Ví này không có khoá bỏ phiếu masternode nào đang hoạt động nên không thể bỏ phiếu. Các nút đã đăng ký xuất hiện tại Công cụ → Masternode.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "Thao tác này rút toàn bộ số dư Platform của bạn trong một lần chuyển. Dash sẽ tới địa chỉ người nhận ngay khi mạng xử lý lệnh rút.";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "Thao tác này rút toàn bộ số dư Platform của bạn trong một lần chuyển. Dash sẽ tới số dư minh bạch của bạn ngay khi mạng xử lý lệnh rút.";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "Không có lịch sử giao dịch";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Mã giao dịch";
+
+/* Raw transaction inspector */
+"Transaction ID" = "Mã giao dịch";
 
 /* A verb, button title. */
 "Transfer" = "Chuyển";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "Chuyển vào";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "Chuyển ra";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "Việc chuyển mất nhiều thời gian hơn — tạo bằng chứng riêng tư cần thời gian";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "Chuyển tới các địa chỉ Platform khác và địa chỉ được che chắn là tức thì và không thể đảo ngược";
+
+/* Balance breakdown */
+"Transparent" = "Minh bạch";
+
+/* Send screen destination type */
+"Transparent address" = "Địa chỉ minh bạch";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "Số dư minh bạch";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "Chi trả bằng tiền minh bạch sẽ liên kết công khai tên người dùng của bạn với số tiền đó.";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "Minh bạch → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "Minh bạch → Che chắn";
 
 /* An action */
 "Try again" = "Thử lại";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "Không thể đưa ra gợi ý";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "Loại đặc biệt không xác định %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "Không được che chắn";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Địa chỉ URL không được hỗ trợ";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "Nâng cấp lên Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "Dùng số dư minh bạch thay thế";
+
+/* Masternode keys */
+"Used" = "Đã dùng";
+
+/* Masternode keys */
+"Used at: " = "Đã dùng vào: ";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "Người dùng (Đang lấy thông tin)";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "Tên người dùng";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "Tên người dùng được lưu ở dạng chuẩn hoá để tránh những cái tên trông giống nhau, nên có thể khác với những gì mỗi người đã gõ.";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "Tên người dùng, không phải địa chỉ";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "Người dùng khớp với %@ và hiện chưa có trong danh bạ của bạn";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "Dùng một trong những thư viện zero-knowledge được kiểm toán và thử nghiệm kỹ nhất (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "Lời mời hợp lệ";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "Đã xác minh khi đăng ký";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Đã kiểm tra thành công";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "Phiên bản";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "Rất hiệu quả với phí thấp";
+
 /* adjective, security level */
 "Very High" = "Rất cao";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "Xem tất cả";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "Xem trên công cụ khám phá khối";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "Xem cụm từ phục hồi";
 
+/* Raw transaction inspector */
+"View Transaction" = "Xem giao dịch";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "Bỏ phiếu";
+
+"Vote cast" = "Đã gửi phiếu";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "Bỏ phiếu cho các tên người dùng đang tranh chấp";
+
+"Vote on several" = "Bỏ phiếu cho nhiều tên";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "Bỏ phiếu bằng";
+
+"Votes that nobody should receive these usernames." = "Bỏ phiếu rằng không ai nên nhận được những tên người dùng này.";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Địa chỉ bỏ phiếu";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "Địa chỉ bỏ phiếu";
+
+"Voting ended with no winner" = "Bỏ phiếu kết thúc mà không có người thắng";
+
+"Voting ends" = "Bỏ phiếu kết thúc";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "Đang bỏ phiếu";
+
+"Voting in progress — lock votes are ahead" = "Đang bỏ phiếu — phiếu khoá đang dẫn trước";
+
+"Voting in progress — you are ahead" = "Đang bỏ phiếu — bạn đang dẫn trước";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "Hash khoá bỏ phiếu";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Khoá bỏ phiếu";
+
+"Voting on this username has closed. The counts below are the last ones read." = "Cuộc bỏ phiếu cho tên người dùng này đã đóng. Các con số dưới đây là lần đọc cuối cùng.";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "Cuộc bỏ phiếu cho “%@” đã đóng. Hãy làm mới để xem kết quả.";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "Đang đợi Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "Độ cao khởi đầu của ví";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Ví đã bị vô hiệu hoá";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Còn Unstoppable Domains và các dịch vụ tên tương tự thì sao?";
+
+/* DashPay FAQ */
+"What does it cost?" = "Chi phí là bao nhiêu?";
+
+/* DashPay FAQ */
+"What is DashPay?" = "DashPay là gì?";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "Sắp tới có gì?";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "Khi nào yêu cầu liên hệ trở nên riêng tư?";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "Ai đang xin cái tên này";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "Vì sao tôi cần bật nó?";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "Rút toàn bộ số dư";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "Hoạt động với mọi ví, sàn giao dịch và người bán Dash";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "Bạn";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "Bạn đã chấp nhận yêu cầu liên hệ từ %@";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "Hiện bạn chưa có liên hệ nào";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "Bạn không có đủ kinh phí để hoàn tất giao dịch này";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "Đến giờ bạn có %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "Bạn đã gửi yêu cầu liên hệ tới %@";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "Bạn đã giành được tên người dùng này";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "Mọi thứ đã sẵn sàng. Người dùng khác giờ có thể gửi yêu cầu liên hệ cho bạn — và bạn cũng gửi được của mình.";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "Danh tính Dash Platform của bạn sẽ xuất hiện ở đây khi bạn đăng ký một tên người dùng.";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "Lịch sử của bạn, gọn gàng";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Danh tính của bạn cần thêm hai khoá để yêu cầu liên hệ có thể được mã hoá giữa bạn và người dùng khác. Việc bật sẽ thêm chúng bằng một giao dịch mạng duy nhất. Việc này chỉ diễn ra một lần.";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "Lời mời của bạn sẽ trả phí đăng ký cho tên người dùng này.";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "Số dư Dash chính của bạn trên blockchain Core — thứ bạn gửi và nhận với các ví, sàn giao dịch và người bán khác.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "Số coin đã trộn của bạn được chuyển sang số dư ví Dash.";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "Số coin đã trộn của bạn được chuyển sang số dư được che chắn. Để riêng tư tốt nhất, hãy đợi ít nhất 2 giờ trước khi dùng số tiền này.";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "Số dư Platform của bạn";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Số dư riêng tư của bạn. Số tiền và địa chỉ được mã hoá trên chuỗi, nên tài sản và lịch sử của bạn vẫn được giữ kín.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "Số dư được che chắn của bạn";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "Số dư được che chắn của bạn gần sẵn sàng — bạn có thể đăng ký riêng tư vào khoảng %@.";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "Số dư được che chắn của bạn đã sẵn sàng — hãy đăng ký tên người dùng riêng tư ngay bây giờ";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "Số dư được che chắn của bạn đang để yên — bạn có thể đăng ký riêng tư vào khoảng %@";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "Số dư được che chắn của bạn vẫn đang hoàn thiện. Sẽ sẵn sàng vào khoảng %@.";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "Số dư minh bạch của bạn";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Tên người dùng của bạn %@ đã được tạo lập thành công trên mạng lưới Dash";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "Tên người dùng của bạn ai cũng thấy. Chi trả cho nó từ số dư được che chắn — sau khi để tiền yên vài giờ — nghĩa là không ai liên kết được tên người dùng của bạn với số Dash còn lại.";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "Tên người dùng, hồ sơ và danh bạ của bạn gắn với danh tính này.";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "Tên người dùng, hồ sơ và danh bạ của bạn sẽ gắn với danh tính này.";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "Phiếu của bạn";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Bây giờ ví của bạn đã được an toàn. Bạn có thể sử dụng dòng chữ phục hồi bất kỳ khi nào để khôi phục số tiền của mình trên một thiết bị khác.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "Ví của bạn vẫn đang đồng bộ với mạng Dash. Bạn sẽ gửi được khi đồng bộ xong.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "Ví của bạn vẫn đang đồng bộ. Bạn sẽ gửi được từ số dư minh bạch khi đồng bộ xong.";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "Không đọc được “%@” như một tên người dùng Dash.";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@” đã được đăng ký. Gửi yêu cầu liên hệ tới người đã mời bạn chứ?";

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "Tất cả các nút cùng lúc";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tất cả masternode của bạn đã bỏ phiếu cho tên người dùng này. Để đổi phiếu, hãy bỏ phiếu lại từ người xin mà bạn ủng hộ bây giờ.";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "Tất cả masternode của bạn đã bỏ phiếu cho tên người dùng này. Để đổi phiếu, hãy bỏ phiếu lại cho người xin mà bạn ủng hộ bây giờ.";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/vi.lproj/Localizable.stringsdict
+++ b/DashWallet/vi.lproj/Localizable.stringsdict
@@ -80,5 +80,215 @@
 			<string>%d keys</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@votes@ được tính cho “%2$@”</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u phiếu</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Đã bỏ phiếu %1$d trên %#@names@</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d tên người dùng</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>Bỏ %u phiếu</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d trên %#@nodes@ đã bỏ phiếu</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d masternode</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%1$d trên %#@nodes@ đã bỏ phiếu</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d nút</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>Tổng cộng %u phiếu</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d masternode</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Đã chọn %d</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d nút của bạn đã bỏ phiếu tại đây nên không được liệt kê.</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u phiếu mỗi cuộc tranh chấp — evonode tính là 4, masternode tính là 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Bỏ phiếu cho %d tên người dùng</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u phiếu</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>Bỏ phiếu ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d yêu cầu</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "所有节点一次性投票";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请从您现在支持的申请者处再次投票。";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请再次为您现在支持的申请者投票。";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " 或 ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "无法在 Dash 网络上找到 %@，因此无法向其发送联系人请求。";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 可用";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ 已接受您的联系人请求";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d 字节";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld 笔存入";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platform 上的积分余额，用于 Platform 地址之间的即时支付以及用户名等功能。";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "关于";
 
+/* DashPay FAQ title */
+"About DashPay" = "关于 DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "弃权";
+
+"Abstain on “%@”" = "在“%@”上弃权";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "已激活";
+
+/* No comment provided by engineer. */
+"Activity" = "活动";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "活动是公开的，但不易追踪";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "将 %@ 添加为联系人";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "将 %@ 添加为联系人，即可直接向用户名付款并保留双方的交易记录";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "向您的屏蔽余额添加 %@ Dash，并让它静置数小时后再注册，这样您的用户名就不会与您的其他资金关联。";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "向您的屏蔽余额至少添加 %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "现在向屏蔽余额添加资金，数小时后再私密地注册用户名";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "所有节点一次性投票";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请从您现在支持的申请者处再次投票。";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "余额同步几乎即时完成";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "金额和地址在区块链上是公开的";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "以太坊账户是一个可重复使用的地址：您的全部余额和支付记录都公开地归于它之下，而一个名称（例如 ENS 域名）通常直接指向该地址，任何人都能解析。DashPay 的结构恰好相反——名称解析到的是身份，而不是支付地址，真正的支付地址保留在加密的联系人交换中，且对每位联系人都是全新的。";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "批准";
+
+"Approving a specific request can only be done one username at a time." = "批准特定申请一次只能针对一个用户名。";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "以文本显示";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "身份验证已取消。您的选票未被投出。";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "身份验证失败。您的选票未被投出。";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "将“%@”授予此申请者";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "之后余额";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "余额和转账不会公开可见";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "已保存起始区块高度——提高后的扫描下限将从下次启动开始生效。";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "绑定到合约";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "绑定到合约，文档类型“%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "仅浏览";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "将最近的诊断日志打包为 zip，以便通过 AirDrop、邮件发送或保存到“文件”";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "投出选票";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "更换节点";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "正在检查…";
+
+"Choice" = "选择";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "领取您的邀请";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "可领取余额";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "清除并重新同步";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "要清除链数据并重新同步吗？";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "即将结束";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase（新币）";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin 已不再受支持——请选择将已混币资金转移到何处。";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "抵押";
+
+/* DashPay intro: feature title */
+"Coming soon" = "即将推出";
+
+/* Shielded transfer status */
+"Completed" = "已完成";
 
 /* No comment provided by engineer. */
 "Confirm" = "确认";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "已确认";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "确认后将保存起始区块高度 %u，并在下次启动应用时清除该网络的链数据，重新下载并从该高度重新扫描过滤器。当前会话仍沿用旧的扫描下限——退出并重新打开应用即可开始。";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "已连接节点";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "缺点";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "联系人请求失败";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "已向 %@ 发送联系人请求";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "联系人请求";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "申请者 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "继续以选择您的用户名。邀请将支付注册费用。";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "复制原始交易";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "无法创建日志归档：%@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "无法刷新 %d 个身份";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "无法获取余额（网络错误）。请尝试刷新。";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "创建您的用户名，通过用户名找到亲友并将他们加入联系人";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "积分";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform 尚未索引此次争夺。索引完成后，票数将显示在这里。";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform 尚未连接。请等待同步完成后重试。";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "发送到错误地址的 Dash 无法找回。请确认地址与您要支付的地址完全一致。";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash 以防形似的形式存储用户名，因此存储的名称可能与每个人输入的内容不同。";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash 钱包余额";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay 已启用";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay 是构建在 Dash Platform 上的 Dash 社交支付体验。您可以注册用户名、将其他用户添加为联系人，并按名称向他们付款——不必再复制地址。";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay 用用户名取代冗长难懂的地址。将好友添加为联系人，向一个名称汇款，并按人整理每一笔支付。";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "截止时间未知";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "派生路径";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "已停用";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "完成";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "完成——您的余额已静置足够长的时间";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "请再次核对地址";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "每个主节点在每次争夺中拥有一张有效选票。您之后可以更改，但 Dash Platform 在每次争夺中每个主节点总共只允许 5 次投票。";
+
+"Each tap votes with one more node, so you choose how many to link together." = "每点按一次就多一个节点参与投票，因此您可以决定关联多少个节点。";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "编辑起始区块高度";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "启用";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "启用 DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "启用 DashPay 需要一笔小额的一次性网络手续费，从您身份的积分余额中支付。确认前会显示确切的预估金额。发送联系人请求和支付则收取通常的网络手续费。";
+
+"Ending soonest" = "最早结束";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "预计网络手续费";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "所有节点一起投票。速度更快，但会公开地将您的各个主节点关联起来。";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode 操作者密钥";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "导出日志";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "外部地址";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "面容ID限制";
+
+/* No comment provided by engineer. */
+"Failed" = "失败";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "获取中…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "过滤器区块头";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "在 Dash 网络上查找用户";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "查找身份";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "找到 %d 个新身份";
+
+/* Identities */
+"Found 1 new identity" = "找到 1 个新身份";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "用您的屏蔽余额为用户名提供资金。请提前几个小时添加资金——短暂的静置可让您的用户名无法与您的其他 Dash 关联。";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "已由您的屏蔽余额提供资金——您的用户名无法与您的其他 Dash 关联。";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "资金已锁定——正在完成转账";
+
+/* CoinJoin */
+"Funds moved" = "资金已转移";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "准备加入 DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "知道了";
+
+/* Governance */
+"Governance" = "治理";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "请求成为您的好友";
+
+/* DashPay Invitations */
+"Have an invitation?" = "有邀请吗？";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "区块头";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "高度 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "手续费较高，约 7 美分（仍低于提供类似隐私保护的其他区块链）";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "在隐私方面，这与比特币相比如何？";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "在隐私方面，这与以太坊账户相比如何？";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay 的隐私性如何？";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "身份";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "身份积分";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "身份索引";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "身份注册";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "身份充值";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "未激活";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "输入 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "输入 %d — 输出点";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "输入 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "来自 %@ 的邀请";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "邀请他人加入 Dash 网络";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "邀请您的亲友加入 Dash 网络";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "让这些币保持私密。将收取网络和隐私手续费。";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "密钥 #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "密钥数据";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "密钥归属";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "密钥";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "领先";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "了解更多";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "正在加载交易";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "仅本地";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "锁定";
+
+"Lock the name" = "锁定该名称";
+
+"Lock “%@” so nobody gets it" = "锁定“%@”，使任何人都无法获得";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "已锁定——任何人都无法获得此用户名";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "锁定时间";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "日常消费手续费低廉";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "主要";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "主节点钥匙串";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "主节点列表";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "主节点票数";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "主节点";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "使用此钱包密钥注册的主节点和 Evonode 将在钱包同步后显示在这里。";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "使用此钱包密钥的主节点和 Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "主节点会为多人申请的名称投票。投票结束时我们会通知您。";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "已达最低要求";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "更多建议";
+
+"Most lock votes" = "锁定票最多";
+
+"Most votes" = "得票最多";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "转入您的常规可用余额。";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "正在转移资金";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains 之类的域名服务，会把一个便于阅读的名称映射到链上一个固定的公开地址。任何人都可以解析该名称并查看曾向它支付的每一笔款项。DashPay 用户名绝不会公开解析到支付地址——地址仅在与每位联系人的加密交换中披露，因此您的名称和资金在外部观察者看来始终是不关联的。";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "需要处理";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "此设备上未找到诊断日志。日志将从下次启动开始记录。";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "无身份";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "暂无主节点";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "没有匹配的争夺";
+
+/* Identities */
+"No new identities were found for this wallet" = "未为此钱包找到新身份";
+
+"No open contest matches that search." = "没有进行中的争夺与该搜索匹配。";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "没有进行中的争夺与该搜索匹配。名称以规范化形式存储，因此“alice”会显示为“a11ce”。";
+
+"No open contests" = "没有进行中的争夺";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "未找到所绑定钱包的已保存记录。";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "尚无可用于屏蔽注册回退的 Platform 地址。请在钱包完成同步后重试。";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "目前没有用户名处于争夺状态。当两人或更多人申请同一个名称时，就会开启争夺。";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "未投出任何选票";
+
+"Nobody gets it" = "无人获得";
+
+/* SPV sync peer type */
+"Node" = "节点";
+
+/* Raw transaction inspector */
+"Non-standard" = "非标准";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "尚不可用";
+
+"Not cast" = "未投出";
+
+/* Masternodes */
+"Not checked yet" = "尚未检查";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "屏蔽余额不足，无法注册身份";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "不在钱包记录中";
+
+"Not now" = "暂不";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "商家接受度不高";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "商家接受度尚不高";
+
+/* Masternode keys */
+"Not yet used" = "尚未使用";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "比特币没有名称层，所以人们公开地共享和重复使用地址——一旦某个地址为人所知，它曾收到的一切都可以与其所有者关联起来。在 DashPay 中，您的用户名是公开的，但它绝不会指向支付地址：地址按联系人私下交换并会轮换，因此按名称付款不会公开您的资金去向。两者都是透明链，因此链上分析仍然适用于币本身。";
+
+/* Identities */
+"On Network" = "在网络上";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "当 %@ 接受您的请求后，您就可以直接向用户名付款";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "每次一个节点";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "只有主节点和 Evonode 才能为用户名投票。此钱包不含有效的主节点投票密钥。";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "操作者";
+
+/* Masternode keys */
+"Operator keys" = "操作者密钥";
+
+/* Masternodes */
+"Operator public key (BLS)" = "操作者公钥 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "或";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "其他结果";
+
+/* Masternodes */
+"Outpoint" = "输出点";
+
+/* Raw transaction inspector */
+"Output %d" = "输出 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "输出 (%d)";
+
+/* Masternodes */
+"Owner" = "所有者";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "所有者地址";
+
+/* Masternodes */
+"Owner key hash" = "所有者密钥哈希";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "从您身份的积分余额中支付。";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "粘贴您收到的邀请链接，或扫描其二维码。它将支付您的用户名注册费用。";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "直接向用户名付款";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "向人付款，而非向地址付款";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "载荷十六进制";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "支付是私密的：您与联系人交换的地址包含在只有你们两人能读取的加密载荷中，且从不公开——因此您的支付无法被轻易关联到您的用户名。不过它们仍是透明链上的普通支付：高级链上分析仍可能泄露信息。Shielded DashPay（即将推出）将弥补这一缺口。联系人请求本身目前并不私密：任何人都能看到两个身份之间存在关联。私密联系人请求是即将推出的功能。您的用户名和资料在 Dash Platform 上同样是公开的。";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "使用 InstantSend，支付几秒内即可确认";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "直接向地址进行的支付不会保留在活动中。";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "与每位联系人的支付都汇集在一处，显示姓名和资料，而不是原始交易。";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "收款地址";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform 地址";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 余额";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform 节点";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform 节点 ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform 支付不会标明付款方。此笔支付是在钱包发现余额变动时记录的——实际到账时间可能更早。";
+
+"Platform SDK not ready" = "Platform SDK 尚未就绪";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform 同步未在运行。请打开“同步信息 → Platform 同步状态”以启动它。";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → 屏蔽";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "上次使用于：";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "隐私源于设计";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "私密联系人请求（让您与谁建立联系保持私密）、Shielded DashPay——从您的私密屏蔽余额向联系人付款——以及向尚未在您联系人中的用户付款，均即将推出。";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "私密联系人请求正在开发中，预计在 2026 年 9 月至 10 月左右推出。目前请求本身是公开的——即使其中的支付信息已加密，任何人仍能看到两个身份之间存在关联。私密联系人请求推出后，您可以选择让这段好友关系公开或保持私密。";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "私密联系人请求、Shielded DashPay，以及向尚未成为联系人的用户付款。";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "私密支付地址在您与联系人之间交换。只有您和您的联系人知道你们之间支付的收款方和付款方。";
+
+/* DashPay intro: feature title */
+"Private payments" = "私密支付";
+
+/* Usernames */
+"Private registration" = "私密注册";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "处理时间";
+
+/* Balance info sheet section */
+"Pros" = "优点";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "提供者交易";
+
+/* Masternode keys */
+"Public key" = "公钥";
+
+/* Masternode keys */
+"Public key (legacy)" = "公钥（旧版）";
+
+/* Identities */
+"Public keys" = "公钥";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "用途";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "原始交易";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "原始交易不可用";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "从所选高度开始，重新检查紧凑区块过滤器中属于此钱包的交易，重新下载并重新匹配。重新扫描的下限为钱包的创建高度以及本地存储的链数据——若要恢复更早的记录，请改为降低钱包起始区块高度。";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "只读";
+
+/* Usernames */
+"Ready around %@" = "约在 %@ 就绪";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "原因";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "收自 %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "记录您的主节点已投票，但不偏向任何一方。";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "刷新";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "注册于";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "私密注册需要屏蔽余额中至少有 %@ Dash，并静置数小时——接下来的界面会引导您完成。";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "注册";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "正在申请此名称";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "已恢复的钱包并不总能还原操作类型。此条目是根据链上备注数据重建的。";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "已准备从高度 %u 重新同步——退出并重新打开应用即可开始。";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "保留双方的交易记录";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "已退役";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "撤销";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "屏幕截图可以被其他程序或者设备获得。请生成一个新的恢复密语并妥善保管。";
 
+/* Raw transaction inspector */
+"Script" = "脚本";
+
+/* Raw transaction inspector */
+"Script signature" = "脚本签名";
+
+/* Raw transaction inspector */
+"Script type" = "脚本类型";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "搜索联系人";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "搜索联系人请求";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "在 Dash 网络上搜索用户";
+
+/* No comment provided by engineer. */
+"Search for a username" = "搜索用户名";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "搜索结果：\"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "搜索用户名";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "正在 Dash 网络上搜索用户名 %@";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "安全级别";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "全选";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "请至少选择一个用于投票的主节点。";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "选择的节点越少，越不容易暴露您运行的是哪些主节点。";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "发送给联系人";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "向一个您真正能记住并核实的用户名发送。";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "发送您的第一个联系人请求";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "正在发送联系人请求";
+
+/* No comment provided by engineer. */
+"Sending to" = "发送至";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "已发送给 %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "序列号";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "服务";
+
+/* Identities */
+"Set as Main" = "设为主要";
+
+/* Identities */
+"Set as Main Identity" = "设为主要身份";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "共享隐私池已达最小规模";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "屏蔽地址";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "屏蔽支出";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "正在启动屏蔽钱包…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "屏蔽 → Platform";
+
+"Shielded → Transparent" = "屏蔽 → 透明";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "大小";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "此列表中可能缺少您的部分主节点——钱包无法读取您完整的投票密钥集合。请完成同步后重新打开此界面。";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "排序联系人";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "特殊载荷";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "在您添加资金后开始";
+
+/* Transaction details */
+"Status" = "状态";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "存储为";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "同步信息";
+
+/* SPV sync */
+"Sync too slow?" = "同步太慢？";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "不偏向任何一方";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "点按以复制";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash 节点密钥 (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "网络处理提现后，Dash 将到达收款人的地址——这最多可能需要 10 分钟。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "网络处理提现后，Dash 即会到达收款人的地址。";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "网络处理提现后，Dash 即会到达您的透明余额。";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "只能从当前钱包中选择主要身份";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "存放您的 Dash 最私密的地方";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "已保存的钱包记录没有网络——无法准备重新同步。";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "注册已提交，但无法确认其结果。请等待一分钟让钱包完成同步，然后重试——不要立即重新提交。";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "共享隐私池仍在增长（%1$ld / %2$ld 笔存入）。达到最低规模后即可解锁私密注册。";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "共享隐私池仍在增长（%1$ld / %2$ld 笔存入）。请在其达到最低规模后重试。";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "钱包的创建高度——过滤器扫描和“自钱包创建起”重新扫描的下限。请将其设置为不高于钱包首次收到资金的高度；导入时主网默认为 200000，测试网默认为 0。保存一个不高于当前值的高度，将在下次启动时清除该网络的链数据并从该高度重新扫描。";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "他（正在获取信息）";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "没有新通知";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "没有与名称 %@ 匹配的用户";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "您的联系人中没有与名称 %@ 匹配的用户";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "这些资金将转入您的 Platform 余额，转账完成后即可使用。";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "无法从您的 %@ 余额向此地址付款";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "这会为您的身份添加两个密钥，让其他用户能够向您发送联系人请求，也让您能够接受他们的请求。此操作只需进行一次。";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "这会将同一个选择应用于全部 %d 个所选用户名。";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "此邀请链接无效。";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "这不是此网络的有效 Dash 地址";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "这不是有效的邀请链接";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "这是您的主要身份";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "此主节点尚无 Platform 身份。";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "这仍会计为您的主节点已在此次争夺中投票。";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "此交易的原始字节未存储在此设备上。";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "此用户名归他人所有";
+
+"This wallet could not derive the voting key for this node." = "此钱包无法为该节点派生投票密钥。";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "此钱包不含有效的主节点投票密钥，因此无法投票。已注册的节点会显示在“工具 → 主节点”中。";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "这会一次性提取您的全部 Platform 余额。网络处理提现后，Dash 即会到达收款人的地址。";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "这会一次性提取您的全部 Platform 余额。网络处理提现后，Dash 即会到达您的透明余额。";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "交易记录不可用";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "交易 ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "转入";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "转出";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "转账耗时较长——生成隐私证明需要时间";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "向其他 Platform 地址和屏蔽地址的转账是即时且最终的";
+
+/* Balance breakdown */
+"Transparent" = "透明";
+
+/* Send screen destination type */
+"Transparent address" = "透明地址";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "透明余额";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "透明资金会将您的用户名与这些资金公开关联起来。";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "透明 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "透明 → 屏蔽";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "无法提供建议";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "未知的特殊类型 %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "未屏蔽";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "升级到 Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "改用透明余额";
+
+/* Masternode keys */
+"Used" = "已使用";
+
+/* Masternode keys */
+"Used at: " = "使用于：";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "用户（正在获取信息）";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "用户名";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "用户名以规范化形式存储，以防止出现形似名称，因此这可能与每个人输入的内容不同。";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "用户名，而非地址";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "与 %@ 匹配且当前不在您联系人中的用户";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "使用经过最充分审计和测试的零知识库之一 (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "有效邀请";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "已在注册时验证";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "版本";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "非常高效且手续费低廉";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "查看全部";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "查看交易";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "投票";
+
+"Vote cast" = "已投票";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "为有争议的用户名投票";
+
+"Vote on several" = "为多个投票";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "使用以下节点投票";
+
+"Votes that nobody should receive these usernames." = "投票支持任何人都不应获得这些用户名。";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "投票地址";
+
+"Voting ended with no winner" = "投票结束，无人胜出";
+
+"Voting ends" = "投票结束";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "投票进行中";
+
+"Voting in progress — lock votes are ahead" = "投票进行中——锁定票领先";
+
+"Voting in progress — you are ahead" = "投票进行中——您领先";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "投票密钥哈希";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "对此用户名的投票已结束。以下计数为最后一次读取的结果。";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "对“%@”的投票已经结束。请刷新以查看结果。";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "正在等待 Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "钱包起始区块高度";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains 及类似域名服务如何？";
+
+/* DashPay FAQ */
+"What does it cost?" = "费用是多少？";
+
+/* DashPay FAQ */
+"What is DashPay?" = "什么是 DashPay？";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "接下来会有什么？";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "联系人请求何时会变为私密？";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "谁在申请此名称";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "为什么我需要启用它？";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "提取全部余额";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "适用于所有 Dash 钱包、交易所和商家";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "您";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "您已接受来自 %@ 的联系人请求";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "您目前没有任何联系人";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "您目前有 %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "您已向 %@ 发送联系人请求";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "您赢得了此用户名";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "一切就绪。其他用户现在可以向您发送联系人请求——您也可以发送自己的请求。";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "注册用户名后，您的 Dash Platform 身份会显示在这里。";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "井然有序的记录";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "您的身份需要两个额外的密钥，才能在您与其他用户之间加密联系人请求。启用时会通过一笔网络交易添加它们。此操作只需进行一次。";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "您的邀请将支付此用户名的注册费用。";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "您在 Core 区块链上的主要 Dash 余额——用于与其他钱包、交易所和商家收发资金。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "您的已混币资金已转入 Dash 钱包余额。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "您的已混币资金已转入屏蔽余额。为获得最佳隐私效果，请至少等待 2 小时后再使用这些资金。";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "您的 Platform 余额";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "您的私密余额。金额和地址在链上均已加密，因此您的持有量和记录都保持机密。";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "您的屏蔽余额";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "您的屏蔽余额即将就绪——您大约可在 %@ 私密注册。";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "您的屏蔽余额已就绪——立即私密注册您的用户名";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "您的屏蔽余额正在静置——您大约可在 %@ 私密注册";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "您的屏蔽余额仍在成熟中。大约将在 %@ 就绪。";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "您的透明余额";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "您的用户名对所有人可见。让资金静置数小时后再用屏蔽余额为其提供资金，任何人都无法将您的用户名与您的其他 Dash 关联起来。";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "您的用户名、资料和联系人都归属于此身份。";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "您的用户名、资料和联系人都将归属于此身份。";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "您的选票";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "您的钱包仍在与 Dash 网络同步。同步完成后即可发送。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "您的钱包仍在同步。同步完成后即可从透明余额发送。";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "无法将“%@”识别为 Dash 用户名。";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@”已注册。要向邀请您的人发送联系人请求吗？";

--- a/DashWallet/zh-Hans.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hans.lproj/Localizable.stringsdict
@@ -32,5 +32,257 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>为“%2$@”统计了 %#@votes@</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@中已对 %1$d 个投票</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个用户名</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>投出 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个主节点</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个节点</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个 Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>共 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个主节点</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>已选择 %d 个</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>您有 %d 个节点已在此投票，未显示在列表中。</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>每次争夺 %u 票 —— Evonode 计为 4，主节点计为 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>为 %d 个用户名投票</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>投票 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个请求</string>
+		</dict>
+	</dict>
+	<key>%d merchant(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@merchants@</string>
+		<key>merchants</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 商户在 %@</string>
+		</dict>
+	</dict>
+	<key>%d merchant(s)</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@merchants@</string>
+		<key>merchants</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 商户</string>
+		</dict>
+	</dict>
+	<key>%d transaction(s)</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@transactions@</string>
+		<key>transactions</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 交易</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/zh-Hans.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hans.lproj/Localizable.stringsdict
@@ -49,7 +49,7 @@
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@names@中已对 %1$d 个投票</string>
+		<string>已投票：%1$d / %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -77,7 +77,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -91,7 +91,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "所有節點一次投票";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請從您現在支持的申請者處再次投票。";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請再次為您現在支持的申請者投票。";
 
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " 或 ";
+
 /* CrowdNode */
 " Privacy Policy " = " Privacy Policy ";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "無法在 Dash 網絡上找到 %@，因此無法向其發送聯繫請求。";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 可用";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ 已接受您的聯繫請求";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu contacts / %3$lu profile updates";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d 位元組";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d votes will be cast as you have multiple voting keys stored in the wallet";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld duplicates";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld 筆存入";
 
 /* Voting */
 "%ld requests" = "%ld requests";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platform 上的積分餘額，用於 Platform 位址之間的即時支付以及用戶名稱等功能。";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "關於";
 
+/* DashPay FAQ title */
+"About DashPay" = "關於 DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "About me";
+
+"Abstain" = "棄權";
+
+"Abstain on “%@”" = "在「%@」上棄權";
 
 /* No comment provided by engineer. */
 "Accept" = "Accept";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "Account Recovery";
 
+/* Masternode status */
+"Active" = "已啟用";
+
+/* No comment provided by engineer. */
+"Activity" = "活動";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "活動是公開的，但不易追蹤";
+
 /* No comment provided by engineer. */
 "Add" = "Add";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "將 %@ 加入聯絡人";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "將 %@ 加入聯絡人，即可直接向用戶名稱付款並保留雙方的交易紀錄";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "向您的遮蔽餘額加入 %@ Dash，並讓它靜置數小時後再註冊，這樣您的用戶名稱就不會與您的其他資金關聯。";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "向您的遮蔽餘額至少加入 %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "現在向遮蔽餘額加入資金，數小時後再私密地註冊用戶名稱";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "All";
 
+"All nodes at once" = "所有節點一次投票";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請從您現在支持的申請者處再次投票。";
+
 /* No comment provided by engineer. */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "Allow sending all transactions from Dash Wallet to Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "餘額同步幾乎即時完成";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "金額和位址在區塊鏈上是公開的";
+
 /* No comment provided by engineer. */
 "An error occurred" = "An error occurred";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "以太坊帳戶是一個可重複使用的位址：您的全部餘額和支付紀錄都公開地歸於它之下，而一個名稱（例如 ENS 網域）通常直接指向該位址，任何人都能解析。DashPay 的結構恰好相反——名稱解析到的是身分，而不是支付位址，真正的支付位址保留在加密的聯絡人交換中，且對每位聯絡人都是全新的。";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "An intuitive and familiar experience across all your devices";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "Apply";
 
+"Approve" = "核准";
+
+"Approving a specific request can only be done one username at a time." = "核准特定申請一次只能針對一個用戶名稱。";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "Are you sure you want to cancel this order?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "以文字顯示";
 
 /* DashSpend */
 "at" = "at";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "已取消驗證。您的選票未被投出。";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "驗證失敗。您的選票未被投出。";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "Authentication is unvailable";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "將「%@」授予此申請者";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "Balance";
 
 /* CrowdNode */
+"Balance after" = "之後餘額";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "Balance On CrowdNode";
 
 /* CrowdNode */
 "Balance: " = "Balance: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "餘額和轉帳不會公開可見";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "Bank Account";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "Biometrics Access Required";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "已儲存起始區塊高度——提高後的掃描下限將從下次啟動開始生效。";
+
 /* Voting */
 "Block" = "Block";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "綁定至合約";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "綁定至合約，文件類型「%@」";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "僅供瀏覽";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "將最近的診斷紀錄打包為 zip，以便透過 AirDrop、郵件發送或儲存到「檔案」";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "投出選票";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "更換節點";
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "正在檢查…";
+
+"Choice" = "選擇";
+
 /* Choose your Dash username */
 "Choose your" = "Choose your";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "Choose Your Username";
 
+/* DashPay Invitations */
+"Claim your invitation" = "領取您的邀請";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "可領取餘額";
+
 /* No comment provided by engineer. */
 "Claimed" = "Claimed";
+
+/* SPV diagnostics */
+"Clear & resync" = "清除並重新同步";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "要清除鏈資料並重新同步嗎？";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "Close App";
 
+"Closing" = "即將結束";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase（新幣）";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2FA code";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin 已不再支援——請選擇將已混合資金轉移到何處。";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "抵押";
+
+/* DashPay intro: feature title */
+"Coming soon" = "即將推出";
+
+/* Shielded transfer status */
+"Completed" = "已完成";
 
 /* No comment provided by engineer. */
 "Confirm" = "確認:";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "已確認";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "確認後將儲存起始區塊高度 %u，並在下次啟動應用程式時清除該網絡的鏈資料，重新下載並從該高度重新掃描過濾器。目前的工作階段仍沿用舊的掃描下限——結束並重新開啟應用程式即可開始。";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "Connected Dash address";
 
+/* SPV sync */
+"Connected peers" = "已連線節點";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "缺點";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "聯繫請求失敗";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "已向 %@ 發送聯繫請求";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "聯繫請求";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "Contacts";
 
+"Contender %@" = "申請者 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "Continue";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "繼續以選擇您的用戶名稱。邀請將支付註冊費用。";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "Copy Invitation Link";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "複製原始交易";
+
 /* No comment provided by engineer. */
 "Copy text" = "Copy text";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "Could not automatically recover missing or incorrect words";
 
+/* Log export */
+"Could not create the log archive: %@" = "無法建立紀錄封存檔：%@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "Could not find exchange rate.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "無法重新整理 %d 個身分";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "無法取得餘額（網絡錯誤）。請嘗試重新整理。";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "Couldn't make payment";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "Create your username";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "建立您的用戶名稱，透過用戶名稱找到親友並將他們加入聯絡人";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "Credit Card";
+
+/* Masternodes */
+"Credits" = "積分";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash payments can't be less than %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform 尚未索引此次爭奪。索引完成後，票數將顯示在這裡。";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform 尚未連線。請等待同步完成後重試。";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "發送到錯誤位址的 Dash 無法找回。請確認位址與您要支付的位址完全一致。";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash 以防形似的形式儲存用戶名稱，因此儲存的名稱可能與每個人輸入的內容不同。";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash username";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash Wallet";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash 錢包餘額";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "Dash Wallet on this device";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay 已啟用";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay Invitation";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay 是建構在 Dash Platform 上的 Dash 社交支付體驗。您可以註冊用戶名稱、將其他用戶加入聯絡人，並按名稱向他們付款——不必再複製位址。";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay 用用戶名稱取代冗長難懂的位址。將好友加入聯絡人，向一個名稱匯款，並按人整理每一筆支付。";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay Upgrade Fee";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "Date: Old to new";
+
+"Deadline unknown" = "截止時間不明";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "Deposit sent";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "衍生路徑";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "已停用";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "Disconnect Coinbase Account";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "完成";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "完成——您的餘額已靜置足夠長的時間";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "請再次核對位址";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "每個主節點在每次爭奪中擁有一張有效選票。您之後可以變更，但 Dash Platform 在每次爭奪中每個主節點總共只允許 5 次投票。";
+
+"Each tap votes with one more node, so you choose how many to link together." = "每點一下就多一個節點參與投票，因此您可以決定關聯多少個節點。";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "Earlier";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "Easily stake Dash and earn passive income with a few simple clicks.";
+
+/* SPV diagnostics */
+"Edit birth height" = "編輯起始區塊高度";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "Edit Profile";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "Email";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "啟用";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "啟用 DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "Enable Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "Enable Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "啟用 DashPay 需要一筆小額的一次性網絡費用，從您身分的積分餘額中支付。確認前會顯示確切的預估金額。發送聯繫請求和支付則收取通常的網絡費用。";
+
+"Ending soonest" = "最早結束";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "Error updating your profile";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "預估網絡費用";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "所有節點一起投票。速度更快，但會公開地將您的各個主節點關聯起來。";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode 操作者鑰匙";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "Export CSV";
 
+/* Log export */
+"Export Logs" = "匯出紀錄";
+
 /* No comment provided by engineer. */
 "Extended public key (BIP44)" = "Extended public key (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "外部位址";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID 解鎖的限制";
+
+/* No comment provided by engineer. */
+"Failed" = "失敗";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "Failed to load barcode";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "Fetching rates…";
 
+/* Masternodes */
+"Fetching…" = "取得中…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "Fiat Account";
 
 /* No comment provided by engineer. */
 "Filter" = "Filter";
+
+/* SPV sync phase */
+"Filter headers" = "過濾器區塊標頭";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "Filter transactions";
@@ -1138,10 +1404,16 @@
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
 /* No comment provided by engineer. */
+"Find a user on the Dash Network" = "在 Dash 網絡上尋找用戶";
+
+/* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "Find ATMs where you can buy or sell Dash.";
+
+/* Identities */
+"Find identities" = "尋找身分";
 
 /* No comment provided by engineer. */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "Forgot PIN?";
 
+/* Identities */
+"Found %d new identities" = "找到 %d 個新身分";
+
+/* Identities */
+"Found 1 new identity" = "找到 1 個新身分";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "Found missing word:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "用您的遮蔽餘額為用戶名稱提供資金。請提前幾個小時加入資金——短暫的靜置可讓您的用戶名稱無法與您的其他 Dash 關聯。";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "已由您的遮蔽餘額提供資金——您的用戶名稱無法與您的其他 Dash 關聯。";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "資金已鎖定——正在完成轉帳";
+
+/* CoinJoin */
+"Funds moved" = "資金已轉移";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "Get Quote";
+
+/* Usernames */
+"Get ready to join DashPay" = "準備加入 DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "Get Rewards Instantly";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "知道了";
+
+/* Governance */
+"Governance" = "治理";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "Grant GPS permissions so we can show you locations near you.";
 
 /* Voting */
 "Has blocked votes" = "Has blocked votes";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "請求成為您的好友";
+
+/* DashPay Invitations */
+"Have an invitation?" = "有邀請嗎？";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "Have complete control and customize your wallet based on your needs";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "header #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "區塊標頭";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "高度 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "High to low";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "費用較高，約 7 美分（仍低於提供類似隱私保護的其他區塊鏈）";
+
 /* No comment provided by engineer. */
 "History" = "History";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "How do I get Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "在隱私方面，這與比特幣相比如何？";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "在隱私方面，這與以太坊帳戶相比如何？";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay 的隱私性如何？";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "How to confirm your API Dash address";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "I wrote it down";
 
+/* Identities */
+"Identities" = "身分";
+
 /* Voting */
 "Identity" = "Identity";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "身分積分";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "身分索引";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "身分註冊";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "身分儲值";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "In the payment section of your checkout, select \"gift card\" and enter your card number and pin.";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "未啟用";
+
+/* No comment provided by engineer. */
 "Income" = "Income";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "Initializing";
+
+/* Raw transaction inspector */
+"Input %d" = "輸入 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "輸入 %d — 輸出點";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "輸入 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "Insufficient funds";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "Invitation Fee";
 
+/* DashPay Invitations */
+"Invitation from %@" = "來自 %@ 的邀請";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "Invitation used by";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "Invite";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "邀請他人加入 Dash 網絡";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "Invite your family, find your friends by searching their usernames";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "Invite your friends and family to join the Dash Network.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "邀請您的親友加入 Dash 網絡";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash Wallet: %@ Reported issue";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "Joining the pool";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "讓這些幣保持私密。將收取網絡與隱私費用。";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "Keep your passphrase safe";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "鑰匙 #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "鑰匙資料";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "鑰匙歸屬";
+
 /* No comment provided by engineer. */
 "Keypair" = "Keypair";
+
+/* Masternodes */
+"Keys" = "鑰匙";
 
 /* Explore Dash */
 "Last device sync" = "Last device sync";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "領先";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "了解更多";
 
 /* Info Screen */
 "Learn More..." = "Learn More...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "正在載入交易";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "Local Currency";
 
+/* Identities */
+"Local Only" = "僅限本機";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "Local requested amount: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "Location";
 
+"Lock" = "鎖定";
+
+"Lock the name" = "鎖定該名稱";
+
+"Lock “%@” so nobody gets it" = "鎖定「%@」，使任何人都無法取得";
+
 /* No comment provided by engineer. */
 "Locked" = "Locked";
 
+"Locked — nobody receives this username" = "已鎖定——任何人都無法取得此用戶名稱";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "鎖定時間";
 
 /* Log in */
 "Log in" = "Log in";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "Low";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "日常消費費用低廉";
+
 /* Voting */
 "Low to high" = "Low to high";
+
+/* Identities — the wallet's main identity */
+"Main" = "主要";
 
 /* No comment provided by engineer. */
 "Mainnet" = "Mainnet";
@@ -1783,8 +2188,15 @@
 /* Voting */
 "Masternode IP address" = "Masternode IP address";
 
+/* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "主節點鑰匙圈";
+
 /* No comment provided by engineer. */
 "Masternode keys" = "Masternode keys";
+
+/* SPV sync phase */
+"Masternode list" = "主節點清單";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "masternode list #%1$d of %2$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "Masternode Update";
 
+"Masternode votes" = "主節點票數";
+
 /* Voting */
 "Masternode Voting Key" = "Masternode Voting Key";
+
+/* Tools menu */
+"Masternodes" = "主節點";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "使用此錢包鑰匙註冊的主節點和 Evonode 將在錢包同步後顯示在這裡。";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "使用此錢包鑰匙的主節點和 Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "主節點會為多人申請的名稱投票。投票結束時我們會通知您。";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "Max";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "Min: %@";
 
+/* Usernames */
+"Minimum met" = "已達最低要求";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "More Control";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "更多建議";
+
+"Most lock votes" = "鎖定票最多";
+
+"Most votes" = "得票最多";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "Move and Zoom your photo to find the perfect fit";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "轉入您的一般可用餘額。";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "Moved to Address";
+
+/* CoinJoin */
+"Moving funds" = "正在轉移資金";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "Name";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains 之類的網域服務，會把一個便於閱讀的名稱對應到鏈上一個固定的公開位址。任何人都可以解析該名稱並查看曾向它支付的每一筆款項。DashPay 用戶名稱絕不會公開解析到支付位址——位址僅在與每位聯絡人的加密交換中揭露，因此您的名稱和資金在外部觀察者看來始終是不關聯的。";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "Need help? ";
+
+"Needs attention" = "需要處理";
 
 /* No comment provided by engineer. */
 "Network" = "Network";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "此裝置上未找到診斷紀錄。紀錄將從下次啟動開始記錄。";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "無身分";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1981,8 +2433,23 @@
 /* Explore Dash */
 "No locations found." = "No locations found.";
 
+/* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "尚無主節點";
+
 /* Local Currency: no search matches */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "沒有相符的爭奪";
+
+/* Identities */
+"No new identities were found for this wallet" = "未為此錢包找到新身分";
+
+"No open contest matches that search." = "沒有進行中的爭奪與該搜尋相符。";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "沒有進行中的爭奪與該搜尋相符。名稱以正規化形式儲存，因此「alice」會顯示為「a11ce」。";
+
+"No open contests" = "沒有進行中的爭奪";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "No payment methods";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "未找到所綁定錢包的已儲存紀錄。";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "尚無可用於遮蔽註冊備援的 Platform 位址。請在錢包完成同步後重試。";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "No Results Found";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "目前沒有用戶名稱處於爭奪狀態。當兩人或更多人申請同一個名稱時，就會開啟爭奪。";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "No votes left";
+
+"No votes were cast" = "未投出任何選票";
+
+"Nobody gets it" = "無人取得";
+
+/* SPV sync peer type */
+"Node" = "節點";
+
+/* Raw transaction inspector */
+"Non-standard" = "非標準";
 
 /* adjective, security level */
 "None" = "None";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "Not available";
 
+"Not available yet" = "尚無法使用";
+
+"Not cast" = "未投出";
+
+/* Masternodes */
+"Not checked yet" = "尚未檢查";
+
 /* Location Service Status */
 "Not Determined" = "Not Determined";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "遮蔽餘額不足，無法註冊身分";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "不在錢包紀錄中";
+
+"Not now" = "暫不";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "商家接受度不高";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "商家接受度尚不高";
+
+/* Masternode keys */
+"Not yet used" = "尚未使用";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "Old to new";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "比特幣沒有名稱層，所以人們公開地共享和重複使用位址——一旦某個位址為人所知，它曾收到的一切都可以與其擁有者關聯起來。在 DashPay 中，您的用戶名稱是公開的，但它絕不會指向支付位址：位址按聯絡人私下交換並會輪換，因此按名稱付款不會公開您的資金去向。兩者都是透明鏈，因此鏈上分析仍然適用於幣本身。";
+
+/* Identities */
+"On Network" = "在網絡上";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "當 %@ 接受您的請求後，您就可以直接向用戶名稱付款";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "每次一個節點";
 
 /* Voting */
 "One vote left" = "One vote left";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "Only duplicates";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "只有主節點和 Evonode 才能為用戶名稱投票。此錢包不含有效的主節點投票鑰匙。";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "Only requests with links";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "Only with links";
+
+/* Masternodes */
+"Operator" = "操作者";
+
+/* Masternode keys */
+"Operator keys" = "操作者鑰匙";
+
+/* Masternodes */
+"Operator public key (BLS)" = "操作者公鑰 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "或";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "Order Preview";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "其他結果";
+
+/* Masternodes */
+"Outpoint" = "輸出點";
+
+/* Raw transaction inspector */
+"Output %d" = "輸出 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "輸出 (%d)";
+
+/* Masternodes */
+"Owner" = "擁有者";
+
 /* No comment provided by engineer. */
 "Owner Address" = "Owner Address";
+
+/* Masternodes */
+"Owner address" = "擁有者位址";
+
+/* Masternodes */
+"Owner key hash" = "擁有者鑰匙雜湊";
 
 /* No comment provided by engineer. */
 "Owner keys" = "Owner keys";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "從您身分的積分餘額中支付。";
 
 /* DashSpend */
 "Password" = "Password";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "Paste link here";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "貼上您收到的邀請連結，或掃描其 QR 碼。它將支付您的用戶名稱註冊費用。";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "Paste your image URL";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "Pay and get paid instantly with easy to use payment flows";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "直接向用戶名稱付款";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "向人付款，而非向位址付款";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "Pay to usernames. No more alphanumeric addresses";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "Paying...";
 
+/* Raw transaction inspector */
+"Payload hex" = "酬載十六進位";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "Payment method";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "支付是私密的：您與聯絡人交換的位址包含在只有你們兩人能讀取的加密酬載中，且從不公開——因此您的支付無法被輕易關聯到您的用戶名稱。不過它們仍是透明鏈上的普通支付：進階鏈上分析仍可能洩漏資訊。Shielded DashPay（即將推出）將彌補這一缺口。聯繫請求本身目前並不私密：任何人都能看到兩個身分之間存在關聯。私密聯繫請求是即將推出的功能。您的用戶名稱和個人資料在 Dash Platform 上同樣是公開的。";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "使用 InstantSend，支付幾秒內即可確認";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "直接向位址進行的支付不會保留在活動中。";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "與每位聯絡人的支付都彙集在一處，顯示姓名和個人資料，而不是原始交易。";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "收款位址";
 
 /* CrowdNode */
 "Payout Options" = "Payout Options";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform 位址";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 餘額";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform 節點";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform 節點 ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform 支付不會標明付款方。此筆支付是在錢包發現餘額變動時記錄的——實際入帳時間可能更早。";
+
+"Platform SDK not ready" = "Platform SDK 尚未就緒";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform 同步未在執行。請開啟「同步資訊 → Platform 同步狀態」以啟動它。";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → 遮蔽";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "Please add a payment method on Coinbase";
@@ -2300,6 +2909,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "Preview Invitation";
 
+/* Masternode keys */
+"Previously used at: " = "上次使用於：";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "Prices are at least 30 minutes old. Fiat values may be incorrect.";
 
@@ -2315,11 +2927,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "隱私源於設計";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "私密聯繫請求（讓您與誰建立聯繫保持私密）、Shielded DashPay——從您的私密遮蔽餘額向聯絡人付款——以及向尚未在您聯絡人中的用戶付款，均即將推出。";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "私密聯繫請求正在開發中，預計在 2026 年 9 月至 10 月左右推出。目前請求本身是公開的——即使其中的支付資訊已加密，任何人仍能看到兩個身分之間存在關聯。私密聯繫請求推出後，您可以選擇讓這段好友關係公開或保持私密。";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "私密聯繫請求、Shielded DashPay，以及向尚未成為聯絡人的用戶付款。";
+
 /* No comment provided by engineer. */
 "Private key" = "Private key";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "私密支付位址在您與聯絡人之間交換。只有您和您的聯絡人知道你們之間支付的收款方和付款方。";
+
+/* DashPay intro: feature title */
+"Private payments" = "私密支付";
+
+/* Usernames */
+"Private registration" = "私密註冊";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "處理時間";
+
+/* Balance info sheet section */
+"Pros" = "優點";
 
 /* CrowdNode Portal */
 "Protect your savings" = "Protect your savings";
@@ -2330,6 +2969,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "Provider Address";
 
+/* Masternodes */
+"Provider transactions" = "提供者交易";
+
+/* Masternode keys */
+"Public key" = "公鑰";
+
+/* Masternode keys */
+"Public key (legacy)" = "公鑰（舊版）";
+
+/* Identities */
+"Public keys" = "公鑰";
+
 /* No comment provided by engineer. */
 "Public URL" = "Public URL";
 
@@ -2338,6 +2989,9 @@
 
 /* Alert title */
 "Purchase Failed" = "Purchase Failed";
+
+/* Identities: what a public key is used for */
+"Purpose" = "用途";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2357,11 +3011,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "Rate: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "原始交易";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "原始交易無法使用";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "從所選高度開始，重新檢查精簡區塊過濾器中屬於此錢包的交易，重新下載並重新比對。重新掃描的下限為錢包的建立高度以及本機儲存的鏈資料——若要復原更早的紀錄，請改為降低錢包起始區塊高度。";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "Read Withdrawal Policy";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "唯讀";
+
+/* Usernames */
+"Ready around %@" = "約在 %@ 就緒";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "原因";
 
 /* No comment provided by engineer. */
 "Receive" = "Receive";
@@ -2390,8 +3063,13 @@
 /* No comment provided by engineer. */
 "Received from" = "Received from";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "收自 %@";
+
 /* CrowdNode */
 "Receiving rewards" = "Receiving rewards";
+
+"Records your masternodes as having voted, without taking a side." = "記錄您的主節點已投票，但不偏向任何一方。";
 
 /* No comment provided by engineer. */
 "Recover" = "Recover";
@@ -2412,6 +3090,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "Recovery phrase must have 12, 15, 18, 21 or 24 words";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "重新整理";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2424,10 +3106,21 @@
 "Register?" = "Register?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "註冊於";
+
+/* No comment provided by engineer. */
 "Registered from" = "Registered from";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "Registered Masternode";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "私密註冊需要遮蔽餘額中至少有 %@ Dash，並靜置數小時——接下來的畫面會引導您完成。";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "註冊";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2474,6 +3167,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "正在申請此名稱";
+
 /* An action */
 "Rescan" = "Rescan";
 
@@ -2502,10 +3197,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "已復原的錢包並不總能還原操作類型。此項目是根據鏈上備註資料重建的。";
+
+/* Location Service Status */
 "Restricted" = "Restricted";
 
 /* Usernames */
 "Results" = "Results";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "已準備從高度 %u 重新同步——結束並重新開啟應用程式即可開始。";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "保留雙方的交易紀錄";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "已退役";
 
 /* No comment provided by engineer. */
 "Retry" = "Retry";
@@ -2515,6 +3223,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "Review the posting below to verify the ownership of this username";
+
+/* Masternodes */
+"Revocation" = "撤銷";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2552,6 +3263,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "屏幕截圖可以被其他程序或者設備獲得。請生成一個新的恢復詞組並妥善保管。";
 
+/* Raw transaction inspector */
+"Script" = "指令碼";
+
+/* Raw transaction inspector */
+"Script signature" = "指令碼簽章";
+
+/* Raw transaction inspector */
+"Script type" = "指令碼類型";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2564,11 +3284,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "搜尋聯絡人";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "搜尋聯繫請求";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "在 Dash 網絡上搜尋用戶";
+
+/* No comment provided by engineer. */
+"Search for a username" = "搜尋用戶名稱";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "搜尋結果：\"";
+
+/* No comment provided by engineer. */
 "Search territories" = "Search territories";
+
+"Search usernames" = "搜尋用戶名稱";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "正在 Dash 網絡上搜尋用戶名稱 %@";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "Secure Your Wallet";
@@ -2578,6 +3318,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "Security Level";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "安全等級";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2598,8 +3341,12 @@
    Buy Sell Portal */
 "Select a service to buy, sell, convert and transfer Dash" = "Select a service to buy, sell, convert and transfer Dash";
 
+"Select all" = "全選";
+
 /* DashSpend denomination selection */
 "Select amount" = "Select amount";
+
+"Select at least one masternode to vote with." = "請至少選擇一個用於投票的主節點。";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2622,6 +3369,8 @@
 
 /* Coinbase */
 "Select the coin" = "Select the coin";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "選擇的節點越少，越不容易暴露您執行的是哪些主節點。";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
@@ -2663,6 +3412,12 @@
 /* No comment provided by engineer. */
 "Send to" = "Send to";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "發送給聯絡人";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "向一個您真正能記住並核實的用戶名稱發送。";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "Send to Address";
 
@@ -2687,8 +3442,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "發送您的第一個聯繫請求";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "Sending";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "正在發送聯繫請求";
+
+/* No comment provided by engineer. */
+"Sending to" = "發送至";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "Sending to CrowdNode account";
@@ -2717,11 +3481,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "Sent to";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "已發送給 %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "序號";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "Server error occurred. Please try again later.";
+
+/* Masternodes */
+"Service" = "服務";
+
+/* Identities */
+"Set as Main" = "設為主要";
+
+/* Identities */
+"Set as Main Identity" = "設為主要身分";
 
 /* No comment provided by engineer. */
 "Set PIN" = "Set PIN";
@@ -2744,8 +3523,14 @@
 /* No comment provided by engineer. */
 "Share key" = "Share key";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "共享隱私池已達最小規模";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "遮蔽位址";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2759,11 +3544,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "遮蔽支出";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "正在啟動遮蔽錢包…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "遮蔽 → Platform";
+
+"Shielded → Transparent" = "遮蔽 → 透明";
 
 /* Explore Dash */
 "Show all locations" = "Show all locations";
@@ -2798,11 +3592,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "大小";
+
 /* No comment provided by engineer. */
 "Skip" = "Skip";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "此清單中可能缺少您的部分主節點——錢包無法讀取您完整的投票鑰匙集合。請完成同步後重新開啟此畫面。";
 
 /* Usernames */
 "Some usernames can be blocked" = "Some usernames can be blocked";
@@ -2816,6 +3615,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "Sort by";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "排序聯絡人";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "Sorted by discount";
 
@@ -2824,6 +3626,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "Sorted by name";
+
+/* Raw transaction inspector */
+"Special payload" = "特殊酬載";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "Specify Amount";
@@ -2846,12 +3651,20 @@
 /* No comment provided by engineer. */
 "Staking" = "Staking";
 
+/* Usernames */
+"Starts after you add funds" = "在您加入資金後開始";
+
+/* Transaction details */
+"Status" = "狀態";
+
 /* Step 1 */
 "Step %ld" = "Step %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "儲存為";
 
 /* Voting */
 "Submit" = "Submit";
@@ -2928,6 +3741,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "Sync in progress… Results may not be complete.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "同步資訊";
+
+/* SPV sync */
+"Sync too slow?" = "同步太慢？";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2958,8 +3777,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "Take a Photo from Camera";
 
+"Take no side" = "不偏向任何一方";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "Tap the address from the clipboard to paste it";
+
+/* Raw transaction inspector */
+"Tap to copy" = "點一下以複製";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "Tap to hide balance";
@@ -2976,6 +3800,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "Temporarily unavailable";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash 節點鑰匙 (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "Terms & conditions";
 
@@ -2987,6 +3814,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "Testnet";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3002,6 +3832,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "The code is incorrect. Please check and try again!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "網絡處理提領後，Dash 將到達收款人的位址——這最多可能需要 10 分鐘。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "網絡處理提領後，Dash 即會到達收款人的位址。";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "網絡處理提領後，Dash 即會到達您的透明餘額。";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "The Dash network has to vote to approve some usernames before they are created";
@@ -3036,11 +3875,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "The link you send will be visible only to the network owners";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "只能從目前的錢包中選擇主要身分";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "The minimum amount you can send is %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "存放您的 Dash 最私密的地方";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "已儲存的錢包紀錄沒有網絡——無法準備重新同步。";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3051,6 +3899,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "註冊已送出，但無法確認其結果。請等待一分鐘讓錢包完成同步，然後重試——不要立即重新送出。";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "共享隱私池仍在成長（%1$ld / %2$ld 筆存入）。達到最低規模後即可解鎖私密註冊。";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "共享隱私池仍在成長（%1$ld / %2$ld 筆存入）。請在其達到最低規模後重試。";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3060,8 +3917,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "The username '%@' was blocked by the Dash Network. Please try again by requesting another username.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "錢包的建立高度——過濾器掃描和「自錢包建立起」重新掃描的下限。請將其設定為不高於錢包首次收到資金的高度；匯入時主網預設為 200000，測試網預設為 0。儲存一個不高於目前值的高度，將在下次啟動時清除該網絡的鏈資料並從該高度重新掃描。";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "他（正在取得資訊）";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "沒有新通知";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "There are no transactions to display";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "沒有與名稱 %@ 相符的用戶";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "您的聯絡人中沒有與名稱 %@ 相符的用戶";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "There was an error when exporting your transaction history to ZenLedger";
@@ -3073,10 +3945,16 @@
 "There was an error, please try again later" = "There was an error, please try again later";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "這些資金將轉入您的 Platform 餘額，轉帳完成後即可使用。";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "無法從您的 %@ 餘額向此位址付款";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3084,11 +3962,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "這會為您的身分加入兩把鑰匙，讓其他用戶能夠向您發送聯繫請求，也讓您能夠接受他們的請求。此操作只需進行一次。";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "這會將同一個選擇套用於全部 %d 個所選用戶名稱。";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3096,11 +3979,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "This extra step shows it’s really you trying to make a transaction.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "此邀請連結無效。";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "這不是此網絡的有效 Dash 位址";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "這不是有效的邀請連結";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "這是您的主要身分";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "此主節點尚無 Platform 身分。";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "This merchant is currently unavailable.";
@@ -3135,14 +4033,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price.";
 
+"This still counts as your masternodes having voted in this contest." = "這仍會計為您的主節點已在此次爭奪中投票。";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "此交易的原始位元組未儲存在此裝置上。";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "此用戶名稱歸他人所有";
+
+"This wallet could not derive the voting key for this node." = "此錢包無法為該節點衍生投票鑰匙。";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "此錢包不含有效的主節點投票鑰匙，因此無法投票。已註冊的節點會顯示在「工具 → 主節點」中。";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3152,6 +4061,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "這會一次性提領您的全部 Platform 餘額。網絡處理提領後，Dash 即會到達收款人的位址。";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "這會一次性提領您的全部 Platform 餘額。網絡處理提領後，Dash 即會到達您的透明餘額。";
 
 /* Send Screen: to address */
 "to" = "to";
@@ -3192,8 +4107,14 @@
 /* CrowdNode */
 "Transaction History" = "Transaction History";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "交易紀錄無法使用";
+
 /* No comment provided by engineer. */
 "Transaction id" = "Transaction id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "交易 ID";
 
 /* A verb, button title. */
 "Transfer" = "Transfer";
@@ -3221,8 +4142,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "Transfer In";
 
+/* Balance breakdown */
+"Transfer in" = "轉入";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "Transfer Out";
+
+/* Balance breakdown */
+"Transfer out" = "轉出";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3232,6 +4159,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "轉帳耗時較長——產生隱私證明需要時間";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "向其他 Platform 位址和遮蔽位址的轉帳是即時且最終的";
+
+/* Balance breakdown */
+"Transparent" = "透明";
+
+/* Send screen destination type */
+"Transparent address" = "透明位址";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "透明餘額";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "透明資金會將您的用戶名稱與這些資金公開關聯起來。";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "透明 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "透明 → 遮蔽";
 
 /* An action */
 "Try again" = "Try again";
@@ -3281,6 +4232,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "無法提供建議";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3314,6 +4268,12 @@
 /* Coinbase */
 "Unknown Balance" = "Unknown Balance";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "未知的特殊類型 %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "未遮蔽";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "Unsupported URL";
 
@@ -3336,6 +4296,9 @@
 "Upgrade to DashPay" = "Upgrade to DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "升級至 Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3355,6 +4318,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "改用透明餘額";
+
+/* Masternode keys */
+"Used" = "已使用";
+
+/* Masternode keys */
+"Used at: " = "使用於：";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "用戶（正在取得資訊）";
 
 /* Voting */
 "Username" = "Username";
@@ -3386,6 +4361,23 @@
 /* Usernames */
 "Username was successfully requested" = "Username was successfully requested";
 
+/* Identities */
+"Usernames" = "用戶名稱";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "用戶名稱以正規化形式儲存，以防止出現形似名稱，因此這可能與每個人輸入的內容不同。";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "用戶名稱，而非位址";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "與 %@ 相符且目前不在您聯絡人中的用戶";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "使用經過最充分稽核和測試的零知識程式庫之一 (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "有效邀請";
+
 /* CrowdNode Portal */
 "Validating address…" = "Validating address…";
 
@@ -3401,6 +4393,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "Verification Required";
 
+/* Usernames */
+"Verified during registration" = "已在註冊時驗證";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
 
@@ -3413,11 +4408,20 @@
 /* Usernames */
 "Verify your identity" = "Verify your identity";
 
+/* Raw transaction inspector */
+"Version" = "版本";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "非常有效率且費用低廉";
+
 /* adjective, security level */
 "Very High" = "Very High";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address.";
+
+/* No comment provided by engineer. */
+"View All" = "檢視全部";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "View in Explorer";
@@ -3431,17 +4435,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "View Recovery Phrase";
 
+/* Raw transaction inspector */
+"View Transaction" = "檢視交易";
+
 /* No comment provided by engineer. */
 "View transaction details" = "View transaction details";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "投票";
+
+"Vote cast" = "已投票";
+
 /* Voting */
 "Vote for All" = "Vote for All";
 
 /* Voting */
+"Vote on contested usernames" = "為有爭議的用戶名稱投票";
+
+"Vote on several" = "為多個投票";
+
+/* Voting */
 "Vote to Approve" = "Vote to Approve";
+
+"Vote with" = "使用以下節點投票";
+
+"Votes that nobody should receive these usernames." = "投票支持任何人都不應取得這些用戶名稱。";
 
 /* Voting */
 "Votes: High to low" = "Votes: High to low";
@@ -3455,14 +4475,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "Voting Address";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "投票位址";
+
+"Voting ended with no winner" = "投票結束，無人勝出";
+
+"Voting ends" = "投票結束";
+
 /* Voting */
 "Voting ends in %dd" = "Voting ends in %dd";
+
+"Voting in progress" = "投票進行中";
+
+"Voting in progress — lock votes are ahead" = "投票進行中——鎖定票領先";
+
+"Voting in progress — you are ahead" = "投票進行中——您領先";
 
 /* Usernames */
 "Voting is only required in some cases" = "Voting is only required in some cases";
 
+/* Masternodes */
+"Voting key hash" = "投票鑰匙雜湊";
+
 /* No comment provided by engineer. */
 "Voting keys" = "Voting keys";
+
+"Voting on this username has closed. The counts below are the last ones read." = "對此用戶名稱的投票已結束。以下計數為最後一次讀取的結果。";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "對「%@」的投票已經結束。請重新整理以查看結果。";
 
 /* No comment provided by engineer. */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3476,11 +4517,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "Wait until wallet is synced to complete the transaction";
 
+"Waiting for Dash Platform" = "正在等待 Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "Wallet Address";
+
+/* SPV diagnostics */
+"Wallet birth height" = "錢包起始區塊高度";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "Wallet disabled";
@@ -3554,14 +4600,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "Welcome to DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains 及類似網域服務如何？";
+
+/* DashPay FAQ */
+"What does it cost?" = "費用是多少？";
+
+/* DashPay FAQ */
+"What is DashPay?" = "什麼是 DashPay？";
+
 /* Usernames */
 "What is username voting?" = "What is username voting?";
+
+/* DashPay FAQ */
+"What's coming next?" = "接下來會有什麼？";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "聯繫請求何時會變為私密？";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "Where to Spend";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "Where to Spend?";
+
+"Who is requesting this name" = "誰在申請此名稱";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "為什麼我需要啟用它？";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "Why do I see all these transactions?";
@@ -3600,6 +4666,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "Withdrawal requested";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "提領全部餘額";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "適用於所有 Dash 錢包、交易所和商家";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "Would you like to accept the invitation?";
 
@@ -3623,6 +4695,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "Yesterday";
+
+"You" = "您";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "您已接受來自 %@ 的聯繫請求";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3672,6 +4749,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "You chose “%@” as your username.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "您目前沒有任何聯絡人";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "You do not have sufficient funds to complete this transaction";
 
@@ -3680,6 +4760,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "You exceeded the authorization limit on Coinbase.";
+
+/* Usernames */
+"You have %@ Dash so far" = "您目前有 %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "You have %1$@ Dash.\nSome usernames cost up to %2$@ Dash.";
@@ -3750,6 +4833,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "您已向 %@ 發送聯繫請求";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "You should have a positive balance on Dash Wallet";
 
@@ -3776,6 +4862,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "您贏得了此用戶名稱";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "一切就緒。其他用戶現在可以向您發送聯繫請求——您也可以發送自己的請求。";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3807,6 +4898,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "註冊用戶名稱後，您的 Dash Platform 身分會顯示在這裡。";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3837,11 +4931,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "Your email is only used to send a one-time password.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "井然有序的紀錄";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "您的身分需要兩把額外的鑰匙，才能在您與其他用戶之間加密聯繫請求。啟用時會透過一筆網絡交易加入它們。此操作只需進行一次。";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "Your invitation from %@ has been already claimed";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "Your invitation from %@ is not valid";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "您的邀請將支付此用戶名稱的註冊費用。";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "Your location is used to show your position on the map, ATMs in the selected redius and improve search results.";
@@ -3849,8 +4952,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "Your location is used to show your position on the map, merchants in the selected redius and improve search results.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "您在 Core 區塊鏈上的主要 Dash 餘額——用於與其他錢包、交易所和商家收付資金。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "您的已混合資金已轉入 Dash 錢包餘額。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "您的已混合資金已轉入遮蔽餘額。為獲得最佳隱私效果，請至少等待 2 小時後再使用這些資金。";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "您的 Platform 餘額";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3858,11 +4973,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "Your primary Dash address that you currently use for your CrowdNode account";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "您的私密餘額。金額和位址在鏈上均已加密，因此您的持有量和紀錄都保持機密。";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 
 /* DashSpend */
 "Your session expired" = "Your session expired";
+
+/* Usernames */
+"Your Shielded balance" = "您的遮蔽餘額";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "您的遮蔽餘額即將就緒——您大約可在 %@ 私密註冊。";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "您的遮蔽餘額已就緒——立即私密註冊您的用戶名稱";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "您的遮蔽餘額正在靜置——您大約可在 %@ 私密註冊";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "您的遮蔽餘額仍在成熟中。大約將在 %@ 就緒。";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3880,6 +5012,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "您的透明餘額";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "Your username %@ has been successfully created on the Dash Network";
 
 /* No comment provided by engineer. */
@@ -3888,14 +5023,31 @@
 /* Usernames */
 "Your username has been successfully created" = "Your username has been successfully created";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "您的用戶名稱對所有人可見。讓資金靜置數小時後再用遮蔽餘額為其提供資金，任何人都無法將您的用戶名稱與您的其他 Dash 關聯起來。";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "您的用戶名稱、個人資料和聯絡人都歸屬於此身分。";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "您的用戶名稱、個人資料和聯絡人都將歸屬於此身分。";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "Your vote was cancelled";
 
 /* Voting */
 "Your vote was submitted" = "Your vote was submitted";
 
+"Your votes" = "您的選票";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "您的錢包仍在與 Dash 網絡同步。同步完成後即可發送。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "您的錢包仍在同步。同步完成後即可從透明餘額發送。";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3903,5 +5055,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "無法將「%@」識別為 Dash 用戶名稱。";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "「%@」已註冊。要向邀請您的人發送聯繫請求嗎？";

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
@@ -32,5 +32,257 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>為「%2$@」統計了 %#@votes@</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@中已對 %1$d 個投票</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個用戶名稱</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>投出 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個主節點</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個節點</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個 Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>共 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個主節點</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>已選擇 %d 個</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>您有 %d 個節點已在此投票，未顯示在清單中。</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>每次爭奪 %u 票 —— Evonode 計為 4，主節點計為 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>為 %d 個用戶名稱投票</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>投票 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個請求</string>
+		</dict>
+	</dict>
+	<key>%d merchant(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@merchants@</string>
+		<key>merchants</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 商家在 %@</string>
+		</dict>
+	</dict>
+	<key>%d merchant(s)</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@merchants@</string>
+		<key>merchants</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 商家</string>
+		</dict>
+	</dict>
+	<key>%d transaction(s)</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@transactions@</string>
+		<key>transactions</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 交易</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
@@ -49,7 +49,7 @@
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@names@中已對 %1$d 個投票</string>
+		<string>已投票：%1$d / %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -77,7 +77,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -91,7 +91,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " 或 ";
+
 /* CrowdNode */
 " Privacy Policy " = "隐私政策";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "无法在 Dash 网络上找到 %@，因此无法向其发送联系人请求。";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 可用";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ 已接受您的联系人请求";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu 联系人/ %3$lu 个人资料更新";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d 字节";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "由于您的钱包存储了多个投票私钥, 您可以进行多次 %d 投票";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld 重复项";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld 笔存入";
 
 /* Voting */
 "%ld requests" = "%ld 申请";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" 不是一个助记词. 您是否想尝试找回正确的单词?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platform 上的积分余额，用于 Platform 地址之间的即时支付以及用户名等功能。";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "您需要一个密码来保护您的钱包. 请转到设置并打开密码再继续.";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "关于";
 
+/* DashPay FAQ title */
+"About DashPay" = "关于 DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "关于我";
+
+"Abstain" = "弃权";
+
+"Abstain on “%@”" = "在“%@”上弃权";
 
 /* No comment provided by engineer. */
 "Accept" = "同意";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "账号恢复";
 
+/* Masternode status */
+"Active" = "已激活";
+
+/* No comment provided by engineer. */
+"Activity" = "活动";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "活动是公开的，但不易追踪";
+
 /* No comment provided by engineer. */
 "Add" = "添加";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "将 %@ 添加为联系人";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "将 %@ 添加为联系人，即可直接向用户名付款并保留双方的交易记录";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "向您的屏蔽余额添加 %@ Dash，并让它静置数小时后再注册，这样您的用户名就不会与您的其他资金关联。";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "添加新朋友";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "向您的屏蔽余额至少添加 %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "现在向屏蔽余额添加资金，数小时后再私密地注册用户名";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "所有";
 
+"All nodes at once" = "所有节点一次性投票";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请从您现在支持的申请者处再次投票。";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "允许将所有交易从 Dash 钱包发送到 Zenledger?";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "余额同步几乎即时完成";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "金额和地址在区块链上是公开的";
+
 /* No comment provided by engineer. */
 "An error occurred" = "发生了一个错误";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "以太坊账户是一个可重复使用的地址：您的全部余额和支付记录都公开地归于它之下，而一个名称（例如 ENS 域名）通常直接指向该地址，任何人都能解析。DashPay 的结构恰好相反——名称解析到的是身份，而不是支付地址，真正的支付地址保留在加密的联系人交换中，且对每位联系人都是全新的。";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "所有设备上的直观熟悉体验";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超过20个字符且包含数字2-9, 或含有连字符的用户名将被自动批准";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "应用";
 
+"Approve" = "批准";
+
+"Approving a specific request can only be done one username at a time." = "批准特定申请一次只能针对一个用户名。";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "您确定要取消此订单吗?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "以文本显示";
 
 /* DashSpend */
 "at" = "在";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "身份验证已取消。您的选票未被投出。";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "身份验证失败。您的选票未被投出。";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "身份验证不可用";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "将“%@”授予此申请者";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "余额";
 
 /* CrowdNode */
+"Balance after" = "之后余额";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "CrowdNode 的余额";
 
 /* CrowdNode */
 "Balance: " = "余额:";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "余额和转账不会公开可见";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "银行账户";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "需要生物识别访问权限";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "已保存起始区块高度——提高后的扫描下限将从下次启动开始生效。";
+
 /* Voting */
 "Block" = "区块";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "禁止了 '%@' 用户名";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "绑定到合约";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "绑定到合约，文档类型“%@”";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "仅浏览";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "将最近的诊断日志打包为 zip，以便通过 AirDrop、邮件发送或保存到“文件”";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "投出选票";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "更换节点";
 
 /* No comment provided by engineer. */
 "Change PIN" = "更改PIN";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "正在检查…";
+
+"Choice" = "选择";
+
 /* Choose your Dash username */
 "Choose your" = "选择您的";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "选择您的用户名";
 
+/* DashPay Invitations */
+"Claim your invitation" = "领取您的邀请";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "可领取余额";
+
 /* No comment provided by engineer. */
 "Claimed" = "已认领";
+
+/* SPV diagnostics */
+"Clear & resync" = "清除并重新同步";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "要清除链数据并重新同步吗？";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "关闭App";
 
+"Closing" = "即将结束";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase（新币）";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 2次验证码";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin 已不再受支持——请选择将已混币资金转移到何处。";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "抵押";
+
+/* DashPay intro: feature title */
+"Coming soon" = "即将推出";
+
+/* Shielded transfer status */
+"Completed" = "已完成";
 
 /* No comment provided by engineer. */
 "Confirm" = "确认";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "已确认";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "确认后将保存起始区块高度 %u，并在下次启动应用时清除该网络的链数据，重新下载并从该高度重新扫描过滤器。当前会话仍沿用旧的扫描下限——退出并重新打开应用即可开始。";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "将您的加密数字货币钱包连接至 ZenLedger 平台. 了解更多信息并开始使用您的 Dash 钱包进行交易.";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "连接的 Dash地址";
 
+/* SPV sync */
+"Connected peers" = "已连接节点";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "缺点";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "联系人请求失败";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "已向 %@ 发送联系人请求";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "联系人请求";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "通讯录";
 
+"Contender %@" = "申请者 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "继续";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "继续以选择您的用户名。邀请将支付注册费用。";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "复制邀请链接";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "复制原始交易";
+
 /* No comment provided by engineer. */
 "Copy text" = "复制文本";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "无法自动恢复缺失或错误单词";
 
+/* Log export */
+"Could not create the log archive: %@" = "无法创建日志归档：%@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "汇率未找到.";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "无法刷新 %d 个身份";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "无法获取余额（网络错误）。请尝试刷新。";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "无法付款";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "创建您的用户名";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "创建您的用户名，通过用户名找到亲友并将他们加入联系人";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "信用卡";
+
+/* Masternodes */
+"Credits" = "积分";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "Dash付款不能小于 %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform 尚未索引此次争夺。索引完成后，票数将显示在这里。";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform 尚未连接。请等待同步完成后重试。";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "发送到错误地址的 Dash 无法找回。请确认地址与您要支付的地址完全一致。";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash 以防形似的形式存储用户名，因此存储的名称可能与每个人输入的内容不同。";
+
 /* No comment provided by engineer. */
 "Dash username" = "Dash用户名";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "Dash 钱包";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash 钱包余额";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "此设备的 Dash钱包";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay 已启用";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay邀请";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay 是构建在 Dash Platform 上的 Dash 社交支付体验。您可以注册用户名、将其他用户添加为联系人，并按名称向他们付款——不必再复制地址。";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay 用用户名取代冗长难懂的地址。将好友添加为联系人，向一个名称汇款，并按人整理每一笔支付。";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay升级费用";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "日期: 从旧到新";
+
+"Deadline unknown" = "截止时间未知";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "存款已发送";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "派生路径";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "该设备的安全性受到威胁\n任何'越狱'的应用程序都可以访问任何其他应用程序的钥匙链数据(并窃取您的Dash). 请立即清除该钱包并在安全设备上将其恢复.";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "已停用";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "取消 Coinbase账户的关联";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "完成";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "完成——您的余额已静置足够长的时间";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "请再次核对地址";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "每个邀请都将获得该金额的资助, 以便收款人可以在Dash网络上快速创建他们的用户名";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "每个主节点在每次争夺中拥有一张有效选票。您之后可以更改，但 Dash Platform 在每次争夺中每个主节点总共只允许 5 次投票。";
+
+"Each tap votes with one more node, so you choose how many to link together." = "每点按一次就多一个节点参与投票，因此您可以决定关联多少个节点。";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "先前的";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "只需点击几下, 即可轻松质押Dash并赚取被动收益.";
+
+/* SPV diagnostics */
+"Edit birth height" = "编辑起始区块高度";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "编辑个人资料";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "邮箱";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "启用";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "启用 DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "启用脸部识别";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "启用指纹识别";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "启用 DashPay 需要一笔小额的一次性网络手续费，从您身份的积分余额中支付。确认前会显示确切的预估金额。发送联系人请求和支付则收取通常的网络手续费。";
+
+"Ending soonest" = "最早结束";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "更新您个人资料时出错";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "预计网络手续费";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "所有节点一起投票。速度更快，但会公开地将您的各个主节点关联起来。";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode 操作者密钥";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "导出 CSV";
 
+/* Log export */
+"Export Logs" = "导出日志";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "扩展公钥 (BIP44)";
 
 /* No comment provided by engineer. */
+"External address" = "外部地址";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "脸部识别限制";
+
+/* No comment provided by engineer. */
+"Failed" = "失败";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "条形码加载失败";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "获取汇率...";
 
+/* Masternodes */
+"Fetching…" = "获取中…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "法币账户";
 
 /* No comment provided by engineer. */
 "Filter" = "过滤";
+
+/* SPV sync phase */
+"Filter headers" = "过滤器区块头";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "过滤交易";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "在 Dash 网络上查找用户";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "查找可以购买或出售 Dash 的自动取款机.";
+
+/* Identities */
+"Find identities" = "查找身份";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "忘记PIN?";
 
+/* Identities */
+"Found %d new identities" = "找到 %d 个新身份";
+
+/* Identities */
+"Found 1 new identity" = "找到 1 个新身份";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "找到缺失的单词:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "用您的屏蔽余额为用户名提供资金。请提前几个小时添加资金——短暂的静置可让您的用户名无法与您的其他 Dash 关联。";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "已由您的屏蔽余额提供资金——您的用户名无法与您的其他 Dash 关联。";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "资金已锁定——正在完成转账";
+
+/* CoinJoin */
+"Funds moved" = "资金已转移";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "仅需 0.5 Dash的存款即可从Dash主节点中获得奖励.";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "获得报价";
+
+/* Usernames */
+"Get ready to join DashPay" = "准备加入 DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "立即获得奖励";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "知道了";
+
+/* Governance */
+"Governance" = "治理";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "授予 GPS权限, 以便我们能向您显示您附近的位置.";
 
 /* Voting */
 "Has blocked votes" = "已阻止投票";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "请求成为您的好友";
+
+/* DashPay Invitations */
+"Have an invitation?" = "有邀请吗？";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "完全控制并根据需求定制您的钱包";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "头部 %2$d分之#%1$d";
+
+/* SPV sync phase */
+"Headers" = "区块头";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "高度 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "这是在此设备上的 Dash钱包中为您的 CrowdNode账户指定的 Dash地址";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "从高到低";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "手续费较高，约 7 美分（仍低于提供类似隐私保护的其他区块链）";
+
 /* No comment provided by engineer. */
 "History" = "历史";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "我如何获得 Test Dash?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "在隐私方面，这与比特币相比如何？";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "在隐私方面，这与以太坊账户相比如何？";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay 的隐私性如何？";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "如何确认您的API Dash地址";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "我已将它写下来";
 
+/* Identities */
+"Identities" = "身份";
+
 /* Voting */
 "Identity" = "身份";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "身份积分";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "身份索引";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "身份注册";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "身份充值";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "在结账的付款时, 选择\"礼品卡\", 然后输入您的卡号和密码";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "未激活";
+
+/* No comment provided by engineer. */
 "Income" = "收入";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "正在初始化";
+
+/* Raw transaction inspector */
+"Input %d" = "输入 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "输入 %d — 输出点";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "输入 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "资金不足";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "邀请费用";
 
+/* DashPay Invitations */
+"Invitation from %@" = "来自 %@ 的邀请";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "邀请已用于";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "邀请";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "邀请他人加入 Dash 网络";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "邀请您的家人, 通过搜索用户名找到您的朋友";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "邀请您的朋友和家人加入Dash网络.";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "邀请您的亲友加入 Dash 网络";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS Dash 钱包: %@ 已报告的问题";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "加入资金池";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "让这些币保持私密。将收取网络和隐私手续费。";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "保证您的密码安全";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "密钥 #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "密钥数据";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "密钥归属";
+
 /* No comment provided by engineer. */
 "Keypair" = "密钥对";
+
+/* Masternodes */
+"Keys" = "密钥";
 
 /* Explore Dash */
 "Last device sync" = "最后一次设备同步";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "领先";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "了解更多";
 
 /* Info Screen */
 "Learn More..." = "了解更多...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "正在加载交易";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "本地货币";
 
+/* Identities */
+"Local Only" = "仅本地";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "本地申请数额: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "位置";
 
+"Lock" = "锁定";
+
+"Lock the name" = "锁定该名称";
+
+"Lock “%@” so nobody gets it" = "锁定“%@”，使任何人都无法获得";
+
 /* No comment provided by engineer. */
 "Locked" = "已锁定";
 
+"Locked — nobody receives this username" = "已锁定——任何人都无法获得此用户名";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "锁定时间";
 
 /* Log in */
 "Log in" = "登录";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "低";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "日常消费手续费低廉";
+
 /* Voting */
 "Low to high" = "低到高";
+
+/* Identities — the wallet's main identity */
+"Main" = "主要";
 
 /* No comment provided by engineer. */
 "Mainnet" = "主网";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "主节点 IP 地址";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "主节点钥匙串";
+
+/* Masternode keys */
 "Masternode keys" = "主节点密钥";
+
+/* SPV sync phase */
+"Masternode list" = "主节点列表";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "主节点列表 #%2$d 分之  %1$d";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "主节点升级";
 
+"Masternode votes" = "主节点票数";
+
 /* Voting */
 "Masternode Voting Key" = "主节点投票密钥";
+
+/* Tools menu */
+"Masternodes" = "主节点";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "使用此钱包密钥注册的主节点和 Evonode 将在钱包同步后显示在这里。";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "使用此钱包密钥的主节点和 Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "主节点会为多人申请的名称投票。投票结束时我们会通知您。";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "最大";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "最少: %@";
 
+/* Usernames */
+"Minimum met" = "已达最低要求";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "更多控制";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "更多建议";
+
+"Most lock votes" = "锁定票最多";
+
+"Most votes" = "得票最多";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "移动并缩放您的照片以找到最适合的效果";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "转入您的常规可用余额。";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "移动至地址";
+
+/* CoinJoin */
+"Moving funds" = "正在转移资金";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "名称";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains 之类的域名服务，会把一个便于阅读的名称映射到链上一个固定的公开地址。任何人都可以解析该名称并查看曾向它支付的每一笔款项。DashPay 用户名绝不会公开解析到支付地址——地址仅在与每位联系人的加密交换中披露，因此您的名称和资金在外部观察者看来始终是不关联的。";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "需要帮助吗?";
+
+"Needs attention" = "需要处理";
 
 /* No comment provided by engineer. */
 "Network" = "网络";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "此设备上未找到诊断日志。日志将从下次启动开始记录。";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "无身份";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "暂无主节点";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "没有匹配的争夺";
+
+/* Identities */
+"No new identities were found for this wallet" = "未为此钱包找到新身份";
+
+"No open contest matches that search." = "没有进行中的争夺与该搜索匹配。";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "没有进行中的争夺与该搜索匹配。名称以规范化形式存储，因此“alice”会显示为“a11ce”。";
+
+"No open contests" = "没有进行中的争夺";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "没有支付方式";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "未找到所绑定钱包的已保存记录。";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "尚无可用于屏蔽注册回退的 Platform 地址。请在钱包完成同步后重试。";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "未找到结果";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "目前没有用户名处于争夺状态。当两人或更多人申请同一个名称时，就会开启争夺。";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "没有剩余投票";
+
+"No votes were cast" = "未投出任何选票";
+
+"Nobody gets it" = "无人获得";
+
+/* SPV sync peer type */
+"Node" = "节点";
+
+/* Raw transaction inspector */
+"Non-standard" = "非标准";
 
 /* adjective, security level */
 "None" = "无";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "不可用";
 
+"Not available yet" = "尚不可用";
+
+"Not cast" = "未投出";
+
+/* Masternodes */
+"Not checked yet" = "尚未检查";
+
 /* Location Service Status */
 "Not Determined" = "尚未确定";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "屏蔽余额不足，无法注册身份";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "不在钱包记录中";
+
+"Not now" = "暂不";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "商家接受度不高";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "商家接受度尚不高";
+
+/* Masternode keys */
+"Not yet used" = "尚未使用";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "旧到新";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "比特币没有名称层，所以人们公开地共享和重复使用地址——一旦某个地址为人所知，它曾收到的一切都可以与其所有者关联起来。在 DashPay 中，您的用户名是公开的，但它绝不会指向支付地址：地址按联系人私下交换并会轮换，因此按名称付款不会公开您的资金去向。两者都是透明链，因此链上分析仍然适用于币本身。";
+
+/* Identities */
+"On Network" = "在网络上";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "当 %@ 接受您的请求后，您就可以直接向用户名付款";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "每次一个节点";
 
 /* Voting */
 "One vote left" = "还剩一票";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "仅重复项";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "只有主节点和 Evonode 才能为用户名投票。此钱包不含有效的主节点投票密钥。";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "仅以链接申请";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "仅以链接";
+
+/* Masternodes */
+"Operator" = "操作者";
+
+/* Masternode keys */
+"Operator keys" = "操作者密钥";
+
+/* Masternodes */
+"Operator public key (BLS)" = "操作者公钥 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "或";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "订单预览";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "其他结果";
+
+/* Masternodes */
+"Outpoint" = "输出点";
+
+/* Raw transaction inspector */
+"Output %d" = "输出 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "输出 (%d)";
+
+/* Masternodes */
+"Owner" = "所有者";
+
 /* No comment provided by engineer. */
 "Owner Address" = "所有者地址";
+
+/* Masternodes */
+"Owner address" = "所有者地址";
+
+/* Masternodes */
+"Owner key hash" = "所有者密钥哈希";
 
 /* Owner keys */
 "Owner keys" = "所有者密钥";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "从您身份的积分余额中支付。";
 
 /* DashSpend */
 "Password" = "密码";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "在此处粘贴链接";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "粘贴您收到的邀请链接，或扫描其二维码。它将支付您的用户名注册费用。";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "粘贴您的图片链接";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "易用的付款流程即时支付和接收交易";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "直接向用户名付款";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "向人付款，而非向地址付款";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "以用户名支付. 无需使用字母数字地址";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "付款中...";
 
+/* Raw transaction inspector */
+"Payload hex" = "载荷十六进制";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "付款方式";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "支付是私密的：您与联系人交换的地址包含在只有你们两人能读取的加密载荷中，且从不公开——因此您的支付无法被轻易关联到您的用户名。不过它们仍是透明链上的普通支付：高级链上分析仍可能泄露信息。Shielded DashPay（即将推出）将弥补这一缺口。联系人请求本身目前并不私密：任何人都能看到两个身份之间存在关联。私密联系人请求是即将推出的功能。您的用户名和资料在 Dash Platform 上同样是公开的。";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "使用 InstantSend，支付几秒内即可确认";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "直接向地址进行的支付不会保留在活动中。";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "与每位联系人的支付都汇集在一处，显示姓名和资料，而不是原始交易。";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "收款地址";
 
 /* CrowdNode */
 "Payout Options" = "支付选项";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform 地址";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 余额";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform 节点";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform 节点 ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform 支付不会标明付款方。此笔支付是在钱包发现余额变动时记录的——实际到账时间可能更早。";
+
+"Platform SDK not ready" = "Platform SDK 尚未就绪";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform 同步未在运行。请打开“同步信息 → Platform 同步状态”以启动它。";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → 屏蔽";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "请在Coinbase上添加一种支付方式";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "预览链接";
 
+/* Masternode keys */
+"Previously used at: " = "上次使用于：";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "价格至少有30分钟的延迟. 法币显示价值或许错误.";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "隐私源于设计";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "私密联系人请求（让您与谁建立联系保持私密）、Shielded DashPay——从您的私密屏蔽余额向联系人付款——以及向尚未在您联系人中的用户付款，均即将推出。";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "私密联系人请求正在开发中，预计在 2026 年 9 月至 10 月左右推出。目前请求本身是公开的——即使其中的支付信息已加密，任何人仍能看到两个身份之间存在关联。私密联系人请求推出后，您可以选择让这段好友关系公开或保持私密。";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "私密联系人请求、Shielded DashPay，以及向尚未成为联系人的用户付款。";
+
 /* No comment provided by engineer. */
 "Private key" = "私钥";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "私密支付地址在您与联系人之间交换。只有您和您的联系人知道你们之间支付的收款方和付款方。";
+
+/* DashPay intro: feature title */
+"Private payments" = "私密支付";
+
+/* Usernames */
+"Private registration" = "私密注册";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "处理时间";
+
+/* Balance info sheet section */
+"Pros" = "优点";
 
 /* CrowdNode Portal */
 "Protect your savings" = "保护您的存款";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "供应商地址";
 
+/* Masternodes */
+"Provider transactions" = "提供者交易";
+
+/* Masternode keys */
+"Public key" = "公钥";
+
+/* Masternode keys */
+"Public key (legacy)" = "公钥（旧版）";
+
+/* Identities */
+"Public keys" = "公钥";
+
 /* No comment provided by engineer. */
 "Public URL" = "公共链接";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "购买失败";
+
+/* Identities: what a public key is used for */
+"Purpose" = "用途";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "比率: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "原始交易";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "原始交易不可用";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "从所选高度开始，重新检查紧凑区块过滤器中属于此钱包的交易，重新下载并重新匹配。重新扫描的下限为钱包的创建高度以及本地存储的链数据——若要恢复更早的记录，请改为降低钱包起始区块高度。";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "阅读提款政策";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "只读";
+
+/* Usernames */
+"Ready around %@" = "约在 %@ 就绪";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "原因";
 
 /* No comment provided by engineer. */
 "Receive" = "接收";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "接收于";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "收自 %@";
+
 /* CrowdNode */
 "Receiving rewards" = "领取奖励";
+
+"Records your masternodes as having voted, without taking a side." = "记录您的主节点已投票，但不偏向任何一方。";
 
 /* No comment provided by engineer. */
 "Recover" = "恢复";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "助记词必须包括 12, 15, 18, 21 或24个词";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "刷新";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "注册?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "注册于";
+
+/* No comment provided by engineer. */
 "Registered from" = "注册于";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "已注册主节点";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "私密注册需要屏蔽余额中至少有 %@ Dash，并静置数小时——接下来的界面会引导您完成。";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "注册";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "正在申请此名称";
+
 /* An action */
 "Rescan" = "重新扫描";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "已恢复的钱包并不总能还原操作类型。此条目是根据链上备注数据重建的。";
+
+/* Location Service Status */
 "Restricted" = "受限的";
 
 /* Usernames */
 "Results" = "结果";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "已准备从高度 %u 重新同步——退出并重新打开应用即可开始。";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "保留双方的交易记录";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "已退役";
 
 /* No comment provided by engineer. */
 "Retry" = "重试";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "查看下方内容来验证此用户名的所有权";
+
+/* Masternodes */
+"Revocation" = "撤销";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "屏幕截图可以被其他程序或者设备获得. 请生成一个新的助记词并妥善保管.";
 
+/* Raw transaction inspector */
+"Script" = "脚本";
+
+/* Raw transaction inspector */
+"Script signature" = "脚本签名";
+
+/* Raw transaction inspector */
+"Script type" = "脚本类型";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "搜索联系人";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "搜索联系人请求";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "在 Dash 网络上搜索用户";
+
+/* No comment provided by engineer. */
+"Search for a username" = "搜索用户名";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "搜索结果：\"";
+
+/* No comment provided by engineer. */
 "Search territories" = "搜索区域";
+
+"Search usernames" = "搜索用户名";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "正在 Dash 网络上搜索用户名 %@";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "保护您的钱包";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "安全级别";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "安全级别";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "请选择购买、出售、转换和转移Dash的服务";
 
+"Select all" = "全选";
+
 /* DashSpend denomination selection */
 "Select amount" = "选择面额";
+
+"Select at least one masternode to vote with." = "请至少选择一个用于投票的主节点。";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "选择币种";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "选择的节点越少，越不容易暴露您运行的是哪些主节点。";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "自助结账";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "发送至";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "发送给联系人";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "向一个您真正能记住并核实的用户名发送。";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "发送至地址";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "发送您的第一个联系人请求";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "正在发送";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "正在发送联系人请求";
+
+/* No comment provided by engineer. */
+"Sending to" = "发送至";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "发送到CrowdNode账户";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "发送至";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "已发送给 %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "序列号";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "服务器发生错误, 请稍后再试.";
+
+/* Masternodes */
+"Service" = "服务";
+
+/* Identities */
+"Set as Main" = "设为主要";
+
+/* Identities */
+"Set as Main Identity" = "设为主要身份";
 
 /* No comment provided by engineer. */
 "Set PIN" = "设置PIN";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "分享密钥";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "共享隐私池已达最小规模";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "屏蔽地址";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "屏蔽支出";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "正在启动屏蔽钱包…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "屏蔽 → Platform";
+
+"Shielded → Transparent" = "屏蔽 → 透明";
 
 /* Explore Dash */
 "Show all locations" = "显示所有位置";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "大小";
+
 /* No comment provided by engineer. */
 "Skip" = "跳过";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "此列表中可能缺少您的部分主节点——钱包无法读取您完整的投票密钥集合。请完成同步后重新打开此界面。";
 
 /* Usernames */
 "Some usernames can be blocked" = "一些用户名会被禁止";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "排序方式";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "排序联系人";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "以折扣排序";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "以名称排序";
+
+/* Raw transaction inspector */
+"Special payload" = "特殊载荷";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "指定数额";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "质押";
 
+/* Usernames */
+"Starts after you add funds" = "在您添加资金后开始";
+
+/* Transaction details */
+"Status" = "状态";
+
 /* Step 1 */
 "Step %ld" = "步骤 %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "存储为";
 
 /* Voting */
 "Submit" = "提交";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "同步中… 结果可能不完整.";
 
+/* No comment provided by engineer. */
+"Sync Info" = "同步信息";
+
+/* SPV sync */
+"Sync too slow?" = "同步太慢？";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "从相机拍照";
 
+"Take no side" = "不偏向任何一方";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "点击剪切板中的地址进行粘贴";
+
+/* Raw transaction inspector */
+"Tap to copy" = "点按以复制";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "点击隐藏余额";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "临时不可用";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash 节点密钥 (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "条款和条件";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "测试网";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "验证码不正确. 请检查并重试!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "网络处理提现后，Dash 将到达收款人的地址——这最多可能需要 10 分钟。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "网络处理提现后，Dash 即会到达收款人的地址。";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "网络处理提现后，Dash 即会到达您的透明余额。";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "在用户创建用户名前, Dash 网络需要投票批准某些用户名";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "您发送的链接将仅对网络所有者可见";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "只能从当前钱包中选择主要身份";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "您可以发送的最小额度是%@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "存放您的 Dash 最私密的地方";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "已保存的钱包记录没有网络——无法准备重新同步。";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "注册已提交，但无法确认其结果。请等待一分钟让钱包完成同步，然后重试——不要立即重新提交。";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "共享隐私池仍在增长（%1$ld / %2$ld 笔存入）。达到最低规模后即可解锁私密注册。";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "共享隐私池仍在增长（%1$ld / %2$ld 笔存入）。请在其达到最低规模后重试。";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "用户名 '%@' 被 Dash网络屏蔽. 请尝试申请其它用户名.";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "钱包的创建高度——过滤器扫描和“自钱包创建起”重新扫描的下限。请将其设置为不高于钱包首次收到资金的高度；导入时主网默认为 200000，测试网默认为 0。保存一个不高于当前值的高度，将在下次启动时清除该网络的链数据并从该高度重新扫描。";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "他（正在获取信息）";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "没有新通知";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "没有可显示交易";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "没有与名称 %@ 匹配的用户";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "您的联系人中没有与名称 %@ 匹配的用户";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "当向 ZenLedger 导出您的交易历史时产生了一个错误";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "出现了一个错误, 请稍后再试";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "这些资金将转入您的 Platform 余额，转账完成后即可使用。";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "无法从您的 %@ 余额向此地址付款";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "这会为您的身份添加两个密钥，让其他用户能够向您发送联系人请求，也让您能够接受他们的请求。此操作只需进行一次。";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "这会将同一个选择应用于全部 %d 个所选用户名。";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "此额外步骤用来证明真的是您在尝试进行交易.";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "此邀请链接无效。";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "这不是此网络的有效 Dash 地址";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "这不是有效的邀请链接";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "这是您的主要身份";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "此主节点尚无 Platform 身份。";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "该商户目前不可用.";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "这代表完整主节点当前年度百分比收益减去15%的CrowdNode费用. 这不是保证回报率, 可能会根据CrowdNode资金池的大小和Dash价格而上下浮动.";
 
+"This still counts as your masternodes having voted in this contest." = "这仍会计为您的主节点已在此次争夺中投票。";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "此交易的原始字节未存储在此设备上。";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "此用户名归他人所有";
+
+"This wallet could not derive the voting key for this node." = "此钱包无法为该节点派生投票密钥。";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "此钱包不含有效的主节点投票密钥，因此无法投票。已注册的节点会显示在“工具 → 主节点”中。";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "这会一次性提取您的全部 Platform 余额。网络处理提现后，Dash 即会到达收款人的地址。";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "这会一次性提取您的全部 Platform 余额。网络处理提现后，Dash 即会到达您的透明余额。";
 
 /* Send Screen: to address */
 "to" = "到";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "交易记录";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "交易记录不可用";
+
 /* No comment provided by engineer. */
 "Transaction id" = "交易 id";
+
+/* Raw transaction inspector */
+"Transaction ID" = "交易 ID";
 
 /* A verb, button title. */
 "Transfer" = "转移";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "转入";
 
+/* Balance breakdown */
+"Transfer in" = "转入";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "转出";
+
+/* Balance breakdown */
+"Transfer out" = "转出";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "转账耗时较长——生成隐私证明需要时间";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "向其他 Platform 地址和屏蔽地址的转账是即时且最终的";
+
+/* Balance breakdown */
+"Transparent" = "透明";
+
+/* Send screen destination type */
+"Transparent address" = "透明地址";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "透明余额";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "透明资金会将您的用户名与这些资金公开关联起来。";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "透明 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "透明 → 屏蔽";
 
 /* An action */
 "Try again" = "再试一次";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "无法提供建议";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "未知余额";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "未知的特殊类型 %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "未屏蔽";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "不支持的链接";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "升级到 DashPay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "升级到 Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "改用透明余额";
+
+/* Masternode keys */
+"Used" = "已使用";
+
+/* Masternode keys */
+"Used at: " = "使用于：";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "用户（正在获取信息）";
 
 /* Voting */
 "Username" = "用户名";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "用户名已被成功申请";
 
+/* Identities */
+"Usernames" = "用户名";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "用户名以规范化形式存储，以防止出现形似名称，因此这可能与每个人输入的内容不同。";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "用户名，而非地址";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "与 %@ 匹配且当前不在您联系人中的用户";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "使用经过最充分审计和测试的零知识库之一 (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "有效邀请";
+
 /* CrowdNode Portal */
 "Validating address…" = "正在确认地址...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "需要验证";
 
+/* Usernames */
+"Verified during registration" = "已在注册时验证";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "验证成功";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "验证您的身份";
 
+/* Raw transaction inspector */
+"Version" = "版本";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "非常高效且手续费低廉";
+
 /* adjective, security level */
 "Very High" = "非常高";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "将会向CrowdNode发送非常少的Dash用以验证您是该钱包地址的所有者.";
+
+/* No comment provided by engineer. */
+"View All" = "查看全部";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "在浏览器中查看";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "查看助记词";
 
+/* Raw transaction inspector */
+"View Transaction" = "查看交易";
+
 /* No comment provided by engineer. */
 "View transaction details" = "查看交易详情";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "投票";
+
+"Vote cast" = "已投票";
+
 /* Voting */
 "Vote for All" = "投给所有";
 
 /* Voting */
+"Vote on contested usernames" = "为有争议的用户名投票";
+
+"Vote on several" = "为多个投票";
+
+/* Voting */
 "Vote to Approve" = "投票通过";
+
+"Vote with" = "使用以下节点投票";
+
+"Votes that nobody should receive these usernames." = "投票支持任何人都不应获得这些用户名。";
 
 /* Voting */
 "Votes: High to low" = "投票: 从高到低";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "投票者地址";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "投票地址";
+
+"Voting ended with no winner" = "投票结束，无人胜出";
+
+"Voting ends" = "投票结束";
+
 /* Voting */
 "Voting ends in %dd" = "投票将于%d 天后结束";
+
+"Voting in progress" = "投票进行中";
+
+"Voting in progress — lock votes are ahead" = "投票进行中——锁定票领先";
+
+"Voting in progress — you are ahead" = "投票进行中——您领先";
 
 /* Usernames */
 "Voting is only required in some cases" = "仅在一些情况下需要投票";
 
+/* Masternodes */
+"Voting key hash" = "投票密钥哈希";
+
 /* Voting keys */
 "Voting keys" = "投票者密钥";
+
+"Voting on this username has closed. The counts below are the last ones read." = "对此用户名的投票已结束。以下计数为最后一次读取的结果。";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "对“%@”的投票已经结束。请刷新以查看结果。";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "等待钱包同步以完成此交易";
 
+"Waiting for Dash Platform" = "正在等待 Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "钱包地址";
+
+/* SPV diagnostics */
+"Wallet birth height" = "钱包起始区块高度";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "钱包被禁用";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "欢迎来到 DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains 及类似域名服务如何？";
+
+/* DashPay FAQ */
+"What does it cost?" = "费用是多少？";
+
+/* DashPay FAQ */
+"What is DashPay?" = "什么是 DashPay？";
+
 /* Usernames */
 "What is username voting?" = "什么是用户名投票?";
+
+/* DashPay FAQ */
+"What's coming next?" = "接下来会有什么？";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "联系人请求何时会变为私密？";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "在哪里消费";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "在哪里消费?";
+
+"Who is requesting this name" = "谁在申请此名称";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "为什么我需要启用它？";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "为什么我看到所有这些交易?";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "提款申请";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "提取全部余额";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "适用于所有 Dash 钱包、交易所和商家";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "您愿意接受这个邀请吗?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "昨天";
+
+"You" = "您";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "您已接受来自 %@ 的联系人请求";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "您选择 \"%@\" 作为您的用户名.";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "您目前没有任何联系人";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "您没有足够的资金来完成此次交易";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "您超出了 Coinbase的授权限制.";
+
+/* Usernames */
+"You have %@ Dash so far" = "您目前有 %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "您拥有 %1$@ Dash. \n一些用户名会至多花费 %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "您已向 %@ 发送联系人请求";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "您Dash钱包的余额应该是正的";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "您赢得了此用户名";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "一切就绪。其他用户现在可以向您发送联系人请求——您也可以发送自己的请求。";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "注册用户名后，您的 Dash Platform 身份会显示在这里。";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "您的电子邮箱仅用于发送一次性密码.";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "井然有序的记录";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "您的身份需要两个额外的密钥，才能在您与其他用户之间加密联系人请求。启用时会通过一笔网络交易添加它们。此操作只需进行一次。";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "您来自%@的邀请已被认领";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "您来自%@的邀请无效";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "您的邀请将支付此用户名的注册费用。";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "您的位置用于显示您在地图上的位置, 所选半径内的自动提款机以及优化搜索结果.";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "您的位置用于显示您在地图上的位置, 所属区域中的商家, 以及改进搜索结果.";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "您在 Core 区块链上的主要 Dash 余额——用于与其他钱包、交易所和商家收发资金。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "您的已混币资金已转入 Dash 钱包余额。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "您的已混币资金已转入屏蔽余额。为获得最佳隐私效果，请至少等待 2 小时后再使用这些资金。";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "您的 Platform 余额";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "您当前用于CrowdNode账户的主要Dash地址";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "您的私密余额。金额和地址在链上均已加密，因此您的持有量和记录都保持机密。";
+
 /* Usernames */
 "Your request was cancelled" = "您的申请已被取消";
 
 /* DashSpend */
 "Your session expired" = "您的对话已过期";
+
+/* Usernames */
+"Your Shielded balance" = "您的屏蔽余额";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "您的屏蔽余额即将就绪——您大约可在 %@ 私密注册。";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "您的屏蔽余额已就绪——立即私密注册您的用户名";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "您的屏蔽余额正在静置——您大约可在 %@ 私密注册";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "您的屏蔽余额仍在成熟中。大约将在 %@ 就绪。";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "您的透明余额";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "您的用户名 %@ 已经在Dash网络上成功创建";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "您的用户名已成功被创建";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "您的用户名对所有人可见。让资金静置数小时后再用屏蔽余额为其提供资金，任何人都无法将您的用户名与您的其他 Dash 关联起来。";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "您的用户名、资料和联系人都归属于此身份。";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "您的用户名、资料和联系人都将归属于此身份。";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "您的投票已被取消";
 
 /* Voting */
 "Your vote was submitted" = "您的投票已被提交";
 
+"Your votes" = "您的选票";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "您的钱包现已安全. 您可以随时在其他设备通过您的助记词找回您的账户.";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "您的钱包仍在与 Dash 网络同步。同步完成后即可发送。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "您的钱包仍在同步。同步完成后即可从透明余额发送。";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "无法将“%@”识别为 Dash 用户名。";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "“%@”已注册。要向邀请您的人发送联系人请求吗？";

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "所有节点一次性投票";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请从您现在支持的申请者处再次投票。";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主节点都已为此用户名投票。若要更改选票，请再次为您现在支持的申请者投票。";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/zh.lproj/Localizable.stringsdict
+++ b/DashWallet/zh.lproj/Localizable.stringsdict
@@ -89,7 +89,7 @@
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@names@中已对 %1$d 个投票</string>
+		<string>已投票：%1$d / %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -117,7 +117,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -131,7 +131,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>

--- a/DashWallet/zh.lproj/Localizable.stringsdict
+++ b/DashWallet/zh.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d 密钥</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>为“%2$@”统计了 %#@votes@</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@中已对 %1$d 个投票</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个用户名</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>投出 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个主节点</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 个已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 个节点</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个 Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>共 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个主节点</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>已选择 %d 个</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>您有 %d 个节点已在此投票，未显示在列表中。</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>每次争夺 %u 票 —— Evonode 计为 4，主节点计为 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>为 %d 个用户名投票</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>投票 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 个请求</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 
 "All nodes at once" = "所有節點一次投票";
 
-"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請從您現在支持的申請者處再次投票。";
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請再次為您現在支持的申請者投票。";
 
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -1,6 +1,8 @@
 /* No comment provided by engineer. */
 " " = " ";
 
+" or " = " 或 ";
+
 /* CrowdNode */
 " Privacy Policy " = "隱私政策";
 
@@ -16,11 +18,20 @@
 /* Dash DEX / dex_error_blacklisted */
 "%@ can't be swapped at the moment." = "%@ can't be swapped at the moment.";
 
+/* DashPay Invitations */
+"%@ couldn't be found on the Dash network to send them a contact request." = "無法在 Dash 網絡上找到 %@，因此無法向其發送聯繫請求。";
+
+/* Usernames */
+"%@ Dash available" = "%@ Dash 可用";
+
 /* DashPay Contacts */
 "%@ DASH sent to %@" = "%1$@ DASH sent to %2$@";
 
 /* Maya/SwapKit order preview */
 "%@ fee" = "%@ fee";
+
+/* No comment provided by engineer. */
+"%@ has accepted your contact request" = "%@ 已接受您的聯繫請求";
 
 /* Dash DEX */
 "%@ has received your transaction and is processing the swap." = "%@ has received your transaction and is processing the swap.";
@@ -49,6 +60,12 @@
 /* Credits */
 "%@ ~ %lu contacts / %lu profile updates" = "%1$@ ~ %2$lu 聯絡人/ %3$lu 個人資料更新";
 
+/* Raw transaction inspector */
+"%d bytes" = "%d 位元組";
+
+/* Network fee in duffs (1 DASH = 100,000,000 duffs) */
+"%d duffs" = "%d duffs";
+
 /* Voting - multiple keys warning */
 "%d votes will be cast as you have multiple voting keys stored in the wallet" = "%d 由於您的錢包中儲存了多個投票密鑰，因此將進行投票";
 
@@ -60,6 +77,9 @@
 
 /* Voting */
 "%ld duplicates" = "%ld 重複項目";
+
+/* Usernames */
+"%ld of %ld deposits" = "%ld / %ld 筆存入";
 
 /* Voting */
 "%ld requests" = "%ld 請求";
@@ -136,6 +156,9 @@
 /* No comment provided by engineer. */
 "\"%@\" is not a recovery phrase word. Would you like to try to recover the correct word that should be in its place?" = "\"%@\" 不是有效的恢復短單詞。 您想嘗試用另一個的正確單詞代替其位置嗎?";
 
+/* Balance info sheet */
+"A credit balance on Dash Platform used for instant payments between Platform addresses and for features like usernames." = "Dash Platform 上的積分餘額，用於 Platform 位址之間的即時支付以及用戶名稱等功能。";
+
 /* No comment provided by engineer. */
 "A device passcode is needed to safeguard your wallet. Go to settings and turn passcode on to continue." = "需要一個裝置密碼來保護你的錢包。請到設置並打開密碼才能繼續。";
 
@@ -154,8 +177,15 @@
 /* No comment provided by engineer. */
 "About" = "關於";
 
+/* DashPay FAQ title */
+"About DashPay" = "關於 DashPay";
+
 /* No comment provided by engineer. */
 "About me" = "關於我";
+
+"Abstain" = "棄權";
+
+"Abstain on “%@”" = "在「%@」上棄權";
 
 /* No comment provided by engineer. */
 "Accept" = "接受";
@@ -178,17 +208,41 @@
 /* CrowdNode */
 "Account Recovery" = "恢復帳戶";
 
+/* Masternode status */
+"Active" = "已啟用";
+
+/* No comment provided by engineer. */
+"Activity" = "活動";
+
+/* Balance info sheet */
+"Activity is public but not easy to trace" = "活動是公開的，但不易追蹤";
+
 /* No comment provided by engineer. */
 "Add" = "新增";
 
+/* DashPay Invitations */
+"Add %@ as a contact" = "將 %@ 加入聯絡人";
+
 /* DashPay Contacts */
 "Add %@ as a contact to pay them directly by username and keep a shared history of your payments." = "Add %@ as a contact to pay them directly by username and keep a shared history of your payments.";
+
+/* Add <username> as your contact... */
+"Add %@ as your contact to Pay Directly to Username and Retain Mutual Transaction History" = "將 %@ 加入聯絡人，即可直接向用戶名稱付款並保留雙方的交易紀錄";
+
+/* Usernames */
+"Add %@ Dash to your Shielded balance and let it rest a few hours to register without linking your username to your other funds." = "向您的遮蔽餘額加入 %@ Dash，並讓它靜置數小時後再註冊，這樣您的用戶名稱就不會與您的其他資金關聯。";
 
 /* No comment provided by engineer. */
 "Add a New Contact" = "新增聯絡人";
 
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
+
+/* Usernames */
+"Add at least %@ Dash to your Shielded balance" = "向您的遮蔽餘額至少加入 %@ Dash";
+
+/* Usernames */
+"Add to your Shielded balance now and register your username privately a few hours later" = "現在向遮蔽餘額加入資金，數小時後再私密地註冊用戶名稱";
 
 /* Wallets */
 "Add Wallet" = "Add Wallet";
@@ -227,6 +281,10 @@
 /* No comment provided by engineer. */
 "All" = "所有";
 
+"All nodes at once" = "所有節點一次投票";
+
+"All of your masternodes have voted on this username. To change a vote, vote again from the contender you now prefer." = "您的所有主節點都已為此用戶名稱投票。若要變更選票，請從您現在支持的申請者處再次投票。";
+
 /* CSV Export */
 "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system." = "All payments will be considered as an expense and all incoming transactions will be income.\nThe owner of this wallet is responsible for making any cost basis adjustments in their chosen tax reporting system.";
 
@@ -244,6 +302,9 @@
 
 /* ZenLedger */
 "Allow sending all transactions from Dash Wallet to Zenledger?" = "允許將所有交易從達世幣錢包發送到 Zenledger 嗎？";
+
+/* Balance info sheet */
+"Almost instantaneous to sync balances" = "餘額同步幾乎即時完成";
 
 /* DashPay Contacts */
 "Already a contact" = "Already a contact";
@@ -266,8 +327,14 @@
 /* Maya */
 "Amount too small to cover fees" = "Amount too small to cover fees";
 
+/* Balance info sheet */
+"Amounts and addresses are public on the blockchain" = "金額和位址在區塊鏈上是公開的";
+
 /* No comment provided by engineer. */
 "An error occurred" = "發生錯誤";
+
+/* DashPay FAQ */
+"An Ethereum account is one reusable address: your entire balance and payment history sit publicly under it, and a name (like an ENS domain) typically points straight at that address for anyone to resolve. DashPay is the opposite shape — the name resolves to an identity, not a payment address, and actual payment addresses stay inside encrypted contact exchanges, fresh for each contact." = "以太坊帳戶是一個可重複使用的位址：您的全部餘額和支付紀錄都公開地歸於它之下，而一個名稱（例如 ENS 網域）通常直接指向該位址，任何人都能解析。DashPay 的結構恰好相反——名稱解析到的是身分，而不是支付位址，真正的支付位址保留在加密的聯絡人交換中，且對每位聯絡人都是全新的。";
 
 /* No comment provided by engineer. */
 "An intuitive and familiar experience across all your devices" = "跨所有設備的直觀熟悉的體驗";
@@ -280,6 +347,9 @@
 
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超20個字符或包含2-9個數字，或含有連字符的用戶名稱，將會自動批准";
+
+/* Balance info sheet */
+"Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";
 
 /* AboutDash */
 "App version" = "App version";
@@ -296,6 +366,10 @@
 /* No comment provided by engineer. */
 "Apply" = "應用";
 
+"Approve" = "核准";
+
+"Approving a specific request can only be done one username at a time." = "核准特定申請一次只能針對一個用戶名稱。";
+
 /* Coinbase/Buy Dash/Cancel Order     */
 "Are you sure you want to cancel this order?" = "您確定要取消此訂單嗎?";
 
@@ -310,6 +384,9 @@
 
 /* DashSpend */
 "As soon as your code is generated, it will be displayed here" = "As soon as your code is generated, it will be displayed here";
+
+/* Raw transaction inspector */
+"As text" = "以文字顯示";
 
 /* DashSpend */
 "at" = "在";
@@ -329,10 +406,14 @@
 /* DashSpend/Maya */
 "Authentication cancelled" = "Authentication cancelled";
 
+"Authentication cancelled. Your vote was not cast." = "已取消驗證。您的選票未被投出。";
+
 /* DashPay
    DashPay identity registration
    InternalTransfer */
 "Authentication failed" = "Authentication failed";
+
+"Authentication failed. Your vote was not cast." = "驗證失敗。您的選票未被投出。";
 
 /* No comment provided by engineer. */
 "Authentication is unvailable" = "身份驗證不可用";
@@ -354,6 +435,8 @@
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
+
+"Award “%@” to this contender" = "將「%@」授予此申請者";
 
 /* Dash DEX */
 "Back home" = "Back home";
@@ -386,10 +469,16 @@
 "Balance" = "餘額";
 
 /* CrowdNode */
+"Balance after" = "之後餘額";
+
+/* CrowdNode */
 "Balance On CrowdNode" = "CrowdNode 上的餘額";
 
 /* CrowdNode */
 "Balance: " = "結餘: ";
+
+/* Balance info sheet */
+"Balances and transfers are not publicly visible" = "餘額和轉帳不會公開可見";
 
 /* Coinbase/Payment Methods */
 "Bank Account" = "銀行賬戶";
@@ -418,6 +507,9 @@
 /* No comment provided by engineer. */
 "Biometrics Access Required" = "需要生物識別訪問權限";
 
+/* SPV diagnostics */
+"Birth height saved — the raised scan floor applies from the next launch." = "已儲存起始區塊高度——提高後的掃描下限將從下次啟動開始生效。";
+
 /* Voting */
 "Block" = "區塊";
 
@@ -433,11 +525,22 @@
 /* Voting */
 "Blocked '%@' username" = "阻止了 '%@' 用戶名";
 
+/* Identities: this key only signs for one data contract */
+"Bound to contract" = "綁定至合約";
+
+/* Identities: this key only signs one document type of one data contract */
+"Bound to contract, document type “%@”" = "綁定至合約，文件類型「%@」";
+
 /* No comment provided by engineer. */
 "Broadcasting" = "Broadcasting";
 
+"Browsing only" = "僅供瀏覽";
+
 /* InternalTransfer recovery */
 "Building the privacy proof can take up to a minute. Keep the app open." = "Building the privacy proof can take up to a minute. Keep the app open.";
+
+/* Log export */
+"Bundle recent diagnostic logs into a zip to AirDrop, mail, or save to Files" = "將最近的診斷紀錄打包為 zip，以便透過 AirDrop、郵件發送或儲存到「檔案」";
 
 /* Buy
    buy */
@@ -518,8 +621,13 @@
 /* DashSpend */
 "Cashier instructions" = "Cashier instructions";
 
+"Cast vote" = "投出選票";
+
 /* DashSpend */
 "Challenge" = "Challenge";
+
+/* SPV sync */
+"Change peers" = "更換節點";
 
 /* No comment provided by engineer. */
 "Change PIN" = "更改密碼";
@@ -536,14 +644,30 @@
 /* Dash DEX */
 "Checking amount…" = "Checking amount…";
 
+"Checking…" = "正在檢查…";
+
+"Choice" = "選擇";
+
 /* Choose your Dash username */
 "Choose your" = "選擇你的";
 
 /* No comment provided by engineer. */
 "Choose Your Username" = "選擇你的用戶名";
 
+/* DashPay Invitations */
+"Claim your invitation" = "領取您的邀請";
+
+/* No comment provided by engineer. */
+"Claimable balance" = "可領取餘額";
+
 /* No comment provided by engineer. */
 "Claimed" = "已被認領";
+
+/* SPV diagnostics */
+"Clear & resync" = "清除並重新同步";
+
+/* SPV diagnostics */
+"Clear chain data and resync?" = "要清除鏈資料並重新同步嗎？";
 
 /* Maya */
 "Clipboard" = "Clipboard";
@@ -560,8 +684,13 @@
 /* No comment provided by engineer. */
 "Close App" = "關閉程序";
 
+"Closing" = "即將結束";
+
 /* Dash Portal */
 "Coinbase" = "Coinbase";
+
+/* Raw transaction inspector */
+"Coinbase (new coins)" = "Coinbase（新幣）";
 
 /* Coinbase Two Factor Auth */
 "Coinbase 2FA code" = "Coinbase 兩步認證代碼";
@@ -573,7 +702,19 @@
 "CoinJoin is no longer supported" = "CoinJoin is no longer supported";
 
 /* CoinJoin */
+"CoinJoin is no longer supported — choose where to move your mixed coins." = "CoinJoin 已不再支援——請選擇將已混合資金轉移到何處。";
+
+/* CoinJoin */
 "CoinJoin Withdrawals" = "CoinJoin Withdrawals";
+
+/* Masternodes */
+"Collateral" = "抵押";
+
+/* DashPay intro: feature title */
+"Coming soon" = "即將推出";
+
+/* Shielded transfer status */
+"Completed" = "已完成";
 
 /* No comment provided by engineer. */
 "Confirm" = "確認:";
@@ -587,6 +728,11 @@
 /* No comment provided by engineer. */
 "Confirm Platform Send" = "Confirm Platform Send";
 
+/* SPV diagnostics */
+"Confirmed" = "已確認";
+
+"Confirming saves birth height %u and clears this network's chain data at the next app launch, re-downloading it and rescanning filters from that height. The running session keeps its old scan floor — quit and reopen the app to start." = "確認後將儲存起始區塊高度 %u，並在下次啟動應用程式時清除該網絡的鏈資料，重新下載並從該高度重新掃描過濾器。目前的工作階段仍沿用舊的掃描下限——結束並重新開啟應用程式即可開始。";
+
 /* ZenLedger */
 "Connect your crypto wallets to the ZenLedger platform. Learn more and get started with your Dash Wallet transactions." = "將您的加密錢包連接到 ZenLedger 平台。了解更多並開始使用您的達世幣錢包交易。";
 
@@ -597,6 +743,9 @@
 /* CrowdNode */
 "Connected Dash address" = "連接的達世幣位址";
 
+/* SPV sync */
+"Connected peers" = "已連線節點";
+
 /* About screen tech info: SPV state */
 "connecting" = "connecting";
 
@@ -605,6 +754,9 @@
 
 /* DashSpend */
 "Connection Error" = "Connection Error";
+
+/* Balance info sheet section */
+"Cons" = "缺點";
 
 /* DashSpend */
 "Contact %@ Support" = "Contact %@ Support";
@@ -616,6 +768,9 @@
 /* Maya */
 "Contact Maya Support" = "Contact Maya Support";
 
+/* DashPay Invitations */
+"Contact request failed" = "聯繫請求失敗";
+
 /* DashPay */
 "Contact request not found" = "Contact request not found";
 
@@ -624,6 +779,12 @@
 
 /* DashPay Contacts */
 "Contact request sent" = "Contact request sent";
+
+/* DashPay Contacts: success card after sending a request */
+"Contact request sent to %@" = "已向 %@ 發送聯繫請求";
+
+/* No comment provided by engineer. */
+"Contact Requests" = "聯繫請求";
 
 /* DashPay Contacts */
 "Contact Requests (%d)" = "Contact Requests (%d)";
@@ -637,11 +798,16 @@
 /* No comment provided by engineer. */
 "Contacts" = "通訊錄";
 
+"Contender %@" = "申請者 %@";
+
 /* Usernames */
 "Contested name" = "Contested name";
 
 /* No comment provided by engineer. */
 "Continue" = "繼續";
+
+/* DashPay Invitations */
+"Continue to pick your username. The invitation pays the registration fee." = "繼續以選擇您的用戶名稱。邀請將支付註冊費用。";
 
 /* Maya */
 "Conversion failed" = "Conversion failed";
@@ -670,6 +836,9 @@
 /* No comment provided by engineer. */
 "Copy Invitation Link" = "複製邀請鏈接";
 
+/* Raw transaction inspector */
+"Copy Raw Transaction" = "複製原始交易";
+
 /* No comment provided by engineer. */
 "Copy text" = "複製文字";
 
@@ -682,6 +851,9 @@
 /* No comment provided by engineer. */
 "Could not automatically recover missing or incorrect words" = "無法自動恢復遺漏或不正確的單詞";
 
+/* Log export */
+"Could not create the log archive: %@" = "無法建立紀錄封存檔：%@";
+
 /* No comment provided by engineer. */
 "Could not find exchange rate." = "無法找到匯率";
 
@@ -691,6 +863,9 @@
 /* SwapKit */
 "Could not load Buy Dash options — please check your connection and try again" = "Could not load Buy Dash options — please check your connection and try again";
 
+/* Identities */
+"Could not refresh %d identities" = "無法重新整理 %d 個身分";
+
 /* Wallets */
 "Could not rename this wallet." = "Could not rename this wallet.";
 
@@ -699,6 +874,9 @@
 
 /* InternalTransfer */
 "Could not resolve a destination wallet address" = "Could not resolve a destination wallet address";
+
+/* Masternodes */
+"Couldn't fetch the balance (network error). Try Refresh." = "無法取得餘額（網絡錯誤）。請嘗試重新整理。";
 
 /* No comment provided by engineer. */
 "Couldn't make payment" = "無法進行支付";
@@ -749,8 +927,14 @@
 /* Usernames */
 "Create your username" = "建立您的用戶名";
 
+/* No comment provided by engineer. */
+"Create your Username, find friends & family with their usernames and add them to your contacts" = "建立您的用戶名稱，透過用戶名稱找到親友並將他們加入聯絡人";
+
 /* Coinbase/Payment Methods */
 "Credit Card" = "信用卡";
+
+/* Masternodes */
+"Credits" = "積分";
 
 /* Translate it as short as possible! (24 symbols max) */
 "CrowdNode" = "CrowdNode";
@@ -828,11 +1012,23 @@
 /* No comment provided by engineer. */
 "Dash payments can't be less than %@" = "達世幣付款不能低於 %@";
 
+"Dash Platform has not indexed this contest yet. Vote counts appear here once it does." = "Dash Platform 尚未索引此次爭奪。索引完成後，票數將顯示在這裡。";
+
+"Dash Platform is not connected yet. Wait for syncing to finish and try again." = "Dash Platform 尚未連線。請等待同步完成後重試。";
+
+/* Send confirm sheet */
+"Dash sent to a wrong address can't be recovered. Make sure the address is exactly the one you intend to pay." = "發送到錯誤位址的 Dash 無法找回。請確認位址與您要支付的位址完全一致。";
+
+"Dash stores usernames in a look-alike-safe form, so the stored name can differ from what each person typed." = "Dash 以防形似的形式儲存用戶名稱，因此儲存的名稱可能與每個人輸入的內容不同。";
+
 /* No comment provided by engineer. */
 "Dash username" = "達世幣用戶名";
 
 /* DashSpend confirmation */
 "Dash Wallet" = "達世幣錢包";
+
+/* CoinJoin */
+"Dash Wallet balance" = "Dash 錢包餘額";
 
 /* AboutDash */
 "Dash Wallet is an open sourced app forked from Bitcoin Wallet" = "Dash Wallet is an open sourced app forked from Bitcoin Wallet";
@@ -840,8 +1036,20 @@
 /* Buy Dash */
 "Dash Wallet on this device" = "此設備上的達世幣錢包";
 
+/* DashPay */
+"DashPay" = "DashPay";
+
+/* DashPay: title of the enable success sheet */
+"DashPay enabled" = "DashPay 已啟用";
+
 /* No comment provided by engineer. */
 "DashPay Invitation" = "DashPay 邀請函";
+
+/* DashPay FAQ */
+"DashPay is Dash's social payments experience, built on Dash Platform. You register a username, add other users as contacts, and pay them by name — no more copying addresses." = "DashPay 是建構在 Dash Platform 上的 Dash 社交支付體驗。您可以註冊用戶名稱、將其他用戶加入聯絡人，並按名稱向他們付款——不必再複製位址。";
+
+/* DashPay intro: pitch paragraph */
+"DashPay replaces long cryptic addresses with usernames. Add friends as contacts, send money to a name, and keep every payment organized by person." = "DashPay 用用戶名稱取代冗長難懂的位址。將好友加入聯絡人，向一個名稱匯款，並按人整理每一筆支付。";
 
 /* No comment provided by engineer. */
 "DashPay Upgrade Fee" = "DashPay 升級費";
@@ -860,6 +1068,8 @@
 
 /* Voting */
 "Date: Old to new" = "日期：從舊到新";
+
+"Deadline unknown" = "截止時間不明";
 
 /* DashSpend */
 "Decrease quantity" = "Decrease quantity";
@@ -895,6 +1105,9 @@
 /* CrowdNode */
 "Deposit sent" = "存款已發送";
 
+/* Identities: BIP-32 style derivation path of this key */
+"Derivation path" = "衍生路徑";
+
 /* No comment provided by engineer. */
 "Destination" = "Destination";
 
@@ -906,6 +1119,9 @@
 
 /* No comment provided by engineer. */
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "設備的安全性已經受到損害\n任何'越獄'的應用程序可以訪問任何其他應用程序的數據鑰匙扣 (和竊取你的達世幣的)。立即清除這個錢包並在安全的裝置上恢復數據。";
+
+/* Identities: this identity key was disabled on Platform */
+"Disabled" = "已停用";
 
 /* Coinbase Entry Point */
 "Disconnect Coinbase Account" = "斷開 Coinbase 帳戶的連接";
@@ -938,11 +1154,17 @@
 /* No comment provided by engineer. */
 "Done" = "完成";
 
+/* Usernames */
+"Done — your balance has rested long enough" = "完成——您的餘額已靜置足夠長的時間";
+
 /* DashSpend */
 "Double tap to change quantity" = "Double tap to change quantity";
 
 /* SegmentedControl */
 "Double tap to select" = "Double tap to select";
+
+/* Send confirm sheet */
+"Double-check the address" = "請再次核對位址";
 
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
@@ -966,6 +1188,10 @@
 /* No comment provided by engineer. */
 "Each invitation will be funded with this amount so that the receiver can quickly create their username on the Dash Network" = "每個邀請都將獲得該金額的資助，以便接收者可以在達世幣網絡上快速創建他們的用戶名";
 
+"Each masternode has one live vote per contest. You can change it later, but Dash Platform allows only 5 votes in total per masternode per contest." = "每個主節點在每次爭奪中擁有一張有效選票。您之後可以變更，但 Dash Platform 在每次爭奪中每個主節點總共只允許 5 次投票。";
+
+"Each tap votes with one more node, so you choose how many to link together." = "每點一下就多一個節點參與投票，因此您可以決定關聯多少個節點。";
+
 /* (List of notifications happened) Earlier (some time ago) */
 "Earlier" = "之前";
 
@@ -974,6 +1200,9 @@
 
 /* No comment provided by engineer. */
 "Easily stake Dash and earn passive income with a few simple clicks." = "只需點擊幾下，即可輕鬆質押達世幣並賺取被動收入。";
+
+/* SPV diagnostics */
+"Edit birth height" = "編輯起始區塊高度";
 
 /* No comment provided by engineer. */
 "Edit Profile" = "編輯個人資料";
@@ -990,11 +1219,22 @@
 /* CrowdNode */
 "Email" = "電子郵件";
 
+/* DashPay: confirm button of the Enable DashPay sheet */
+"Enable" = "啟用";
+
+/* DashPay: add the identity keys other users need to send contact requests */
+"Enable DashPay" = "啟用 DashPay";
+
 /* No comment provided by engineer. */
 "Enable Face ID" = "啟用 Face ID";
 
 /* No comment provided by engineer. */
 "Enable Touch ID" = "啟用Touch ID";
+
+/* DashPay FAQ */
+"Enabling DashPay costs a small one-time network fee, paid from your identity's credit balance. The exact estimate is shown before you confirm. Sending contact requests and payments costs the usual network fees." = "啟用 DashPay 需要一筆小額的一次性網絡費用，從您身分的積分餘額中支付。確認前會顯示確切的預估金額。發送聯繫請求和支付則收取通常的網絡費用。";
+
+"Ending soonest" = "最早結束";
 
 /* Swap */
 "Enter a valid %@ address. %@ here is on %@, so an Ethereum (0x…) address won’t work." = "Enter a valid %1$@ address. %2$@ here is on %3$@, so an Ethereum (0x…) address won’t work.";
@@ -1056,6 +1296,17 @@
 /* No comment provided by engineer. */
 "Error updating your profile" = "更新您的個人資料時出錯";
 
+/* DashPay: fee line of the Enable DashPay confirmation */
+"Estimated network fee" = "預估網絡費用";
+
+"Every node votes together. Faster, but it publicly links your masternodes to each other." = "所有節點一起投票。速度更快，但會公開地將您的各個主節點關聯起來。";
+
+/* SPV sync peer type */
+"Evonode" = "Evonode";
+
+/* Masternode keys */
+"Evonode Operator keys" = "Evonode 操作者鑰匙";
+
 /* Maya */
 "Exchange rate not available" = "Exchange rate not available";
 
@@ -1074,11 +1325,20 @@
 /* No comment provided by engineer. */
 "Export CSV" = "匯出 CSV";
 
+/* Log export */
+"Export Logs" = "匯出紀錄";
+
 /* Extended public key (BIP44) */
 "Extended public key (BIP44)" = "擴展公鑰（BIP44）";
 
 /* No comment provided by engineer. */
+"External address" = "外部位址";
+
+/* No comment provided by engineer. */
 "Face ID limit" = "Face ID 解鎖的限制";
+
+/* No comment provided by engineer. */
+"Failed" = "失敗";
 
 /* No comment provided by engineer. */
 "Failed to load barcode" = "無法加載條形碼";
@@ -1113,11 +1373,17 @@
 /* Balance */
 "Fetching rates…" = "正在獲取滙率...";
 
+/* Masternodes */
+"Fetching…" = "取得中…";
+
 /* Coinbase/Payment Methods */
 "Fiat Account" = "法幣賬戶";
 
 /* No comment provided by engineer. */
 "Filter" = "篩選";
+
+/* SPV sync phase */
+"Filter headers" = "過濾器區塊標頭";
 
 /* No comment provided by engineer. */
 "Filter transactions" = "過濾交易";
@@ -1137,11 +1403,17 @@
 /* DashPay Contacts */
 "Find a user and add them to your contacts." = "Find a user and add them to your contacts.";
 
+/* No comment provided by engineer. */
+"Find a user on the Dash Network" = "在 Dash 網絡上尋找用戶";
+
 /* Explore Dash */
 "Find ATMs where you can buy or sell Dash" = "Find ATMs where you can buy or sell Dash";
 
 /* No comment provided by engineer. */
 "Find ATMs where you can buy or sell Dash." = "找到可以買賣達世幣的自動櫃員機。";
+
+/* Identities */
+"Find identities" = "尋找身分";
 
 /* Explore Dash */
 "Find merchants that accept Dash payments" = "Find merchants that accept Dash payments";
@@ -1191,6 +1463,12 @@
 /* No comment provided by engineer. */
 "Forgot PIN?" = "忘記密碼了嗎?";
 
+/* Identities */
+"Found %d new identities" = "找到 %d 個新身分";
+
+/* Identities */
+"Found 1 new identity" = "找到 1 個新身分";
+
 /* No comment provided by engineer. */
 "Found missing word:\n%@" = "找到遺漏的單詞:\n%@";
 
@@ -1239,6 +1517,18 @@
 /* SPV diagnostics */
 "Full rescan (from 0) — slow" = "Full rescan (from 0) — slow";
 
+/* Usernames */
+"Fund your username from your Shielded balance. Add funds a few hours ahead — the short rest keeps your username unlinkable to your other Dash." = "用您的遮蔽餘額為用戶名稱提供資金。請提前幾個小時加入資金——短暫的靜置可讓您的用戶名稱無法與您的其他 Dash 關聯。";
+
+/* Usernames */
+"Funded from your Shielded balance — your username can't be linked to your other Dash." = "已由您的遮蔽餘額提供資金——您的用戶名稱無法與您的其他 Dash 關聯。";
+
+/* Shielded transfer status */
+"Funds locked — finishing transfer" = "資金已鎖定——正在完成轉帳";
+
+/* CoinJoin */
+"Funds moved" = "資金已轉移";
+
 /* CrowdNode */
 "Gain rewards from deposits in Dash Masternodes with as little as 0.5 Dash." = "只需 0.5 Dash，即可從達世幣主節點中的存款中獲得獎勵。";
 
@@ -1253,6 +1543,9 @@
 
 /* Coinbase/Convert Crypto */
 "Get Quote" = "獲得報價";
+
+/* Usernames */
+"Get ready to join DashPay" = "準備加入 DashPay";
 
 /* CrowdNode */
 "Get Rewards Instantly" = "立即獲得獎勵";
@@ -1303,16 +1596,35 @@
 "Google Pay" = "Google Pay";
 
 /* No comment provided by engineer. */
+"Got it" = "知道了";
+
+/* Governance */
+"Governance" = "治理";
+
+/* No comment provided by engineer. */
 "Grant GPS permissions so we can show you locations near you." = "授予 GPS 權限，以便我們向您顯示您附近的位置。";
 
 /* Voting */
 "Has blocked votes" = "已阻止了投票";
+
+/* Username has requested to be your friend */
+"has requested to be your friend" = "請求成為您的好友";
+
+/* DashPay Invitations */
+"Have an invitation?" = "有邀請嗎？";
 
 /* No comment provided by engineer. */
 "Have complete control and customize your wallet based on your needs" = "能夠讓您完全控制並根據您的個人需要自定義錢包";
 
 /* No comment provided by engineer. */
 "header #%d of %d" = "標頭 #%1$d of %2$d";
+
+/* SPV sync phase */
+"Headers" = "區塊標頭";
+
+/* DashPay Contacts */
+/* Masternodes */
+"Height %u" = "高度 %u";
 
 /* CrowdNode */
 "Here is a Dash address designated for your CrowdNode account in the Dash Wallet on this device" = "這是在此設備上的達世幣錢包中為您的 CrowdNode 帳戶指定的達世幣位址。";
@@ -1332,6 +1644,9 @@
 /* Voting */
 "High to low" = "從高到低";
 
+/* Balance info sheet */
+"Higher fees around 7 cents (still lower than other blockchains offering similar privacy)" = "費用較高，約 7 美分（仍低於提供類似隱私保護的其他區塊鏈）";
+
 /* No comment provided by engineer. */
 "History" = "歷史";
 
@@ -1343,6 +1658,15 @@
 
 /* No comment provided by engineer. */
 "How do I get Test Dash?" = "如何才能索取測試的達世幣?";
+
+/* DashPay FAQ */
+"How does this compare to Bitcoin in terms of privacy?" = "在隱私方面，這與比特幣相比如何？";
+
+/* DashPay FAQ */
+"How does this compare to Ethereum Accounts in terms of privacy?" = "在隱私方面，這與以太坊帳戶相比如何？";
+
+/* DashPay FAQ */
+"How private is DashPay?" = "DashPay 的隱私性如何？";
 
 /* CrowdNode */
 "How to confirm your API Dash address" = "如何確認您的 API 達世幣位址";
@@ -1380,14 +1704,29 @@
 /* No comment provided by engineer. */
 "I wrote it down" = "我寫下來";
 
+/* Identities */
+"Identities" = "身分";
+
 /* Voting */
 "Identity" = "身分";
+
+/* Destination of an identity funding asset lock */
+"Identity credits" = "身分積分";
 
 /* SDK identity profile sheet */
 "Identity ID" = "Identity ID";
 
+/* Identities */
+"Identity index" = "身分索引";
+
+/* Asset lock funding a DashPay identity registration */
+"Identity registration" = "身分註冊";
+
 /* DashPay */
 "Identity registration already in progress" = "Identity registration already in progress";
+
+/* Asset lock topping up a DashPay identity's credits */
+"Identity top-up" = "身分儲值";
 
 /* About screen tech info: SPV state */
 "idle" = "idle";
@@ -1462,6 +1801,10 @@
 "In the payment section of your checkout, select \"gift card\" and enter your card number and pin." = "在結帳的付款部分中，選擇“禮品卡”，然後輸入您的卡號和密碼。";
 
 /* No comment provided by engineer. */
+/* Masternode status */
+"Inactive" = "未啟用";
+
+/* No comment provided by engineer. */
 "Income" = "收入";
 
 /* DashSpend */
@@ -1472,6 +1815,15 @@
 
 /* Buy Sell Portal */
 "Initializing" = "正在初始化";
+
+/* Raw transaction inspector */
+"Input %d" = "輸入 %d";
+
+/* Raw transaction inspector */
+"Input %d — outpoint" = "輸入 %d — 輸出點";
+
+/* Raw transaction inspector */
+"Inputs (%d)" = "輸入 (%d)";
 
 /* No comment provided by engineer. */
 "Insufficient funds" = "餘額不足";
@@ -1548,6 +1900,9 @@
 /* No comment provided by engineer. */
 "Invitation Fee" = "邀請費";
 
+/* DashPay Invitations */
+"Invitation from %@" = "來自 %@ 的邀請";
+
 /* No comment provided by engineer. */
 "Invitation used by" = "邀請己被使用";
 
@@ -1556,6 +1911,9 @@
 
 /* No comment provided by engineer. */
 "Invite" = "邀請";
+
+/* No comment provided by engineer. */
+"Invite Someone to join the Dash Network" = "邀請他人加入 Dash 網絡";
 
 /* No comment provided by engineer. */
 "Invite your family, find your friends by searching their usernames" = "邀請您的家人，通過搜索用戶名來找到您的朋友";
@@ -1568,6 +1926,9 @@
 
 /* No comment provided by engineer. */
 "Invite your friends and family to join the Dash Network." = "邀請您的朋友和家人加入達世幣網絡。";
+
+/* No comment provided by engineer. */
+"Invite your friends and family to the Dash Network" = "邀請您的親友加入 Dash 網絡";
 
 /* No comment provided by engineer. */
 "iOS Dash Wallet: %@ Reported issue" = "iOS 達世幣錢包: %@ 已報告的問題";
@@ -1608,14 +1969,30 @@
 /* CrowdNode */
 "Joining the pool" = "加入資金池";
 
+/* CoinJoin */
+"Keep these coins private. Network and privacy fees apply." = "讓這些幣保持私密。將收取網絡與隱私費用。";
+
 /* No comment provided by engineer. */
 "Keep Wallet" = "Keep Wallet";
 
 /* Usernames */
 "Keep your passphrase safe" = "確保您的密語安全";
 
+/* Identities: one identity public key, by its DPP key id */
+"Key #%d" = "鑰匙 #%d";
+
+/* Identities: the public key bytes */
+"Key data" = "鑰匙資料";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Key ownership" = "鑰匙歸屬";
+
 /* No comment provided by engineer. */
 "Keypair" = "密鑰對";
+
+/* Masternodes */
+"Keys" = "鑰匙";
 
 /* Explore Dash */
 "Last device sync" = "上一次設備同步";
@@ -1633,8 +2010,13 @@
 /* CoinJoin */
 "Later" = "Later";
 
+"Leading" = "領先";
+
 /* Maya */
 "Learn more" = "Learn more";
+
+/* DashPay intro: opens the FAQ */
+"Learn More" = "了解更多";
 
 /* Info Screen */
 "Learn More..." = "了解更多...";
@@ -1693,6 +2075,9 @@
 /* Dash DEX */
 "Loading rates…" = "Loading rates…";
 
+/* Home */
+"Loading transactions" = "正在載入交易";
+
 /* Maya */
 "Loading..." = "Loading...";
 
@@ -1702,17 +2087,31 @@
 /* Translate it as short as possible! (24 symbols max) */
 "Local Currency" = "本地貨幣";
 
+/* Identities */
+"Local Only" = "僅限本機";
+
 /* No comment provided by engineer. */
 "Local requested amount: %@" = "本地請求金額: %@";
 
 /* Explore Dash/Merchants/Filters */
 "Location" = "位置";
 
+"Lock" = "鎖定";
+
+"Lock the name" = "鎖定該名稱";
+
+"Lock “%@” so nobody gets it" = "鎖定「%@」，使任何人都無法取得";
+
 /* No comment provided by engineer. */
 "Locked" = "己鎖定";
 
+"Locked — nobody receives this username" = "已鎖定——任何人都無法取得此用戶名稱";
+
 /* No comment provided by engineer. */
 "Locking funds" = "Locking funds";
+
+/* Raw transaction inspector */
+"Locktime" = "鎖定時間";
 
 /* Log in */
 "Log in" = "登入";
@@ -1762,8 +2161,14 @@
 /* adjective, security level */
 "Low" = "低";
 
+/* Balance info sheet */
+"Low fees for everyday spending" = "日常消費費用低廉";
+
 /* Voting */
 "Low to high" = "從低到高";
+
+/* Identities — the wallet's main identity */
+"Main" = "主要";
 
 /* No comment provided by engineer. */
 "Mainnet" = "主網";
@@ -1784,7 +2189,14 @@
 "Masternode IP address" = "主節點IP位址";
 
 /* Masternode keys */
+/* Tools menu */
+"Masternode Keychain" = "主節點鑰匙圈";
+
+/* Masternode keys */
 "Masternode keys" = "主節點鑰匙";
+
+/* SPV sync phase */
+"Masternode list" = "主節點清單";
 
 /* No comment provided by engineer. */
 "masternode list #%d of %d" = "%2$d 中 #%1$d 的主節點列表 ";
@@ -1807,8 +2219,21 @@
 /* No comment provided by engineer. */
 "Masternode Update" = "主節點更新";
 
+"Masternode votes" = "主節點票數";
+
 /* Voting */
 "Masternode Voting Key" = "主節點投票金鑰";
+
+/* Tools menu */
+"Masternodes" = "主節點";
+
+/* Masternodes */
+"Masternodes and evonodes registered with this wallet's keys will appear here after the wallet syncs." = "使用此錢包鑰匙註冊的主節點和 Evonode 將在錢包同步後顯示在這裡。";
+
+/* Masternodes */
+"Masternodes and evonodes using this wallet's keys" = "使用此錢包鑰匙的主節點和 Evonode";
+
+"Masternodes vote on names more than one person requested. You will be notified when voting ends." = "主節點會為多人申請的名稱投票。投票結束時我們會通知您。";
 
 /* Contracted variant of 'Maximum' word */
 "Max" = "最大值";
@@ -1847,6 +2272,9 @@
 /* DashSpend */
 "Min: %@" = "最少: %@";
 
+/* Usernames */
+"Minimum met" = "已達最低要求";
+
 /* Transaction type: coinbase/masternode mining reward */
 "Mining Reward" = "Mining Reward";
 
@@ -1866,6 +2294,13 @@
 "More Control" = "更多控制選項";
 
 /* No comment provided by engineer. */
+"More Suggestions" = "更多建議";
+
+"Most lock votes" = "鎖定票最多";
+
+"Most votes" = "得票最多";
+
+/* No comment provided by engineer. */
 "Move and Zoom your photo to find the perfect fit" = "移動和縮放您的照片以找到最適當的效果";
 
 /* CoinJoin */
@@ -1873,6 +2308,9 @@
 
 /* CoinJoin */
 "Move funds" = "Move funds";
+
+/* CoinJoin */
+"Move to your regular spendable balance." = "轉入您的一般可用餘額。";
 
 /* CoinJoin */
 "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported." = "Move your %@ in mixed coins to your spendable balance? CoinJoin is no longer supported.";
@@ -1885,6 +2323,9 @@
 
 /* No comment provided by engineer. */
 "Moved to Address" = "移至位址";
+
+/* CoinJoin */
+"Moving funds" = "正在轉移資金";
 
 /* DashSpend */
 "Multiple" = "Multiple";
@@ -1904,6 +2345,9 @@
 /* No comment provided by engineer. */
 "Name" = "名稱";
 
+/* DashPay FAQ */
+"Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Unstoppable Domains 之類的網域服務，會把一個便於閱讀的名稱對應到鏈上一個固定的公開位址。任何人都可以解析該名稱並查看曾向它支付的每一筆款項。DashPay 用戶名稱絕不會公開解析到支付位址——位址僅在與每位聯絡人的加密交換中揭露，因此您的名稱和資金在外部觀察者看來始終是不關聯的。";
+
 /* Swap route provider
    Swap route provider short */
 "NEAR" = "NEAR";
@@ -1913,6 +2357,8 @@
 
 /* Coinbase Two Factor Auth */
 "Need help? " = "需要幫忙嗎? ";
+
+"Needs attention" = "需要處理";
 
 /* No comment provided by engineer. */
 "Network" = "網絡";
@@ -1972,8 +2418,14 @@
 /* SwapKit */
 "No deposit address returned by SwapKit" = "No deposit address returned by SwapKit";
 
+/* Log export */
+"No diagnostic logs were found on this device. Logs are written from the next launch onward." = "此裝置上未找到診斷紀錄。紀錄將從下次啟動開始記錄。";
+
 /* No comment provided by engineer. */
 "No funded Platform address has enough balance to cover this amount plus fees." = "No funded Platform address has enough balance to cover this amount plus fees.";
+
+/* Identities */
+"No Identities" = "無身分";
 
 /* No connection */
 "No internet connection" = "No internet connection";
@@ -1982,7 +2434,22 @@
 "No locations found." = "No locations found.";
 
 /* local currency empty state */
+/* Masternodes */
+"No masternodes yet" = "尚無主節點";
+
+/* local currency empty state */
 "No matches for \"%@\"" = "No matches for \"%@\"";
+
+"No matching contests" = "沒有相符的爭奪";
+
+/* Identities */
+"No new identities were found for this wallet" = "未為此錢包找到新身分";
+
+"No open contest matches that search." = "沒有進行中的爭奪與該搜尋相符。";
+
+"No open contest matches that search. Names are stored in a normalized form, so “alice” is listed as “a11ce”." = "沒有進行中的爭奪與該搜尋相符。名稱以正規化形式儲存，因此「alice」會顯示為「a11ce」。";
+
+"No open contests" = "沒有進行中的爭奪";
 
 /* Coinbase/Buy Dash */
 "No payment methods" = "沒有付款方式";
@@ -1993,11 +2460,19 @@
 /* DashPay Contacts */
 "No payments with this contact yet" = "No payments with this contact yet";
 
+/* SPV diagnostics */
+"No persisted wallet row found for the bound wallet." = "未找到所綁定錢包的已儲存紀錄。";
+
+/* DashPay */
+"No Platform address is available yet for the shielded registration fallback. Try again after the wallet finishes syncing." = "尚無可用於遮蔽註冊備援的 Platform 位址。請在錢包完成同步後重試。";
+
 /* Explore Dash/Merchants/Filters */
 "No Results Found" = "未找到結果";
 
 /* SwapKit */
 "No route available" = "No route available";
+
+"No usernames are being contested right now. Contests open when two or more people request the same name." = "目前沒有用戶名稱處於爭奪狀態。當兩人或更多人申請同一個名稱時，就會開啟爭奪。";
 
 /* DashPay Contacts */
 "No usernames found" = "No usernames found";
@@ -2007,6 +2482,16 @@
 
 /* Voting */
 "No votes left" = "沒有剩餘選票";
+
+"No votes were cast" = "未投出任何選票";
+
+"Nobody gets it" = "無人取得";
+
+/* SPV sync peer type */
+"Node" = "節點";
+
+/* Raw transaction inspector */
+"Non-standard" = "非標準";
 
 /* adjective, security level */
 "None" = "沒有";
@@ -2026,11 +2511,36 @@
 /* Fiat amount */
 "Not available" = "無法使用";
 
+"Not available yet" = "尚無法使用";
+
+"Not cast" = "未投出";
+
+/* Masternodes */
+"Not checked yet" = "尚未檢查";
+
 /* Location Service Status */
 "Not Determined" = "尚未決定";
 
 /* DashPay */
 "Not enough Platform credits to register an identity" = "Not enough Platform credits to register an identity";
+
+/* DashPay */
+"Not enough shielded balance to register an identity" = "遮蔽餘額不足，無法註冊身分";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Not in wallet history" = "不在錢包紀錄中";
+
+"Not now" = "暫不";
+
+/* Balance info sheet */
+"Not widely accepted by merchants" = "商家接受度不高";
+
+/* Balance info sheet */
+"Not widely accepted by merchants yet" = "商家接受度尚不高";
+
+/* Masternode keys */
+"Not yet used" = "尚未使用";
 
 /* DashPay Contacts */
 "Note" = "Note";
@@ -2050,8 +2560,19 @@
 /* Voting */
 "Old to new" = "從舊到新";
 
+/* DashPay FAQ */
+"On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "比特幣沒有名稱層，所以人們公開地共享和重複使用位址——一旦某個位址為人所知，它曾收到的一切都可以與其擁有者關聯起來。在 DashPay 中，您的用戶名稱是公開的，但它絕不會指向支付位址：位址按聯絡人私下交換並會輪換，因此按名稱付款不會公開您的資金去向。兩者都是透明鏈，因此鏈上分析仍然適用於幣本身。";
+
+/* Identities */
+"On Network" = "在網絡上";
+
+/* Once <username> accepts your request... */
+"Once %@ accepts your request you can Pay Directly to Username" = "當 %@ 接受您的請求後，您就可以直接向用戶名稱付款";
+
 /* Dash DEX / dex_receive_description */
 "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet" = "Once the network confirms your transfer, we'll convert it to Dash and deposit it in your DashPay wallet";
+
+"One node at a time" = "每次一個節點";
 
 /* Voting */
 "One vote left" = "還剩一票";
@@ -2071,6 +2592,8 @@
 /* Voting */
 "Only duplicates" = "僅重複的項目";
 
+"Only masternodes and evonodes can vote on usernames. This wallet holds no active masternode voting keys." = "只有主節點和 Evonode 才能為用戶名稱投票。此錢包不含有效的主節點投票鑰匙。";
+
 /* No comment provided by engineer. */
 "Only requests with links" = "僅限帶有連結的請求";
 
@@ -2079,6 +2602,18 @@
 
 /* Voting */
 "Only with links" = "僅包含連結";
+
+/* Masternodes */
+"Operator" = "操作者";
+
+/* Masternode keys */
+"Operator keys" = "操作者鑰匙";
+
+/* Masternodes */
+"Operator public key (BLS)" = "操作者公鑰 (BLS)";
+
+/* No comment provided by engineer. */
+"or" = "或";
 
 /* Coinbase/Buy Dash/Confirm Order */
 "Order Preview" = "訂單預覽";
@@ -2089,14 +2624,37 @@
 /* DashSpend */
 "Original Price" = "Original Price";
 
+"Other outcomes" = "其他結果";
+
+/* Masternodes */
+"Outpoint" = "輸出點";
+
+/* Raw transaction inspector */
+"Output %d" = "輸出 %d";
+
+/* Raw transaction inspector */
+"Outputs (%d)" = "輸出 (%d)";
+
+/* Masternodes */
+"Owner" = "擁有者";
+
 /* No comment provided by engineer. */
 "Owner Address" = "所有者位址";
+
+/* Masternodes */
+"Owner address" = "擁有者位址";
+
+/* Masternodes */
+"Owner key hash" = "擁有者鑰匙雜湊";
 
 /* Owner keys */
 "Owner keys" = "所有者鑰匙";
 
 /* No comment provided by engineer. */
 "P2SH platform addresses aren't supported yet. Use a P2PKH recipient." = "P2SH platform addresses aren't supported yet. Use a P2PKH recipient.";
+
+/* DashPay: fee source note of the Enable DashPay confirmation */
+"Paid from your identity's credit balance." = "從您身分的積分餘額中支付。";
 
 /* DashSpend */
 "Password" = "密碼";
@@ -2106,6 +2664,9 @@
 
 /* Usernames */
 "Paste link here" = "粘貼鏈接在這裡";
+
+/* DashPay Invitations */
+"Paste the invitation link you received, or scan its QR code. It funds your username registration." = "貼上您收到的邀請連結，或掃描其 QR 碼。它將支付您的用戶名稱註冊費用。";
 
 /* No comment provided by engineer. */
 "Paste your image URL" = "貼上您的圖片網址";
@@ -2118,6 +2679,12 @@
 
 /* No comment provided by engineer. */
 "Pay and get paid instantly with easy to use payment flows" = "易於使用的付款流程，可立即付款並能即時確認付款";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Pay Directly to Username" = "直接向用戶名稱付款";
+
+/* DashPay intro: headline */
+"Pay people, not addresses" = "向人付款，而非向位址付款";
 
 /* No comment provided by engineer. */
 "Pay to usernames. No more alphanumeric addresses" = "以用戶名來支付。不再需要使用字母數字位址";
@@ -2146,6 +2713,9 @@
 /* 4 out of 4 in the Paying Animation */
 "Paying..." = "付款中...";
 
+/* Raw transaction inspector */
+"Payload hex" = "酬載十六進位";
+
 /* Coinbase/Buy Dash */
 "Payment method" = "付款方式";
 
@@ -2158,8 +2728,24 @@
 /* DashPay Contacts */
 "Payments" = "Payments";
 
+/* DashPay FAQ */
+"Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "支付是私密的：您與聯絡人交換的位址包含在只有你們兩人能讀取的加密酬載中，且從不公開——因此您的支付無法被輕易關聯到您的用戶名稱。不過它們仍是透明鏈上的普通支付：進階鏈上分析仍可能洩漏資訊。Shielded DashPay（即將推出）將彌補這一缺口。聯繫請求本身目前並不私密：任何人都能看到兩個身分之間存在關聯。私密聯繫請求是即將推出的功能。您的用戶名稱和個人資料在 Dash Platform 上同樣是公開的。";
+
+/* Balance info sheet */
+"Payments confirm in seconds with InstantSend" = "使用 InstantSend，支付幾秒內即可確認";
+
+/* No comment provided by engineer. */
+"Payments made directly to addresses won’t be retained in activity." = "直接向位址進行的支付不會保留在活動中。";
+
 /* DashPay Contacts */
 "Payments made directly to an address aren't retained here." = "Payments made directly to an address aren't retained here.";
+
+/* DashPay intro: feature body */
+"Payments with each contact are grouped in one place, with names and profiles instead of raw transactions." = "與每位聯絡人的支付都彙集在一處，顯示姓名和個人資料，而不是原始交易。";
+
+/* CrowdNode */
+/* Masternodes */
+"Payout address" = "收款位址";
 
 /* CrowdNode */
 "Payout Options" = "支付選項";
@@ -2206,11 +2792,31 @@
 /* Dash Platform chain */
 "Platform" = "Platform";
 
+/* Send screen destination type */
+"Platform address" = "Platform 位址";
+
+/* The Dash Platform credits balance */
+"Platform balance" = "Platform 餘額";
+
 /* SDK identity profile sheet */
 "Platform Credits" = "Platform Credits";
 
+/* Masternodes */
+"Platform node" = "Platform 節點";
+
+/* Masternode keys */
+"Platform Node ID" = "Platform 節點 ID";
+
 /* No comment provided by engineer. */
 "Platform Payment" = "Platform Payment";
+
+/* Masternodes */
+"Platform payments don't identify the sender. This payment was recorded when the wallet noticed the balance change — it may have arrived earlier." = "Platform 支付不會標明付款方。此筆支付是在錢包發現餘額變動時記錄的——實際入帳時間可能更早。";
+
+"Platform SDK not ready" = "Platform SDK 尚未就緒";
+
+/* No comment provided by engineer. */
+"Platform sync is not running. Open Sync Info → Platform Sync Status to start it." = "Platform 同步未在執行。請開啟「同步資訊 → Platform 同步狀態」以啟動它。";
 
 /* No comment provided by engineer. */
 "Platform sync is not running. Open Tools → Platform Sync Status to start it." = "Platform sync is not running. Open Tools → Platform Sync Status to start it.";
@@ -2220,6 +2826,9 @@
 
 /* InternalTransfer */
 "Platform wallet manager unavailable" = "Platform wallet manager unavailable";
+
+/* Coinbase/Buy Dash */
+"Platform → Shielded" = "Platform → 遮蔽";
 
 /* Coinbase/Buy Dash */
 "Please add a payment method on Coinbase" = "請在 Coinbase 上添加一種付款方式";
@@ -2299,6 +2908,9 @@
 /* No comment provided by engineer. */
 "Preview Invitation" = "預覽邀請";
 
+/* Masternode keys */
+"Previously used at: " = "上次使用於：";
+
 /* Stale rates */
 "Prices are at least 30 minutes old. Fiat values may be incorrect." = "價格至少有 30 分鐘延遲，所以相關的法幣的價值可能不正確。";
 
@@ -2314,11 +2926,38 @@
 /* No comment provided by engineer. */
 "Privacy tip" = "Privacy tip";
 
+/* Usernames */
+"Private by design" = "隱私源於設計";
+
+/* DashPay FAQ */
+"Private contact requests (so who you connect with stays private), Shielded DashPay — contact payments from your private Shielded balance — and paying users who aren't in your contacts yet are all coming soon." = "私密聯繫請求（讓您與誰建立聯繫保持私密）、Shielded DashPay——從您的私密遮蔽餘額向聯絡人付款——以及向尚未在您聯絡人中的用戶付款，均即將推出。";
+
+/* DashPay FAQ */
+"Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "私密聯繫請求正在開發中，預計在 2026 年 9 月至 10 月左右推出。目前請求本身是公開的——即使其中的支付資訊已加密，任何人仍能看到兩個身分之間存在關聯。私密聯繫請求推出後，您可以選擇讓這段好友關係公開或保持私密。";
+
+/* DashPay intro: coming-soon body */
+"Private contact requests, Shielded DashPay, and paying people who aren't contacts yet." = "私密聯繫請求、Shielded DashPay，以及向尚未成為聯絡人的用戶付款。";
+
 /* No comment provided by engineer. */
 "Private key" = "私鑰";
 
 /* No comment provided by engineer. */
 "Private key could not be decoded: %@" = "Private key could not be decoded: %@";
+
+/* DashPay intro: feature body */
+"Private payment addresses are exchanged between you and your contacts. Only you and your contact know the recipient and sender of payments between yourselves." = "私密支付位址在您與聯絡人之間交換。只有您和您的聯絡人知道你們之間支付的收款方和付款方。";
+
+/* DashPay intro: feature title */
+"Private payments" = "私密支付";
+
+/* Usernames */
+"Private registration" = "私密註冊";
+
+/* Platform → Transparent withdrawal */
+"Processing time" = "處理時間";
+
+/* Balance info sheet section */
+"Pros" = "優點";
 
 /* CrowdNode Portal */
 "Protect your savings" = "保護您的存款";
@@ -2329,6 +2968,18 @@
 /* No comment provided by engineer. */
 "Provider Address" = "提供者位址";
 
+/* Masternodes */
+"Provider transactions" = "提供者交易";
+
+/* Masternode keys */
+"Public key" = "公鑰";
+
+/* Masternode keys */
+"Public key (legacy)" = "公鑰（舊版）";
+
+/* Identities */
+"Public keys" = "公鑰";
+
 /* No comment provided by engineer. */
 "Public URL" = "公共網址";
 
@@ -2337,6 +2988,9 @@
 
 /* Alert title */
 "Purchase Failed" = "購買失敗";
+
+/* Identities: what a public key is used for */
+"Purpose" = "用途";
 
 /* DashSpend */
 "Quantity" = "Quantity";
@@ -2356,11 +3010,30 @@
 /* ex., Rate 1 US $ = 0.000009 Dash */
 "Rate: %@ = %@" = "比率: %1$@ = %2$@";
 
+/* Raw transaction inspector */
+"Raw transaction" = "原始交易";
+
+/* Raw transaction inspector */
+"Raw transaction unavailable" = "原始交易無法使用";
+
+/* SPV diagnostics */
+"Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. Rescans are floored at the wallet's creation height and at the locally stored chain data — to recover history below that, lower the wallet birth height instead." = "從所選高度開始，重新檢查精簡區塊過濾器中屬於此錢包的交易，重新下載並重新比對。重新掃描的下限為錢包的建立高度以及本機儲存的鏈資料——若要復原更早的紀錄，請改為降低錢包起始區塊高度。";
+
 /* SPV diagnostics */
 "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet." = "Re-checks the compact block filters from the chosen height for this wallet's transactions, re-downloading and re-matching them. This rediscovers any missed transactions but can take a while. Full rescan re-checks every filter since genesis and can take a long time on mainnet.";
 
 /* CrowdNode */
 "Read Withdrawal Policy" = "閱讀提款政策";
+
+/* Identities: key visible to the wallet but not usable for signing */
+"Read-only" = "唯讀";
+
+/* Usernames */
+"Ready around %@" = "約在 %@ 就緒";
+
+/* No comment provided by engineer. */
+/* Masternodes */
+"Reason" = "原因";
 
 /* No comment provided by engineer. */
 "Receive" = "接收";
@@ -2389,8 +3062,13 @@
 /* No comment provided by engineer. */
 "Received from" = "從......收到";
 
+/* DashPay payment row — sender's display name */
+"Received from %@" = "收自 %@";
+
 /* CrowdNode */
 "Receiving rewards" = "領取獎勵";
+
+"Records your masternodes as having voted, without taking a side." = "記錄您的主節點已投票，但不偏向任何一方。";
 
 /* No comment provided by engineer. */
 "Recover" = "恢復";
@@ -2411,6 +3089,10 @@
 "Recovery phrase must have 12, 15, 18, 21 or 24 words" = "恢復詞組必須包含 12, 15, 18, 21 或24 個字";
 
 /* Maya */
+/* Masternodes */
+"Refresh" = "重新整理";
+
+/* Maya */
 "Refresh quote" = "Refresh quote";
 
 /* Dash DEX / dex_refund_address_field_label */
@@ -2423,10 +3105,21 @@
 "Register?" = "要注冊嗎?";
 
 /* No comment provided by engineer. */
+/* Masternodes */
+"Registered at" = "註冊於";
+
+/* No comment provided by engineer. */
 "Registered from" = "從......註冊";
 
 /* No comment provided by engineer. */
 "Registered Masternode" = "已註冊的主節點";
+
+/* Usernames */
+"Registering privately takes at least %@ Dash in your Shielded balance plus a few hours of rest time — the next screens walk you through it." = "私密註冊需要遮蔽餘額中至少有 %@ Dash，並靜置數小時——接下來的畫面會引導您完成。";
+
+/* Usernames */
+/* Masternodes */
+"Registration" = "註冊";
 
 /* Usernames */
 "Registration failed" = "Registration failed";
@@ -2473,6 +3166,8 @@
 /* Testnet faucet */
 "Requesting tDash…" = "Requesting tDash…";
 
+"Requesting this name" = "正在申請此名稱";
+
 /* An action */
 "Rescan" = "重新掃瞄";
 
@@ -2501,10 +3196,23 @@
 "Restore an existing wallet" = "Restore an existing wallet";
 
 /* Location Service Status */
+"Restored wallets can't always recover the operation type. This entry was reconstructed from on-chain note data." = "已復原的錢包並不總能還原操作類型。此項目是根據鏈上備註資料重建的。";
+
+/* Location Service Status */
 "Restricted" = "受限制的";
 
 /* Usernames */
 "Results" = "結果";
+
+/* SPV diagnostics */
+"Resync armed from height %u — quit and reopen the app to start." = "已準備從高度 %u 重新同步——結束並重新開啟應用程式即可開始。";
+
+/* emphasized text in: Add <username> as your contact to Pay Directly to Username and Retain Mutual Transaction History */
+"Retain Mutual Transaction History" = "保留雙方的交易紀錄";
+
+/* No comment provided by engineer. */
+/* Masternode status */
+"Retired" = "已退役";
 
 /* No comment provided by engineer. */
 "Retry" = "重試";
@@ -2514,6 +3222,9 @@
 
 /* Voting */
 "Review the posting below to verify the ownership of this username" = "請參閱下面的內容以驗證該用戶名的所有權";
+
+/* Masternodes */
+"Revocation" = "撤銷";
 
 /* Transaction filter */
 "Rewards" = "Rewards";
@@ -2551,6 +3262,15 @@
 /* No comment provided by engineer. */
 "Screenshots are visible to other apps and devices. Generate a new recovery phrase and keep it secret." = "屏幕截圖可以被其他程序或者設備獲得。請生成一個新的恢復詞組並妥善保管。";
 
+/* Raw transaction inspector */
+"Script" = "指令碼";
+
+/* Raw transaction inspector */
+"Script signature" = "指令碼簽章";
+
+/* Raw transaction inspector */
+"Script type" = "指令碼類型";
+
 /* DashPay */
 "SDK is not initialized" = "SDK is not initialized";
 
@@ -2563,11 +3283,31 @@
 /* DashPay Contacts */
 "Search Contacts" = "Search Contacts";
 
+/* No comment provided by engineer. */
+"Search for a contact" = "搜尋聯絡人";
+
+/* No comment provided by engineer. */
+"Search for a contact request" = "搜尋聯繫請求";
+
 /* DashPay Contacts */
 "Search for a User" = "Search for a User";
 
 /* No comment provided by engineer. */
+"Search for a User on the Dash Network" = "在 Dash 網絡上搜尋用戶";
+
+/* No comment provided by engineer. */
+"Search for a username" = "搜尋用戶名稱";
+
+/* Search results for \"John Doe\" */
+"Search results for \"" = "搜尋結果：\"";
+
+/* No comment provided by engineer. */
 "Search territories" = "搜索地區";
+
+"Search usernames" = "搜尋用戶名稱";
+
+/* No comment provided by engineer. */
+"Searching for username %@ on the Dash Network" = "正在 Dash 網絡上搜尋用戶名稱 %@";
 
 /* No comment provided by engineer. */
 "Secure Your Wallet" = "保護您的錢包";
@@ -2577,6 +3317,9 @@
 
 /* No comment provided by engineer. */
 "Security Level" = "安全等級";
+
+/* Identities: DPP security level of a public key */
+"Security level" = "安全等級";
 
 /* DashSpend */
 "See card details" = "See card details";
@@ -2596,8 +3339,12 @@
 /* Buy Sell Dash */
 "Select a service to buy, sell, convert and transfer Dash" = "請選擇購買、出售、轉換和轉移達世幣的服務";
 
+"Select all" = "全選";
+
 /* DashSpend denomination selection */
 "Select amount" = "選擇金額";
+
+"Select at least one masternode to vote with." = "請至少選擇一個用於投票的主節點。";
 
 /* Block explorer picker
    Block explorer selection title */
@@ -2620,6 +3367,8 @@
 
 /* Coinbase */
 "Select the coin" = "選擇幣種";
+
+"Selecting fewer nodes reveals less about which masternodes you run." = "選擇的節點越少，越不容易暴露您執行的是哪些主節點。";
 
 /* No comment provided by engineer. */
 "Self-checkout" = "自助結帳";
@@ -2661,6 +3410,12 @@
 /* No comment provided by engineer. */
 "Send to" = "發給";
 
+/* No comment provided by engineer. */
+"Send to a Contact" = "發送給聯絡人";
+
+/* DashPay intro: feature body */
+"Send to a username you can actually remember and verify." = "向一個您真正能記住並核實的用戶名稱發送。";
+
 /* Translate it as short as possible! (24 symbols max) */
 "Send to Address" = "發送到位址";
 
@@ -2685,8 +3440,17 @@
 /* Dash DEX */
 "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted." = "Send your %@ before the timer runs out. If you send after the address expires, your funds will be refunded — not converted.";
 
+/* DashPay: CTA of the enable success sheet */
+"Send your first contact request" = "發送您的第一個聯繫請求";
+
 /* 1 out of 4 in the Sending Animation */
 "Sending" = "發送中";
+
+/* No comment provided by engineer. */
+"Sending Contact Request" = "正在發送聯繫請求";
+
+/* No comment provided by engineer. */
+"Sending to" = "發送至";
 
 /* CrowdNode */
 "Sending to CrowdNode account" = "發送到 CrowdNode 帳戶";
@@ -2715,11 +3479,26 @@
 /* No comment provided by engineer. */
 "Sent to" = "發給";
 
+/* DashPay payment row — recipient's display name */
+"Sent to %@" = "已發送給 %@";
+
 /* DashPay Contacts */
 "Sent you a request" = "Sent you a request";
 
+/* Raw transaction inspector */
+"Sequence" = "序號";
+
 /* DashSpend */
 "Server error occurred. Please try again later." = "服務器錯誤發生。請稍後再試。";
+
+/* Masternodes */
+"Service" = "服務";
+
+/* Identities */
+"Set as Main" = "設為主要";
+
+/* Identities */
+"Set as Main Identity" = "設為主要身分";
 
 /* No comment provided by engineer. */
 "Set PIN" = "設置密碼";
@@ -2742,8 +3521,14 @@
 /* Share key */
 "Share key" = "共享金鑰";
 
+/* Usernames */
+"Shared privacy pool at minimum size" = "共享隱私池已達最小規模";
+
 /* No comment provided by engineer. */
 "Shielded" = "Shielded";
+
+/* Send screen destination type */
+"Shielded address" = "遮蔽位址";
 
 /* InternalTransfer */
 "Shielded address is not bound for this wallet" = "Shielded address is not bound for this wallet";
@@ -2757,11 +3542,20 @@
 /* Transaction filter */
 "Shielded sent" = "Shielded sent";
 
+"Shielded Spend" = "遮蔽支出";
+
 /* Transfer of own funds into the private shielded balance */
 "Shielded transfer" = "Shielded transfer";
 
 /* A to-Shielded transfer whose asset lock is committed but the shield hasn't completed yet */
 "Shielded transfer (pending)" = "Shielded transfer (pending)";
+
+"Shielded wallet starting…" = "正在啟動遮蔽錢包…";
+
+/* Transfer of own funds from the private shielded balance back to the transparent wallet */
+"Shielded → Platform" = "遮蔽 → Platform";
+
+"Shielded → Transparent" = "遮蔽 → 透明";
 
 /* Explore Dash */
 "Show all locations" = "顯示所有地點";
@@ -2796,11 +3590,16 @@
 /* DashSpend */
 "Single" = "Single";
 
+/* Raw transaction inspector */
+"Size" = "大小";
+
 /* No comment provided by engineer. */
 "Skip" = "略過";
 
 /* Maya */
 "Some coins are not available because of the halted chain" = "Some coins are not available because of the halted chain";
+
+"Some of your masternodes may be missing from this list — the wallet could not read your full voting-key pool. Finish syncing and reopen this screen." = "此清單中可能缺少您的部分主節點——錢包無法讀取您完整的投票鑰匙集合。請完成同步後重新開啟此畫面。";
 
 /* Usernames */
 "Some usernames can be blocked" = "某些使用者名稱可能會被阻止";
@@ -2814,6 +3613,9 @@
 /* No comment provided by engineer. */
 "Sort by" = "排序方式";
 
+/* No comment provided by engineer. */
+"Sort Contacts" = "排序聯絡人";
+
 /* Explore Dash/Filters */
 "Sorted by discount" = "按折扣排序";
 
@@ -2822,6 +3624,9 @@
 
 /* Explore Dash/Filters */
 "Sorted by name" = "按名稱排序";
+
+/* Raw transaction inspector */
+"Special payload" = "特殊酬載";
 
 /* No comment provided by engineer. */
 "Specify Amount" = "指定金額";
@@ -2844,12 +3649,20 @@
 /* No comment provided by engineer. */
 "Staking" = "質押";
 
+/* Usernames */
+"Starts after you add funds" = "在您加入資金後開始";
+
+/* Transaction details */
+"Status" = "狀態";
+
 /* Step 1 */
 "Step %ld" = "步驟 %ld";
 
 /* DashPay
    InternalTransfer */
 "Storage is not configured" = "Storage is not configured";
+
+"Stored as" = "儲存為";
 
 /* Voting */
 "Submit" = "提交";
@@ -2926,6 +3739,12 @@
 /* Explore Dash */
 "Sync in progress… Results may not be complete." = "同步中...  結果可能不完整。";
 
+/* No comment provided by engineer. */
+"Sync Info" = "同步資訊";
+
+/* SPV sync */
+"Sync too slow?" = "同步太慢？";
+
 /* About screen tech info: SPV state */
 "synced" = "synced";
 
@@ -2956,8 +3775,13 @@
 /* No comment provided by engineer. */
 "Take a Photo from Camera" = "從相機拍照";
 
+"Take no side" = "不偏向任何一方";
+
 /* Enter Address Screen */
 "Tap the address from the clipboard to paste it" = "點擊剪貼板中的地址進行粘貼";
+
+/* Raw transaction inspector */
+"Tap to copy" = "點一下以複製";
 
 /* No comment provided by engineer. */
 "Tap to hide balance" = "點按即可隱藏餘額";
@@ -2974,6 +3798,9 @@
 /* DashSpend */
 "Temporarily unavailable" = "暫時不可用";
 
+/* Masternode keys - dashmate Ed25519 node key format */
+"Tenderdash node key (base64)" = "Tenderdash 節點鑰匙 (base64)";
+
 /* Terms & conditions */
 "Terms & conditions" = "條款和條件";
 
@@ -2985,6 +3812,9 @@
 
 /* No comment provided by engineer. */
 "Testnet" = "測試網";
+
+/* Badge on the home balance while the wallet runs on testnet */
+"TESTNET" = "TESTNET";
 
 /* Wallets */
 "That is not this wallet's recovery phrase." = "That is not this wallet's recovery phrase.";
@@ -3000,6 +3830,15 @@
 
 /* Coinbase Two Factor Auth */
 "The code is incorrect. Please check and try again!" = "代碼不正確。請檢查並重試!";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address after the network processes the withdrawal — this can take up to 10 minutes." = "網絡處理提領後，Dash 將到達收款人的位址——這最多可能需要 10 分鐘。";
+
+/* Send confirm sheet */
+"The Dash arrives at the recipient's address once the network processes the withdrawal." = "網絡處理提領後，Dash 即會到達收款人的位址。";
+
+/* No comment provided by engineer. */
+"The Dash arrives in your Transparent balance once the network processes the withdrawal." = "網絡處理提領後，Dash 即會到達您的透明餘額。";
 
 /* Usernames */
 "The Dash network has to vote to approve some usernames before they are created" = "某些用戶名稱在建立之前，必須經過達世幣網絡投票批准方能使用。";
@@ -3034,11 +3873,20 @@
 /* Usernames */
 "The link you send will be visible only to the network owners" = "您發送的連結僅對網路所有者可見";
 
+/* Identities */
+"The main identity can only be chosen from the active wallet" = "只能從目前的錢包中選擇主要身分";
+
 /* Dash DEX */
 "The maximum transaction amount is %@" = "The maximum transaction amount is %@";
 
 /* Coinbase */
 "The minimum amount you can send is %@" = "您可以發送的最小金額是 %@";
+
+/* Balance info sheet */
+"The most private place to hold your Dash" = "存放您的 Dash 最私密的地方";
+
+/* SPV diagnostics */
+"The persisted wallet row has no network — cannot arm a resync." = "已儲存的錢包紀錄沒有網絡——無法準備重新同步。";
 
 /* Dash DEX / dex_error_price_moved */
 "The price moved too much. Please go back and try again." = "The price moved too much. Please go back and try again.";
@@ -3049,6 +3897,15 @@
 /* Dash DEX */
 "The refund address is required" = "The refund address is required";
 
+/* DashPay */
+"The registration was submitted but its result couldn't be confirmed. Wait a minute for the wallet to sync, then try again — don't resubmit immediately." = "註冊已送出，但無法確認其結果。請等待一分鐘讓錢包完成同步，然後重試——不要立即重新送出。";
+
+/* Usernames */
+"The shared privacy pool is still growing (%ld of %ld deposits). Private registration unlocks once it reaches the minimum." = "共享隱私池仍在成長（%1$ld / %2$ld 筆存入）。達到最低規模後即可解鎖私密註冊。";
+
+/* DashPay */
+"The shared privacy pool is still growing (%ld of %ld deposits). Try again once it reaches the minimum." = "共享隱私池仍在成長（%1$ld / %2$ld 筆存入）。請在其達到最低規模後重試。";
+
 /* No comment provided by engineer. */
 "The transfer could take up to 10 minutes" = "The transfer could take up to 10 minutes";
 
@@ -3058,8 +3915,23 @@
 /* Usernames */
 "The username '%@' was blocked by the Dash Network. Please try again by requesting another username." = "用戶名稱 '%@' 被達世幣網絡封鎖。請通過請求另一個用戶名來重試。";
 
+/* SPV diagnostics */
+"The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it." = "錢包的建立高度——過濾器掃描和「自錢包建立起」重新掃描的下限。請將其設定為不高於錢包首次收到資金的高度；匯入時主網預設為 200000，測試網預設為 0。儲存一個不高於目前值的高度，將在下次啟動時清除該網絡的鏈資料並從該高度重新掃描。";
+
+/* No comment provided by engineer. */
+"them (Fetching Info)" = "他（正在取得資訊）";
+
+/* No comment provided by engineer. */
+"There are no new notifications" = "沒有新通知";
+
 /* No comment provided by engineer. */
 "There are no transactions to display" = "沒有交易能夠顯示";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@" = "沒有與名稱 %@ 相符的用戶";
+
+/* No comment provided by engineer. */
+"There are no users that match with the name %@ in your contacts" = "您的聯絡人中沒有與名稱 %@ 相符的用戶";
 
 /* ZenLedger */
 "There was an error when exporting your transaction history to ZenLedger" = "將交易歷史記錄匯出到 ZenLedger 時發生錯誤";
@@ -3071,10 +3943,16 @@
 "There was an error, please try again later" = "出現錯誤，請稍後重試";
 
 /* No comment provided by engineer. */
+"These funds move to your Platform balance and are ready to spend as soon as the transfer completes." = "這些資金將轉入您的 Platform 餘額，轉帳完成後即可使用。";
+
+/* No comment provided by engineer. */
 "These funds move to your Platform Payment balance and are ready to spend right away." = "These funds move to your Platform Payment balance and are ready to spend right away.";
 
 /* CrowdNode */
 "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device." = "These funds should be withdrawn from CrowdNode. You can transfer these funds to this wallet or via your online account on some other device.";
+
+/* Send sheet source/destination mismatch */
+"This address can't be paid from your %@ balance" = "無法從您的 %@ 餘額向此位址付款";
 
 /* Dash DEX / dex_error_sanctioned */
 "This address can't be used for swaps." = "This address can't be used for swaps.";
@@ -3082,11 +3960,16 @@
 /* Dash DEX */
 "This address expires in 10 minutes" = "This address expires in 10 minutes";
 
+/* DashPay: body of the Enable DashPay confirmation */
+"This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "這會為您的身分加入兩把鑰匙，讓其他用戶能夠向您發送聯繫請求，也讓您能夠接受他們的請求。此操作只需進行一次。";
+
 /* Dash DEX / dex_error_no_route */
 "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount." = "This amount can't be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.";
 
 /* Dash DEX / dex_enter_amount_invalid */
 "This amount can't be swapped right now. Try a different amount, or try again shortly." = "This amount can't be swapped right now. Try a different amount, or try again shortly.";
+
+"This applies one choice to all %d selected usernames." = "這會將同一個選擇套用於全部 %d 個所選用戶名稱。";
 
 /* DashSpend */
 "This card works only in the United States." = "This card works only in the United States.";
@@ -3094,11 +3977,26 @@
 /* Coinbase Two Factor Auth */
 "This extra step shows it’s really you trying to make a transaction." = "這個額外的步驟用來證明真的是你在嘗試進行交易。";
 
+/* DashPay Invitations */
+"This invitation link is not valid." = "此邀請連結無效。";
+
+/* Send screen */
+"This is not a valid Dash address for this network" = "這不是此網絡的有效 Dash 位址";
+
+/* DashPay Invitations */
+"This is not a valid invitation link" = "這不是有效的邀請連結";
+
 /* DashPay Contacts */
 "This is you" = "This is you";
 
+/* Identities */
+"This is your main identity" = "這是您的主要身分";
+
 /* DashPay Contacts */
 "This is your own identity." = "This is your own identity.";
+
+/* Masternodes */
+"This masternode has no Platform identity yet." = "此主節點尚無 Platform 身分。";
 
 /* CTXSpend error */
 "This merchant is currently unavailable." = "該商戶目前不可用。";
@@ -3133,14 +4031,25 @@
 /* CrowdNode */
 "This represents the current Annual Percentage Yield of a full Masternode less the 15% CrowdNode fee. It is not a guaranteed rate of return and may go up or down based on the size of the CrowdNode pools and the Dash price." = "這代表完整主節點的當前年度百分比收益率減去 15% 的 CrowdNode 費用。這不是保證回報率，可能會根據 CrowdNode 資金池的大小和達世幣價格而上升或下降。";
 
+"This still counts as your masternodes having voted in this contest." = "這仍會計為您的主節點已在此次爭奪中投票。";
+
 /* Dash DEX / dex_error_allowance */
 "This token needs approval before it can be swapped." = "This token needs approval before it can be swapped.";
+
+/* Raw transaction inspector */
+"This transaction's raw bytes are not stored on this device." = "此交易的原始位元組未儲存在此裝置上。";
 
 /* InternalTransfer recovery */
 "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it." = "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.";
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+"This username went to someone else" = "此用戶名稱歸他人所有";
+
+"This wallet could not derive the voting key for this node." = "此錢包無法為該節點衍生投票鑰匙。";
+
+"This wallet holds no active masternode voting keys, so it cannot vote. Registered nodes appear under Tools → Masternodes." = "此錢包不含有效的主節點投票鑰匙，因此無法投票。已註冊的節點會顯示在「工具 → 主節點」中。";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
@@ -3150,6 +4059,12 @@
 
 /* No comment provided by engineer. */
 "This will erase this wallet from this device. You can only restore it with your recovery phrase." = "This will erase this wallet from this device. You can only restore it with your recovery phrase.";
+
+/* Send confirm sheet */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives at the recipient's address once the network processes the withdrawal." = "這會一次性提領您的全部 Platform 餘額。網絡處理提領後，Dash 即會到達收款人的位址。";
+
+/* No comment provided by engineer. */
+"This withdraws your entire Platform balance in one transfer. The Dash arrives in your Transparent balance once the network processes the withdrawal." = "這會一次性提領您的全部 Platform 餘額。網絡處理提領後，Dash 即會到達您的透明餘額。";
 
 /* Send Screen: to address */
 "to" = "至";
@@ -3190,8 +4105,14 @@
 /* CrowdNode */
 "Transaction History" = "交易記錄";
 
+/* Balance info sheet */
+"Transaction history isn't available" = "交易紀錄無法使用";
+
 /* No comment provided by engineer. */
 "Transaction id" = "交易ID";
+
+/* Raw transaction inspector */
+"Transaction ID" = "交易 ID";
 
 /* A verb, button title. */
 "Transfer" = "轉帳";
@@ -3219,8 +4140,14 @@
 /* No comment provided by engineer. */
 "Transfer In" = "轉入";
 
+/* Balance breakdown */
+"Transfer in" = "轉入";
+
 /* No comment provided by engineer. */
 "Transfer Out" = "轉出";
+
+/* Balance breakdown */
+"Transfer out" = "轉出";
 
 /* No comment provided by engineer. */
 "Transfer submitted" = "Transfer submitted";
@@ -3230,6 +4157,30 @@
 
 /* No comment provided by engineer. */
 "Transfers take different times" = "Transfers take different times";
+
+/* Balance info sheet */
+"Transfers take longer — privacy proofs take time to build" = "轉帳耗時較長——產生隱私證明需要時間";
+
+/* Balance info sheet */
+"Transfers to other platform addresses and shielded addresses are instant and final" = "向其他 Platform 位址和遮蔽位址的轉帳是即時且最終的";
+
+/* Balance breakdown */
+"Transparent" = "透明";
+
+/* Send screen destination type */
+"Transparent address" = "透明位址";
+
+/* The transparent (Core) balance of the Dash Wallet */
+"Transparent balance" = "透明餘額";
+
+/* Usernames */
+"Transparent funding publicly links your username to these funds." = "透明資金會將您的用戶名稱與這些資金公開關聯起來。";
+
+/* Transfer of own funds into the Platform balance */
+"Transparent → Platform" = "透明 → Platform";
+
+/* Transfer of own funds into the private shielded balance */
+"Transparent → Shielded" = "透明 → 遮蔽";
 
 /* An action */
 "Try again" = "再試一次";
@@ -3279,6 +4230,9 @@
 /* Dash DEX */
 "Unable to load rate data" = "Unable to load rate data";
 
+/* No comment provided by engineer. */
+"Unable to provide suggestions" = "無法提供建議";
+
 /* Swap */
 "Unable to refresh quote. Please try again." = "Unable to refresh quote. Please try again.";
 
@@ -3312,6 +4266,12 @@
 /* Coinbase */
 "Unknown Balance" = "未知餘額";
 
+/* Raw transaction inspector */
+"Unknown special type %d" = "未知的特殊類型 %d";
+
+/* No comment provided by engineer. */
+"Unshielded" = "未遮蔽";
+
 /* No comment provided by engineer. */
 "Unsupported URL" = "不支援的URL";
 
@@ -3334,6 +4294,9 @@
 "Upgrade to DashPay" = "升級到Dashpay";
 
 /* No comment provided by engineer. */
+"Upgrade to Evolution" = "升級至 Evolution";
+
+/* No comment provided by engineer. */
 "Uphold" = "Uphold";
 
 /* Uphold */
@@ -3353,6 +4316,18 @@
 
 /* Dash DEX */
 "URI" = "URI";
+
+/* Usernames */
+"Use transparent balance instead" = "改用透明餘額";
+
+/* Masternode keys */
+"Used" = "已使用";
+
+/* Masternode keys */
+"Used at: " = "使用於：";
+
+/* No comment provided by engineer. */
+"User (Fetching Info)" = "用戶（正在取得資訊）";
 
 /* Voting */
 "Username" = "用戶名稱";
@@ -3384,6 +4359,23 @@
 /* Usernames */
 "Username was successfully requested" = "使用者名稱申请成功";
 
+/* Identities */
+"Usernames" = "用戶名稱";
+
+"Usernames are stored in a normalized form to prevent look-alike names, so this may differ from what each person typed." = "用戶名稱以正規化形式儲存，以防止出現形似名稱，因此這可能與每個人輸入的內容不同。";
+
+/* DashPay intro: feature title */
+"Usernames, not addresses" = "用戶名稱，而非位址";
+
+/* No comment provided by engineer. */
+"Users that matches %@ who are currently not in your contacts" = "與 %@ 相符且目前不在您聯絡人中的用戶";
+
+/* Balance info sheet */
+"Uses one of the most audited and tested zero-knowledge libraries (Orchard)" = "使用經過最充分稽核和測試的零知識程式庫之一 (Orchard)";
+
+/* DashPay Invitations */
+"Valid invitation" = "有效邀請";
+
 /* CrowdNode Portal */
 "Validating address…" = "正在核實位址...";
 
@@ -3399,6 +4391,9 @@
 /* CrowdNode Portal */
 "Verification Required" = "需要驗證";
 
+/* Usernames */
+"Verified during registration" = "已在註冊時驗證";
+
 /* No comment provided by engineer. */
 "Verified Successfully" = "已成功驗證";
 
@@ -3411,11 +4406,20 @@
 /* Usernames */
 "Verify your identity" = "驗證您的身份";
 
+/* Raw transaction inspector */
+"Version" = "版本";
+
+/* Balance info sheet */
+"Very efficient with low fees" = "非常有效率且費用低廉";
+
 /* adjective, security level */
 "Very High" = "非常高";
 
 /* CrowdNode */
 "Very small amounts of Dash will be sent to and from CrowdNode to verify that you are the owner of this wallet address." = "將會向 CrowdNode 發送非常少量的達世幣，以驗證您是該錢包位址的所有者。";
+
+/* No comment provided by engineer. */
+"View All" = "檢視全部";
 
 /* No comment provided by engineer. */
 "View in Block Explorer" = "在瀏覽器中查看";
@@ -3429,17 +4433,33 @@
 /* No comment provided by engineer. */
 "View Recovery Phrase" = "查看恢復詞組";
 
+/* Raw transaction inspector */
+"View Transaction" = "檢視交易";
+
 /* No comment provided by engineer. */
 "View transaction details" = "查看交易的詳細信息";
 
 /* Maya */
 "View transaction on MayaScan" = "View transaction on MayaScan";
 
+"Vote" = "投票";
+
+"Vote cast" = "已投票";
+
 /* Voting */
 "Vote for All" = "給所有人投票";
 
 /* Voting */
+"Vote on contested usernames" = "為有爭議的用戶名稱投票";
+
+"Vote on several" = "為多個投票";
+
+/* Voting */
 "Vote to Approve" = "投票通過";
+
+"Vote with" = "使用以下節點投票";
+
+"Votes that nobody should receive these usernames." = "投票支持任何人都不應取得這些用戶名稱。";
 
 /* Voting */
 "Votes: High to low" = "得票數：從高到低";
@@ -3453,14 +4473,35 @@
 /* No comment provided by engineer. */
 "Voting Address" = "投票位址";
 
+/* Voting keys */
+/* Masternodes */
+"Voting address" = "投票位址";
+
+"Voting ended with no winner" = "投票結束，無人勝出";
+
+"Voting ends" = "投票結束";
+
 /* Voting */
 "Voting ends in %dd" = "投票將於 %d天後結束";
+
+"Voting in progress" = "投票進行中";
+
+"Voting in progress — lock votes are ahead" = "投票進行中——鎖定票領先";
+
+"Voting in progress — you are ahead" = "投票進行中——您領先";
 
 /* Usernames */
 "Voting is only required in some cases" = "僅在某些情況下才需要投票";
 
+/* Masternodes */
+"Voting key hash" = "投票鑰匙雜湊";
+
 /* Voting keys */
 "Voting keys" = "投票鑰匙";
+
+"Voting on this username has closed. The counts below are the last ones read." = "對此用戶名稱的投票已結束。以下計數為最後一次讀取的結果。";
+
+"Voting on “%@” has already closed. Refresh to see the result." = "對「%@」的投票已經結束。請重新整理以查看結果。";
 
 /* CrowdNode */
 "Wait until the chain is fully synced before using CrowdNode." = "Wait until the chain is fully synced before using CrowdNode.";
@@ -3474,11 +4515,16 @@
 /* Send screen */
 "Wait until wallet is synced to complete the transaction" = "等到錢包同步後完成交易";
 
+"Waiting for Dash Platform" = "正在等待 Dash Platform";
+
 /* Wallets — placeholder name with short id */
 "Wallet %@…" = "Wallet %@…";
 
 /* Enter Address Screen */
 "Wallet Address" = "錢包位址";
+
+/* SPV diagnostics */
+"Wallet birth height" = "錢包起始區塊高度";
 
 /* No comment provided by engineer. */
 "Wallet disabled" = "錢包被禁用";
@@ -3552,14 +4598,34 @@
 /* No comment provided by engineer. */
 "Welcome to DashPay" = "歡迎來到 DashPay";
 
+/* DashPay FAQ */
+"What about Unstoppable Domains and similar name services?" = "Unstoppable Domains 及類似網域服務如何？";
+
+/* DashPay FAQ */
+"What does it cost?" = "費用是多少？";
+
+/* DashPay FAQ */
+"What is DashPay?" = "什麼是 DashPay？";
+
 /* Usernames */
 "What is username voting?" = "什麼是用戶名投票？";
+
+/* DashPay FAQ */
+"What's coming next?" = "接下來會有什麼？";
+
+/* DashPay FAQ */
+"When will contact requests become private?" = "聯繫請求何時會變為私密？";
 
 /* No comment provided by engineer. */
 "Where to Spend" = "在哪裡消費";
 
 /* No comment provided by engineer. */
 "Where to Spend?" = "在哪裡消費?";
+
+"Who is requesting this name" = "誰在申請此名稱";
+
+/* DashPay FAQ */
+"Why do I need to enable it?" = "為什麼我需要啟用它？";
 
 /* Crowdnode */
 "Why do I see all these transactions?" = "為什麼我會看到所有這些交易？";
@@ -3598,6 +4664,12 @@
 /* CrowdNode */
 "Withdrawal requested" = "提款請求";
 
+/* Full-balance Platform → Transparent withdrawal */
+"Withdraws the entire balance" = "提領全部餘額";
+
+/* Balance info sheet */
+"Works with every Dash wallet, exchange, and merchant" = "適用於所有 Dash 錢包、交易所和商家";
+
 /* No comment provided by engineer. */
 "Would you like to accept the invitation?" = "你願意接受這個邀請嗎?";
 
@@ -3621,6 +4693,11 @@
 
 /* No comment provided by engineer. */
 "Yesterday" = "昨天";
+
+"You" = "您";
+
+/* No comment provided by engineer. */
+"You accepted the contact request from %@" = "您已接受來自 %@ 的聯繫請求";
 
 /* DashPay Notifications */
 "You added %@ as a contact" = "You added %@ as a contact";
@@ -3670,6 +4747,9 @@
 /* Usernames */
 "You chose “%@” as your username." = "您選擇 “%@” 作為您的用戶名稱。";
 
+/* No comment provided by engineer. */
+"You do not have any contacts at the moment" = "您目前沒有任何聯絡人";
+
 /* DashSpend */
 "You do not have sufficient funds to complete this transaction" = "您沒有足夠的資金來完成此交易";
 
@@ -3678,6 +4758,9 @@
 
 /* Coinbase */
 "You exceeded the authorization limit on Coinbase." = "你超出了 Coinbase 的授權限制。";
+
+/* Usernames */
+"You have %@ Dash so far" = "您目前有 %@ Dash";
 
 /* Usernames */
 "You have %@ Dash.\nSome usernames cost up to %@ Dash." = "您有 %1$@ Dash.\n一些用戶名稱的成本高達 %2$@ Dash.";
@@ -3748,6 +4831,9 @@
 /* DashPay Notifications */
 "You sent a contact request to %@" = "You sent a contact request to %@";
 
+/* No comment provided by engineer. */
+"You sent the contact request to %@" = "您已向 %@ 發送聯繫請求";
+
 /* CrowdNode */
 "You should have a positive balance on Dash Wallet" = "你的達世幣錢包上的餘額應該是一個正數";
 
@@ -3774,6 +4860,11 @@
 
 /* No comment provided by engineer. */
 "You will transfer" = "You will transfer";
+
+"You won this username" = "您贏得了此用戶名稱";
+
+/* DashPay: body of the enable success sheet */
+"You're all set. Other users can now send you contact requests — and you can send yours." = "一切就緒。其他用戶現在可以向您發送聯繫請求——您也可以發送自己的請求。";
 
 /* DashPay Contacts */
 "You're already connected — you can pay each other directly by username." = "You're already connected — you can pay each other directly by username.";
@@ -3805,6 +4896,9 @@
 /* InternalTransfer recovery */
 "Your Dash is safe" = "Your Dash is safe";
 
+/* Identities */
+"Your Dash Platform identity appears here once you register a username." = "註冊用戶名稱後，您的 Dash Platform 身分會顯示在這裡。";
+
 /* Maya/SwapKit */
 "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds." = "Your Dash transaction has been sent. Waiting for InstantSend lock — this usually takes a few seconds.";
 
@@ -3835,11 +4929,20 @@
 /* Email is only used for OTP */
 "Your email is only used to send a one-time password." = "您的電子郵件僅用於發送一次性密碼。";
 
+/* DashPay intro: feature title */
+"Your history, organized" = "井然有序的紀錄";
+
+/* DashPay FAQ */
+"Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "您的身分需要兩把額外的鑰匙，才能在您與其他用戶之間加密聯繫請求。啟用時會透過一筆網絡交易加入它們。此操作只需進行一次。";
+
 /* No comment provided by engineer. */
 "Your invitation from %@ has been already claimed" = "您來自 %@ 的邀請已被認領";
 
 /* No comment provided by engineer. */
 "Your invitation from %@ is not valid" = "您來自 %@ 的邀請無效";
+
+/* DashPay Invitations */
+"Your invitation pays the registration fee for this username." = "您的邀請將支付此用戶名稱的註冊費用。";
 
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, ATMs in the selected redius and improve search results." = "您的位置用於顯示您在地圖上的位置、所選範圍內中的 ATM 並改進搜索結果。";
@@ -3847,8 +4950,20 @@
 /* No comment provided by engineer. */
 "Your location is used to show your position on the map, merchants in the selected redius and improve search results." = "您的位置用於顯示您在地圖上的位置、所選區域中的商家以及改進搜索結果。";
 
+/* Balance info sheet */
+"Your main Dash balance on the Core blockchain — what you send and receive with other wallets, exchanges, and merchants." = "您在 Core 區塊鏈上的主要 Dash 餘額——用於與其他錢包、交易所和商家收付資金。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Dash Wallet balance." = "您的已混合資金已轉入 Dash 錢包餘額。";
+
+/* CoinJoin */
+"Your mixed coins were moved to your Shielded balance. For best privacy, wait at least 2 hours before using these funds." = "您的已混合資金已轉入遮蔽餘額。為獲得最佳隱私效果，請至少等待 2 小時後再使用這些資金。";
+
 /* CoinJoin */
 "Your mixed Dash was moved to your spendable balance using these transactions." = "Your mixed Dash was moved to your spendable balance using these transactions.";
+
+/* Maya/SwapKit */
+"Your Platform balance" = "您的 Platform 餘額";
 
 /* Maya/SwapKit */
 "Your previous swap is still locking in. Please wait a few seconds before starting another one." = "Your previous swap is still locking in. Please wait a few seconds before starting another one.";
@@ -3856,11 +4971,28 @@
 /* CrowdNode */
 "Your primary Dash address that you currently use for your CrowdNode account" = "您當前用於 CrowdNode 帳戶的主要達世幣位址";
 
+/* Balance info sheet */
+"Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "您的私密餘額。金額和位址在鏈上均已加密，因此您的持有量和紀錄都保持機密。";
+
 /* Usernames */
 "Your request was cancelled" = "您的申请已取消";
 
 /* DashSpend */
 "Your session expired" = "您的工作階段已經過期";
+
+/* Usernames */
+"Your Shielded balance" = "您的遮蔽餘額";
+
+"Your Shielded balance is almost ready — you can register privately around %@." = "您的遮蔽餘額即將就緒——您大約可在 %@ 私密註冊。";
+
+/* Usernames */
+"Your Shielded balance is ready — register your username privately now" = "您的遮蔽餘額已就緒——立即私密註冊您的用戶名稱";
+
+/* Usernames */
+"Your Shielded balance is resting — you can register privately around %@" = "您的遮蔽餘額正在靜置——您大約可在 %@ 私密註冊";
+
+/* DashPay */
+"Your shielded balance is still maturing. It will be ready around %@." = "您的遮蔽餘額仍在成熟中。大約將在 %@ 就緒。";
 
 /* Dash DEX */
 "Your swap can NOT be processed without a refund address" = "Your swap can NOT be processed without a refund address";
@@ -3878,6 +5010,9 @@
 "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it." = "Your transfer was broadcast and is confirming on the network. Don't resend it — it will appear once the network confirms it.";
 
 /* No comment provided by engineer. */
+"Your Transparent balance" = "您的透明餘額";
+
+/* No comment provided by engineer. */
 "Your username %@ has been successfully created on the Dash Network" = "您的用戶名 %@ 已在達世幣網絡上成功創建";
 
 /* No comment provided by engineer. */
@@ -3886,14 +5021,31 @@
 /* Usernames */
 "Your username has been successfully created" = "您的用戶名已成功創建";
 
+/* Usernames */
+"Your username is visible to everyone. Funding it from your Shielded balance — after letting the funds rest for a few hours — means no one can link your username to your other Dash." = "您的用戶名稱對所有人可見。讓資金靜置數小時後再用遮蔽餘額為其提供資金，任何人都無法將您的用戶名稱與您的其他 Dash 關聯起來。";
+
+/* Identities */
+"Your username, profile, and contacts follow this identity." = "您的用戶名稱、個人資料和聯絡人都歸屬於此身分。";
+
+/* Identities */
+"Your username, profile, and contacts will follow this identity." = "您的用戶名稱、個人資料和聯絡人都將歸屬於此身分。";
+
 /* No comment provided by engineer. */
 "Your vote was cancelled" = "您的投票已被取消";
 
 /* Voting */
 "Your vote was submitted" = "您的投票已提交";
 
+"Your votes" = "您的選票";
+
 /* No comment provided by engineer. */
 "Your wallet is secured now. You can use your recovery phrase anytime to recover your account on another device." = "您的錢包現在已經安全了。 您可以隨時使用恢復詞組在另一台設備上恢復帳戶。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing with the Dash network. Sending will be available once syncing completes." = "您的錢包仍在與 Dash 網絡同步。同步完成後即可發送。";
+
+/* Core send blocked until chain sync completes */
+"Your wallet is still syncing. Sending from your Transparent balance will be available once syncing completes." = "您的錢包仍在同步。同步完成後即可從透明餘額發送。";
 
 /* No comment provided by engineer. */
 "ZenLedger" = "ZenLedger";
@@ -3901,5 +5053,13 @@
 /* Savings percentage */
 "~%.0f%%" = "~%.0f%%";
 
+/* DashPay: estimated network fee — DASH amount, then its local-currency equivalent */
+"~%@ DASH (≈ %@)" = "~%@ DASH (≈ %@)";
+
+"“%@” could not be read as a Dash username." = "無法將「%@」識別為 Dash 用戶名稱。";
+
 /* Usernames */
 "“%@” has been registered." = "“%@” has been registered.";
+
+/* DashPay Invitations */
+"“%@” has been registered. Send a contact request to the person who invited you?" = "「%@」已註冊。要向邀請您的人發送聯繫請求嗎？";

--- a/DashWallet/zh_TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh_TW.lproj/Localizable.stringsdict
@@ -72,5 +72,215 @@
 			<string>%d 密鑰</string>
 		</dict>
 	</dict>
+	<key>%u votes counted for “%@”</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>為「%2$@」統計了 %#@votes@</string>
+		<key>votes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%1$u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d usernames voted on</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@names@中已對 %1$d 個投票</string>
+		<key>names</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個用戶名稱</string>
+		</dict>
+	</dict>
+	<key>Cast %u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>投出 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d of %d masternodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個主節點</string>
+		</dict>
+	</dict>
+	<key>%d of %d nodes voted</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<key>nodes</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%2$d 個節點</string>
+		</dict>
+	</dict>
+	<key>%d evonodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個 Evonode</string>
+		</dict>
+	</dict>
+	<key>%u votes in total</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>共 %u 票</string>
+		</dict>
+	</dict>
+	<key>%d masternodes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個主節點</string>
+		</dict>
+	</dict>
+	<key>%d selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>已選擇 %d 個</string>
+		</dict>
+	</dict>
+	<key>%d of your nodes already voted here and are not listed.</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>您有 %d 個節點已在此投票，未顯示在清單中。</string>
+		</dict>
+	</dict>
+	<key>%u votes per contest — evonodes count as 4, masternodes as 1</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>每次爭奪 %u 票 —— Evonode 計為 4，主節點計為 1</string>
+		</dict>
+	</dict>
+	<key>Vote on %d usernames</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>為 %d 個用戶名稱投票</string>
+		</dict>
+	</dict>
+	<key>%u votes</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>u</string>
+			<key>other</key>
+			<string>%u 票</string>
+		</dict>
+	</dict>
+	<key>Vote ×%d</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>投票 ×%d</string>
+		</dict>
+	</dict>
+	<key>%d requests</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@count@</string>
+		<key>count</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d 個請求</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/DashWallet/zh_TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh_TW.lproj/Localizable.stringsdict
@@ -89,7 +89,7 @@
 	<key>%d of %d usernames voted on</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@names@中已對 %1$d 個投票</string>
+		<string>已投票：%1$d / %#@names@</string>
 		<key>names</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -117,7 +117,7 @@
 	<key>%d of %d masternodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -131,7 +131,7 @@
 	<key>%d of %d nodes voted</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@nodes@中有 %1$d 個已投票</string>
+		<string>已投票：%1$d / %#@nodes@</string>
 		<key>nodes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>


### PR DESCRIPTION
## What

Fills the **411 missing `Localizable.strings` keys** and the **15 missing `Localizable.stringsdict` plural entries** in all **42** non-`en` localizations. These are the whole SwiftDashSDK-migration era of new UI — the DashPay intro/FAQ/Enable flow, identity public keys, shielded/internal transfer history, Platform balance copy, masternode keys, username voting and the raw-transaction inspector.

Every language goes from 1294 → **1705** keys and 5 → **20** plural entries.

```
84 files changed, 59214 insertions(+), 0 deletions(-)
```

One commit per language so a single bad language can be reverted on its own.

## ⚠️ These translations are machine-generated

They have **not** been reviewed by a human translator. I raised the Transifex conflict before starting and the owner chose to land them in-repo as a stopgap.

Two consequences worth being explicit about:

1. **A `tx pull -a` will overwrite this.** `.tx/config` maps `DashWallet/<lang>.lproj/Localizable.strings` to `o:dash:p:dash-mobile-wallets:r:app-localizable-strings`. To keep this work, push the en source up (`tx push -s`) so translators see the 411 new keys, and treat these strings as a placeholder that real translations supersede.
2. **They compete with human translators.** Anything here that a translator later corrects should win.

`tx` is not installed on this machine, so I could not push the source myself.

## Terminology decisions

The three balance names had **no existing precedent** in any of the 42 files, so I had to establish them. Everything else reuses the terminology already in each file (checked per language before writing).

| en | choice | rationale |
|---|---|---|
| `Platform`, `DashPay`, `Dash`, `CoinJoin`, `InstantSend`, `Orchard`, `Tenderdash`, `duffs`, `TESTNET`, `Evonode` | left untranslated | product / brand names |
| `Shielded` | translated per language (de *abgeschirmt*, es *blindado*, ru *экранированный*, ja シールド, zh 屏蔽 …) | descriptive English word, not a coined brand; follows each language's established Zcash-ecosystem term |
| `Transparent` | translated per language | cognate almost everywhere |

`masternode` / `evonode` / `identity` / `contact request` / `credits` follow each file's existing usage — e.g. tr uses **Anadüğüm**, ru **мастернода**, zh **主节点**, fil keeps English technical loanwords as that file already does.

Reviewers who disagree with the `Shielded`/`Transparent` rendering for their language should change it — it is the one call that was genuinely mine and is applied consistently within each file, so it is cheap to sed.

## Verification

Per language, all 42:

- `plutil -lint` clean on both `Localizable.strings` and `Localizable.stringsdict`
- exactly 1705 string keys / 20 plural entries; no duplicates
- **format specifiers match `en` exactly** (multiset-compared, `%1$@` normalised against `%@`); the 53 format-bearing strings use positional specifiers wherever word order moves
- sort order preserved (stable, case-insensitive — what `bartycrouch normalize` produces)
- **insert-only diffs: 0 deletions across all 84 files**; every pre-existing line is byte-identical
- stringsdict category sets match each locale's CLDR rules — `other`-only for CJK/SEA, `one/other` for most European, `one/few/other` for hr/sr/ro, `one/few/many/other` for ru/uk/pl/cs/sk, `one/two/few/other` for sl, `zero/one/two/few/many/other` for ar

Build:

```
xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator \
  -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build
** BUILD SUCCEEDED **
```

The build's `bartycrouch` run-script phase **left every file untouched**, which independently confirms the formatting and sort order are what the tool expects.

Runtime spot-check against the *built* bundle (`de`, `ru`, `ja`, `pl`) — the longest FAQ string resolves, and format specifiers render correctly:

```
de 2-arg: Der gemeinsame Privatsphäre-Pool wächst noch (3 von 10 Einzahlungen). …
ja 2-arg: 共有プライバシープールはまだ拡大中です（3 / 10 件の入金）。…
de fee  : ~0.0012 DASH (≈ €0.04)
```

I could not drive the FAQ screen itself in the simulator — the test device sits behind a PIN I don't have — so the FAQ check is bundle-level (string resolves, correct length, correct text) rather than a screenshot.

## Pre-existing issues found along the way (not fixed here)

These are all **pre-existing** and none are introduced by this PR, but they affect how much of this work reaches users:

1. **21 of the 43 `.lproj` dirs are not in the Xcode target.** `knownRegions` lists only 22 languages + Base. These do **not** ship in the app today: `ar ca da eo et fa fi fil hr hu mk ms nb ro sl sl_SI sq sr sv zh zh_TW`. They are still tracked by Transifex, so filling them is not wasted — but adding them to the target is a separate, deliberate decision (it changes the App Store language list).
2. **`Localizable.stringsdict` ships for only 4 localizations** — `en`, `cs`, `sk`, `uk`. The other 38 stringsdict files are not in the target, so their plural entries never load. Worth fixing separately.
3. **`zh-Hans` / `zh-Hant-TW` are near-empty stubs that shadow the real files.** `zh` (909 translated) and `zh_TW` (908) are the well-translated ones, but *only* `zh-Hans` and `zh-Hant-TW` are in `knownRegions` — and each had just 43 of 1294 entries translated. So Chinese users have effectively been getting English. I filled all four, so the new strings land correctly either way, and I backfilled the 3 baseline plural entries the two stubs were missing. **The pre-existing 1251 untranslated entries in those stubs are still untranslated** — worth a follow-up to either populate them from `zh`/`zh_TW` or switch `knownRegions`.
4. `sl` (52/1294) and `sl_SI` (28/1294) are similarly near-empty; neither ships today.

## Not done

- No human review of any string.
- The 3 stale keys each language carries that no longer exist in `en` were left in place (`Platform sync is not running…`, `Shielded transfer`, `Shielded transfer (pending)`) — harmless, and removing them is bartycrouch's job.
- Nothing pushed to Transifex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Expanded wallet translations across numerous languages, covering DashPay, usernames, invitations, identities, voting, nodes, balances, transactions, CoinJoin, synchronization, and wallet status.
  * Added localized plural forms for vote counts, node counts, selections, contests, requests, merchants, and transactions.
  * Improved language-specific handling of singular, plural, and multi-count messages.
  * Added broader coverage for guidance, privacy explanations, diagnostics, confirmations, errors, and FAQ content.
  * Preserved numeric formatting and translated count-based messages consistently across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->