### PR TITLE
feat(dashpay): DPNS username marketplace in the Explore tab

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1897,6 +1897,10 @@
 		RC00A0012FA0000000000001 /* TopIntro.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00A0032FA0000000000001 /* TopIntro.swift */; };
 		RC00A0022FA0000000000001 /* TopIntro.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00A0032FA0000000000001 /* TopIntro.swift */; };
 		RC00A0042FA0000000000001 /* ExploreMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00A0062FA0000000000001 /* ExploreMenuScreen.swift */; };
+		UM00A0012FA0000000000001 /* UsernameMarketplaceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = UM00A0032FA0000000000001 /* UsernameMarketplaceScreen.swift */; };
+		UM00A0022FA0000000000001 /* UsernameMarketplaceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = UM00A0032FA0000000000001 /* UsernameMarketplaceScreen.swift */; };
+		UM00B0012FA0000000000001 /* UsernameMarketplaceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */; };
+		UM00B0022FA0000000000001 /* UsernameMarketplaceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */; };
 		RC00A0052FA0000000000001 /* ExploreMenuScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00A0062FA0000000000001 /* ExploreMenuScreen.swift */; };
 		RC00C0012FA0000000000001 /* CSVExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00C0032FA0000000000001 /* CSVExportSheet.swift */; };
 		RC00C0022FA0000000000001 /* CSVExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RC00C0032FA0000000000001 /* CSVExportSheet.swift */; };
@@ -3635,6 +3639,8 @@
 		GG0000032DUMMYID001234567 /* GeoRestrictionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoRestrictionService.swift; sourceTree = "<group>"; };
 		RC00A0032FA0000000000001 /* TopIntro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopIntro.swift; sourceTree = "<group>"; };
 		RC00A0062FA0000000000001 /* ExploreMenuScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreMenuScreen.swift; sourceTree = "<group>"; };
+		UM00A0032FA0000000000001 /* UsernameMarketplaceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameMarketplaceScreen.swift; sourceTree = "<group>"; };
+		UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameMarketplaceService.swift; sourceTree = "<group>"; };
 		RC00C0032FA0000000000001 /* CSVExportSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CSVExportSheet.swift; sourceTree = "<group>"; };
 		FC1426BD13E794C788646055 /* ContestedNamesService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContestedNamesService.swift; sourceTree = "<group>"; };
 		15D89828EC913714251D0B58 /* MasternodeVoterRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MasternodeVoterRegistry.swift; sourceTree = "<group>"; };
@@ -6256,6 +6262,7 @@
 				47AE8BDF28C1305E00490F5E /* Views */,
 				7569D6822DE6DA6800768BFF /* ExploreViewController.swift */,
 				RC00A0062FA0000000000001 /* ExploreMenuScreen.swift */,
+				UM00A0032FA0000000000001 /* UsernameMarketplaceScreen.swift */,
 			);
 			path = "Explore Dash";
 			sourceTree = "<group>";
@@ -7109,6 +7116,7 @@
 				E181EB71C8803101EA789AA4 /* SwiftDashSDKHost.swift */,
 				35F37C177039C76661FA2DB2 /* SwiftDashSDKSPVCoordinator.swift */,
 				E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */,
+				UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */,
 				51AA000D2F97000D005A000D /* ShieldedSyncMonitor.swift */,
 				43C830DD6D63115525925F75 /* PlatformCreditsFormatter.swift */,
 				44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */,
@@ -9820,6 +9828,8 @@
 				75EBAA0F2BB99036004488E3 /* TextIntro.swift in Sources */,
 				RC00A0012FA0000000000001 /* TopIntro.swift in Sources */,
 				RC00A0042FA0000000000001 /* ExploreMenuScreen.swift in Sources */,
+				UM00A0012FA0000000000001 /* UsernameMarketplaceScreen.swift in Sources */,
+				UM00B0012FA0000000000001 /* UsernameMarketplaceService.swift in Sources */,
 				0F71317728F436920072F454 /* ServiceOverviewTableCell.swift in Sources */,
 				47838B87290670630003E8AB /* IntegrationViewController.swift in Sources */,
 				758A8F172C4D35A80012FA41 /* NSLayoutConstraint+DashWallet.swift in Sources */,
@@ -10535,6 +10545,8 @@
 				75EBAA102BB99036004488E3 /* TextIntro.swift in Sources */,
 				RC00A0022FA0000000000001 /* TopIntro.swift in Sources */,
 				RC00A0052FA0000000000001 /* ExploreMenuScreen.swift in Sources */,
+				UM00A0022FA0000000000001 /* UsernameMarketplaceScreen.swift in Sources */,
+				UM00B0022FA0000000000001 /* UsernameMarketplaceService.swift in Sources */,
 				757514E52B1735370026AD8E /* JoinDashPayView.swift in Sources */,
 				C9D2C73C2A320AA000D15901 /* DWDecimalInputValidator.m in Sources */,
 				C9D2C73D2A320AA000D15901 /* PaymentMethods.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWContestedNameStatusService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWContestedNameStatusService.swift
@@ -213,8 +213,15 @@ public final class DWContestedNameStatusService: NSObject {
 
     @nonobjc
     func finalizeWon(username: String, network: Network) {
-        DWGlobalOptions.sharedInstance().dashpayUsername = username
-        DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = true
+        // Backfill the global username mirror only when it's empty (the
+        // setup-flow first-username case). A contested win on a SECOND
+        // name — requested from the username marketplace — must not
+        // displace the username the user already shows everywhere.
+        let options = DWGlobalOptions.sharedInstance()
+        if options.dashpayUsername?.isEmpty != false {
+            options.dashpayUsername = username
+        }
+        options.dashpayRegistrationCompleted = true
         clearPending(for: network)
         Self.logger.info("🪪 CONTEST-SVC :: finalizeWon label=\(username, privacy: .public)")
         DWCurrentUserIdentityInfo.shared.refreshFromSDK()

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -813,6 +813,21 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         } catch {
             Self.logger.error("👥 DASHPAY-SYNC :: startDashPaySync failed: \(String(describing: error), privacy: .public)")
         }
+
+        // Start the recurring DPNS username-marketplace sync (tracks the
+        // wallet identities' names with sale state, detects sold/
+        // transferred departures, refreshes seller balances). Same
+        // best-effort contract as the blocks above; the marketplace
+        // screen's pull-to-refresh (`syncDpnsMarketplace`) still works
+        // without the loop.
+        do {
+            if try !manager.isDpnsSyncRunning() {
+                try manager.startDpnsSync()
+            }
+            Self.logger.info("🏷️ DPNS-SYNC :: started for \(network.rawValue, privacy: .public)")
+        } catch {
+            Self.logger.error("🏷️ DPNS-SYNC :: startDpnsSync failed: \(String(describing: error), privacy: .public)")
+        }
 #endif
 
         self.sdk = SwiftDashSDKHost.shared.sdk

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -22,8 +22,8 @@
 
 import Foundation
 import OSLog
-import SwiftData
 import SwiftDashSDK
+import SwiftData
 
 // MARK: - Identifiable projections for SwiftUI
 
@@ -65,6 +65,9 @@ struct UsernameMarketplaceService {
         case noIdentity
         case contestedName
         case invalidRecipient
+        case invalidPrice
+        case authCancelled
+        case authFailed
 
         var errorDescription: String? {
             switch self {
@@ -74,6 +77,12 @@ struct UsernameMarketplaceService {
                 return NSLocalizedString("Short names are decided by a network vote — use Request Username instead.", comment: "Username marketplace")
             case .invalidRecipient:
                 return NSLocalizedString("The recipient identity couldn't be resolved.", comment: "Username marketplace")
+            case .invalidPrice:
+                return NSLocalizedString("This price is too high to list.", comment: "Username marketplace: listing price exceeds the representable maximum")
+            case .authCancelled:
+                return NSLocalizedString("Authentication cancelled", comment: "DashPay")
+            case .authFailed:
+                return NSLocalizedString("Authentication failed", comment: "DashPay")
             }
         }
     }
@@ -124,7 +133,10 @@ struct UsernameMarketplaceService {
 
     func setPrice(name: String, priceDuffs: UInt64) async throws {
         let (wallet, container, ownerId) = try requireOwnContext()
-        try await authorizer.authorize()
+        guard priceDuffs <= UInt64.max / 1_000 else {
+            throw ServiceError.invalidPrice
+        }
+        try await authorize()
         _ = try await wallet.setDpnsNamePrice(
             ownerIdentityId: ownerId,
             name: name,
@@ -135,7 +147,7 @@ struct UsernameMarketplaceService {
 
     func removeFromSale(name: String) async throws {
         let (wallet, container, ownerId) = try requireOwnContext()
-        try await authorizer.authorize()
+        try await authorize()
         _ = try await wallet.delistDpnsName(
             ownerIdentityId: ownerId,
             name: name,
@@ -148,7 +160,7 @@ struct UsernameMarketplaceService {
         guard let recipientId = Data.identifier(fromBase58: recipient), recipientId.count == 32 else {
             throw ServiceError.invalidRecipient
         }
-        try await authorizer.authorize()
+        try await authorize()
         _ = try await wallet.transferDpnsName(
             ownerIdentityId: ownerId,
             name: name,
@@ -164,7 +176,7 @@ struct UsernameMarketplaceService {
     /// seller-side change (typed `.priceChanged`).
     func purchase(name: String, expectedPriceCredits: UInt64) async throws {
         let (wallet, container, buyerId) = try requireOwnContext()
-        try await authorizer.authorize()
+        try await authorize()
         _ = try await wallet.purchaseDpnsName(
             purchaserIdentityId: buyerId,
             name: name,
@@ -184,7 +196,7 @@ struct UsernameMarketplaceService {
             throw ServiceError.contestedName
         }
         let (wallet, container, identityId) = try requireOwnContext()
-        try await authorizer.authorize()
+        try await authorize()
         _ = try await wallet.registerDpnsName(
             identityId: identityId,
             name: label,
@@ -212,7 +224,14 @@ struct UsernameMarketplaceService {
     @discardableResult
     func requestContestedName(label: String) async throws -> Date? {
         let (wallet, container, identityId) = try requireOwnContext()
-        try await authorizer.authorize()
+        // Capture the network BEFORE the PIN prompt and FFI awaits — a
+        // network switch mid-flight must not scope the bookmark to the
+        // newly-selected network (the network-explicit overload exists
+        // for exactly this).
+        guard let network = WalletEnvironment.network else {
+            throw ServiceError.noIdentity
+        }
+        try await authorize()
         _ = try await wallet.registerDpnsName(
             identityId: identityId,
             name: label,
@@ -221,15 +240,14 @@ struct UsernameMarketplaceService {
         // Bookmark BEFORE the vote-state read — Platform can legitimately
         // return nil until the contest is indexed, and the conservative
         // fallback deadline written here is what reconciliation leans on.
-        DWContestedNameStatusService.shared.recordSubmission(label: label)
+        DWContestedNameStatusService.shared.recordSubmission(label: label, network: network)
         do {
             _ = try await wallet.syncContestedDpnsNames(identityId: identityId)
         } catch {
             Self.logger.warning("🏷️ MARKET :: syncContestedDpnsNames failed: \(String(describing: error), privacy: .public)")
         }
         var endTime: Date?
-        if let network = WalletEnvironment.network,
-           let state = try? await wallet.fetchContestVoteState(identityId: identityId, label: label) {
+        if let state = try? await wallet.fetchContestVoteState(identityId: identityId, label: label) {
             endTime = state.endTime
             DWContestedNameStatusService.shared.recordVotingEndTime(state.endTime, network: network)
         }
@@ -277,11 +295,11 @@ struct UsernameMarketplaceService {
         guard let sdk = SwiftDashSDKHost.shared.sdk else { return .unknown }
         do {
             let state = try await sdk.dpnsGetContestedVoteState(name: label)
-            if let winner = state["winner"] as? String {
-                // "LOCKED" or a winning identity's base58 id. A won label
-                // has a domain document, so the search path already shows
-                // it as taken; treat it as locked-for-registration too.
-                return winner == "LOCKED" ? .locked : .activeContest(contenders: 0)
+            if state["winner"] is String {
+                // "LOCKED" or a winning identity's base58 id. Either way
+                // the vote is over and nobody can register the label, so
+                // both resolve to locked-for-registration.
+                return .locked
             }
             let contenders = (state["contenders"] as? [[String: Any]]) ?? []
             return contenders.isEmpty ? .fresh : .activeContest(contenders: contenders.count)
@@ -332,7 +350,7 @@ struct UsernameMarketplaceService {
                 return NSLocalizedString("This username is not for sale.", comment: "Username marketplace")
             case .priceChanged:
                 return NSLocalizedString("The seller changed the price before your purchase was accepted. Review the new price and try again.", comment: "Username marketplace")
-            case .insufficientIdentityCredits(_, let required, let available):
+            case let .insufficientIdentityCredits(_, required, available):
                 return String.localizedStringWithFormat(
                     NSLocalizedString("Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.", comment: "Username marketplace"),
                     (required / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol,
@@ -353,5 +371,20 @@ struct UsernameMarketplaceService {
             throw ServiceError.noIdentity
         }
         return (wallet, container, identityId)
+    }
+
+    /// PIN / biometric prompt with the authorizer's errors translated to
+    /// service errors, so a user cancellation stays distinguishable from
+    /// a failed marketplace action without callers importing the
+    /// authorizer's symbols (same shape as
+    /// `SwiftDashSDKContactsService.authorize()`).
+    private func authorize() async throws {
+        do {
+            try await authorizer.authorize()
+        } catch DWIdentityAuthorizer.AuthError.cancelled {
+            throw ServiceError.authCancelled
+        } catch {
+            throw ServiceError.authFailed
+        }
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -1,0 +1,386 @@
+//
+//  UsernameMarketplaceService.swift
+//  DashWallet
+//
+//  DPNS username marketplace over the v2 contract's trade surface
+//  (`transferable = 1`, `tradeMode = 1` — direct purchase):
+//
+//  - Reads go through `SDK.documentList` on the two indices the contract
+//    actually has: `parentNameAndLabel` (search) and `records.identity`
+//    (my names). There is NO `$price` index, so a global "browse
+//    everything for sale" query is not possible today — the marketplace
+//    is search-driven until the contract grows a price index (tracked in
+//    the platform-wallet marketplace task).
+//  - Trade actions compose the generic FFI-wired document transitions on
+//    `ManagedPlatformWallet`: `setDocumentPrice`, `purchaseDocument`,
+//    `transferDocument`. Consensus (verified in rs-drive) removes
+//    `$price` on BOTH purchase and transfer, so delisting is a transfer
+//    to the owner's own identity. Purchases require the transition price
+//    to equal the listed price, so a seller-side price change between
+//    view and confirm is rejected on-chain — surfaced here as
+//    `.priceChanged`.
+//
+//  Every action authenticates (PIN/biometric) BEFORE anything is signed
+//  or broadcast, and signs with the identity's critical authentication
+//  key (id 1) — critical satisfies every document security-level
+//  requirement short of master, and master keys cannot sign document
+//  transitions.
+//
+//  dashpay target only.
+//
+
+import Foundation
+import OSLog
+import SwiftData
+import SwiftDashSDK
+
+// MARK: - MarketplaceName
+
+/// One DPNS `domain` document projected for the marketplace UI. Every
+/// field is read defensively from the document JSON; absent data stays
+/// nil rather than defaulting.
+struct MarketplaceName: Identifiable, Equatable {
+    /// Base58 document id (`$id`) — the handle every trade action needs.
+    let documentIdBase58: String
+    /// Display label ("Alice"); falls back to the normalized label when
+    /// the pretty-cased one is absent.
+    let label: String
+    let normalizedLabel: String
+    /// Base58 `$ownerId` — the identity that owns (and may sell) the name.
+    let ownerIdBase58: String
+    /// Listed price in credits (`$price`); nil = not for sale.
+    let priceCredits: UInt64?
+    /// `$createdAt` / `$transferredAt` in ms when the document carries
+    /// them — the only trade-history facts readable without the SDK's
+    /// revision-history query (in progress).
+    let createdAtMs: UInt64?
+    let transferredAtMs: UInt64?
+
+    var id: String { documentIdBase58 }
+    var isForSale: Bool { priceCredits != nil }
+    var priceDuffs: UInt64? { priceCredits.map { $0 / 1_000 } }
+
+    func isOwned(by identityId: Data?) -> Bool {
+        guard let identityId else { return false }
+        return Data.identifier(fromBase58: ownerIdBase58) == identityId
+    }
+}
+
+// MARK: - UsernameMarketplaceService
+
+/// Stateless facade over the SDK marketplace surface. Instantiated per
+/// view model (it holds only an authorizer); deliberately NOT a
+/// singleton.
+@MainActor
+struct UsernameMarketplaceService {
+
+    private static let logger = Logger(
+        subsystem: "org.dashfoundation.dash",
+        category: "swift-sdk-migration.username-marketplace")
+
+    /// DPNS domain documents live under this parent domain.
+    private static let parentDomain = "dash"
+    private static let documentType = "domain"
+
+    /// Identity key id 1 = the critical authentication key every
+    /// registration creates; satisfies the document transitions'
+    /// security-level requirements (master keys are not allowed to sign
+    /// document transitions).
+    private static let signingKeyId: UInt32 = 1
+
+    /// Conservative fee reserve (credits) required ON TOP of the listed
+    /// price before a purchase is attempted: the observed document-batch
+    /// transition fee is well under 0.0005 DASH; 0.001 DASH keeps a 2x
+    /// margin. The actual fee is metered at execution from the buyer
+    /// identity's credits.
+    static let purchaseFeeReserveCredits: UInt64 = 100_000_000
+
+    enum ServiceError: LocalizedError, Equatable {
+        case noIdentity
+        case notForSale
+        case priceChanged
+        case insufficientIdentityCredits(neededCredits: UInt64, availableCredits: UInt64)
+        case contestedName
+        case invalidRecipient
+        case invalidDocument
+
+        var errorDescription: String? {
+            switch self {
+            case .noIdentity:
+                return NSLocalizedString("No DashPay identity is registered", comment: "DashPay")
+            case .notForSale:
+                return NSLocalizedString("This username is not for sale.", comment: "Username marketplace")
+            case .priceChanged:
+                return NSLocalizedString("The seller changed the price before your purchase was accepted. Review the new price and try again.", comment: "Username marketplace")
+            case .insufficientIdentityCredits(let needed, let available):
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.", comment: "Username marketplace"),
+                    (needed / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol,
+                    (available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
+            case .contestedName:
+                return NSLocalizedString("This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.", comment: "Username marketplace")
+            case .invalidRecipient:
+                return NSLocalizedString("The recipient identity couldn't be resolved.", comment: "Username marketplace")
+            case .invalidDocument:
+                return NSLocalizedString("This username's record couldn't be read from the network.", comment: "Username marketplace")
+            }
+        }
+    }
+
+    private let authorizer = DWIdentityAuthorizer()
+
+    // MARK: Reads
+
+    /// Prefix search over the `parentNameAndLabel` index — one query
+    /// returns the full documents, so sale state and price come with the
+    /// results (unlike `searchDpnsNames`, which only returns name +
+    /// identity).
+    func search(prefix: String, limit: UInt32 = 25) async throws -> [MarketplaceName] {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
+        let normalized = (try? sdk.dpnsNormalizeLabel(prefix)) ?? prefix.lowercased()
+        guard !normalized.isEmpty else { return [] }
+        let whereClause = """
+        [["normalizedParentDomainName","==","\(Self.parentDomain)"],["normalizedLabel","startsWith","\(normalized)"]]
+        """
+        let orderBy = "[[\"normalizedLabel\",\"asc\"]]"
+        let result = try await sdk.documentList(
+            dataContractId: DPNSVotePoll.contractId,
+            documentType: Self.documentType,
+            whereClause: whereClause,
+            orderByClause: orderBy,
+            limit: limit)
+        return Self.parseDomainDocuments(result)
+    }
+
+    /// Every domain document owned by `identityIdBase58`, via the
+    /// `records.identity` index.
+    func names(ownedBy identityIdBase58: String) async throws -> [MarketplaceName] {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
+        let whereClause = "[[\"records.identity\",\"==\",\"\(identityIdBase58)\"]]"
+        let result = try await sdk.documentList(
+            dataContractId: DPNSVotePoll.contractId,
+            documentType: Self.documentType,
+            whereClause: whereClause,
+            limit: 50)
+        return Self.parseDomainDocuments(result)
+    }
+
+    /// The single domain document for an exact label, or nil when the
+    /// name is unregistered. Used to re-read the authoritative sale
+    /// state right before a purchase.
+    func name(exactLabel: String) async throws -> MarketplaceName? {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return nil }
+        let normalized = (try? sdk.dpnsNormalizeLabel(exactLabel)) ?? exactLabel.lowercased()
+        let whereClause = """
+        [["normalizedParentDomainName","==","\(Self.parentDomain)"],["normalizedLabel","==","\(normalized)"]]
+        """
+        let result = try await sdk.documentList(
+            dataContractId: DPNSVotePoll.contractId,
+            documentType: Self.documentType,
+            whereClause: whereClause,
+            limit: 1)
+        return Self.parseDomainDocuments(result).first
+    }
+
+    // MARK: Trade actions (all PIN-gated)
+
+    /// List a name for sale, or change its price. `priceDuffs` is what
+    /// the user typed; the document stores credits.
+    func setPrice(name: MarketplaceName, priceDuffs: UInt64) async throws {
+        let (wallet, container, ownerId) = try requireOwnContext()
+        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
+        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
+            throw ServiceError.invalidDocument
+        }
+        try await authorizer.authorize()
+        _ = try await wallet.setDocumentPrice(
+            ownerIdentityId: ownerId,
+            contractId: Self.contractIdentifier(),
+            documentType: Self.documentType,
+            documentId: documentId,
+            price: priceDuffs * 1_000,
+            signingKeyId: Self.signingKeyId,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: price set on \(name.normalizedLabel, privacy: .public)")
+    }
+
+    /// Remove a name from sale. Consensus clears `$price` on every
+    /// transfer (rs-drive `document_transfer_transition_action`), so a
+    /// transfer to the owner's own identity delists without changing
+    /// ownership — the contract has no dedicated "remove price"
+    /// transition (`documentsMutable = false`).
+    func removeFromSale(name: MarketplaceName) async throws {
+        let (wallet, container, ownerId) = try requireOwnContext()
+        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
+        try await transfer(name: name, toIdentity: ownerId, wallet: wallet, container: container, ownerId: ownerId)
+        Self.logger.info("🏷️ MARKET :: delisted \(name.normalizedLabel, privacy: .public) via self-transfer")
+    }
+
+    /// Gift/transfer a name to another identity (also clears any listing).
+    func transfer(name: MarketplaceName, toIdentityBase58 recipient: String) async throws {
+        let (wallet, container, ownerId) = try requireOwnContext()
+        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
+        guard let recipientId = Data.identifier(fromBase58: recipient), recipientId.count == 32 else {
+            throw ServiceError.invalidRecipient
+        }
+        try await transfer(name: name, toIdentity: recipientId, wallet: wallet, container: container, ownerId: ownerId)
+    }
+
+    /// Buy a listed name. `expectedPriceCredits` is the price the user
+    /// confirmed — the transition pins it, and consensus rejects the
+    /// purchase if the seller changed the listing in between (surfaced
+    /// as `.priceChanged` after a re-read).
+    func purchase(name: MarketplaceName, expectedPriceCredits: UInt64) async throws {
+        let (wallet, container, buyerId) = try requireOwnContext()
+        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
+            throw ServiceError.invalidDocument
+        }
+        // Authoritative pre-flight: the listing may have changed or gone
+        // since the row rendered.
+        guard let current = try await self.name(exactLabel: name.normalizedLabel) else {
+            throw ServiceError.invalidDocument
+        }
+        guard let listedPrice = current.priceCredits else { throw ServiceError.notForSale }
+        guard listedPrice == expectedPriceCredits else { throw ServiceError.priceChanged }
+
+        let needed = listedPrice + Self.purchaseFeeReserveCredits
+        let available = Self.identityBalanceCredits(identityId: buyerId, container: container)
+        guard available >= needed else {
+            throw ServiceError.insufficientIdentityCredits(
+                neededCredits: needed, availableCredits: available)
+        }
+
+        try await authorizer.authorize()
+        _ = try await wallet.purchaseDocument(
+            purchaserId: buyerId,
+            contractId: Self.contractIdentifier(),
+            documentType: Self.documentType,
+            documentId: documentId,
+            price: listedPrice,
+            signingKeyId: Self.signingKeyId,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: purchased \(name.normalizedLabel, privacy: .public) for \(listedPrice, privacy: .public) credits")
+        // The name now points at the buyer's identity; refresh the
+        // snapshots the rest of the app renders usernames from.
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+    }
+
+    /// Register a name nobody owns. Contested-eligible labels (3–19
+    /// characters, letters/digits only per DPNS rules) must go through
+    /// the voting flow instead — this path refuses them rather than
+    /// silently starting a vote.
+    func register(label: String) async throws {
+        let (wallet, container, identityId) = try requireOwnContext()
+        if let sdk = SwiftDashSDKHost.shared.sdk {
+            let normalized = (try? sdk.dpnsNormalizeLabel(label)) ?? label.lowercased()
+            if Self.isContestedEligible(normalizedLabel: normalized) {
+                throw ServiceError.contestedName
+            }
+        }
+        try await authorizer.authorize()
+        _ = try await wallet.registerDpnsName(
+            identityId: identityId,
+            name: label,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: registered \(label, privacy: .public)")
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+    }
+
+    // MARK: Helpers
+
+    /// DPNS contested-name eligibility per the platform rules the
+    /// username flow enforces: normalized labels of 3–19 characters
+    /// consisting only of letters and digits (no hyphen) go to a vote.
+    static func isContestedEligible(normalizedLabel: String) -> Bool {
+        let length = normalizedLabel.count
+        guard (3...19).contains(length) else { return false }
+        return normalizedLabel.allSatisfy { $0.isLetter || $0.isNumber }
+            && !normalizedLabel.allSatisfy { $0.isNumber }
+    }
+
+    /// Buyer identity's credit balance from the persisted row (same
+    /// bit-pattern read the identities screen uses).
+    static func identityBalanceCredits(identityId: Data, container: ModelContainer) -> UInt64 {
+        var descriptor = FetchDescriptor<PersistentIdentity>(
+            predicate: #Predicate { $0.identityId == identityId })
+        descriptor.fetchLimit = 1
+        guard let identity = (try? container.mainContext.fetch(descriptor))?.first else { return 0 }
+        return UInt64(bitPattern: identity.balance)
+    }
+
+    private func transfer(
+        name: MarketplaceName,
+        toIdentity recipientId: Data,
+        wallet: ManagedPlatformWallet,
+        container: ModelContainer,
+        ownerId: Data
+    ) async throws {
+        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
+            throw ServiceError.invalidDocument
+        }
+        try await authorizer.authorize()
+        _ = try await wallet.transferDocument(
+            ownerIdentityId: ownerId,
+            contractId: Self.contractIdentifier(),
+            documentType: Self.documentType,
+            documentId: documentId,
+            recipientId: recipientId,
+            signingKeyId: Self.signingKeyId,
+            signer: KeychainSigner(modelContainer: container))
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+    }
+
+    private func requireOwnContext() throws -> (ManagedPlatformWallet, ModelContainer, Data) {
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let container = SwiftDashSDKHost.shared.modelContainer,
+              let identityId = DWCurrentUserIdentityInfo.shared.identityId else {
+            throw ServiceError.noIdentity
+        }
+        return (wallet, container, identityId)
+    }
+
+    private static func contractIdentifier() throws -> Data {
+        guard let id = Data.identifier(fromBase58: DPNSVotePoll.contractId) else {
+            throw ServiceError.invalidDocument
+        }
+        return id
+    }
+
+    /// Parse `documentList`'s JSON payload into projections. Accepts the
+    /// `{"documents": [...]}` envelope or a bare array; anything that
+    /// doesn't carry the required identity fields is dropped rather than
+    /// guessed at.
+    static func parseDomainDocuments(_ payload: [String: Any]) -> [MarketplaceName] {
+        let docs: [[String: Any]]
+        if let array = payload["documents"] as? [[String: Any]] {
+            docs = array
+        } else if let array = payload["items"] as? [[String: Any]] {
+            docs = array
+        } else if payload["$id"] != nil {
+            docs = [payload]
+        } else {
+            docs = payload.values.compactMap { $0 as? [String: Any] }
+        }
+        return docs.compactMap { doc in
+            guard let documentId = doc["$id"] as? String,
+                  let ownerId = doc["$ownerId"] as? String else { return nil }
+            let normalized = (doc["normalizedLabel"] as? String) ?? ""
+            let label = (doc["label"] as? String) ?? normalized
+            guard !label.isEmpty else { return nil }
+            return MarketplaceName(
+                documentIdBase58: documentId,
+                label: label,
+                normalizedLabel: normalized.isEmpty ? label.lowercased() : normalized,
+                ownerIdBase58: ownerId,
+                priceCredits: Self.uint64(doc["$price"]),
+                createdAtMs: Self.uint64(doc["$createdAt"]),
+                transferredAtMs: Self.uint64(doc["$transferredAt"]))
+        }
+    }
+
+    private static func uint64(_ value: Any?) -> UInt64? {
+        if let number = value as? NSNumber { return number.uint64Value }
+        if let string = value as? String, let parsed = UInt64(string) { return parsed }
+        return nil
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -2,29 +2,20 @@
 //  UsernameMarketplaceService.swift
 //  DashWallet
 //
-//  DPNS username marketplace over the v2 contract's trade surface
-//  (`transferable = 1`, `tradeMode = 1` — direct purchase):
+//  DPNS username marketplace over the wallet-level SDK surface that
+//  landed with platform #4348 (`DpnsMarketplace.swift`): typed search
+//  with sale state, locally persisted my-names rows (including retained
+//  sold/transferred departures), per-name trade history from the
+//  Document History contract, and orchestrated trade operations with
+//  typed errors — `notForSale`, `priceChanged` (a purchase never
+//  executes at a price the user didn't confirm; consensus is the
+//  backstop), `insufficientIdentityCredits`, and
+//  `contestedNameNotTradable`.
 //
-//  - Reads go through `SDK.documentList` on the two indices the contract
-//    actually has: `parentNameAndLabel` (search) and `records.identity`
-//    (my names). There is NO `$price` index, so a global "browse
-//    everything for sale" query is not possible today — the marketplace
-//    is search-driven until the contract grows a price index (tracked in
-//    the platform-wallet marketplace task).
-//  - Trade actions compose the generic FFI-wired document transitions on
-//    `ManagedPlatformWallet`: `setDocumentPrice`, `purchaseDocument`,
-//    `transferDocument`. Consensus (verified in rs-drive) removes
-//    `$price` on BOTH purchase and transfer, so delisting is a transfer
-//    to the owner's own identity. Purchases require the transition price
-//    to equal the listed price, so a seller-side price change between
-//    view and confirm is rejected on-chain — surfaced here as
-//    `.priceChanged`.
-//
-//  Every action authenticates (PIN/biometric) BEFORE anything is signed
-//  or broadcast, and signs with the identity's critical authentication
-//  key (id 1) — critical satisfies every document security-level
-//  requirement short of master, and master keys cannot sign document
-//  transitions.
+//  This layer adds only what belongs to the app: the PIN/biometric gate
+//  before anything is signed, resolution of the wallet's main identity,
+//  friendlier wording for the errors users act on, and the contested
+//  guard for direct registration (the trade ops are typed by the SDK).
 //
 //  dashpay target only.
 //
@@ -34,35 +25,27 @@ import OSLog
 import SwiftData
 import SwiftDashSDK
 
-// MARK: - MarketplaceName
+// MARK: - Identifiable projections for SwiftUI
 
-/// One DPNS `domain` document projected for the marketplace UI. Every
-/// field is read defensively from the document JSON; absent data stays
-/// nil rather than defaulting.
-struct MarketplaceName: Identifiable, Equatable {
-    /// Base58 document id (`$id`) — the handle every trade action needs.
-    let documentIdBase58: String
-    /// Display label ("Alice"); falls back to the normalized label when
-    /// the pretty-cased one is absent.
-    let label: String
-    let normalizedLabel: String
-    /// Base58 `$ownerId` — the identity that owns (and may sell) the name.
-    let ownerIdBase58: String
-    /// Listed price in credits (`$price`); nil = not for sale.
-    let priceCredits: UInt64?
-    /// `$createdAt` / `$transferredAt` in ms when the document carries
-    /// them — the only trade-history facts readable without the SDK's
-    /// revision-history query (in progress).
-    let createdAtMs: UInt64?
-    let transferredAtMs: UInt64?
+extension DpnsMarketplaceName: Identifiable {
+    public var id: Data { documentId }
 
-    var id: String { documentIdBase58 }
-    var isForSale: Bool { priceCredits != nil }
     var priceDuffs: UInt64? { priceCredits.map { $0 / 1_000 } }
+    var isForSale: Bool { priceCredits != nil }
 
     func isOwned(by identityId: Data?) -> Bool {
         guard let identityId else { return false }
-        return Data.identifier(fromBase58: ownerIdBase58) == identityId
+        return ownerId == identityId
+    }
+}
+
+extension DpnsNameStateRow: Identifiable {
+    public var id: Data { documentId }
+
+    var priceDuffs: UInt64? { priceCredits.map { $0 / 1_000 } }
+    var isForSale: Bool {
+        guard case .owned = status else { return false }
+        return priceCredits != nil
     }
 }
 
@@ -78,51 +61,19 @@ struct UsernameMarketplaceService {
         subsystem: "org.dashfoundation.dash",
         category: "swift-sdk-migration.username-marketplace")
 
-    /// DPNS domain documents live under this parent domain.
-    private static let parentDomain = "dash"
-    private static let documentType = "domain"
-
-    /// Identity key id 1 = the critical authentication key every
-    /// registration creates; satisfies the document transitions'
-    /// security-level requirements (master keys are not allowed to sign
-    /// document transitions).
-    private static let signingKeyId: UInt32 = 1
-
-    /// Conservative fee reserve (credits) required ON TOP of the listed
-    /// price before a purchase is attempted: the observed document-batch
-    /// transition fee is well under 0.0005 DASH; 0.001 DASH keeps a 2x
-    /// margin. The actual fee is metered at execution from the buyer
-    /// identity's credits.
-    static let purchaseFeeReserveCredits: UInt64 = 100_000_000
-
-    enum ServiceError: LocalizedError, Equatable {
+    enum ServiceError: LocalizedError {
         case noIdentity
-        case notForSale
-        case priceChanged
-        case insufficientIdentityCredits(neededCredits: UInt64, availableCredits: UInt64)
         case contestedName
         case invalidRecipient
-        case invalidDocument
 
         var errorDescription: String? {
             switch self {
             case .noIdentity:
                 return NSLocalizedString("No DashPay identity is registered", comment: "DashPay")
-            case .notForSale:
-                return NSLocalizedString("This username is not for sale.", comment: "Username marketplace")
-            case .priceChanged:
-                return NSLocalizedString("The seller changed the price before your purchase was accepted. Review the new price and try again.", comment: "Username marketplace")
-            case .insufficientIdentityCredits(let needed, let available):
-                return String.localizedStringWithFormat(
-                    NSLocalizedString("Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.", comment: "Username marketplace"),
-                    (needed / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol,
-                    (available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
             case .contestedName:
                 return NSLocalizedString("This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.", comment: "Username marketplace")
             case .invalidRecipient:
                 return NSLocalizedString("The recipient identity couldn't be resolved.", comment: "Username marketplace")
-            case .invalidDocument:
-                return NSLocalizedString("This username's record couldn't be read from the network.", comment: "Username marketplace")
             }
         }
     }
@@ -131,144 +82,103 @@ struct UsernameMarketplaceService {
 
     // MARK: Reads
 
-    /// Prefix search over the `parentNameAndLabel` index — one query
-    /// returns the full documents, so sale state and price come with the
-    /// results (unlike `searchDpnsNames`, which only returns name +
-    /// identity).
-    func search(prefix: String, limit: UInt32 = 25) async throws -> [MarketplaceName] {
-        guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
-        let normalized = (try? sdk.dpnsNormalizeLabel(prefix)) ?? prefix.lowercased()
-        guard !normalized.isEmpty else { return [] }
-        let whereClause = """
-        [["normalizedParentDomainName","==","\(Self.parentDomain)"],["normalizedLabel","startsWith","\(normalized)"]]
-        """
-        let orderBy = "[[\"normalizedLabel\",\"asc\"]]"
-        let result = try await sdk.documentList(
-            dataContractId: DPNSVotePoll.contractId,
-            documentType: Self.documentType,
-            whereClause: whereClause,
-            orderByClause: orderBy,
-            limit: limit)
-        return Self.parseDomainDocuments(result)
+    /// Prefix search with live sale state — one network query.
+    func search(prefix: String, limit: UInt32 = 25) async throws -> [DpnsMarketplaceName] {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return [] }
+        return try await wallet.searchDpnsMarketplace(prefix: prefix, limit: limit)
     }
 
-    /// Every domain document owned by `identityIdBase58`, via the
-    /// `records.identity` index.
-    func names(ownedBy identityIdBase58: String) async throws -> [MarketplaceName] {
-        guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
-        let whereClause = "[[\"records.identity\",\"==\",\"\(identityIdBase58)\"]]"
-        let result = try await sdk.documentList(
-            dataContractId: DPNSVotePoll.contractId,
-            documentType: Self.documentType,
-            whereClause: whereClause,
-            limit: 50)
-        return Self.parseDomainDocuments(result)
+    /// The main identity's tracked names from the wallet's local rows —
+    /// no network round-trip. Includes retained `.sold` / `.transferred`
+    /// departures so the UI can show what left and to whom.
+    func myNames() async throws -> [DpnsNameStateRow] {
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let identityId = DWCurrentUserIdentityInfo.shared.identityId else { return [] }
+        return try await wallet.myDpnsMarketplaceNames(identityId: identityId)
     }
 
-    /// The single domain document for an exact label, or nil when the
-    /// name is unregistered. Used to re-read the authoritative sale
-    /// state right before a purchase.
-    func name(exactLabel: String) async throws -> MarketplaceName? {
-        guard let sdk = SwiftDashSDKHost.shared.sdk else { return nil }
-        let normalized = (try? sdk.dpnsNormalizeLabel(exactLabel)) ?? exactLabel.lowercased()
-        let whereClause = """
-        [["normalizedParentDomainName","==","\(Self.parentDomain)"],["normalizedLabel","==","\(normalized)"]]
-        """
-        let result = try await sdk.documentList(
-            dataContractId: DPNSVotePoll.contractId,
-            documentType: Self.documentType,
-            whereClause: whereClause,
-            limit: 1)
-        return Self.parseDomainDocuments(result).first
+    /// Authoritative live state of one exact name; nil = unregistered.
+    func nameState(_ name: String) async throws -> DpnsMarketplaceName? {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
+        return try await wallet.dpnsMarketplaceNameState(name: name)
     }
 
-    // MARK: Trade actions (all PIN-gated)
+    /// Full trade timeline (registration, listings, purchases with
+    /// counterparties, transfers), block-time ascending.
+    func history(_ name: String) async throws -> [DpnsNameHistoryEvent] {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return [] }
+        return try await wallet.dpnsNameHistory(name: name)
+    }
 
-    /// List a name for sale, or change its price. `priceDuffs` is what
-    /// the user typed; the document stores credits.
-    func setPrice(name: MarketplaceName, priceDuffs: UInt64) async throws {
-        let (wallet, container, ownerId) = try requireOwnContext()
-        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
-        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
-            throw ServiceError.invalidDocument
+    /// Pull-to-refresh: one marketplace sync pass (tracked names, added/
+    /// departed labels, price changes, seller balance refreshes).
+    @discardableResult
+    func syncNow() async throws -> DpnsMarketplaceSyncSummary {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            throw ServiceError.noIdentity
         }
+        return try await wallet.syncDpnsMarketplace()
+    }
+
+    // MARK: Trade actions (all PIN-gated; SDK errors are typed)
+
+    func setPrice(name: String, priceDuffs: UInt64) async throws {
+        let (wallet, container, ownerId) = try requireOwnContext()
         try await authorizer.authorize()
-        _ = try await wallet.setDocumentPrice(
+        _ = try await wallet.setDpnsNamePrice(
             ownerIdentityId: ownerId,
-            contractId: Self.contractIdentifier(),
-            documentType: Self.documentType,
-            documentId: documentId,
-            price: priceDuffs * 1_000,
-            signingKeyId: Self.signingKeyId,
+            name: name,
+            priceCredits: priceDuffs * 1_000,
             signer: KeychainSigner(modelContainer: container))
-        Self.logger.info("🏷️ MARKET :: price set on \(name.normalizedLabel, privacy: .public)")
+        Self.logger.info("🏷️ MARKET :: price set on \(name, privacy: .public)")
     }
 
-    /// Remove a name from sale. Consensus clears `$price` on every
-    /// transfer (rs-drive `document_transfer_transition_action`), so a
-    /// transfer to the owner's own identity delists without changing
-    /// ownership — the contract has no dedicated "remove price"
-    /// transition (`documentsMutable = false`).
-    func removeFromSale(name: MarketplaceName) async throws {
+    func removeFromSale(name: String) async throws {
         let (wallet, container, ownerId) = try requireOwnContext()
-        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
-        try await transfer(name: name, toIdentity: ownerId, wallet: wallet, container: container, ownerId: ownerId)
-        Self.logger.info("🏷️ MARKET :: delisted \(name.normalizedLabel, privacy: .public) via self-transfer")
+        try await authorizer.authorize()
+        _ = try await wallet.delistDpnsName(
+            ownerIdentityId: ownerId,
+            name: name,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: delisted \(name, privacy: .public)")
     }
 
-    /// Gift/transfer a name to another identity (also clears any listing).
-    func transfer(name: MarketplaceName, toIdentityBase58 recipient: String) async throws {
+    func transfer(name: String, toIdentityBase58 recipient: String) async throws {
         let (wallet, container, ownerId) = try requireOwnContext()
-        guard name.isOwned(by: ownerId) else { throw ServiceError.invalidDocument }
         guard let recipientId = Data.identifier(fromBase58: recipient), recipientId.count == 32 else {
             throw ServiceError.invalidRecipient
         }
-        try await transfer(name: name, toIdentity: recipientId, wallet: wallet, container: container, ownerId: ownerId)
+        try await authorizer.authorize()
+        _ = try await wallet.transferDpnsName(
+            ownerIdentityId: ownerId,
+            name: name,
+            recipientId: recipientId,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: transferred \(name, privacy: .public)")
+        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
     }
 
-    /// Buy a listed name. `expectedPriceCredits` is the price the user
-    /// confirmed — the transition pins it, and consensus rejects the
-    /// purchase if the seller changed the listing in between (surfaced
-    /// as `.priceChanged` after a re-read).
-    func purchase(name: MarketplaceName, expectedPriceCredits: UInt64) async throws {
+    /// Buy a listed name at exactly `expectedPriceCredits` — the SDK
+    /// pre-flights the listing and the buyer's identity balance, pins the
+    /// confirmed price into the transition, and consensus rejects any
+    /// seller-side change (typed `.priceChanged`).
+    func purchase(name: String, expectedPriceCredits: UInt64) async throws {
         let (wallet, container, buyerId) = try requireOwnContext()
-        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
-            throw ServiceError.invalidDocument
-        }
-        // Authoritative pre-flight: the listing may have changed or gone
-        // since the row rendered.
-        guard let current = try await self.name(exactLabel: name.normalizedLabel) else {
-            throw ServiceError.invalidDocument
-        }
-        guard let listedPrice = current.priceCredits else { throw ServiceError.notForSale }
-        guard listedPrice == expectedPriceCredits else { throw ServiceError.priceChanged }
-
-        let needed = listedPrice + Self.purchaseFeeReserveCredits
-        let available = Self.identityBalanceCredits(identityId: buyerId, container: container)
-        guard available >= needed else {
-            throw ServiceError.insufficientIdentityCredits(
-                neededCredits: needed, availableCredits: available)
-        }
-
         try await authorizer.authorize()
-        _ = try await wallet.purchaseDocument(
-            purchaserId: buyerId,
-            contractId: Self.contractIdentifier(),
-            documentType: Self.documentType,
-            documentId: documentId,
-            price: listedPrice,
-            signingKeyId: Self.signingKeyId,
+        _ = try await wallet.purchaseDpnsName(
+            purchaserIdentityId: buyerId,
+            name: name,
+            expectedPriceCredits: expectedPriceCredits,
             signer: KeychainSigner(modelContainer: container))
-        Self.logger.info("🏷️ MARKET :: purchased \(name.normalizedLabel, privacy: .public) for \(listedPrice, privacy: .public) credits")
+        Self.logger.info("🏷️ MARKET :: purchased \(name, privacy: .public) for \(expectedPriceCredits, privacy: .public) credits")
         // The name now points at the buyer's identity; refresh the
         // snapshots the rest of the app renders usernames from.
         DWCurrentUserIdentityInfo.shared.refreshFromSDK()
     }
 
-    /// Register a name nobody owns. Contested-eligible labels (3–19
-    /// characters, letters/digits only per DPNS rules) must go through
-    /// the voting flow instead — this path refuses them rather than
-    /// silently starting a vote.
+    /// Register a name nobody owns. Contested-eligible labels must go
+    /// through the voting flow instead — this path refuses them rather
+    /// than silently starting a vote.
     func register(label: String) async throws {
         let (wallet, container, identityId) = try requireOwnContext()
         if let sdk = SwiftDashSDKHost.shared.sdk {
@@ -298,8 +208,8 @@ struct UsernameMarketplaceService {
             && !normalizedLabel.allSatisfy { $0.isNumber }
     }
 
-    /// Buyer identity's credit balance from the persisted row (same
-    /// bit-pattern read the identities screen uses).
+    /// Buyer identity's credit balance from the persisted row — for the
+    /// affordability hint; the SDK re-checks authoritatively at purchase.
     static func identityBalanceCredits(identityId: Data, container: ModelContainer) -> UInt64 {
         var descriptor = FetchDescriptor<PersistentIdentity>(
             predicate: #Predicate { $0.identityId == identityId })
@@ -308,26 +218,27 @@ struct UsernameMarketplaceService {
         return UInt64(bitPattern: identity.balance)
     }
 
-    private func transfer(
-        name: MarketplaceName,
-        toIdentity recipientId: Data,
-        wallet: ManagedPlatformWallet,
-        container: ModelContainer,
-        ownerId: Data
-    ) async throws {
-        guard let documentId = Data.identifier(fromBase58: name.documentIdBase58) else {
-            throw ServiceError.invalidDocument
+    /// Friendlier wording for the typed SDK failures a user acts on;
+    /// everything else keeps the SDK's own description.
+    static func userFacingMessage(for error: Error) -> String {
+        if let walletError = error as? PlatformWalletError {
+            switch walletError {
+            case .notForSale:
+                return NSLocalizedString("This username is not for sale.", comment: "Username marketplace")
+            case .priceChanged:
+                return NSLocalizedString("The seller changed the price before your purchase was accepted. Review the new price and try again.", comment: "Username marketplace")
+            case .insufficientIdentityCredits(_, let required, let available):
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.", comment: "Username marketplace"),
+                    (required / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol,
+                    (available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
+            case .contestedNameNotTradable:
+                return NSLocalizedString("This name is in an active network vote and can't be traded until the contest ends.", comment: "Username marketplace")
+            default:
+                break
+            }
         }
-        try await authorizer.authorize()
-        _ = try await wallet.transferDocument(
-            ownerIdentityId: ownerId,
-            contractId: Self.contractIdentifier(),
-            documentType: Self.documentType,
-            documentId: documentId,
-            recipientId: recipientId,
-            signingKeyId: Self.signingKeyId,
-            signer: KeychainSigner(modelContainer: container))
-        DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+        return error.localizedDescription
     }
 
     private func requireOwnContext() throws -> (ManagedPlatformWallet, ModelContainer, Data) {
@@ -337,50 +248,5 @@ struct UsernameMarketplaceService {
             throw ServiceError.noIdentity
         }
         return (wallet, container, identityId)
-    }
-
-    private static func contractIdentifier() throws -> Data {
-        guard let id = Data.identifier(fromBase58: DPNSVotePoll.contractId) else {
-            throw ServiceError.invalidDocument
-        }
-        return id
-    }
-
-    /// Parse `documentList`'s JSON payload into projections. Accepts the
-    /// `{"documents": [...]}` envelope or a bare array; anything that
-    /// doesn't carry the required identity fields is dropped rather than
-    /// guessed at.
-    static func parseDomainDocuments(_ payload: [String: Any]) -> [MarketplaceName] {
-        let docs: [[String: Any]]
-        if let array = payload["documents"] as? [[String: Any]] {
-            docs = array
-        } else if let array = payload["items"] as? [[String: Any]] {
-            docs = array
-        } else if payload["$id"] != nil {
-            docs = [payload]
-        } else {
-            docs = payload.values.compactMap { $0 as? [String: Any] }
-        }
-        return docs.compactMap { doc in
-            guard let documentId = doc["$id"] as? String,
-                  let ownerId = doc["$ownerId"] as? String else { return nil }
-            let normalized = (doc["normalizedLabel"] as? String) ?? ""
-            let label = (doc["label"] as? String) ?? normalized
-            guard !label.isEmpty else { return nil }
-            return MarketplaceName(
-                documentIdBase58: documentId,
-                label: label,
-                normalizedLabel: normalized.isEmpty ? label.lowercased() : normalized,
-                ownerIdBase58: ownerId,
-                priceCredits: Self.uint64(doc["$price"]),
-                createdAtMs: Self.uint64(doc["$createdAt"]),
-                transferredAtMs: Self.uint64(doc["$transferredAt"]))
-        }
-    }
-
-    private static func uint64(_ value: Any?) -> UInt64? {
-        if let number = value as? NSNumber { return number.uint64Value }
-        if let string = value as? String, let parsed = UInt64(string) { return parsed }
-        return nil
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -71,7 +71,7 @@ struct UsernameMarketplaceService {
             case .noIdentity:
                 return NSLocalizedString("No DashPay identity is registered", comment: "DashPay")
             case .contestedName:
-                return NSLocalizedString("This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.", comment: "Username marketplace")
+                return NSLocalizedString("Short names are decided by a network vote — use Request Username instead.", comment: "Username marketplace")
             case .invalidRecipient:
                 return NSLocalizedString("The recipient identity couldn't be resolved.", comment: "Username marketplace")
             }
@@ -176,17 +176,14 @@ struct UsernameMarketplaceService {
         DWCurrentUserIdentityInfo.shared.refreshFromSDK()
     }
 
-    /// Register a name nobody owns. Contested-eligible labels must go
-    /// through the voting flow instead — this path refuses them rather
-    /// than silently starting a vote.
+    /// Register a name nobody owns, claimed instantly. Contested-eligible
+    /// labels go through `requestContestedName` instead — this path
+    /// refuses them rather than silently starting a vote.
     func register(label: String) async throws {
-        let (wallet, container, identityId) = try requireOwnContext()
-        if let sdk = SwiftDashSDKHost.shared.sdk {
-            let normalized = (try? sdk.dpnsNormalizeLabel(label)) ?? label.lowercased()
-            if Self.isContestedEligible(normalizedLabel: normalized) {
-                throw ServiceError.contestedName
-            }
+        guard !Self.isContested(label) else {
+            throw ServiceError.contestedName
         }
+        let (wallet, container, identityId) = try requireOwnContext()
         try await authorizer.authorize()
         _ = try await wallet.registerDpnsName(
             identityId: identityId,
@@ -196,17 +193,125 @@ struct UsernameMarketplaceService {
         DWCurrentUserIdentityInfo.shared.refreshFromSDK()
     }
 
+    /// Request a contested-eligible name. Same `registerDpnsName`
+    /// transition, but the on-chain effect differs: the label enters a
+    /// masternode vote (~2 weeks mainnet) instead of being claimed, and
+    /// the transition locks the protocol's vote-resolution fund
+    /// (`contestedFundCredits`) from the identity balance.
+    ///
+    /// Mirrors step 3.5 of `DWIdentityRegistrationCoordinator`: the
+    /// submission is bookmarked in `DWContestedNameStatusService` so the
+    /// not-yet-owned label stays out of every username surface
+    /// (`DWCurrentUserIdentityInfo`'s pending filter) and the Home-appear
+    /// reconciliation resolves the eventual win/loss. The bookmark is
+    /// single-slot — a newer contested submission replaces an older one
+    /// there, but the SDK's contested-names cache tracks all of them.
+    ///
+    /// Returns the authoritative voting end time when Platform has
+    /// already indexed the contest, nil while indexing lags.
+    @discardableResult
+    func requestContestedName(label: String) async throws -> Date? {
+        let (wallet, container, identityId) = try requireOwnContext()
+        try await authorizer.authorize()
+        _ = try await wallet.registerDpnsName(
+            identityId: identityId,
+            name: label,
+            signer: KeychainSigner(modelContainer: container))
+        Self.logger.info("🏷️ MARKET :: contested request submitted for \(label, privacy: .public)")
+        // Bookmark BEFORE the vote-state read — Platform can legitimately
+        // return nil until the contest is indexed, and the conservative
+        // fallback deadline written here is what reconciliation leans on.
+        DWContestedNameStatusService.shared.recordSubmission(label: label)
+        do {
+            _ = try await wallet.syncContestedDpnsNames(identityId: identityId)
+        } catch {
+            Self.logger.warning("🏷️ MARKET :: syncContestedDpnsNames failed: \(String(describing: error), privacy: .public)")
+        }
+        var endTime: Date?
+        if let network = WalletEnvironment.network,
+           let state = try? await wallet.fetchContestVoteState(identityId: identityId, label: label) {
+            endTime = state.endTime
+            DWContestedNameStatusService.shared.recordVotingEndTime(state.endTime, network: network)
+        }
+        return endTime
+    }
+
+    // MARK: Contest reads
+
+    /// Labels this identity is actively contending for, from the SDK's
+    /// local cache (resolved contests drop out wholesale on sync).
+    func myContestedNames(syncFirst: Bool = false) async -> [String] {
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let identityId = DWCurrentUserIdentityInfo.shared.identityId else { return [] }
+        if syncFirst {
+            _ = try? await wallet.syncContestedDpnsNames(identityId: identityId)
+        }
+        return (try? wallet.managedIdentity(identityId: identityId).getContestedDpnsNames()) ?? []
+    }
+
+    /// Live vote state for a contest this identity is part of. nil while
+    /// Platform hasn't indexed the contest, or once it resolved.
+    func contestState(label: String) async -> ContestVoteState? {
+        guard let wallet = SwiftDashSDKHost.shared.wallet,
+              let identityId = DWCurrentUserIdentityInfo.shared.identityId else { return nil }
+        return try? await wallet.fetchContestVoteState(identityId: identityId, label: label)
+    }
+
+    /// What an unregistered contested-eligible label looks like on the
+    /// network BEFORE we submit. Best-effort: an unavailable query
+    /// reports `.unknown` (never a fabricated all-clear) and the
+    /// submit-time transition stays the authority.
+    enum ContestPrecheck: Equatable {
+        /// No contest exists — a request starts a fresh vote.
+        case fresh
+        /// An active vote already holds this label; a request joins it
+        /// as another contender.
+        case activeContest(contenders: Int)
+        /// A past vote locked the label — nobody can register it.
+        case locked
+        /// The query failed; state can't be determined.
+        case unknown
+    }
+
+    func contestPrecheck(label: String) async -> ContestPrecheck {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return .unknown }
+        do {
+            let state = try await sdk.dpnsGetContestedVoteState(name: label)
+            if let winner = state["winner"] as? String {
+                // "LOCKED" or a winning identity's base58 id. A won label
+                // has a domain document, so the search path already shows
+                // it as taken; treat it as locked-for-registration too.
+                return winner == "LOCKED" ? .locked : .activeContest(contenders: 0)
+            }
+            let contenders = (state["contenders"] as? [[String: Any]]) ?? []
+            return contenders.isEmpty ? .fresh : .activeContest(contenders: contenders.count)
+        } catch {
+            // rs-sdk reports "no contest" as an error rather than an
+            // empty result; a missing contest is the normal fresh case.
+            let text = String(describing: error).lowercased()
+            if text.contains("not found") || text.contains("no contest") {
+                return .fresh
+            }
+            Self.logger.info("🏷️ MARKET :: contest precheck unavailable for \(label, privacy: .public): \(String(describing: error), privacy: .public)")
+            return .unknown
+        }
+    }
+
     // MARK: Helpers
 
-    /// DPNS contested-name eligibility per the platform rules the
-    /// username flow enforces: normalized labels of 3–19 characters
-    /// consisting only of letters and digits (no hyphen) go to a vote.
-    static func isContestedEligible(normalizedLabel: String) -> Bool {
-        let length = normalizedLabel.count
-        guard (3...19).contains(length) else { return false }
-        return normalizedLabel.allSatisfy { $0.isLetter || $0.isNumber }
-            && !normalizedLabel.allSatisfy { $0.isNumber }
+    /// Contested-name eligibility — delegates to the SDK's own
+    /// `dash_sdk_dpns_is_contested_username` predicate so the client
+    /// can't drift from the network rule.
+    static func isContested(_ label: String) -> Bool {
+        DWContestedNameStatusService.isContestedLabel(label)
     }
+
+    /// The protocol's contested-document vote-resolution fund: what a
+    /// contested request locks from the identity balance on top of the
+    /// normal registration fee. Mirrors
+    /// `vote_resolution_fund_fees::v1` in rs-platform-version
+    /// (20_000_000_000 credits = 0.2 DASH).
+    static let contestedFundCredits: UInt64 = 20_000_000_000
 
     /// Buyer identity's credit balance from the persisted row — for the
     /// affordability hint; the SDK re-checks authoritatively at purchase.

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -68,6 +68,7 @@ struct UsernameMarketplaceService {
         case invalidPrice
         case authCancelled
         case authFailed
+        case contestInProgress(pendingLabel: String)
 
         var errorDescription: String? {
             switch self {
@@ -77,6 +78,10 @@ struct UsernameMarketplaceService {
                 return NSLocalizedString("Short names are decided by a network vote — use Request Username instead.", comment: "Username marketplace")
             case .invalidRecipient:
                 return NSLocalizedString("The recipient identity couldn't be resolved.", comment: "Username marketplace")
+            case let .contestInProgress(pendingLabel):
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("Your request for “%@” is still in the network vote. Wait for that vote to finish before requesting another name.", comment: "Username marketplace: a second contested request is refused while one is pending"),
+                    pendingLabel)
             case .invalidPrice:
                 return NSLocalizedString("This price is too high to list.", comment: "Username marketplace: listing price exceeds the representable maximum")
             case .authCancelled:
@@ -216,8 +221,14 @@ struct UsernameMarketplaceService {
     /// not-yet-owned label stays out of every username surface
     /// (`DWCurrentUserIdentityInfo`'s pending filter) and the Home-appear
     /// reconciliation resolves the eventual win/loss. The bookmark is
-    /// single-slot — a newer contested submission replaces an older one
-    /// there, but the SDK's contested-names cache tracks all of them.
+    /// single-slot, so only ONE contested request may be in flight at a
+    /// time — a second submission would overwrite the first's bookmark,
+    /// leaking the still-voting label into username surfaces and
+    /// orphaning its reconciliation. This method refuses (typed
+    /// `contestInProgress`) while any bookmark is pending.
+    /// TODO(contest-multi): lift the one-at-a-time limit by making the
+    /// bookmark store, `DWCurrentUserIdentityInfo`'s filter, and
+    /// `checkPendingContestResolution` multi-label.
     ///
     /// Returns the authoritative voting end time when Platform has
     /// already indexed the contest, nil while indexing lags.
@@ -230,6 +241,9 @@ struct UsernameMarketplaceService {
         // for exactly this).
         guard let network = WalletEnvironment.network else {
             throw ServiceError.noIdentity
+        }
+        if let pending = DWContestedNameStatusService.shared.pendingLabel(for: network) {
+            throw ServiceError.contestInProgress(pendingLabel: pending)
         }
         try await authorize()
         _ = try await wallet.registerDpnsName(

--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -102,6 +102,14 @@ struct ExploreMenuScreen: View {
                 .frame(minHeight: 56)
 
                 MenuItem(
+                    title: NSLocalizedString("Username Marketplace", comment: "Username marketplace"),
+                    subtitle: NSLocalizedString("Buy, sell and transfer DashPay usernames", comment: "Username marketplace: Explore row subtitle"),
+                    icon: .system("at.circle.fill"),
+                    action: { showUsernameMarketplace() }
+                )
+                .frame(minHeight: 56)
+
+                MenuItem(
                     title: NSLocalizedString("ATMs", comment: ""),
                     subtitle: NSLocalizedString("Find ATMs where you can buy or sell Dash", comment: ""),
                     icon: .custom("image-menu-atm", maxHeight: 30),
@@ -217,6 +225,13 @@ struct ExploreMenuScreen: View {
             controller.hidesBottomBarWhenPushed = true
             vc.pushViewController(controller, animated: true)
         }
+    }
+
+    private func showUsernameMarketplace() {
+        let controller = UIHostingController(
+            rootView: UsernameMarketplaceScreen(vc: vc))
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
     }
 
     private func showAtms() {

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -1,0 +1,950 @@
+//
+//  UsernameMarketplaceScreen.swift
+//  DashWallet
+//
+//  DPNS username marketplace (Explore tab): search any name and see its
+//  live sale state, browse the names on your identity, list/delist/
+//  re-price yours, buy listed ones, gift-transfer, and register
+//  unclaimed non-contested labels. All reads and trade actions go
+//  through `UsernameMarketplaceService`; every mutation is PIN-gated
+//  there and nothing broadcasts before the user confirms a concrete
+//  price. Search-driven by design: the DPNS contract has no `$price`
+//  index yet, so a global "everything for sale" browse isn't queryable
+//  (tracked in the platform marketplace task).
+//
+//  dashpay target only.
+//
+
+import SwiftUI
+import SwiftDashSDK
+import DashUIKit
+import UIKit
+
+// MARK: - UsernameMarketplaceViewModel
+
+@MainActor
+final class UsernameMarketplaceViewModel: ObservableObject {
+
+    enum Segment: Int, CaseIterable {
+        case find
+        case mine
+
+        var title: String {
+            switch self {
+            case .find: return NSLocalizedString("Find Names", comment: "Username marketplace: search segment")
+            case .mine: return NSLocalizedString("My Names", comment: "Username marketplace: owned names segment")
+            }
+        }
+    }
+
+    @Published var segment: Segment = .find
+    @Published var query = ""
+    @Published var searchResults: [MarketplaceName] = []
+    @Published var myNames: [MarketplaceName] = []
+    @Published var isSearching = false
+    @Published var isLoadingMine = false
+    @Published var isPerformingAction = false
+    @Published var errorMessage: String?
+    /// Transient success line ("hilawe listed for 0.05 DASH").
+    @Published var successMessage: String?
+
+    let service = UsernameMarketplaceService()
+    private var searchTask: Task<Void, Never>?
+
+    var ownIdentityId: Data? { DWCurrentUserIdentityInfo.shared.identityId }
+    var ownIdentityIdBase58: String? { ownIdentityId?.toBase58String() }
+
+    /// The typed query as a registrable label: valid DPNS label shape
+    /// AND no document exists for its normalized form. Set by
+    /// `updateSearch` using the SDK's own normalizer (DPNS folds
+    /// look-alike characters, so a plain lowercase compare would lie).
+    @Published var registrableQueryLabel: String?
+
+    /// DPNS label shape: 3–63 characters, letters/digits/hyphen, no
+    /// leading or trailing hyphen.
+    static func isValidLabel(_ label: String) -> Bool {
+        guard (3...63).contains(label.count) else { return false }
+        guard label.first != "-", label.last != "-" else { return false }
+        return label.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" }
+    }
+
+    func updateSearch() {
+        searchTask?.cancel()
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= 2 else {
+            searchResults = []
+            registrableQueryLabel = nil
+            isSearching = false
+            return
+        }
+        searchResults = []
+        registrableQueryLabel = nil
+        isSearching = true
+        searchTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 350_000_000)
+            guard let self, !Task.isCancelled else { return }
+            do {
+                let results = try await service.search(prefix: trimmed)
+                guard !Task.isCancelled else { return }
+                searchResults = results
+                if UsernameMarketplaceViewModel.isValidLabel(trimmed),
+                   let sdk = SwiftDashSDKHost.shared.sdk {
+                    let normalized = (try? sdk.dpnsNormalizeLabel(trimmed)) ?? trimmed.lowercased()
+                    registrableQueryLabel = results.contains { $0.normalizedLabel == normalized }
+                        ? nil
+                        : trimmed
+                } else {
+                    registrableQueryLabel = nil
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = error.localizedDescription
+            }
+            isSearching = false
+        }
+    }
+
+    func loadMyNames() {
+        guard let ownBase58 = ownIdentityIdBase58 else { return }
+        isLoadingMine = true
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                myNames = try await service.names(ownedBy: ownBase58)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            isLoadingMine = false
+        }
+    }
+
+    /// Run one PIN-gated trade action with shared progress/error/success
+    /// handling, then refresh both lists so the new sale state renders.
+    func perform(
+        successText: String,
+        _ operation: @escaping () async throws -> Void
+    ) {
+        guard !isPerformingAction else { return }
+        isPerformingAction = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { isPerformingAction = false }
+            do {
+                try await operation()
+                withAnimation { successMessage = successText }
+                loadMyNames()
+                updateSearch()
+                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                withAnimation {
+                    if successMessage == successText { successMessage = nil }
+                }
+            } catch DWIdentityAuthorizer.AuthError.cancelled {
+                // Backing out of the PIN prompt is not an error state.
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+// MARK: - UsernameMarketplaceScreen
+
+struct UsernameMarketplaceScreen: View {
+    private let vc: UINavigationController
+
+    @StateObject private var viewModel = UsernameMarketplaceViewModel()
+    @State private var selectedName: MarketplaceName?
+    @State private var registerCandidate: RegisterCandidate?
+
+    init(vc: UINavigationController) {
+        self.vc = vc
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            NavBarBack {
+                vc.popViewController(animated: true)
+            }
+
+            TopIntro(
+                title: NSLocalizedString("Username Marketplace", comment: "Username marketplace"),
+                subtitle: NSLocalizedString("Search usernames, buy ones that are for sale, and sell or transfer your own.", comment: "Username marketplace: screen subtitle")
+            )
+            .padding(.leading, 20)
+            .padding(.trailing, 60)
+            .padding(.top, 10)
+            .padding(.bottom, 12)
+
+            Picker("", selection: $viewModel.segment) {
+                ForEach(UsernameMarketplaceViewModel.Segment.allCases, id: \.self) { segment in
+                    Text(segment.title).tag(segment)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 20)
+            .padding(.bottom, 10)
+
+            switch viewModel.segment {
+            case .find:
+                findSection
+            case .mine:
+                mySection
+            }
+
+            Spacer(minLength: 0)
+        }
+        .background(Color.dash.primaryBackground.ignoresSafeArea())
+        .onAppear { viewModel.loadMyNames() }
+        .sheet(item: $selectedName) { name in
+            MarketplaceNameDetailSheet(name: name, viewModel: viewModel)
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(item: $registerCandidate) { candidate in
+            RegisterNameSheet(label: candidate.label, viewModel: viewModel)
+                .presentationDetents([.medium, .large])
+        }
+        .overlay(alignment: .bottom) {
+            if let success = viewModel.successMessage {
+                Label(success, systemImage: "checkmark.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.dashGreen)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(Capsule().fill(Color.dash.secondaryBackground)
+                        .shadow(color: Color.dash.shadow, radius: 16, x: 0, y: 4))
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .alert(
+            NSLocalizedString("Error", comment: ""),
+            isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } })
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: Find segment
+
+    private var findSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ContactsSearchField(
+                placeholder: NSLocalizedString("Search usernames", comment: "Username marketplace: search placeholder"),
+                text: $viewModel.query)
+                .padding(.horizontal, 20)
+                .onChange(of: viewModel.query) { _, _ in viewModel.updateSearch() }
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    if viewModel.isSearching && viewModel.searchResults.isEmpty {
+                        SwiftUI.ProgressView().padding(.top, 28)
+                    } else if viewModel.query.trimmingCharacters(in: .whitespaces).count < 2 {
+                        emptyHint(NSLocalizedString("Type at least 2 characters to search usernames", comment: "DashPay Contacts"))
+                    } else {
+                        ForEach(viewModel.searchResults) { name in
+                            nameRow(name)
+                        }
+                        if let candidate = viewModel.registrableQueryLabel, !viewModel.isSearching {
+                            registerRow(candidate)
+                        }
+                        if viewModel.searchResults.isEmpty && !viewModel.isSearching
+                            && viewModel.registrableQueryLabel == nil {
+                            emptyHint(NSLocalizedString("No usernames found", comment: "DashPay Contacts"))
+                        }
+                    }
+                }
+                .padding(.horizontal, 15)
+                .padding(.top, 12)
+                .padding(.bottom, 24)
+            }
+        }
+    }
+
+    // MARK: My Names segment
+
+    private var mySection: some View {
+        ScrollView {
+            LazyVStack(spacing: 6) {
+                if viewModel.isLoadingMine && viewModel.myNames.isEmpty {
+                    SwiftUI.ProgressView().padding(.top, 28)
+                } else if viewModel.myNames.isEmpty {
+                    emptyHint(NSLocalizedString("No usernames on this identity yet. Find one to buy or register on the Find Names tab.", comment: "Username marketplace: empty owned list"))
+                } else {
+                    ForEach(viewModel.myNames) { name in
+                        nameRow(name)
+                    }
+                }
+            }
+            .padding(.horizontal, 15)
+            .padding(.top, 12)
+            .padding(.bottom, 24)
+        }
+        .refreshable { viewModel.loadMyNames() }
+    }
+
+    // MARK: Rows
+
+    private func nameRow(_ name: MarketplaceName) -> some View {
+        let isMine = name.isOwned(by: viewModel.ownIdentityId)
+        return Button {
+            selectedName = name
+        } label: {
+            HStack(spacing: 10) {
+                ContactAvatarView(
+                    title: name.label,
+                    avatarURL: nil,
+                    identitySeed: Data.identifier(fromBase58: name.ownerIdBase58) ?? Data())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name.label)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                        .lineLimit(1)
+                    Text(isMine
+                        ? NSLocalizedString("Owned by you", comment: "Username marketplace")
+                        : String(name.ownerIdBase58.prefix(8)) + "…" + String(name.ownerIdBase58.suffix(4)))
+                        .font(.system(size: 11))
+                        .foregroundColor(.dash.tertiaryText)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if let priceDuffs = name.priceDuffs {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.dashGolden)
+                        Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.dash.primaryText)
+                    }
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.dash.secondaryBackground))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func registerRow(_ label: String) -> some View {
+        Button {
+            registerCandidate = RegisterCandidate(label: label)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 26))
+                    .foregroundColor(.dashGreen)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                    Text(NSLocalizedString("Available — register it on your identity", comment: "Username marketplace: unregistered name row"))
+                        .font(.system(size: 11))
+                        .foregroundColor(.dashGreen)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.dash.secondaryBackground))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func emptyHint(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 13))
+            .foregroundColor(.dash.secondaryText)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 28)
+            .padding(.horizontal, 24)
+    }
+}
+
+/// Identifiable wrapper so `.sheet(item:)` can present a register
+/// candidate without a retroactive String conformance.
+struct RegisterCandidate: Identifiable {
+    let label: String
+    var id: String { label }
+}
+
+// MARK: - MarketplaceNameDetailSheet
+
+/// State-driven detail: what the name is, who owns it, its sale state,
+/// and exactly the actions that state allows.
+private struct MarketplaceNameDetailSheet: View {
+    let name: MarketplaceName
+    @ObservedObject var viewModel: UsernameMarketplaceViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showingSetPrice = false
+    @State private var showingTransfer = false
+    @State private var confirmBuy = false
+    @State private var confirmDelist = false
+
+    private var isMine: Bool { name.isOwned(by: viewModel.ownIdentityId) }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                ContactAvatarView(
+                    title: name.label,
+                    avatarURL: nil,
+                    identitySeed: Data.identifier(fromBase58: name.ownerIdBase58) ?? Data(),
+                    size: 72)
+                    .padding(.top, 28)
+
+                Text(name.label)
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                    .padding(.top, 10)
+
+                if let priceDuffs = name.priceDuffs {
+                    VStack(spacing: 2) {
+                        Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.dashGolden)
+                        Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundColor(.dash.primaryText)
+                        Text(CurrencyExchanger.shared.fiatAmountString(for: priceDuffs.dashAmount))
+                            .font(.system(size: 12))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    .padding(.top, 8)
+                } else {
+                    Text(isMine
+                        ? NSLocalizedString("Not listed for sale", comment: "Username marketplace: own unlisted name")
+                        : NSLocalizedString("Not for sale", comment: "Username marketplace: someone else's unlisted name"))
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.dash.secondaryText)
+                        .padding(.top, 8)
+                }
+
+                infoCard
+                    .padding(.horizontal, 20)
+                    .padding(.top, 16)
+
+                actions
+                    .padding(.horizontal, 20)
+                    .padding(.top, 18)
+                    .padding(.bottom, 16)
+            }
+        }
+        .background(Color.dash.primaryBackground)
+        .sheet(isPresented: $showingSetPrice) {
+            SetNamePriceSheet(name: name, viewModel: viewModel, onDone: { dismiss() })
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showingTransfer) {
+            TransferNameSheet(name: name, viewModel: viewModel, onDone: { dismiss() })
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    private var infoCard: some View {
+        VStack(spacing: 0) {
+            detailRow(
+                NSLocalizedString("Owner", comment: "Username marketplace"),
+                isMine
+                    ? NSLocalizedString("You", comment: "Username marketplace: owner is the current user")
+                    : String(name.ownerIdBase58.prefix(10)) + "…" + String(name.ownerIdBase58.suffix(6)))
+            if let createdAtMs = name.createdAtMs {
+                detailRow(
+                    NSLocalizedString("Registered", comment: "Username marketplace: registration date"),
+                    DWDateFormatter.sharedInstance.shortStringFromDate(
+                        Date(timeIntervalSince1970: Double(createdAtMs) / 1000)))
+            }
+            if let transferredAtMs = name.transferredAtMs {
+                detailRow(
+                    NSLocalizedString("Last transferred", comment: "Username marketplace: latest ownership change"),
+                    DWDateFormatter.sharedInstance.shortStringFromDate(
+                        Date(timeIntervalSince1970: Double(transferredAtMs) / 1000)))
+            }
+            // Full pricing/transfer/purchase timeline requires the SDK's
+            // document-revision history query (in progress); until then
+            // this sheet shows only the facts the current document carries.
+        }
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.dash.secondaryBackground))
+    }
+
+    @ViewBuilder
+    private var actions: some View {
+        VStack(spacing: 10) {
+            if isMine {
+                if name.isForSale {
+                    primaryButton(NSLocalizedString("Change Price", comment: "Username marketplace")) {
+                        showingSetPrice = true
+                    }
+                    secondaryButton(NSLocalizedString("Remove From Sale", comment: "Username marketplace")) {
+                        confirmDelist = true
+                    }
+                } else {
+                    primaryButton(NSLocalizedString("Put Up For Sale", comment: "Username marketplace")) {
+                        showingSetPrice = true
+                    }
+                }
+                secondaryButton(NSLocalizedString("Transfer to Another Identity", comment: "Username marketplace")) {
+                    showingTransfer = true
+                }
+            } else if name.isForSale, let priceDuffs = name.priceDuffs {
+                identityBalanceLine
+                primaryButton(String.localizedStringWithFormat(
+                    NSLocalizedString("Buy for %@ DASH", comment: "Username marketplace: purchase button"),
+                    priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)) {
+                    confirmBuy = true
+                }
+            }
+        }
+        .disabled(viewModel.isPerformingAction)
+        .confirmationDialog(
+            String.localizedStringWithFormat(
+                NSLocalizedString("Buy “%@”?", comment: "Username marketplace: purchase confirmation title"),
+                name.label),
+            isPresented: $confirmBuy,
+            titleVisibility: .visible
+        ) {
+            Button(NSLocalizedString("Buy", comment: "Username marketplace"), role: .none) {
+                let expected = name.priceCredits ?? 0
+                viewModel.perform(successText: String.localizedStringWithFormat(
+                    NSLocalizedString("%@ is now yours", comment: "Username marketplace: purchase success"),
+                    name.label)) {
+                    try await viewModel.service.purchase(name: name, expectedPriceCredits: expected)
+                }
+                dismiss()
+            }
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString("The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately.", comment: "Username marketplace: purchase confirmation body"))
+        }
+        .confirmationDialog(
+            String.localizedStringWithFormat(
+                NSLocalizedString("Remove “%@” from sale?", comment: "Username marketplace: delist confirmation title"),
+                name.label),
+            isPresented: $confirmDelist,
+            titleVisibility: .visible
+        ) {
+            Button(NSLocalizedString("Remove From Sale", comment: "Username marketplace"), role: .destructive) {
+                viewModel.perform(successText: String.localizedStringWithFormat(
+                    NSLocalizedString("%@ is no longer for sale", comment: "Username marketplace: delist success"),
+                    name.label)) {
+                    try await viewModel.service.removeFromSale(name: name)
+                }
+                dismiss()
+            }
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString("Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.", comment: "Username marketplace: delist confirmation body"))
+        }
+    }
+
+    /// Buyer-side affordability line, from the same persisted identity
+    /// balance the profile sheet shows.
+    @ViewBuilder
+    private var identityBalanceLine: some View {
+        if let identityId = viewModel.ownIdentityId,
+           let container = SwiftDashSDKHost.shared.modelContainer {
+            let available = UsernameMarketplaceService.identityBalanceCredits(
+                identityId: identityId, container: container)
+            let needed = (name.priceCredits ?? 0) + UsernameMarketplaceService.purchaseFeeReserveCredits
+            HStack {
+                Text(NSLocalizedString("Identity Account Balance", comment: "SDK identity profile sheet — the identity's credit balance"))
+                    .font(.system(size: 12))
+                    .foregroundColor(.dash.secondaryText)
+                Spacer()
+                Text("\((available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(available >= needed ? .dash.primaryText : .orange)
+            }
+            if available < needed {
+                Text(NSLocalizedString("Not enough identity credits for this purchase — top up from My Profile first.", comment: "Username marketplace: insufficient balance hint"))
+                    .font(.system(size: 11))
+                    .foregroundColor(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func detailRow(_ title: String, _ value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 13))
+                .foregroundColor(.dash.secondaryText)
+            Spacer()
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.dash.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(Color.dash.whiteText)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 13)
+                .background(Color.dash.blue)
+                .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func secondaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(.dash.blue)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.dash.blue.opacity(0.08)))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - SetNamePriceSheet
+
+private struct SetNamePriceSheet: View {
+    let name: MarketplaceName
+    @ObservedObject var viewModel: UsernameMarketplaceViewModel
+    let onDone: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var priceText = ""
+    @FocusState private var fieldFocused: Bool
+
+    private var priceDuffs: UInt64? {
+        let normalized = priceText
+            .trimmingCharacters(in: .whitespaces)
+            .replacingOccurrences(of: ",", with: ".")
+        guard let dash = Decimal(string: normalized), dash > 0, dash <= 100_000 else { return nil }
+        let duffsDecimal = dash * Decimal(kOneDash)
+        return UInt64(exactly: NSDecimalNumber(decimal: duffsDecimal).int64Value)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("Set a price for “%@”", comment: "Username marketplace: set price sheet title"),
+                    name.label))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 28)
+                    .padding(.horizontal, 24)
+
+                Text(NSLocalizedString("Anyone will be able to buy the name for this exact price. The proceeds arrive as credits on your identity balance.", comment: "Username marketplace: set price sheet body"))
+                    .font(.system(size: 14))
+                    .foregroundColor(.dash.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 8)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField(
+                        NSLocalizedString("Price in DASH", comment: "Username marketplace: price placeholder"),
+                        text: $priceText)
+                        .keyboardType(.decimalPad)
+                        .focused($fieldFocused)
+                        .font(.system(size: 18, weight: .semibold))
+                        .padding(14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(Color.dash.secondaryBackground))
+                    if let duffs = priceDuffs {
+                        Text(CurrencyExchanger.shared.fiatAmountString(for: duffs.dashAmount))
+                            .font(.system(size: 12))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
+
+                Text(NSLocalizedString("Listing is a network transaction with a small fee, paid from your identity balance.", comment: "Username marketplace: set price fee note"))
+                    .font(.system(size: 12))
+                    .foregroundColor(.dash.tertiaryText)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 10)
+
+                Button {
+                    guard let duffs = priceDuffs else { return }
+                    viewModel.perform(successText: String.localizedStringWithFormat(
+                        NSLocalizedString("%1$@ listed for %2$@ DASH", comment: "Username marketplace: listing success — name, then price"),
+                        name.label,
+                        duffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)) {
+                        try await viewModel.service.setPrice(name: name, priceDuffs: duffs)
+                    }
+                    dismiss()
+                    onDone()
+                } label: {
+                    Text(NSLocalizedString("List For Sale", comment: "Username marketplace: confirm listing button"))
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Color.dash.whiteText)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color.dash.blue)
+                        .cornerRadius(12)
+                }
+                .buttonStyle(.plain)
+                .disabled(priceDuffs == nil || viewModel.isPerformingAction)
+                .opacity(priceDuffs == nil ? 0.55 : 1)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text(NSLocalizedString("Cancel", comment: ""))
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.dash.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 10)
+            }
+        }
+        .background(Color.dash.primaryBackground)
+        .onAppear { fieldFocused = true }
+    }
+}
+
+// MARK: - TransferNameSheet
+
+private struct TransferNameSheet: View {
+    let name: MarketplaceName
+    @ObservedObject var viewModel: UsernameMarketplaceViewModel
+    let onDone: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var recipientText = ""
+    @State private var isResolving = false
+    @State private var resolveError: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("Transfer “%@”", comment: "Username marketplace: transfer sheet title"),
+                    name.label))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                    .padding(.top, 28)
+
+                Text(NSLocalizedString("Send this name to another identity for free. The transfer also removes any sale listing. This can't be undone — the new owner would have to transfer it back.", comment: "Username marketplace: transfer sheet body"))
+                    .font(.system(size: 14))
+                    .foregroundColor(.dash.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 8)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField(
+                        NSLocalizedString("Recipient username or identity ID", comment: "Username marketplace: transfer recipient placeholder"),
+                        text: $recipientText)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .font(.system(size: 15))
+                        .padding(14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(Color.dash.secondaryBackground))
+                    if let resolveError {
+                        Text(resolveError)
+                            .font(.system(size: 12))
+                            .foregroundColor(.orange)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 18)
+
+                Button {
+                    transfer()
+                } label: {
+                    if isResolving {
+                        SwiftUI.ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                    } else {
+                        Text(NSLocalizedString("Transfer", comment: "Username marketplace: confirm transfer button"))
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color.dash.whiteText)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.dash.blue)
+                            .cornerRadius(12)
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(recipientText.trimmingCharacters(in: .whitespaces).isEmpty
+                    || isResolving || viewModel.isPerformingAction)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text(NSLocalizedString("Cancel", comment: ""))
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.dash.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 10)
+            }
+        }
+        .background(Color.dash.primaryBackground)
+    }
+
+    /// Accepts a base58 identity id directly, or resolves a username via
+    /// DPNS. Never guesses: unresolvable input surfaces an error and no
+    /// transition is attempted.
+    private func transfer() {
+        let input = recipientText.trimmingCharacters(in: .whitespaces)
+        resolveError = nil
+        if let direct = Data.identifier(fromBase58: input), direct.count == 32 {
+            run(recipientBase58: input)
+            return
+        }
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return }
+        isResolving = true
+        Task {
+            defer { isResolving = false }
+            do {
+                guard let identityId = try await wallet.resolveDpnsName(input) else {
+                    resolveError = NSLocalizedString("No identity owns that username.", comment: "Username marketplace: unresolvable transfer recipient")
+                    return
+                }
+                run(recipientBase58: identityId.toBase58String())
+            } catch {
+                resolveError = error.localizedDescription
+            }
+        }
+    }
+
+    private func run(recipientBase58: String) {
+        viewModel.perform(successText: String.localizedStringWithFormat(
+            NSLocalizedString("%@ transferred", comment: "Username marketplace: transfer success"),
+            name.label)) {
+            try await viewModel.service.transfer(name: name, toIdentityBase58: recipientBase58)
+        }
+        dismiss()
+        onDone()
+    }
+}
+
+// MARK: - RegisterNameSheet
+
+private struct RegisterNameSheet: View {
+    let label: String
+    @ObservedObject var viewModel: UsernameMarketplaceViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    private var isContested: Bool {
+        UsernameMarketplaceService.isContestedEligible(normalizedLabel: label.lowercased())
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 36))
+                    .foregroundColor(.dashGreen)
+                    .frame(width: 76, height: 76)
+                    .background(Circle().fill(Color.dashGreen.opacity(0.1)))
+                    .padding(.top, 28)
+
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("Register “%@”", comment: "Username marketplace: register sheet title"),
+                    label))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                    .padding(.top, 14)
+
+                if isContested {
+                    Text(NSLocalizedString("This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.", comment: "Username marketplace"))
+                        .font(.system(size: 14))
+                        .foregroundColor(.orange)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 28)
+                        .padding(.top, 8)
+                } else {
+                    Text(NSLocalizedString("The name is registered directly on your identity. Registration is a network transaction paid from your identity balance.", comment: "Username marketplace: register sheet body"))
+                        .font(.system(size: 14))
+                        .foregroundColor(.dash.secondaryText)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 28)
+                        .padding(.top, 8)
+
+                    Button {
+                        viewModel.perform(successText: String.localizedStringWithFormat(
+                            NSLocalizedString("%@ registered", comment: "Username marketplace: registration success"),
+                            label)) {
+                            try await viewModel.service.register(label: label)
+                        }
+                        dismiss()
+                    } label: {
+                        Text(NSLocalizedString("Register", comment: "Username marketplace: confirm register button"))
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(Color.dash.whiteText)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.dash.blue)
+                            .cornerRadius(12)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.isPerformingAction)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
+                }
+
+                Button {
+                    dismiss()
+                } label: {
+                    Text(NSLocalizedString("Cancel", comment: ""))
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(.dash.blue)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 20)
+                .padding(.top, isContested ? 20 : 0)
+                .padding(.bottom, 10)
+            }
+        }
+        .background(Color.dash.primaryBackground)
+    }
+}

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -47,6 +47,11 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     @Published var query = ""
     @Published var searchResults: [DpnsMarketplaceName] = []
     @Published var myNames: [DpnsNameStateRow] = []
+    /// Labels this identity is contending for in active network votes.
+    @Published var contestedNames: [String] = []
+    /// Live vote state per contested label, filled best-effort — a label
+    /// with no entry is a contest Platform hasn't indexed yet.
+    @Published var contestStates: [String: ContestVoteState] = [:]
     @Published var isSearching = false
     @Published var isLoadingMine = false
     @Published var isPerformingAction = false
@@ -118,7 +123,9 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         }
     }
 
-    /// Local read — the wallet's own tracked rows, no network.
+    /// Local read — the wallet's own tracked rows plus the contested
+    /// labels cache, no network. Vote states for contested labels are
+    /// filled in best-effort afterward (those are live queries).
     func loadMyNames() {
         isLoadingMine = true
         Task { [weak self] in
@@ -128,18 +135,26 @@ final class UsernameMarketplaceViewModel: ObservableObject {
             } catch {
                 errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
+            contestedNames = await service.myContestedNames()
             isLoadingMine = false
+            for label in contestedNames where contestStates[label] == nil {
+                if let state = await service.contestState(label: label) {
+                    contestStates[label] = state
+                }
+            }
         }
     }
 
-    /// Pull-to-refresh: run one marketplace sync pass, then re-read the
-    /// local rows.
+    /// Pull-to-refresh: run one marketplace sync pass and refresh the
+    /// contested cache, then re-read the local rows.
     func refreshFromNetwork() async {
         do {
             _ = try await service.syncNow()
         } catch {
             errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
         }
+        contestStates = [:]
+        _ = await service.myContestedNames(syncFirst: true)
         loadMyNames()
     }
 
@@ -294,13 +309,19 @@ struct UsernameMarketplaceScreen: View {
     private var mySection: some View {
         ScrollView {
             LazyVStack(spacing: 6) {
-                if viewModel.isLoadingMine && viewModel.myNames.isEmpty {
+                if viewModel.isLoadingMine && viewModel.myNames.isEmpty && viewModel.contestedNames.isEmpty {
                     SwiftUI.ProgressView().padding(.top, 28)
-                } else if viewModel.myNames.isEmpty {
+                } else if viewModel.myNames.isEmpty && viewModel.contestedNames.isEmpty {
                     emptyHint(NSLocalizedString("No usernames on this identity yet. Find one to buy or register on the Find Names tab.", comment: "Username marketplace: empty owned list"))
                 } else {
                     ForEach(viewModel.ownedNames) { row in
                         stateRow(row)
+                    }
+                    if !viewModel.contestedNames.isEmpty {
+                        sectionHeader(NSLocalizedString("In network vote", comment: "Username marketplace: section of contested-name requests awaiting the masternode vote"))
+                        ForEach(viewModel.contestedNames, id: \.self) { label in
+                            contestedRow(label)
+                        }
                     }
                     if !viewModel.departedNames.isEmpty {
                         sectionHeader(NSLocalizedString("No longer yours", comment: "Username marketplace: names that were sold or transferred away"))
@@ -443,8 +464,45 @@ struct UsernameMarketplaceScreen: View {
         return String(base58.prefix(8)) + "…" + String(base58.suffix(4))
     }
 
+    /// A contested request awaiting the masternode vote. Not tappable —
+    /// there is no document to act on until the vote resolves.
+    private func contestedRow(_ label: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "hourglass")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(.dashGolden)
+                .frame(width: 36, height: 36)
+                .background(Circle().fill(Color.dashGolden.opacity(0.12)))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.dash.primaryText)
+                    .lineLimit(1)
+                Text(contestedLine(for: label))
+                    .font(.system(size: 11))
+                    .foregroundColor(.dash.tertiaryText)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.dash.secondaryBackground))
+    }
+
+    private func contestedLine(for label: String) -> String {
+        guard let state = viewModel.contestStates[label] else {
+            return NSLocalizedString("Requested — waiting for the network vote", comment: "Username marketplace: contested request not yet indexed by Platform")
+        }
+        return String.localizedStringWithFormat(
+            NSLocalizedString("Network vote ends %@", comment: "Username marketplace: contested request line — voting deadline"),
+            DWDateFormatter.sharedInstance.shortStringFromDate(state.endTime))
+    }
+
     private func registerRow(_ label: String) -> some View {
-        Button {
+        let contested = UsernameMarketplaceService.isContested(label)
+        return Button {
             registerCandidate = RegisterCandidate(label: label)
         } label: {
             HStack(spacing: 10) {
@@ -455,9 +513,11 @@ struct UsernameMarketplaceScreen: View {
                     Text(label)
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.dash.primaryText)
-                    Text(NSLocalizedString("Available — register it on your identity", comment: "Username marketplace: unregistered name row"))
+                    Text(contested
+                        ? NSLocalizedString("Available — short names are decided by a network vote", comment: "Username marketplace: unregistered contested-eligible name row")
+                        : NSLocalizedString("Available — register it on your identity", comment: "Username marketplace: unregistered name row"))
                         .font(.system(size: 11))
-                        .foregroundColor(.dashGreen)
+                        .foregroundColor(contested ? .dashGolden : .dashGreen)
                 }
                 Spacer()
                 Image(systemName: "chevron.right")
@@ -1143,35 +1203,42 @@ private struct RegisterNameSheet: View {
     @ObservedObject var viewModel: UsernameMarketplaceViewModel
     @Environment(\.dismiss) private var dismiss
 
+    /// Pre-submit network state for contested labels; nil while loading.
+    @State private var precheck: UsernameMarketplaceService.ContestPrecheck?
+
     private var isContested: Bool {
-        UsernameMarketplaceService.isContestedEligible(normalizedLabel: label.lowercased())
+        UsernameMarketplaceService.isContested(label)
+    }
+
+    /// This identity already has a request in for this label — the vote
+    /// is in progress and a second submission would just fail.
+    private var alreadyRequested: Bool {
+        viewModel.contestedNames.contains {
+            DWContestedNameStatusService.labelsMatch($0, label)
+        }
     }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
-                Image(systemName: "plus.circle.fill")
+                Image(systemName: isContested ? "checkmark.seal" : "plus.circle.fill")
                     .font(.system(size: 36))
-                    .foregroundColor(.dashGreen)
+                    .foregroundColor(isContested ? .dashGolden : .dashGreen)
                     .frame(width: 76, height: 76)
-                    .background(Circle().fill(Color.dashGreen.opacity(0.1)))
+                    .background(Circle().fill((isContested ? Color.dashGolden : Color.dashGreen).opacity(0.1)))
                     .padding(.top, 28)
 
                 Text(String.localizedStringWithFormat(
-                    NSLocalizedString("Register “%@”", comment: "Username marketplace: register sheet title"),
+                    isContested
+                        ? NSLocalizedString("Request “%@”", comment: "Username marketplace: contested register sheet title")
+                        : NSLocalizedString("Register “%@”", comment: "Username marketplace: register sheet title"),
                     label))
                     .font(.system(size: 20, weight: .bold))
                     .foregroundColor(.dash.primaryText)
                     .padding(.top, 14)
 
                 if isContested {
-                    Text(NSLocalizedString("This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.", comment: "Username marketplace"))
-                        .font(.system(size: 14))
-                        .foregroundColor(.orange)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, 28)
-                        .padding(.top, 8)
+                    contestedContent
                 } else {
                     Text(NSLocalizedString("The name is registered directly on your identity. Registration is a network transaction paid from your identity balance.", comment: "Username marketplace: register sheet body"))
                         .font(.system(size: 14))
@@ -1181,26 +1248,14 @@ private struct RegisterNameSheet: View {
                         .padding(.horizontal, 28)
                         .padding(.top, 8)
 
-                    Button {
+                    confirmButton(NSLocalizedString("Register", comment: "Username marketplace: confirm register button")) {
                         viewModel.perform(successText: String.localizedStringWithFormat(
                             NSLocalizedString("%@ registered", comment: "Username marketplace: registration success"),
                             label)) {
                             try await viewModel.service.register(label: label)
                         }
                         dismiss()
-                    } label: {
-                        Text(NSLocalizedString("Register", comment: "Username marketplace: confirm register button"))
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(Color.dash.whiteText)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 14)
-                            .background(Color.dash.blue)
-                            .cornerRadius(12)
                     }
-                    .buttonStyle(.plain)
-                    .disabled(viewModel.isPerformingAction)
-                    .padding(.horizontal, 20)
-                    .padding(.top, 20)
                 }
 
                 Button {
@@ -1214,10 +1269,161 @@ private struct RegisterNameSheet: View {
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 20)
-                .padding(.top, isContested ? 20 : 0)
+                .padding(.top, 8)
                 .padding(.bottom, 10)
             }
         }
         .background(Color.dash.primaryBackground)
+        .task {
+            guard isContested, precheck == nil else { return }
+            precheck = await viewModel.service.contestPrecheck(label: label)
+        }
+    }
+
+    // MARK: Contested request
+
+    @ViewBuilder
+    private var contestedContent: some View {
+        Text(NSLocalizedString("Short names — 19 characters or fewer, letters and numbers only — aren't registered instantly. The Dash network votes on who gets them.", comment: "Username marketplace: contested request explainer, paragraph 1"))
+            .font(.system(size: 14))
+            .foregroundColor(.dash.secondaryText)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 28)
+            .padding(.top, 8)
+
+        if alreadyRequested {
+            statusCallout(
+                icon: "hourglass",
+                text: NSLocalizedString("You already requested this name — the network vote is in progress. You'll find it under My Names.", comment: "Username marketplace: contested request already submitted by this identity"))
+        } else if precheck == nil {
+            SwiftUI.ProgressView()
+                .padding(.top, 20)
+                .padding(.bottom, 8)
+        } else if precheck == .locked {
+            statusCallout(
+                icon: "lock",
+                text: NSLocalizedString("The network voted to lock this name, so nobody can register it. Choose a different name.", comment: "Username marketplace: contested label locked by a past vote"))
+        } else {
+            Text(NSLocalizedString("Your request enters a public vote by masternodes for about two weeks. Others can request the same name; when the vote ends, the name goes to the winner — or to nobody, if the network votes to lock it.", comment: "Username marketplace: contested request explainer, paragraph 2"))
+                .font(.system(size: 14))
+                .foregroundColor(.dash.secondaryText)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 28)
+                .padding(.top, 10)
+
+            if case .activeContest = precheck {
+                statusCallout(
+                    icon: "person.2",
+                    text: NSLocalizedString("This name is already in an active network vote. Your request joins it as another contender.", comment: "Username marketplace: contested label already has an active vote"))
+            }
+
+            requestCostCard
+                .padding(.horizontal, 20)
+                .padding(.top, 14)
+
+            confirmButton(NSLocalizedString("Request Username", comment: "Username marketplace: confirm contested request button")) {
+                viewModel.perform(successText: String.localizedStringWithFormat(
+                    NSLocalizedString("Request for %@ submitted — masternodes now vote on it", comment: "Username marketplace: contested request success"),
+                    label)) {
+                    try await viewModel.service.requestContestedName(label: label)
+                }
+                dismiss()
+            }
+        }
+    }
+
+    /// The vote-resolution fund the request locks from the identity
+    /// balance (a protocol constant), next to what's available.
+    @ViewBuilder
+    private var requestCostCard: some View {
+        let fund = UsernameMarketplaceService.contestedFundCredits
+        let available: UInt64 = {
+            guard let identityId = viewModel.ownIdentityId,
+                  let container = SwiftDashSDKHost.shared.modelContainer else { return 0 }
+            return UsernameMarketplaceService.identityBalanceCredits(
+                identityId: identityId, container: container)
+        }()
+        VStack(spacing: 0) {
+            HStack {
+                Text(NSLocalizedString("Request cost", comment: "Username marketplace: contested request cost row"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.dash.secondaryText)
+                Spacer()
+                Text(String.localizedStringWithFormat(
+                    NSLocalizedString("%@ DASH + network fee", comment: "Username marketplace: contested request cost value — the vote-resolution fund amount"),
+                    (fund / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.dash.primaryText)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            HStack {
+                Text(NSLocalizedString("Identity Account Balance", comment: "SDK identity profile sheet — the identity's credit balance"))
+                    .font(.system(size: 13))
+                    .foregroundColor(.dash.secondaryText)
+                Spacer()
+                Text("\((available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(available > fund ? .dash.primaryText : .orange)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            Text(NSLocalizedString("The cost is paid from your identity balance. It funds the network vote and isn't returned if another contender wins.", comment: "Username marketplace: contested request cost footnote"))
+                .font(.system(size: 11))
+                .foregroundColor(.dash.tertiaryText)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.bottom, 10)
+            if available <= fund {
+                Text(NSLocalizedString("Not enough identity credits for this request — top up from My Profile first.", comment: "Username marketplace: insufficient balance hint for a contested request"))
+                    .font(.system(size: 11))
+                    .foregroundColor(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 10)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.dash.secondaryBackground))
+    }
+
+    private func statusCallout(icon: String, text: String) -> some View {
+        Label {
+            Text(text)
+                .font(.system(size: 12))
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: icon)
+                .font(.system(size: 13))
+        }
+        .foregroundColor(.dash.secondaryText)
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.dashGolden.opacity(0.1)))
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+    }
+
+    private func confirmButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(Color.dash.whiteText)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.dash.blue)
+                .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isPerformingAction)
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -2,15 +2,21 @@
 //  UsernameMarketplaceScreen.swift
 //  DashWallet
 //
-//  DPNS username marketplace (Explore tab): search any name and see its
-//  live sale state, browse the names on your identity, list/delist/
-//  re-price yours, buy listed ones, gift-transfer, and register
-//  unclaimed non-contested labels. All reads and trade actions go
-//  through `UsernameMarketplaceService`; every mutation is PIN-gated
-//  there and nothing broadcasts before the user confirms a concrete
-//  price. Search-driven by design: the DPNS contract has no `$price`
-//  index yet, so a global "everything for sale" browse isn't queryable
-//  (tracked in the platform marketplace task).
+//  DPNS username marketplace (Explore tab) over the wallet-level SDK
+//  surface (platform #4348): search any name with live sale state, see
+//  the names on your identity — including ones that were sold or
+//  transferred away — list/re-price/delist yours, buy listed ones with
+//  the price pinned at confirmation, gift-transfer, register unclaimed
+//  non-contested labels, and read each name's full trade timeline.
+//
+//  Names offered by other identities are explicitly labeled as sold by
+//  an independent user: prices are set by sellers, not by Dash or this
+//  app, and the UI says so on the row, in the detail sheet, and in the
+//  purchase confirmation.
+//
+//  Search-driven by design: `$price` is not an indexable system
+//  property on Dash Platform, so a global "everything for sale" browse
+//  is not buildable at any layer today.
 //
 //  dashpay target only.
 //
@@ -39,26 +45,34 @@ final class UsernameMarketplaceViewModel: ObservableObject {
 
     @Published var segment: Segment = .find
     @Published var query = ""
-    @Published var searchResults: [MarketplaceName] = []
-    @Published var myNames: [MarketplaceName] = []
+    @Published var searchResults: [DpnsMarketplaceName] = []
+    @Published var myNames: [DpnsNameStateRow] = []
     @Published var isSearching = false
     @Published var isLoadingMine = false
     @Published var isPerformingAction = false
     @Published var errorMessage: String?
     /// Transient success line ("hilawe listed for 0.05 DASH").
     @Published var successMessage: String?
-
-    let service = UsernameMarketplaceService()
-    private var searchTask: Task<Void, Never>?
-
-    var ownIdentityId: Data? { DWCurrentUserIdentityInfo.shared.identityId }
-    var ownIdentityIdBase58: String? { ownIdentityId?.toBase58String() }
-
     /// The typed query as a registrable label: valid DPNS label shape
     /// AND no document exists for its normalized form. Set by
     /// `updateSearch` using the SDK's own normalizer (DPNS folds
     /// look-alike characters, so a plain lowercase compare would lie).
     @Published var registrableQueryLabel: String?
+
+    let service = UsernameMarketplaceService()
+    private var searchTask: Task<Void, Never>?
+
+    var ownIdentityId: Data? { DWCurrentUserIdentityInfo.shared.identityId }
+
+    var ownedNames: [DpnsNameStateRow] {
+        myNames.filter { if case .owned = $0.status { return true }; return false }
+    }
+
+    /// Retained rows for names that left this identity — sold or
+    /// transferred away — kept by the SDK so the departure is visible.
+    var departedNames: [DpnsNameStateRow] {
+        myNames.filter { if case .owned = $0.status { return false }; return true }
+    }
 
     /// DPNS label shape: 3–63 characters, letters/digits/hyphen, no
     /// leading or trailing hyphen.
@@ -98,24 +112,35 @@ final class UsernameMarketplaceViewModel: ObservableObject {
                 }
             } catch {
                 guard !Task.isCancelled else { return }
-                errorMessage = error.localizedDescription
+                errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
             isSearching = false
         }
     }
 
+    /// Local read — the wallet's own tracked rows, no network.
     func loadMyNames() {
-        guard let ownBase58 = ownIdentityIdBase58 else { return }
         isLoadingMine = true
         Task { [weak self] in
             guard let self else { return }
             do {
-                myNames = try await service.names(ownedBy: ownBase58)
+                myNames = try await service.myNames()
             } catch {
-                errorMessage = error.localizedDescription
+                errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
             isLoadingMine = false
         }
+    }
+
+    /// Pull-to-refresh: run one marketplace sync pass, then re-read the
+    /// local rows.
+    func refreshFromNetwork() async {
+        do {
+            _ = try await service.syncNow()
+        } catch {
+            errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
+        }
+        loadMyNames()
     }
 
     /// Run one PIN-gated trade action with shared progress/error/success
@@ -141,7 +166,7 @@ final class UsernameMarketplaceViewModel: ObservableObject {
             } catch DWIdentityAuthorizer.AuthError.cancelled {
                 // Backing out of the PIN prompt is not an error state.
             } catch {
-                errorMessage = error.localizedDescription
+                errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
         }
     }
@@ -153,7 +178,7 @@ struct UsernameMarketplaceScreen: View {
     private let vc: UINavigationController
 
     @StateObject private var viewModel = UsernameMarketplaceViewModel()
-    @State private var selectedName: MarketplaceName?
+    @State private var selectedLabel: SelectedMarketplaceLabel?
     @State private var registerCandidate: RegisterCandidate?
 
     init(vc: UINavigationController) {
@@ -195,8 +220,8 @@ struct UsernameMarketplaceScreen: View {
         }
         .background(Color.dash.primaryBackground.ignoresSafeArea())
         .onAppear { viewModel.loadMyNames() }
-        .sheet(item: $selectedName) { name in
-            MarketplaceNameDetailSheet(name: name, viewModel: viewModel)
+        .sheet(item: $selectedLabel) { selected in
+            MarketplaceNameDetailSheet(label: selected.label, viewModel: viewModel)
                 .presentationDetents([.medium, .large])
         }
         .sheet(item: $registerCandidate) { candidate in
@@ -246,7 +271,7 @@ struct UsernameMarketplaceScreen: View {
                         emptyHint(NSLocalizedString("Type at least 2 characters to search usernames", comment: "DashPay Contacts"))
                     } else {
                         ForEach(viewModel.searchResults) { name in
-                            nameRow(name)
+                            searchRow(name)
                         }
                         if let candidate = viewModel.registrableQueryLabel, !viewModel.isSearching {
                             registerRow(candidate)
@@ -274,8 +299,14 @@ struct UsernameMarketplaceScreen: View {
                 } else if viewModel.myNames.isEmpty {
                     emptyHint(NSLocalizedString("No usernames on this identity yet. Find one to buy or register on the Find Names tab.", comment: "Username marketplace: empty owned list"))
                 } else {
-                    ForEach(viewModel.myNames) { name in
-                        nameRow(name)
+                    ForEach(viewModel.ownedNames) { row in
+                        stateRow(row)
+                    }
+                    if !viewModel.departedNames.isEmpty {
+                        sectionHeader(NSLocalizedString("No longer yours", comment: "Username marketplace: names that were sold or transferred away"))
+                        ForEach(viewModel.departedNames) { row in
+                            stateRow(row)
+                        }
                     }
                 }
             }
@@ -283,31 +314,32 @@ struct UsernameMarketplaceScreen: View {
             .padding(.top, 12)
             .padding(.bottom, 24)
         }
-        .refreshable { viewModel.loadMyNames() }
+        .refreshable { await viewModel.refreshFromNetwork() }
     }
 
     // MARK: Rows
 
-    private func nameRow(_ name: MarketplaceName) -> some View {
+    private func searchRow(_ name: DpnsMarketplaceName) -> some View {
         let isMine = name.isOwned(by: viewModel.ownIdentityId)
         return Button {
-            selectedName = name
+            selectedLabel = SelectedMarketplaceLabel(label: name.label)
         } label: {
             HStack(spacing: 10) {
                 ContactAvatarView(
                     title: name.label,
                     avatarURL: nil,
-                    identitySeed: Data.identifier(fromBase58: name.ownerIdBase58) ?? Data())
+                    identitySeed: name.ownerId)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(name.label)
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.dash.primaryText)
                         .lineLimit(1)
-                    Text(isMine
-                        ? NSLocalizedString("Owned by you", comment: "Username marketplace")
-                        : String(name.ownerIdBase58.prefix(8)) + "…" + String(name.ownerIdBase58.suffix(4)))
+                    // The seller-clarity line: a listed name that isn't
+                    // ours is being sold by an independent user — not by
+                    // Dash, not by this app.
+                    Text(subtitle(for: name, isMine: isMine))
                         .font(.system(size: 11))
-                        .foregroundColor(.dash.tertiaryText)
+                        .foregroundColor(name.isForSale && !isMine ? .dashGolden : .dash.tertiaryText)
                         .lineLimit(1)
                 }
                 Spacer()
@@ -332,6 +364,83 @@ struct UsernameMarketplaceScreen: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    private func subtitle(for name: DpnsMarketplaceName, isMine: Bool) -> String {
+        if isMine {
+            return NSLocalizedString("Owned by you", comment: "Username marketplace")
+        }
+        if name.isForSale {
+            return NSLocalizedString("For sale by an independent user", comment: "Username marketplace: seller-clarity row line — the seller is another user, not Dash or the app")
+        }
+        let owner = name.ownerId.toBase58String()
+        return String(owner.prefix(8)) + "…" + String(owner.suffix(4))
+    }
+
+    private func stateRow(_ row: DpnsNameStateRow) -> some View {
+        Button {
+            selectedLabel = SelectedMarketplaceLabel(label: row.label)
+        } label: {
+            HStack(spacing: 10) {
+                ContactAvatarView(
+                    title: row.label,
+                    avatarURL: nil,
+                    identitySeed: row.walletIdentityId)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.label)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                        .lineLimit(1)
+                    Text(stateLine(for: row))
+                        .font(.system(size: 11))
+                        .foregroundColor(.dash.tertiaryText)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if row.isForSale, let priceDuffs = row.priceDuffs {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.dashGolden)
+                        Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.dash.primaryText)
+                    }
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.dash.secondaryBackground))
+            .contentShape(Rectangle())
+            .opacity({ if case .owned = row.status { return 1 } else { return 0.65 } }())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func stateLine(for row: DpnsNameStateRow) -> String {
+        switch row.status {
+        case .owned:
+            return row.isForSale
+                ? NSLocalizedString("Listed by you", comment: "Username marketplace: own listed name")
+                : NSLocalizedString("Owned by you", comment: "Username marketplace")
+        case .sold(let buyer):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Sold to %@", comment: "Username marketplace: departed-name line — buyer identity"),
+                shortId(buyer))
+        case .transferred(let recipient):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Transferred to %@", comment: "Username marketplace: departed-name line — recipient identity"),
+                shortId(recipient))
+        }
+    }
+
+    private func shortId(_ id: Data) -> String {
+        let base58 = id.toBase58String()
+        return String(base58.prefix(8)) + "…" + String(base58.suffix(4))
     }
 
     private func registerRow(_ label: String) -> some View {
@@ -364,6 +473,18 @@ struct UsernameMarketplaceScreen: View {
         .buttonStyle(.plain)
     }
 
+    private func sectionHeader(_ text: String) -> some View {
+        HStack {
+            Text(text)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.dash.secondaryText)
+            Spacer()
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 14)
+        .padding(.bottom, 2)
+    }
+
     private func emptyHint(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 13))
@@ -375,8 +496,12 @@ struct UsernameMarketplaceScreen: View {
     }
 }
 
-/// Identifiable wrapper so `.sheet(item:)` can present a register
-/// candidate without a retroactive String conformance.
+/// Identifiable wrappers for `.sheet(item:)`.
+struct SelectedMarketplaceLabel: Identifiable {
+    let label: String
+    var id: String { label }
+}
+
 struct RegisterCandidate: Identifiable {
     let label: String
     var id: String { label }
@@ -384,85 +509,146 @@ struct RegisterCandidate: Identifiable {
 
 // MARK: - MarketplaceNameDetailSheet
 
-/// State-driven detail: what the name is, who owns it, its sale state,
-/// and exactly the actions that state allows.
+/// Authoritative detail for one name: loads the live document state and
+/// the full trade timeline on appear, then offers exactly the actions
+/// the state allows. Works for departed names too (the history query
+/// covers names that already left the wallet).
 private struct MarketplaceNameDetailSheet: View {
-    let name: MarketplaceName
+    let label: String
     @ObservedObject var viewModel: UsernameMarketplaceViewModel
     @Environment(\.dismiss) private var dismiss
 
+    @State private var liveName: DpnsMarketplaceName?
+    @State private var history: [DpnsNameHistoryEvent] = []
+    @State private var isLoading = true
     @State private var showingSetPrice = false
     @State private var showingTransfer = false
     @State private var confirmBuy = false
     @State private var confirmDelist = false
 
-    private var isMine: Bool { name.isOwned(by: viewModel.ownIdentityId) }
+    private var isMine: Bool { liveName?.isOwned(by: viewModel.ownIdentityId) ?? false }
 
     var body: some View {
         ScrollView {
             VStack(spacing: 0) {
                 ContactAvatarView(
-                    title: name.label,
+                    title: label,
                     avatarURL: nil,
-                    identitySeed: Data.identifier(fromBase58: name.ownerIdBase58) ?? Data(),
+                    identitySeed: liveName?.ownerId ?? Data(),
                     size: 72)
                     .padding(.top, 28)
 
-                Text(name.label)
+                Text(label)
                     .font(.system(size: 22, weight: .bold))
                     .foregroundColor(.dash.primaryText)
                     .padding(.top, 10)
 
-                if let priceDuffs = name.priceDuffs {
-                    VStack(spacing: 2) {
-                        Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(.dashGolden)
-                        Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
-                            .font(.system(size: 18, weight: .bold))
-                            .foregroundColor(.dash.primaryText)
-                        Text(CurrencyExchanger.shared.fiatAmountString(for: priceDuffs.dashAmount))
-                            .font(.system(size: 12))
-                            .foregroundColor(.dash.secondaryText)
+                if isLoading {
+                    SwiftUI.ProgressView().padding(.top, 20)
+                } else if let name = liveName {
+                    saleState(name)
+                    if name.isForSale && !isMine {
+                        independentSellerCallout
+                            .padding(.horizontal, 20)
+                            .padding(.top, 12)
                     }
-                    .padding(.top, 8)
+                    infoCard(name)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 14)
+                    if !history.isEmpty {
+                        historyCard
+                            .padding(.horizontal, 20)
+                            .padding(.top, 12)
+                    }
+                    actions(name)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 18)
+                        .padding(.bottom, 16)
                 } else {
-                    Text(isMine
-                        ? NSLocalizedString("Not listed for sale", comment: "Username marketplace: own unlisted name")
-                        : NSLocalizedString("Not for sale", comment: "Username marketplace: someone else's unlisted name"))
-                        .font(.system(size: 13, weight: .medium))
+                    Text(NSLocalizedString("This name is not registered.", comment: "Username marketplace: detail for an unregistered name"))
+                        .font(.system(size: 13))
                         .foregroundColor(.dash.secondaryText)
-                        .padding(.top, 8)
+                        .padding(.top, 16)
+                        .padding(.bottom, 24)
                 }
-
-                infoCard
-                    .padding(.horizontal, 20)
-                    .padding(.top, 16)
-
-                actions
-                    .padding(.horizontal, 20)
-                    .padding(.top, 18)
-                    .padding(.bottom, 16)
             }
         }
         .background(Color.dash.primaryBackground)
+        .task { await load() }
         .sheet(isPresented: $showingSetPrice) {
-            SetNamePriceSheet(name: name, viewModel: viewModel, onDone: { dismiss() })
+            SetNamePriceSheet(label: label, viewModel: viewModel, onDone: { dismiss() })
                 .presentationDetents([.medium, .large])
         }
         .sheet(isPresented: $showingTransfer) {
-            TransferNameSheet(name: name, viewModel: viewModel, onDone: { dismiss() })
+            TransferNameSheet(label: label, viewModel: viewModel, onDone: { dismiss() })
                 .presentationDetents([.medium, .large])
         }
     }
 
-    private var infoCard: some View {
+    private func load() async {
+        isLoading = true
+        // Live state and timeline are independent reads; a history
+        // failure must not blank the sale state (and vice versa).
+        do {
+            liveName = try await viewModel.service.nameState(label)
+        } catch {
+            viewModel.errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
+        }
+        history = (try? await viewModel.service.history(label)) ?? []
+        isLoading = false
+    }
+
+    @ViewBuilder
+    private func saleState(_ name: DpnsMarketplaceName) -> some View {
+        if let priceDuffs = name.priceDuffs {
+            VStack(spacing: 2) {
+                Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dashGolden)
+                Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(.dash.primaryText)
+                Text(CurrencyExchanger.shared.fiatAmountString(for: priceDuffs.dashAmount))
+                    .font(.system(size: 12))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            .padding(.top, 8)
+        } else {
+            Text(isMine
+                ? NSLocalizedString("Not listed for sale", comment: "Username marketplace: own unlisted name")
+                : NSLocalizedString("Not for sale", comment: "Username marketplace: someone else's unlisted name"))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.dash.secondaryText)
+                .padding(.top, 8)
+        }
+    }
+
+    /// The seller-clarity callout: this offer comes from an independent
+    /// user, not from Dash or the app.
+    private var independentSellerCallout: some View {
+        Label {
+            Text(NSLocalizedString("This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price.", comment: "Username marketplace: seller-clarity callout on the detail sheet"))
+                .font(.system(size: 12))
+                .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+            Image(systemName: "person.crop.circle.badge.questionmark")
+                .font(.system(size: 13))
+        }
+        .foregroundColor(.dash.secondaryText)
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.dashGolden.opacity(0.1)))
+    }
+
+    private func infoCard(_ name: DpnsMarketplaceName) -> some View {
         VStack(spacing: 0) {
             detailRow(
                 NSLocalizedString("Owner", comment: "Username marketplace"),
                 isMine
                     ? NSLocalizedString("You", comment: "Username marketplace: owner is the current user")
-                    : String(name.ownerIdBase58.prefix(10)) + "…" + String(name.ownerIdBase58.suffix(6)))
+                    : shortId(name.ownerId))
             if let createdAtMs = name.createdAtMs {
                 detailRow(
                     NSLocalizedString("Registered", comment: "Username marketplace: registration date"),
@@ -475,9 +661,6 @@ private struct MarketplaceNameDetailSheet: View {
                     DWDateFormatter.sharedInstance.shortStringFromDate(
                         Date(timeIntervalSince1970: Double(transferredAtMs) / 1000)))
             }
-            // Full pricing/transfer/purchase timeline requires the SDK's
-            // document-revision history query (in progress); until then
-            // this sheet shows only the facts the current document carries.
         }
         .padding(.vertical, 4)
         .background(
@@ -485,8 +668,97 @@ private struct MarketplaceNameDetailSheet: View {
                 .fill(Color.dash.secondaryBackground))
     }
 
+    // MARK: Trade history
+
+    private var historyCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(NSLocalizedString("Trade history", comment: "Username marketplace: timeline card title"))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.dash.secondaryText)
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
+                .padding(.bottom, 4)
+            ForEach(Array(history.enumerated().reversed()), id: \.offset) { _, event in
+                historyRow(event)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.dash.secondaryBackground))
+    }
+
+    private func historyRow(_ event: DpnsNameHistoryEvent) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: historyIcon(event))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.dash.blue)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(historyText(event))
+                    .font(.system(size: 13))
+                    .foregroundColor(.dash.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(DWDateFormatter.sharedInstance.shortStringFromDate(
+                    Date(timeIntervalSince1970: Double(event.atMs) / 1000)))
+                    .font(.system(size: 11))
+                    .foregroundColor(.dash.tertiaryText)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+    }
+
+    private func historyIcon(_ event: DpnsNameHistoryEvent) -> String {
+        switch event {
+        case .registered: return "plus.circle"
+        case .priceSet: return "tag"
+        case .purchased: return "cart"
+        case .transferred(let from, let to, _, _):
+            return from == to ? "tag.slash" : "arrow.right.circle"
+        }
+    }
+
+    private func historyText(_ event: DpnsNameHistoryEvent) -> String {
+        switch event {
+        case .registered:
+            return NSLocalizedString("Registered", comment: "Username marketplace: registration date")
+        case .priceSet(let price, _, _):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Listed for %@ DASH", comment: "Username marketplace: history — price set"),
+                (price / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
+        case .purchased(let price, let seller, let buyer, _, _):
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Bought by %1$@ from %2$@ for %3$@ DASH", comment: "Username marketplace: history — purchase with buyer, seller, price"),
+                participant(buyer), participant(seller),
+                (price / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol)
+        case .transferred(let from, let to, _, _):
+            if from == to {
+                return NSLocalizedString("Removed from sale", comment: "Username marketplace: history — delist (transfer to self)")
+            }
+            return String.localizedStringWithFormat(
+                NSLocalizedString("Transferred from %1$@ to %2$@", comment: "Username marketplace: history — transfer with both identities"),
+                participant(from), participant(to))
+        }
+    }
+
+    private func participant(_ id: Data) -> String {
+        id == viewModel.ownIdentityId
+            ? NSLocalizedString("you", comment: "Username marketplace: history participant is the current user")
+            : shortId(id)
+    }
+
+    private func shortId(_ id: Data) -> String {
+        let base58 = id.toBase58String()
+        return String(base58.prefix(8)) + "…" + String(base58.suffix(4))
+    }
+
+    // MARK: Actions
+
     @ViewBuilder
-    private var actions: some View {
+    private func actions(_ name: DpnsMarketplaceName) -> some View {
         VStack(spacing: 10) {
             if isMine {
                 if name.isForSale {
@@ -505,7 +777,7 @@ private struct MarketplaceNameDetailSheet: View {
                     showingTransfer = true
                 }
             } else if name.isForSale, let priceDuffs = name.priceDuffs {
-                identityBalanceLine
+                identityBalanceLine(name)
                 primaryButton(String.localizedStringWithFormat(
                     NSLocalizedString("Buy for %@ DASH", comment: "Username marketplace: purchase button"),
                     priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)) {
@@ -517,7 +789,7 @@ private struct MarketplaceNameDetailSheet: View {
         .confirmationDialog(
             String.localizedStringWithFormat(
                 NSLocalizedString("Buy “%@”?", comment: "Username marketplace: purchase confirmation title"),
-                name.label),
+                label),
             isPresented: $confirmBuy,
             titleVisibility: .visible
         ) {
@@ -525,27 +797,27 @@ private struct MarketplaceNameDetailSheet: View {
                 let expected = name.priceCredits ?? 0
                 viewModel.perform(successText: String.localizedStringWithFormat(
                     NSLocalizedString("%@ is now yours", comment: "Username marketplace: purchase success"),
-                    name.label)) {
-                    try await viewModel.service.purchase(name: name, expectedPriceCredits: expected)
+                    label)) {
+                    try await viewModel.service.purchase(name: label, expectedPriceCredits: expected)
                 }
                 dismiss()
             }
             Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
         } message: {
-            Text(NSLocalizedString("The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately.", comment: "Username marketplace: purchase confirmation body"))
+            Text(NSLocalizedString("You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately.", comment: "Username marketplace: purchase confirmation body with seller clarity"))
         }
         .confirmationDialog(
             String.localizedStringWithFormat(
                 NSLocalizedString("Remove “%@” from sale?", comment: "Username marketplace: delist confirmation title"),
-                name.label),
+                label),
             isPresented: $confirmDelist,
             titleVisibility: .visible
         ) {
             Button(NSLocalizedString("Remove From Sale", comment: "Username marketplace"), role: .destructive) {
                 viewModel.perform(successText: String.localizedStringWithFormat(
                     NSLocalizedString("%@ is no longer for sale", comment: "Username marketplace: delist success"),
-                    name.label)) {
-                    try await viewModel.service.removeFromSale(name: name)
+                    label)) {
+                    try await viewModel.service.removeFromSale(name: label)
                 }
                 dismiss()
             }
@@ -556,14 +828,15 @@ private struct MarketplaceNameDetailSheet: View {
     }
 
     /// Buyer-side affordability line, from the same persisted identity
-    /// balance the profile sheet shows.
+    /// balance the profile sheet shows. The SDK re-checks
+    /// authoritatively at purchase time.
     @ViewBuilder
-    private var identityBalanceLine: some View {
+    private func identityBalanceLine(_ name: DpnsMarketplaceName) -> some View {
         if let identityId = viewModel.ownIdentityId,
            let container = SwiftDashSDKHost.shared.modelContainer {
             let available = UsernameMarketplaceService.identityBalanceCredits(
                 identityId: identityId, container: container)
-            let needed = (name.priceCredits ?? 0) + UsernameMarketplaceService.purchaseFeeReserveCredits
+            let needed = name.priceCredits ?? 0
             HStack {
                 Text(NSLocalizedString("Identity Account Balance", comment: "SDK identity profile sheet — the identity's credit balance"))
                     .font(.system(size: 12))
@@ -571,9 +844,9 @@ private struct MarketplaceNameDetailSheet: View {
                 Spacer()
                 Text("\((available / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(available >= needed ? .dash.primaryText : .orange)
+                    .foregroundColor(available > needed ? .dash.primaryText : .orange)
             }
-            if available < needed {
+            if available <= needed {
                 Text(NSLocalizedString("Not enough identity credits for this purchase — top up from My Profile first.", comment: "Username marketplace: insufficient balance hint"))
                     .font(.system(size: 11))
                     .foregroundColor(.orange)
@@ -628,7 +901,7 @@ private struct MarketplaceNameDetailSheet: View {
 // MARK: - SetNamePriceSheet
 
 private struct SetNamePriceSheet: View {
-    let name: MarketplaceName
+    let label: String
     @ObservedObject var viewModel: UsernameMarketplaceViewModel
     let onDone: () -> Void
 
@@ -650,7 +923,7 @@ private struct SetNamePriceSheet: View {
             VStack(spacing: 0) {
                 Text(String.localizedStringWithFormat(
                     NSLocalizedString("Set a price for “%@”", comment: "Username marketplace: set price sheet title"),
-                    name.label))
+                    label))
                     .font(.system(size: 20, weight: .bold))
                     .foregroundColor(.dash.primaryText)
                     .multilineTextAlignment(.center)
@@ -696,9 +969,9 @@ private struct SetNamePriceSheet: View {
                     guard let duffs = priceDuffs else { return }
                     viewModel.perform(successText: String.localizedStringWithFormat(
                         NSLocalizedString("%1$@ listed for %2$@ DASH", comment: "Username marketplace: listing success — name, then price"),
-                        name.label,
+                        label,
                         duffs.dashAmount.formattedDashAmountWithoutCurrencySymbol)) {
-                        try await viewModel.service.setPrice(name: name, priceDuffs: duffs)
+                        try await viewModel.service.setPrice(name: label, priceDuffs: duffs)
                     }
                     dismiss()
                     onDone()
@@ -739,7 +1012,7 @@ private struct SetNamePriceSheet: View {
 // MARK: - TransferNameSheet
 
 private struct TransferNameSheet: View {
-    let name: MarketplaceName
+    let label: String
     @ObservedObject var viewModel: UsernameMarketplaceViewModel
     let onDone: () -> Void
 
@@ -753,7 +1026,7 @@ private struct TransferNameSheet: View {
             VStack(spacing: 0) {
                 Text(String.localizedStringWithFormat(
                     NSLocalizedString("Transfer “%@”", comment: "Username marketplace: transfer sheet title"),
-                    name.label))
+                    label))
                     .font(.system(size: 20, weight: .bold))
                     .foregroundColor(.dash.primaryText)
                     .padding(.top, 28)
@@ -847,7 +1120,7 @@ private struct TransferNameSheet: View {
                 }
                 run(recipientBase58: identityId.toBase58String())
             } catch {
-                resolveError = error.localizedDescription
+                resolveError = UsernameMarketplaceService.userFacingMessage(for: error)
             }
         }
     }
@@ -855,8 +1128,8 @@ private struct TransferNameSheet: View {
     private func run(recipientBase58: String) {
         viewModel.perform(successText: String.localizedStringWithFormat(
             NSLocalizedString("%@ transferred", comment: "Username marketplace: transfer success"),
-            name.label)) {
-            try await viewModel.service.transfer(name: name, toIdentityBase58: recipientBase58)
+            label)) {
+            try await viewModel.service.transfer(name: label, toIdentityBase58: recipientBase58)
         }
         dismiss()
         onDone()

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -79,12 +79,13 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         myNames.filter { if case .owned = $0.status { return false }; return true }
     }
 
-    /// DPNS label shape: 3–63 characters, letters/digits/hyphen, no
-    /// leading or trailing hyphen.
+    /// DPNS label shape: 3–63 characters, ASCII letters/digits/hyphen,
+    /// no leading or trailing hyphen. ASCII only — `isLetter` alone
+    /// would admit unregistrable labels like "café".
     static func isValidLabel(_ label: String) -> Bool {
         guard (3...63).contains(label.count) else { return false }
         guard label.first != "-", label.last != "-" else { return false }
-        return label.allSatisfy { $0.isLetter || $0.isNumber || $0 == "-" }
+        return label.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
     }
 
     func updateSearch() {
@@ -168,19 +169,26 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         isPerformingAction = true
         Task { [weak self] in
             guard let self else { return }
-            defer { isPerformingAction = false }
             do {
                 try await operation()
+                isPerformingAction = false
                 withAnimation { successMessage = successText }
                 loadMyNames()
                 updateSearch()
-                try? await Task.sleep(nanoseconds: 2_500_000_000)
-                withAnimation {
-                    if successMessage == successText { successMessage = nil }
+                // Auto-hide in a detached task so the banner's 2.5 s
+                // doesn't keep the action buttons disabled.
+                Task { [weak self] in
+                    try? await Task.sleep(nanoseconds: 2_500_000_000)
+                    guard let self else { return }
+                    withAnimation {
+                        if successMessage == successText { successMessage = nil }
+                    }
                 }
-            } catch DWIdentityAuthorizer.AuthError.cancelled {
+            } catch UsernameMarketplaceService.ServiceError.authCancelled {
                 // Backing out of the PIN prompt is not an error state.
+                isPerformingAction = false
             } catch {
+                isPerformingAction = false
                 errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
         }
@@ -364,7 +372,7 @@ struct UsernameMarketplaceScreen: View {
                         .lineLimit(1)
                 }
                 Spacer()
-                if let priceDuffs = name.priceDuffs {
+                if name.isForSale, let priceDuffs = name.priceDuffs {
                     VStack(alignment: .trailing, spacing: 1) {
                         Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
                             .font(.system(size: 10, weight: .semibold))
@@ -854,7 +862,12 @@ private struct MarketplaceNameDetailSheet: View {
             titleVisibility: .visible
         ) {
             Button(NSLocalizedString("Buy", comment: "Username marketplace"), role: .none) {
-                let expected = name.priceCredits ?? 0
+                // The Buy button only renders for a listed name, but never
+                // let a nil price fall through as a 0-credit purchase.
+                guard let expected = name.priceCredits else {
+                    viewModel.errorMessage = NSLocalizedString("This username is not for sale.", comment: "Username marketplace")
+                    return
+                }
                 viewModel.perform(successText: String.localizedStringWithFormat(
                     NSLocalizedString("%@ is now yours", comment: "Username marketplace: purchase success"),
                     label)) {
@@ -1169,7 +1182,10 @@ private struct TransferNameSheet: View {
             run(recipientBase58: input)
             return
         }
-        guard let wallet = SwiftDashSDKHost.shared.wallet else { return }
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            resolveError = NSLocalizedString("Wallet is not ready", comment: "DashPay")
+            return
+        }
         isResolving = true
         Task {
             defer { isResolving = false }
@@ -1216,6 +1232,17 @@ private struct RegisterNameSheet: View {
         viewModel.contestedNames.contains {
             DWContestedNameStatusService.labelsMatch($0, label)
         }
+    }
+
+    /// Whether the identity balance covers the vote-resolution fund —
+    /// the same check `requestCostCard` renders, reused to keep the
+    /// submit button from offering a request that must fail.
+    private var canAffordRequest: Bool {
+        guard let identityId = viewModel.ownIdentityId,
+              let container = SwiftDashSDKHost.shared.modelContainer else { return false }
+        return UsernameMarketplaceService.identityBalanceCredits(
+            identityId: identityId, container: container)
+            > UsernameMarketplaceService.contestedFundCredits
     }
 
     var body: some View {
@@ -1282,8 +1309,7 @@ private struct RegisterNameSheet: View {
 
     // MARK: Contested request
 
-    @ViewBuilder
-    private var contestedContent: some View {
+    @ViewBuilder private var contestedContent: some View {
         Text(NSLocalizedString("Short names — 19 characters or fewer, letters and numbers only — aren't registered instantly. The Dash network votes on who gets them.", comment: "Username marketplace: contested request explainer, paragraph 1"))
             .font(.system(size: 14))
             .foregroundColor(.dash.secondaryText)
@@ -1331,13 +1357,14 @@ private struct RegisterNameSheet: View {
                 }
                 dismiss()
             }
+            .disabled(!canAffordRequest)
+            .opacity(canAffordRequest ? 1 : 0.55)
         }
     }
 
     /// The vote-resolution fund the request locks from the identity
     /// balance (a protocol constant), next to what's available.
-    @ViewBuilder
-    private var requestCostCard: some View {
+    @ViewBuilder private var requestCostCard: some View {
         let fund = UsernameMarketplaceService.contestedFundCredits
         let available: UInt64 = {
             guard let identityId = viewModel.ownIdentityId,

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -1227,11 +1227,22 @@ private struct RegisterNameSheet: View {
     }
 
     /// This identity already has a request in for this label — the vote
-    /// is in progress and a second submission would just fail.
+    /// is in progress and a second submission would just fail. Checks
+    /// the app bookmark too, in case the SDK cache hasn't synced yet.
     private var alreadyRequested: Bool {
         viewModel.contestedNames.contains {
             DWContestedNameStatusService.labelsMatch($0, label)
-        }
+        } || DWContestedNameStatusService.shared.isPendingLabel(label)
+    }
+
+    /// A DIFFERENT label's contested request is still in the network
+    /// vote. The reconciliation bookmark is single-slot, so a second
+    /// request is refused rather than silently orphaning the first
+    /// (the service enforces the same rule).
+    private var pendingOtherContestLabel: String? {
+        guard let pending = DWContestedNameStatusService.shared.pendingLabel,
+              !DWContestedNameStatusService.labelsMatch(pending, label) else { return nil }
+        return pending
     }
 
     /// Whether the identity balance covers the vote-resolution fund —
@@ -1322,6 +1333,12 @@ private struct RegisterNameSheet: View {
             statusCallout(
                 icon: "hourglass",
                 text: NSLocalizedString("You already requested this name — the network vote is in progress. You'll find it under My Names.", comment: "Username marketplace: contested request already submitted by this identity"))
+        } else if let pending = pendingOtherContestLabel {
+            statusCallout(
+                icon: "hourglass",
+                text: String.localizedStringWithFormat(
+                    NSLocalizedString("Your request for “%@” is still in the network vote. Wait for that vote to finish before requesting another name.", comment: "Username marketplace: a second contested request is refused while one is pending"),
+                    pending))
         } else if precheck == nil {
             SwiftUI.ProgressView()
                 .padding(.top, 20)

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -7,6 +7,9 @@
 /* CrowdNode */
 " Terms of Use " = " Terms of Use ";
 
+/* Username marketplace: listing success — name, then price */
+"%1$@ listed for %2$@ DASH" = "%1$@ listed for %2$@ DASH";
+
 /* DashPay Notifications */
 "%@ accepted your contact request" = "%@ accepted your contact request";
 
@@ -40,6 +43,9 @@
 /* Username has sent you a contact request */
 "%@ has sent you a contact request" = "%@ has sent you a contact request";
 
+/* Username marketplace: delist success */
+"%@ is no longer for sale" = "%@ is no longer for sale";
+
 /* No comment provided by engineer. */
 "%@ is not allowed to access Face ID. Allow Face ID access in Settings" = "%@ is not allowed to access Face ID. Allow Face ID access in Settings";
 
@@ -49,8 +55,17 @@
 /* No comment provided by engineer. */
 "%@ is not allowed to access Touch ID. Allow Touch ID access in Settings" = "%@ is not allowed to access Touch ID. Allow Touch ID access in Settings";
 
+/* Username marketplace: purchase success */
+"%@ is now yours" = "%@ is now yours";
+
+/* Username marketplace: registration success */
+"%@ registered" = "%@ registered";
+
 /* Testnet faucet */
 "%@ tDash requested — it will arrive shortly" = "%@ tDash requested — it will arrive shortly";
+
+/* Username marketplace: transfer success */
+"%@ transferred" = "%@ transferred";
 
 /* DashPay Contacts */
 "%@ wants to connect. Accept to pay each other directly by username." = "%@ wants to connect. Accept to pay each other directly by username.";
@@ -351,6 +366,9 @@
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Anyone who knows an address can view its history";
 
+/* Username marketplace: set price sheet body */
+"Anyone will be able to buy the name for this exact price. The proceeds arrive as credits on your identity balance." = "Anyone will be able to buy the name for this exact price. The proceeds arrive as credits on your identity balance.";
+
 /* AboutDash */
 "App version" = "App version";
 
@@ -424,6 +442,9 @@
 
 /* SPV diagnostics */
 "Available only while SPV is running with a wallet bound." = "Available only while SPV is running with a wallet bound.";
+
+/* Username marketplace: unregistered name row */
+"Available — register it on your identity" = "Available — register it on your identity";
 
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
@@ -560,6 +581,9 @@
 /* Swap */
 "Buy flow is not supported by this swap backend" = "Buy flow is not supported by this swap backend";
 
+/* Username marketplace: purchase button */
+"Buy for %@ DASH" = "Buy for %@ DASH";
+
 /* DashSpend */
 "Buy gift card" = "Buy gift card";
 
@@ -568,6 +592,12 @@
 
 /* No comment provided by engineer. */
 "Buy gift cards with your Dash for the exact amount of your purchase." = "Buy gift cards with your Dash for the exact amount of your purchase.";
+
+/* Username marketplace: purchase confirmation title */
+"Buy “%@”?" = "Buy “%@”?";
+
+/* Username marketplace: Explore row subtitle */
+"Buy, sell and transfer DashPay usernames" = "Buy, sell and transfer DashPay usernames";
 
 /* Buy/Sell */
 "Buy/Sell" = "Buy/Sell";
@@ -616,6 +646,9 @@
 
 /* No comment provided by engineer. */
 "Change PIN" = "Change PIN";
+
+/* Username marketplace */
+"Change Price" = "Change Price";
 
 /* TimeSkew */
 "Check date & time settings" = "Check date & time settings";
@@ -677,6 +710,12 @@
 /* Identity top-up sheet — fee note */
 "Fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance." = "Fees are taken from the amount; from Shielded, a small remainder may stay in your Platform balance.";
 
+/* Username marketplace: search segment */
+"Find Names" = "Find Names";
+
+/* Username marketplace: listed badge */
+"For sale" = "For sale";
+
 /* Identity top-up sheet — linkability warning for transparent-side sources */
 "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance." = "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.";
 
@@ -689,17 +728,44 @@
 /* SDK identity profile sheet — the identity's credit balance */
 "Identity Account Balance" = "Identity Account Balance";
 
+/* Username marketplace: latest ownership change */
+"Last transferred" = "Last transferred";
+
+/* Username marketplace: confirm listing button */
+"List For Sale" = "List For Sale";
+
+/* Username marketplace: set price fee note */
+"Listing is a network transaction with a small fee, paid from your identity balance." = "Listing is a network transaction with a small fee, paid from your identity balance.";
+
 /* DashPay: banner fallback when the identity has no name yet */
 "My identity" = "My identity";
+
+/* Username marketplace: owned names segment */
+"My Names" = "My Names";
 
 /* DashPay FAQ */
 "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers.";
 
+/* Username marketplace: unresolvable transfer recipient */
+"No identity owns that username." = "No identity owns that username.";
+
 /* Identity top-up sheet — missing unshield destination */
 "No Platform receive address is available yet — wait for the Platform sync to finish and try again." = "No Platform receive address is available yet — wait for the Platform sync to finish and try again.";
 
+/* Username marketplace: empty owned list */
+"No usernames on this identity yet. Find one to buy or register on the Find Names tab." = "No usernames on this identity yet. Find one to buy or register on the Find Names tab.";
+
 /* Identity top-up sheet — insufficient funding source */
 "Not enough funds in this balance: %@ DASH needed, %@ DASH available." = "Not enough funds in this balance: %@ DASH needed, %@ DASH available.";
+
+/* Username marketplace: insufficient balance hint */
+"Not enough identity credits for this purchase — top up from My Profile first." = "Not enough identity credits for this purchase — top up from My Profile first.";
+
+/* Username marketplace: someone else's unlisted name */
+"Not for sale" = "Not for sale";
+
+/* Username marketplace: own unlisted name */
+"Not listed for sale" = "Not listed for sale";
 
 /* DashPay FAQ */
 "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves." = "On Bitcoin there is no name layer, so people share and reuse addresses out in the open — once an address is known, everything it ever received is linkable to its owner. With DashPay your username is public, but it never points at a payment address: addresses are exchanged privately per contact and rotate, so paying by name doesn't publish where your money goes. Both are transparent chains, so chain analysis still applies to the coins themselves.";
@@ -707,11 +773,17 @@
 /* DashPay Contacts: search results from DPNS, not the local contact list */
 "On the Dash network" = "On the Dash network";
 
+/* Username marketplace */
+"Owned by you" = "Owned by you";
+
 /* Identity top-up sheet — funding source picker label */
 "Pay from" = "Pay from";
 
 /* DashPay FAQ */
 "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform." = "Payments are private: the addresses you exchange with a contact travel inside an encrypted payload only the two of you can read, and are never published — so your payments aren't trivially linkable to your username. They are still regular transparent-chain payments, though: sophisticated chain analysis might leak information. Shielded DashPay (coming soon) will close that gap. Contact requests themselves are currently NOT private: anyone can see that two identities are connected. Private contact requests are a feature coming soon. Your username and profile are also public on Dash Platform.";
+
+/* Username marketplace: price placeholder */
+"Price in DASH" = "Price in DASH";
 
 /* DashPay FAQ */
 "Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private." = "Private contact requests are in development and expected around September–October 2026. Today the request itself is public — anyone can see that two identities are connected, even though the payment details inside it are encrypted. Once private contact requests ship, you will have the choice of having your friendship be public or private.";
@@ -2326,14 +2398,41 @@
 /* Identities: what a public key is used for */
 "Purpose" = "Purpose";
 
+/* Username marketplace */
+"Put Up For Sale" = "Put Up For Sale";
+
 /* Identities: key visible to the wallet but not usable for signing */
 "Read-only" = "Read-only";
+
+/* Username marketplace: transfer recipient placeholder */
+"Recipient username or identity ID" = "Recipient username or identity ID";
 
 /* Identity top-up sheet — shielded source note */
 "Recommended: a two-step transfer through your own Platform address keeps your identity unlinked from your transparent coins." = "Recommended: a two-step transfer through your own Platform address keeps your identity unlinked from your transparent coins.";
 
+/* Username marketplace: register sheet title */
+"Register “%@”" = "Register “%@”";
+
+/* Username marketplace: registration date */
+"Registered" = "Registered";
+
+/* Username marketplace */
+"Remove From Sale" = "Remove From Sale";
+
+/* Username marketplace: delist confirmation title */
+"Remove “%@” from sale?" = "Remove “%@” from sale?";
+
+/* Username marketplace: delist confirmation body */
+"Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name." = "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.";
+
+/* Username marketplace: screen subtitle */
+"Search usernames, buy ones that are for sale, and sell or transfer your own." = "Search usernames, buy ones that are for sale, and sell or transfer your own.";
+
 /* Identities: DPP security level of a public key */
 "Security level" = "Security level";
+
+/* Username marketplace: transfer sheet body */
+"Send this name to another identity for free. The transfer also removes any sale listing. This can't be undone — the new owner would have to transfer it back." = "Send this name to another identity for free. The transfer also removes any sale listing. This can't be undone — the new owner would have to transfer it back.";
 
 /* DashPay intro: feature body */
 "Send to a username you can actually remember and verify." = "Send to a username you can actually remember and verify.";
@@ -2347,6 +2446,9 @@
 /* DashPay: CTA of the enable success sheet */
 "Send your first contact request" = "Send your first contact request";
 
+/* Username marketplace: set price sheet title */
+"Set a price for “%@”" = "Set a price for “%@”";
+
 /* DashPay Contacts: expands the network search into the full add-contact flow */
 "Show more results" = "Show more results";
 
@@ -2356,17 +2458,47 @@
 /* Identity top-up sheet — shielded route progress */
 "Step 2 of 2 — topping up your identity…" = "Step 2 of 2 — topping up your identity…";
 
+/* Username marketplace: register sheet body */
+"The name is registered directly on your identity. Registration is a network transaction paid from your identity balance." = "The name is registered directly on your identity. Registration is a network transaction paid from your identity balance.";
+
+/* Username marketplace: purchase confirmation body */
+"The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately." = "The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately.";
+
+/* Username marketplace */
+"The recipient identity couldn't be resolved." = "The recipient identity couldn't be resolved.";
+
+/* Username marketplace */
+"The seller changed the price before your purchase was accepted. Review the new price and try again." = "The seller changed the price before your purchase was accepted. Review the new price and try again.";
+
 /* DashPay: body of the Enable DashPay confirmation */
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";
 
 /* SDK identity profile sheet — explains the identity credit balance */
 "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.";
 
+/* Username marketplace */
+"This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote." = "This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.";
+
+/* Username marketplace */
+"This username is not for sale." = "This username is not for sale.";
+
+/* Username marketplace */
+"This username's record couldn't be read from the network." = "This username's record couldn't be read from the network.";
+
 /* SDK identity profile sheet — add credits to the identity */
 "Top Up" = "Top Up";
 
 /* Identity top-up sheet — title */
 "Top Up Identity Balance" = "Top Up Identity Balance";
+
+/* Username marketplace */
+"Transfer to Another Identity" = "Transfer to Another Identity";
+
+/* Username marketplace: transfer sheet title */
+"Transfer “%@”" = "Transfer “%@”";
+
+/* Username marketplace */
+"Username Marketplace" = "Username Marketplace";
 
 /* DashPay intro: feature title */
 "Usernames, not addresses" = "Usernames, not addresses";
@@ -2397,6 +2529,9 @@
 
 /* DashPay intro: feature title */
 "Your history, organized" = "Your history, organized";
+
+/* Username marketplace */
+"Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again." = "Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.";
 
 /* DashPay FAQ */
 "Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5129,6 +5129,9 @@
 /* Username marketplace: contested request explainer, paragraph 2 */
 "Your request enters a public vote by masternodes for about two weeks. Others can request the same name; when the vote ends, the name goes to the winner — or to nobody, if the network votes to lock it." = "Your request enters a public vote by masternodes for about two weeks. Others can request the same name; when the vote ends, the name goes to the winner — or to nobody, if the network votes to lock it.";
 
+/* Username marketplace: a second contested request is refused while one is pending */
+"Your request for “%@” is still in the network vote. Wait for that vote to finish before requesting another name." = "Your request for “%@” is still in the network vote. Wait for that vote to finish before requesting another name.";
+
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -22,6 +22,9 @@
 /* DashPay Invitations */
 "%@ couldn't be found on the Dash network to send them a contact request." = "%@ couldn't be found on the Dash network to send them a contact request.";
 
+/* Username marketplace: contested request cost value — the vote-resolution fund amount */
+"%@ DASH + network fee" = "%@ DASH + network fee";
+
 /* Usernames */
 "%@ Dash available" = "%@ Dash available";
 
@@ -446,6 +449,9 @@
 /* Username marketplace: unregistered name row */
 "Available — register it on your identity" = "Available — register it on your identity";
 
+/* Username marketplace: unregistered contested-eligible name row */
+"Available — short names are decided by a network vote" = "Available — short names are decided by a network vote";
+
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
 
@@ -734,6 +740,9 @@
 /* SDK identity profile sheet — the identity's credit balance */
 "Identity Account Balance" = "Identity Account Balance";
 
+/* Username marketplace: section of contested-name requests awaiting the masternode vote */
+"In network vote" = "In network vote";
+
 /* Username marketplace: latest ownership change */
 "Last transferred" = "Last transferred";
 
@@ -758,6 +767,9 @@
 /* DashPay FAQ */
 "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers." = "Name services like Unstoppable Domains map a human-readable name to a fixed public address on-chain. Anyone can resolve the name and see every payment ever made to it. A DashPay username never publicly resolves to a payment address — addresses are revealed only inside the encrypted exchange with each contact, so your name and your money stay unlinked to outside observers.";
 
+/* Username marketplace: contested request line — voting deadline */
+"Network vote ends %@" = "Network vote ends %@";
+
 /* Username marketplace: unresolvable transfer recipient */
 "No identity owns that username." = "No identity owns that username.";
 
@@ -775,6 +787,9 @@
 
 /* Username marketplace: insufficient balance hint */
 "Not enough identity credits for this purchase — top up from My Profile first." = "Not enough identity credits for this purchase — top up from My Profile first.";
+
+/* Username marketplace: insufficient balance hint for a contested request */
+"Not enough identity credits for this request — top up from My Profile first." = "Not enough identity credits for this request — top up from My Profile first.";
 
 /* Username marketplace: someone else's unlisted name */
 "Not for sale" = "Not for sale";
@@ -2443,6 +2458,21 @@
 /* Username marketplace: delist confirmation body */
 "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name." = "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.";
 
+/* Username marketplace: contested request cost row */
+"Request cost" = "Request cost";
+
+/* Username marketplace: contested request success */
+"Request for %@ submitted — masternodes now vote on it" = "Request for %@ submitted — masternodes now vote on it";
+
+/* Username marketplace: confirm contested request button */
+"Request Username" = "Request Username";
+
+/* Username marketplace: contested register sheet title */
+"Request “%@”" = "Request “%@”";
+
+/* Username marketplace: contested request not yet indexed by Platform */
+"Requested — waiting for the network vote" = "Requested — waiting for the network vote";
+
 /* Username marketplace: screen subtitle */
 "Search usernames, buy ones that are for sale, and sell or transfer your own." = "Search usernames, buy ones that are for sale, and sell or transfer your own.";
 
@@ -2467,6 +2497,12 @@
 /* Username marketplace: set price sheet title */
 "Set a price for “%@”" = "Set a price for “%@”";
 
+/* Username marketplace */
+"Short names are decided by a network vote — use Request Username instead." = "Short names are decided by a network vote — use Request Username instead.";
+
+/* Username marketplace: contested request explainer, paragraph 1 */
+"Short names — 19 characters or fewer, letters and numbers only — aren't registered instantly. The Dash network votes on who gets them." = "Short names — 19 characters or fewer, letters and numbers only — aren't registered instantly. The Dash network votes on who gets them.";
+
 /* DashPay Contacts: expands the network search into the full add-contact flow */
 "Show more results" = "Show more results";
 
@@ -2479,8 +2515,14 @@
 /* Identity top-up sheet — shielded route progress */
 "Step 2 of 2 — topping up your identity…" = "Step 2 of 2 — topping up your identity…";
 
+/* Username marketplace: contested request cost footnote */
+"The cost is paid from your identity balance. It funds the network vote and isn't returned if another contender wins." = "The cost is paid from your identity balance. It funds the network vote and isn't returned if another contender wins.";
+
 /* Username marketplace: register sheet body */
 "The name is registered directly on your identity. Registration is a network transaction paid from your identity balance." = "The name is registered directly on your identity. Registration is a network transaction paid from your identity balance.";
+
+/* Username marketplace: contested label locked by a past vote */
+"The network voted to lock this name, so nobody can register it. Choose a different name." = "The network voted to lock this name, so nobody can register it. Choose a different name.";
 
 /* Username marketplace */
 "The recipient identity couldn't be resolved." = "The recipient identity couldn't be resolved.";
@@ -2494,6 +2536,9 @@
 /* SDK identity profile sheet — explains the identity credit balance */
 "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.";
 
+/* Username marketplace: contested label already has an active vote */
+"This name is already in an active network vote. Your request joins it as another contender." = "This name is already in an active network vote. Your request joins it as another contender.";
+
 /* Username marketplace */
 "This name is in an active network vote and can't be traded until the contest ends." = "This name is in an active network vote and can't be traded until the contest ends.";
 
@@ -2502,9 +2547,6 @@
 
 /* Username marketplace: seller-clarity callout on the detail sheet */
 "This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price." = "This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price.";
-
-/* Username marketplace */
-"This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote." = "This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.";
 
 /* Username marketplace */
 "This username is not for sale." = "This username is not for sale.";
@@ -2562,6 +2604,9 @@
 
 /* Username marketplace: history participant is the current user */
 "you" = "you";
+
+/* Username marketplace: contested request already submitted by this identity */
+"You already requested this name — the network vote is in progress. You'll find it under My Names." = "You already requested this name — the network vote is in progress. You'll find it under My Names.";
 
 /* Username marketplace: purchase confirmation body with seller clarity */
 "You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately." = "You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately.";
@@ -5039,6 +5084,9 @@
 
 /* Balance info sheet */
 "Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential." = "Your private balance. Amounts and addresses are encrypted on-chain, so your holdings and history stay confidential.";
+
+/* Username marketplace: contested request explainer, paragraph 2 */
+"Your request enters a public vote by masternodes for about two weeks. Others can request the same name; when the vote ends, the name goes to the winner — or to nobody, if the network votes to lock it." = "Your request enters a public vote by masternodes for about two weeks. Others can request the same name; when the vote ends, the name goes to the winner — or to nobody, if the network votes to lock it.";
 
 /* Usernames */
 "Your request was cancelled" = "Your request was cancelled";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -535,6 +535,9 @@
 /* Voting */
 "Blocked '%@' username" = "Blocked '%@' username";
 
+/* Username marketplace: history — purchase with buyer, seller, price */
+"Bought by %1$@ from %2$@ for %3$@ DASH" = "Bought by %1$@ from %2$@ for %3$@ DASH";
+
 /* Identities: this key only signs for one data contract */
 "Bound to contract" = "Bound to contract";
 
@@ -716,6 +719,9 @@
 /* Username marketplace: listed badge */
 "For sale" = "For sale";
 
+/* Username marketplace: seller-clarity row line — the seller is another user, not Dash or the app */
+"For sale by an independent user" = "For sale by an independent user";
+
 /* Identity top-up sheet — linkability warning for transparent-side sources */
 "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance." = "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.";
 
@@ -734,6 +740,12 @@
 /* Username marketplace: confirm listing button */
 "List For Sale" = "List For Sale";
 
+/* Username marketplace: own listed name */
+"Listed by you" = "Listed by you";
+
+/* Username marketplace: history — price set */
+"Listed for %@ DASH" = "Listed for %@ DASH";
+
 /* Username marketplace: set price fee note */
 "Listing is a network transaction with a small fee, paid from your identity balance." = "Listing is a network transaction with a small fee, paid from your identity balance.";
 
@@ -748,6 +760,9 @@
 
 /* Username marketplace: unresolvable transfer recipient */
 "No identity owns that username." = "No identity owns that username.";
+
+/* Username marketplace: names that were sold or transferred away */
+"No longer yours" = "No longer yours";
 
 /* Identity top-up sheet — missing unshield destination */
 "No Platform receive address is available yet — wait for the Platform sync to finish and try again." = "No Platform receive address is available yet — wait for the Platform sync to finish and try again.";
@@ -2422,6 +2437,9 @@
 /* Username marketplace: delist confirmation title */
 "Remove “%@” from sale?" = "Remove “%@” from sale?";
 
+/* Username marketplace: history — delist (transfer to self) */
+"Removed from sale" = "Removed from sale";
+
 /* Username marketplace: delist confirmation body */
 "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name." = "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.";
 
@@ -2452,6 +2470,9 @@
 /* DashPay Contacts: expands the network search into the full add-contact flow */
 "Show more results" = "Show more results";
 
+/* Username marketplace: departed-name line — buyer identity */
+"Sold to %@" = "Sold to %@";
+
 /* Identity top-up sheet — shielded route progress */
 "Step 1 of 2 — moving Dash out of your Shielded balance…" = "Step 1 of 2 — moving Dash out of your Shielded balance…";
 
@@ -2460,9 +2481,6 @@
 
 /* Username marketplace: register sheet body */
 "The name is registered directly on your identity. Registration is a network transaction paid from your identity balance." = "The name is registered directly on your identity. Registration is a network transaction paid from your identity balance.";
-
-/* Username marketplace: purchase confirmation body */
-"The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately." = "The price plus a small network fee is paid from your identity balance. The name moves to your identity immediately.";
 
 /* Username marketplace */
 "The recipient identity couldn't be resolved." = "The recipient identity couldn't be resolved.";
@@ -2475,6 +2493,15 @@
 
 /* SDK identity profile sheet — explains the identity credit balance */
 "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.";
+
+/* Username marketplace */
+"This name is in an active network vote and can't be traded until the contest ends." = "This name is in an active network vote and can't be traded until the contest ends.";
+
+/* Username marketplace: detail for an unregistered name */
+"This name is not registered." = "This name is not registered.";
+
+/* Username marketplace: seller-clarity callout on the detail sheet */
+"This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price." = "This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price.";
 
 /* Username marketplace */
 "This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote." = "This name is short enough to be contested and must be requested through the username flow, where it goes to a network vote.";
@@ -2491,11 +2518,20 @@
 /* Identity top-up sheet — title */
 "Top Up Identity Balance" = "Top Up Identity Balance";
 
+/* Username marketplace: timeline card title */
+"Trade history" = "Trade history";
+
 /* Username marketplace */
 "Transfer to Another Identity" = "Transfer to Another Identity";
 
 /* Username marketplace: transfer sheet title */
 "Transfer “%@”" = "Transfer “%@”";
+
+/* Username marketplace: history — transfer with both identities */
+"Transferred from %1$@ to %2$@" = "Transferred from %1$@ to %2$@";
+
+/* Username marketplace: departed-name line — recipient identity */
+"Transferred to %@" = "Transferred to %@";
 
 /* Username marketplace */
 "Username Marketplace" = "Username Marketplace";
@@ -2523,6 +2559,12 @@
 
 /* DashPay FAQ */
 "Why do I need to enable it?" = "Why do I need to enable it?";
+
+/* Username marketplace: history participant is the current user */
+"you" = "you";
+
+/* Username marketplace: purchase confirmation body with seller clarity */
+"You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately." = "You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately.";
 
 /* DashPay: body of the enable success sheet */
 "You're all set. Other users can now send you contact requests — and you can send yours." = "You're all set. Other users can now send you contact requests — and you can send yours.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2569,6 +2569,9 @@
 /* Username marketplace: seller-clarity callout on the detail sheet */
 "This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price." = "This name is offered by an independent user on the Dash network — not by Dash or this app. The seller sets the price.";
 
+/* Username marketplace: listing price exceeds the representable maximum */
+"This price is too high to list." = "This price is too high to list.";
+
 /* Asset-lock retry: unsupported funding route */
 "This transfer can't be retried from here." = "This transfer can't be retried from here.";
 
@@ -2648,7 +2651,7 @@
 "Your history, organized" = "Your history, organized";
 
 /* Username marketplace */
-"Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again." = "Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again.";
+"Your identity balance can't cover this purchase: %@ DASH needed (including a fee reserve), %@ DASH available. Top up your identity balance and try again." = "Your identity balance can't cover this purchase: %1$@ DASH needed (including a fee reserve), %2$@ DASH available. Top up your identity balance and try again.";
 
 /* DashPay FAQ */
 "Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event." = "Your identity needs two extra keys so contact requests can be encrypted between you and other users. Enabling adds them with a single network transaction. This is a one time event.";


### PR DESCRIPTION
## Issue being fixed or feature implemented

A username marketplace over the DPNS v2 contract's trade surface. The v2 contract (`packages/dpns-contract/schema/v2`) enables it all: `transferable = 1`, `tradeMode = 1` (direct purchase), `keepsTransferHistory` / `keepsPurchaseHistory` / `keepsPricingHistory`.

## Layering (what lives where)

**Already in rs-sdk / swift-sdk (used directly by this PR):** the generic document trade transitions — `setDocumentPrice`, `purchaseDocument`, `transferDocument` on `ManagedPlatformWallet` (FFI-wired) — plus `SDK.documentList` with where-clauses, `dpnsNormalizeLabel`, `resolveDpnsName`, `registerDpnsName`.

**Consensus facts this PR is built on (verified in rs-drive source):**
- Purchase requires `$price` present (`DocumentNotForSaleError`) and the transition's price must equal the listed price — built-in protection against seller-side races.
- Purchase AND transfer both remove `$price` (`document_purchase/transfer_transition_action/v0/transformer.rs`) — so **delist = transfer to self** (ownership unchanged, listing cleared). The contract has no dedicated remove-price transition (`documentsMutable = false`).

**Delegated to the platform repo (spawned as the "Username marketplace: platform-wallet orchestration + history" task):** sale-state persistence through the changeset pipeline, wallet-level purchase orchestration with local reconciliation (including the sold-main-username case), per-name transfer/purchase/pricing history via a document-revision query, typed errors at the FFI, and the `$price` index investigation — the contract has **no price index**, so a global "browse everything for sale" is not queryable today. This PR's marketplace is deliberately search-driven until that lands; the app-side service is a thin facade the wallet-level APIs can replace without UI changes.

## What was done (app)

`UsernameMarketplaceService` (stateless facade, no singleton) + `UsernameMarketplaceScreen` reached from a new Explore row:

- **Find Names**: debounced prefix search on the `parentNameAndLabel` index — one `documentList` query returns full domain documents, so every result carries live sale state and price. Exact-label unregistered queries (validated against DPNS label rules, compared via the SDK's own normalizer since DPNS folds look-alike characters) offer a **Register** row — non-contested labels register directly on the identity; contested-eligible labels are refused with a pointer to the voting flow.
- **My Names**: every domain document on the current identity (`records.identity` index), with sale badges. Pull-to-refresh.
- **Name detail sheet** (state-driven actions):
  - yours, unlisted → *Put Up For Sale*, *Transfer to Another Identity*
  - yours, listed → *Change Price*, *Remove From Sale* (confirmation explains the delist is a fee-bearing transaction), *Transfer*
  - someone else's, listed → *Buy for X DASH* with an identity-balance affordability line (same persisted balance the profile sheet shows) and a top-up hint when short
  - facts card: owner, `$createdAt` / `$transferredAt` when the document carries them — the full trade timeline explicitly waits for the SDK revision-history query rather than faking one.
- **Buy flow**: authoritative re-read of the listing before anything signs (gone → *not for sale*; price moved → typed *priceChanged*), affordability pre-check against price + a documented fee reserve (0.001 DASH, ~2× the observed transition fee), then PIN gate → `purchaseDocument` with the exact confirmed price. Post-purchase the identity snapshot refreshes so the name shows everywhere.
- **Transfer flow**: recipient as username (resolved via `resolveDpnsName`, unresolvable input is an error — never guessed) or raw base58 identity id.
- Every mutation authenticates before signing and signs with the identity's critical auth key (id 1); master keys can't sign document transitions.

## Update — wired to the wallet-level SDK (platform #4348)

The second commit consumes the merged wallet layer end to end: typed `searchDpnsMarketplace` / `myDpnsMarketplaceNames` (local rows including retained sold/transferred departures, rendered in a "No longer yours" section) / `dpnsMarketplaceNameState` / **`dpnsNameHistory` — the detail sheet now shows the real trade timeline** (registered / listed / purchased with counterparties and price / transferred, delist rendered as "Removed from sale"). Trade ops use the orchestrated calls with typed errors surfaced in user terms; delist uses the dedicated `delistDpnsName`; the app-side documentList parser, manual pre-flight, and balance pre-check are deleted (the SDK owns them). The recurring DPNS sync starts with the wallet, and My Names pull-to-refresh runs a `syncDpnsMarketplace` pass.

**Seller clarity**: a listed name that isn't yours reads "For sale by an independent user" on the search row, the detail sheet carries a callout ("offered by an independent user on the Dash network — not by Dash or this app; the seller sets the price"), and the purchase confirmation repeats it before the PIN gate.

## Update — contested short names are requestable in place

The register sheet no longer dead-ends on contested-eligible labels. It submits the request natively: an explanation of the masternode vote, a pre-submit check of the label's state (fresh vote / active vote you'd join as a contender / locked by a past vote — no submit button on locked), the protocol's **0.2 DASH vote-resolution fund** shown as the request cost next to the identity balance, and the honest footnote that the fund isn't returned if another contender wins. Submission reuses the setup flow's `registerDpnsName` + bookmark + reconciliation machinery; My Names grows an **"In network vote"** section with the voting deadline. `finalizeWon` now backfills the global username mirror only when it's empty, so a contested win on a *second* name can't displace the user's existing username.

## Not in this PR (tracked)

- Global for-sale browse — `$price` is not an indexable system property on Dash Platform, so this is not buildable at any layer today (confirmed in #4348's API docs).

## How Has This Been Tested?

Clean `dashpay` build (both targets compile the new files; pbxproj registration mirrors the existing pattern). Installed on the mainnet QA simulator: search returns real DPNS documents with sale state, My Names lists the identity's names, and the detail/action sheets render per state. Trade actions (list/buy/transfer/register) are real mainnet transactions and were NOT fired in this pass — the flows stop at the PIN gate; end-to-end trade verification is planned on testnet alongside the platform task's own testnet run. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Username Marketplace accessible from the Explore menu.
  * Search usernames, view availability, ownership, sale status, pricing, trade history, and contest status.
  * Register, list, reprice, delist, purchase, and transfer usernames with confirmation and PIN protection.
  * Added validation, balance checks, contested-name handling, and clear success or error feedback.
* **Improvements**
  * Marketplace data now synchronizes automatically during wallet startup.
  * Added English localization for marketplace actions, statuses, pricing, fees, and errors.
  * Preserved existing primary usernames when winning additional contested-name registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

