### PR TITLE
feat(dashpay): QR contact exchange on the add-contact screen

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		1C2D3E4F5A6B7C8D9E0F1A2B /* TransferAmountHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9D0E1F2A3B4C5D6E7F809 /* TransferAmountHostingController.swift */; };
 		1C887F21B0826303D34B8D90 /* ContactsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764BAE3F8A6B30668FEB1FA6 /* ContactsScreen.swift */; };
 		1CDA90D00719D6249F2761AC /* ContactItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE7E8766B8C1601A85AAB4F /* ContactItem.swift */; };
+		9E51F3B86C207A15D2B84E60 /* DashPayUserLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D0A7C21B5E39F04A11C2D57 /* DashPayUserLink.swift */; };
 		1F3FF21B0295D5A326F08B74 /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		1FAFEA3F516E6CBDD2B49010 /* SwiftDashSDKContactsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02357928871603392E797C9A /* SwiftDashSDKContactsService.swift */; };
 		215F9BB0CAADF4D47D95C444 /* DWAvatarUploadClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E2D975669CB53883D56803 /* DWAvatarUploadClientTests.swift */; };
@@ -2544,6 +2545,7 @@
 		2AFF01DA243F4559003718DC /* DWDPRegistrationStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DWDPRegistrationStatus.m; sourceTree = "<group>"; };
 		2C4FDA5A52AB80D7F349A7AF /* WalletSendService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletSendService.swift; sourceTree = "<group>"; };
 		2CE7E8766B8C1601A85AAB4F /* ContactItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactItem.swift; sourceTree = "<group>"; };
+		4D0A7C21B5E39F04A11C2D57 /* DashPayUserLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DashPayUserLink.swift; sourceTree = "<group>"; };
 		2DCBA057E553F81F54ACE6E1 /* StorageRecordDetailViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageRecordDetailViews.swift; sourceTree = "<group>"; };
 		2E7EE6B2E027DC4062E9983E /* ContactProfileSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContactProfileSheet.swift; sourceTree = "<group>"; };
 		2F134B2E67D68A97892FD760 /* WalletsScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletsScreen.swift; sourceTree = "<group>"; };
@@ -6697,6 +6699,7 @@
 			isa = PBXGroup;
 			children = (
 				2CE7E8766B8C1601A85AAB4F /* ContactItem.swift */,
+				4D0A7C21B5E39F04A11C2D57 /* DashPayUserLink.swift */,
 				02357928871603392E797C9A /* SwiftDashSDKContactsService.swift */,
 			);
 			path = Contacts;
@@ -11116,6 +11119,7 @@
 				E4165429FE629AE7E9CB7E22 /* DWIdentityRegistrationController.swift in Sources */,
 				A15ED0B9E7AAF29C694E4E16 /* DWIdentityAuthorizer.swift in Sources */,
 				1CDA90D00719D6249F2761AC /* ContactItem.swift in Sources */,
+				9E51F3B86C207A15D2B84E60 /* DashPayUserLink.swift in Sources */,
 				1FAFEA3F516E6CBDD2B49010 /* SwiftDashSDKContactsService.swift in Sources */,
 				1C887F21B0826303D34B8D90 /* ContactsScreen.swift in Sources */,
 				07B6BD15F525AAF000B53162 /* AddContactScreen.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayUserLink.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayUserLink.swift
@@ -1,0 +1,68 @@
+//
+//  DashPayUserLink.swift
+//  DashWallet
+//
+//  QR/link payload identifying a DashPay user: the Platform identity
+//  id (base58) plus the preferred DPNS username, encoded as
+//
+//      dashpay://user?id=<base58-identity-id>&username=<label>
+//
+//  Rendered as "my QR code" on the add-contact screen and parsed back
+//  when another user scans it. Parsing is pure and offline; it proves
+//  nothing — the username claim must be verified against Platform
+//  (DPNS lookup, identity id match) before it is shown as that user.
+//
+
+import Foundation
+import SwiftDashSDK
+
+struct DashPayUserLink: Equatable {
+    /// 32-byte Platform identity id.
+    let identityId: Data
+    /// Preferred DPNS label, stored without the ".dash" suffix.
+    let username: String
+
+    var identityIdBase58: String { identityId.toBase58String() }
+
+    /// Canonical URI form — the QR payload.
+    var uriString: String {
+        var components = URLComponents()
+        components.scheme = "dashpay"
+        components.host = "user"
+        components.queryItems = [
+            URLQueryItem(name: "id", value: identityIdBase58),
+            URLQueryItem(name: "username", value: username),
+        ]
+        return components.string ?? "dashpay://user"
+    }
+
+    /// Parse a scanned string. Accepts only the canonical
+    /// `dashpay://user` shape carrying a valid 32-byte base58 `id` and
+    /// a non-empty `username` (a trailing ".dash" is tolerated and
+    /// stripped). Anything else — payment URIs, invitation links, bare
+    /// usernames — returns nil.
+    static func parse(_ string: String) -> DashPayUserLink? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let components = URLComponents(string: trimmed),
+              components.scheme?.lowercased() == "dashpay",
+              components.host?.lowercased() == "user"
+        else { return nil }
+
+        var identityId: Data?
+        var username: String?
+        for item in components.queryItems ?? [] {
+            switch item.name.lowercased() {
+            case "id": identityId = item.value.flatMap { Data.identifier(fromBase58: $0) }
+            case "username": username = item.value
+            default: break
+            }
+        }
+
+        guard let identityId, identityId.count == 32 else { return nil }
+        let label = (username ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .withoutDashSuffix
+        guard !label.isEmpty else { return nil }
+        return DashPayUserLink(identityId: identityId, username: label)
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayUserLink.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/DashPayUserLink.swift
@@ -36,25 +36,37 @@ struct DashPayUserLink: Equatable {
         return components.string ?? "dashpay://user"
     }
 
-    /// Parse a scanned string. Accepts only the canonical
-    /// `dashpay://user` shape carrying a valid 32-byte base58 `id` and
-    /// a non-empty `username` (a trailing ".dash" is tolerated and
-    /// stripped). Anything else — payment URIs, invitation links, bare
-    /// usernames — returns nil.
+    /// Parse a scanned string, enforcing the canonical `dashpay://user`
+    /// shape strictly so the cross-platform wire contract stays
+    /// unambiguous: scheme/host/parameter names are matched
+    /// case-insensitively, but userinfo, port, path, fragment,
+    /// duplicate parameters, and unsupported parameters are all
+    /// rejected. `id` must decode to a 32-byte base58 identifier and
+    /// `username` must be non-empty (a trailing ".dash" is tolerated
+    /// and stripped). Anything else — payment URIs, invitation links,
+    /// bare usernames — returns nil.
     static func parse(_ string: String) -> DashPayUserLink? {
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let components = URLComponents(string: trimmed),
               components.scheme?.lowercased() == "dashpay",
-              components.host?.lowercased() == "user"
+              components.host?.lowercased() == "user",
+              components.user == nil,
+              components.password == nil,
+              components.port == nil,
+              components.path.isEmpty,
+              components.fragment == nil
         else { return nil }
 
         var identityId: Data?
         var username: String?
+        var seenNames: Set<String> = []
         for item in components.queryItems ?? [] {
-            switch item.name.lowercased() {
+            let name = item.name.lowercased()
+            guard seenNames.insert(name).inserted else { return nil }
+            switch name {
             case "id": identityId = item.value.flatMap { Data.identifier(fromBase58: $0) }
             case "username": username = item.value
-            default: break
+            default: return nil
             }
         }
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -489,6 +489,22 @@ final class SwiftDashSDKContactsService: ObservableObject {
         }
     }
 
+    /// Exact DPNS resolution on Platform: the identity id currently
+    /// owning `username` ("alice" or "alice.dash"), or nil when the
+    /// name is unregistered. Unlike `searchUsernames` this is not a
+    /// capped prefix page, so it's the right primitive for verifying a
+    /// scanned QR's username↔identity claim.
+    func resolveUsername(_ username: String) async throws -> Data? {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else {
+            throw ServiceError.noWallet
+        }
+        do {
+            return try await wallet.resolveDpnsName(username)
+        } catch {
+            throw ServiceError.sdk(error)
+        }
+    }
+
     /// Look up an already-materialized `ContactItem` for `identityId`
     /// across the established / incoming / outgoing snapshots. Used by
     /// the add-contact preview to show a contact's real profile fields

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -408,11 +408,18 @@ struct AddContactScreen: View {
     /// scan's spinner nor overwrite its result.
     private func handleScannedCode(_ value: String) {
         showScanner = false
+        // A new scan replaces the previous one wholesale — cancel its
+        // verification before even parsing, so an invalid code can't
+        // leave a stale lookup spinning behind the error alert and
+        // popping the prior QR's preview later.
+        scanVerifyTask?.cancel()
+        scanVerifyTask = nil
+        isVerifyingScan = false
+
         guard let link = DashPayUserLink.parse(value) else {
             errorMessage = NSLocalizedString("This isn't a DashPay user QR code.", comment: "DashPay Contacts: scanned QR is a payment/invitation/foreign code")
             return
         }
-        scanVerifyTask?.cancel()
         isVerifyingScan = true
         scanVerifyTask = Task {
             defer {

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -21,6 +21,18 @@ import SwiftDashSDK
 import SwiftUI
 import DashUIKit
 
+/// Identity + DPNS full name pair driving the send-confirmation sheet
+/// — built from a tapped search row, or from a scan verified via exact
+/// DPNS resolution (the SDK's `DpnsSearchResult` is not constructible
+/// app-side, and a capped prefix page must not gate a verified scan).
+struct ContactCandidate: Identifiable, Equatable {
+    let identityId: Data
+    let fullName: String
+    /// Unique per (name, identity) pair — a contested name shares
+    /// `fullName` across contenders.
+    var id: String { fullName + "|" + identityId.map { String(format: "%02x", $0) }.joined() }
+}
+
 struct AddContactScreen: View {
     @Environment(\.dismiss) private var dismiss
 
@@ -46,7 +58,7 @@ struct AddContactScreen: View {
     @State private var eligibilityInFlight: Set<Data> = []
     /// Tapped result shown in the preview sheet (the single
     /// send/accept confirmation surface).
-    @State private var previewTarget: DpnsSearchResult? = nil
+    @State private var previewTarget: ContactCandidate? = nil
     @State private var errorMessage: String? = nil
     /// Username of the recipient of a just-sent request — drives the
     /// centered success card (nil = hidden).
@@ -126,7 +138,7 @@ struct AddContactScreen: View {
             .sheet(item: $previewTarget) { target in
                 AddContactPreviewSheet(
                     result: target,
-                    collision: collision(for: target),
+                    collision: collision(identityId: target.identityId),
                     contact: service.contactItem(for: target.identityId),
                     onSend: { send(to: target) },
                     onAccept: { accept(target) })
@@ -247,8 +259,8 @@ struct AddContactScreen: View {
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
                                 .fill(Color.dash.secondaryBackground))
                         .contentShape(Rectangle())
-                        .onTapGesture { previewTarget = result }
-                        .onAppear { checkEligibilityIfNeeded(result) }
+                        .onTapGesture { previewTarget = candidate(result) }
+                        .onAppear { checkEligibilityIfNeeded(id: result.identityId) }
                 }
             }
             .padding(.horizontal, 15)
@@ -271,29 +283,34 @@ struct AddContactScreen: View {
         case missingDashPayKeys
     }
 
-    private func collision(for result: DpnsSearchResult) -> Collision {
+    private func collision(identityId: Data) -> Collision {
         if let ownId = DWCurrentUserIdentityInfo.shared.identityId,
-           ownId == result.identityId {
+           ownId == identityId {
             return .isSelf
         }
-        if service.contacts.contains(where: { $0.contactIdentityId == result.identityId }) {
+        if service.contacts.contains(where: { $0.contactIdentityId == identityId }) {
             return .established
         }
-        if service.outgoingRequests.contains(where: { $0.contactIdentityId == result.identityId }) {
+        if service.outgoingRequests.contains(where: { $0.contactIdentityId == identityId }) {
             return .alreadyRequested
         }
-        if service.incomingRequests.contains(where: { $0.contactIdentityId == result.identityId }) {
+        if service.incomingRequests.contains(where: { $0.contactIdentityId == identityId }) {
             return .theyAskedUs
         }
-        if eligibilityById[result.identityId] == false {
+        if eligibilityById[identityId] == false {
             return .missingDashPayKeys
         }
         return .none
     }
 
+    /// The sheet-driving candidate for a tapped search row.
+    private func candidate(_ result: DpnsSearchResult) -> ContactCandidate {
+        ContactCandidate(identityId: result.identityId, fullName: result.fullName)
+    }
+
     @ViewBuilder
     private func resultRow(_ result: DpnsSearchResult) -> some View {
-        let state = collision(for: result)
+        let state = collision(identityId: result.identityId)
         HStack(spacing: 10) {
             ContactAvatarView(
                 title: result.fullName,
@@ -337,7 +354,7 @@ struct AddContactScreen: View {
             switch state {
             case .none:
                 Button {
-                    previewTarget = result
+                    previewTarget = candidate(result)
                 } label: {
                     Image(systemName: "person.badge.plus")
                         .foregroundColor(.dash.blue)
@@ -349,7 +366,7 @@ struct AddContactScreen: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(NSLocalizedString("Send Contact Request", comment: "DashPay Contacts"))
             case .theyAskedUs:
-                AcceptPillButton { accept(result) }
+                AcceptPillButton { accept(candidate(result)) }
             case .established:
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.dashGreen)
@@ -379,9 +396,11 @@ struct AddContactScreen: View {
 
     /// Scanned QR → parse → verify against Platform → the same
     /// send-confirmation sheet a search result tap opens. Verification
-    /// is an exact-username DPNS search whose result must carry the
-    /// scanned identity id — the sheet then renders a Platform-backed
-    /// `DpnsSearchResult`, never the QR's own unproven claim.
+    /// is an exact DPNS resolution (`resolveUsername`) that must return
+    /// the scanned identity id — not a capped prefix page that could
+    /// miss the identity, and never the QR's own unproven claim. The
+    /// search field is left untouched so no second (debounced) lookup
+    /// races this one.
     ///
     /// Every UI-state write happens on the main actor after a
     /// cancellation check, and a new scan cancels the previous task
@@ -393,9 +412,6 @@ struct AddContactScreen: View {
             errorMessage = NSLocalizedString("This isn't a DashPay user QR code.", comment: "DashPay Contacts: scanned QR is a payment/invitation/foreign code")
             return
         }
-        // Mirror the scanned name into the search field so the results
-        // list behind the confirmation sheet shows the same user.
-        query = link.username
         scanVerifyTask?.cancel()
         isVerifyingScan = true
         scanVerifyTask = Task {
@@ -406,19 +422,20 @@ struct AddContactScreen: View {
                 }
             }
             do {
-                let matches = try await service.searchUsernames(prefix: link.username)
+                let ownerId = try await service.resolveUsername(link.username)
                 guard !Task.isCancelled else { return }
-                guard let match = matches.first(where: {
-                    $0.identityId == link.identityId
-                        && $0.fullName.withoutDashSuffix.lowercased() == link.username.lowercased()
-                }) else {
+                guard ownerId == link.identityId else {
                     errorMessage = String(
                         format: NSLocalizedString("%@ couldn't be verified on the Dash network. The QR code may be outdated.", comment: "DashPay Contacts: scanned username doesn't resolve to the scanned identity"),
                         link.username)
                     return
                 }
-                checkEligibilityIfNeeded(match)
-                previewTarget = match
+                checkEligibilityIfNeeded(id: link.identityId)
+                previewTarget = ContactCandidate(
+                    identityId: link.identityId,
+                    // Search rows carry the ".dash"-suffixed full name;
+                    // keep the scan-sourced candidate consistent.
+                    fullName: link.username + ".dash")
             } catch {
                 guard !Task.isCancelled else { return }
                 errorMessage = error.localizedDescription
@@ -462,14 +479,14 @@ struct AddContactScreen: View {
         }
     }
 
-    /// Resolve whether one result can receive a contact request (DIP-15
-    /// needs the recipient's DashPay encryption + decryption keys), the
-    /// first time its row scrolls into view. Marks pre-DashPay
-    /// identities so the user sees "Can't receive contact requests"
-    /// instead of hitting the PIN gate and a network error. One query
-    /// per identity, deduped via `eligibilityInFlight`.
-    private func checkEligibilityIfNeeded(_ result: DpnsSearchResult) {
-        let id = result.identityId
+    /// Resolve whether one identity can receive a contact request
+    /// (DIP-15 needs the recipient's DashPay encryption + decryption
+    /// keys), the first time its row scrolls into view or its scan is
+    /// verified. Marks pre-DashPay identities so the user sees "Can't
+    /// receive contact requests" instead of hitting the PIN gate and a
+    /// network error. One query per identity, deduped via
+    /// `eligibilityInFlight`.
+    private func checkEligibilityIfNeeded(id: Data) {
         guard eligibilityById[id] == nil, !eligibilityInFlight.contains(id) else { return }
         eligibilityInFlight.insert(id)
         Task {
@@ -481,7 +498,7 @@ struct AddContactScreen: View {
 
     // MARK: Actions
 
-    private func send(to target: DpnsSearchResult) {
+    private func send(to target: ContactCandidate) {
         guard eligibilityById[target.identityId] != false else { return }
         guard !sendingIds.contains(target.identityId) else { return }
         sendingIds.insert(target.identityId)
@@ -509,7 +526,7 @@ struct AddContactScreen: View {
         }
     }
 
-    private func accept(_ target: DpnsSearchResult) {
+    private func accept(_ target: ContactCandidate) {
         guard !sendingIds.contains(target.identityId) else { return }
         sendingIds.insert(target.identityId)
         Task {
@@ -540,7 +557,7 @@ struct AddContactScreen: View {
 /// fields appear once the identity is one of our contacts/requesters
 /// (`contact` non-nil). Nothing is fabricated when the data is absent.
 struct AddContactPreviewSheet: View {
-    let result: DpnsSearchResult
+    let result: ContactCandidate
     let collision: AddContactScreen.Collision
     /// The already-materialized contact row when this identity is known
     /// (established / incoming / outgoing); nil for a true stranger.

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -11,6 +11,11 @@
 //  subtitle, elevated rounded white search field, white card result
 //  rows on the gray background.
 //
+//  QR entry points ("My QR" / "Scan QR" buttons under the search
+//  field): scan another user's `dashpay://user` code — verified
+//  against Platform before the send-confirmation sheet opens — and
+//  show your own (`MyDashPayUserQRSheet`).
+//
 
 import SwiftDashSDK
 import SwiftUI
@@ -46,6 +51,11 @@ struct AddContactScreen: View {
     /// Username of the recipient of a just-sent request — drives the
     /// centered success card (nil = hidden).
     @State private var sentToUsername: String?
+    @State private var showScanner = false
+    @State private var showMyQR = false
+    /// A scanned user QR is being verified against Platform (DPNS
+    /// lookup + identity id match) — drives the blocking spinner.
+    @State private var isVerifyingScan = false
 
     @ObservedObject private var service = SwiftDashSDKContactsService.shared
 
@@ -61,6 +71,9 @@ struct AddContactScreen: View {
                         height: 52)
                         .padding(.horizontal, 24)
                         .padding(.top, 22)
+                    qrButtonsRow
+                        .padding(.horizontal, 24)
+                        .padding(.top, 12)
                     resultsList
                 }
             }
@@ -69,6 +82,18 @@ struct AddContactScreen: View {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(NSLocalizedString("Cancel", comment: "")) { dismiss() }
                         .foregroundColor(.dash.blue)
+                }
+            }
+            .fullScreenCover(isPresented: $showScanner) {
+                GenericQRScannerView(
+                    onQRCodeScanned: { handleScannedCode($0) },
+                    onCancel: { showScanner = false })
+            }
+            .sheet(isPresented: $showMyQR) {
+                if let link = myUserLink {
+                    MyDashPayUserQRSheet(
+                        link: link,
+                        displayName: DWCurrentUserIdentityInfo.shared.displayName)
                 }
             }
             .onChange(of: query) { _, _ in
@@ -98,7 +123,19 @@ struct AddContactScreen: View {
                     onAccept: { accept(target) })
             }
             .overlay {
-                if let username = sentToUsername {
+                if isVerifyingScan {
+                    VStack(spacing: 12) {
+                        SwiftUI.ProgressView()
+                        Text(NSLocalizedString("Verifying user…", comment: "DashPay Contacts: spinner after scanning a user QR code"))
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    .padding(24)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color.dash.secondaryBackground)
+                            .shadow(color: Color.dash.shadow, radius: 24, x: 0, y: 8))
+                } else if let username = sentToUsername {
                     VStack(spacing: 12) {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 44))
@@ -120,6 +157,44 @@ struct AddContactScreen: View {
                 }
             }
         }
+    }
+
+    /// "My QR" + "Scan QR" side by side under the search field. "My
+    /// QR" needs an identity with a DPNS name (the QR encodes both),
+    /// so before that "Scan QR" spans the full width alone.
+    private var qrButtonsRow: some View {
+        HStack(spacing: 10) {
+            if myUserLink != nil {
+                qrActionButton(
+                    NSLocalizedString("My QR", comment: "DashPay Contacts: shows the user's own contact QR code"),
+                    systemImage: "qrcode") {
+                    showMyQR = true
+                }
+            }
+            qrActionButton(
+                NSLocalizedString("Scan QR", comment: ""),
+                systemImage: "qrcode.viewfinder") {
+                showScanner = true
+            }
+        }
+    }
+
+    private func qrActionButton(_ title: String, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 17, weight: .medium))
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .foregroundColor(.dash.blue)
+            .frame(maxWidth: .infinity)
+            .frame(height: 46)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color.dash.blue.opacity(0.1)))
+        }
+        .buttonStyle(.plain)
     }
 
     /// Android search screen header: icon, headline, subtitle.
@@ -277,6 +352,54 @@ struct AddContactScreen: View {
             case .missingDashPayKeys:
                 Image(systemName: "lock.slash")
                     .foregroundColor(.dash.tertiaryText)
+            }
+        }
+    }
+
+    // MARK: My QR / scanning
+
+    /// The current user's scannable identity payload — nil until the
+    /// identity is registered AND owns a DPNS name (the QR encodes
+    /// both, so there is nothing honest to show before that).
+    private var myUserLink: DashPayUserLink? {
+        guard let identityId = DWCurrentUserIdentityInfo.shared.identityId,
+              let username = DWCurrentUserIdentityInfo.shared.username
+        else { return nil }
+        return DashPayUserLink(identityId: identityId, username: username.withoutDashSuffix)
+    }
+
+    /// Scanned QR → parse → verify against Platform → the same
+    /// send-confirmation sheet a search result tap opens. Verification
+    /// is an exact-username DPNS search whose result must carry the
+    /// scanned identity id — the sheet then renders a Platform-backed
+    /// `DpnsSearchResult`, never the QR's own unproven claim.
+    private func handleScannedCode(_ value: String) {
+        showScanner = false
+        guard let link = DashPayUserLink.parse(value) else {
+            errorMessage = NSLocalizedString("This isn't a DashPay user QR code.", comment: "DashPay Contacts: scanned QR is a payment/invitation/foreign code")
+            return
+        }
+        // Mirror the scanned name into the search field so the results
+        // list behind the confirmation sheet shows the same user.
+        query = link.username
+        isVerifyingScan = true
+        Task {
+            defer { isVerifyingScan = false }
+            do {
+                let matches = try await service.searchUsernames(prefix: link.username)
+                guard let match = matches.first(where: {
+                    $0.identityId == link.identityId
+                        && $0.fullName.withoutDashSuffix.lowercased() == link.username.lowercased()
+                }) else {
+                    errorMessage = String(
+                        format: NSLocalizedString("%@ couldn't be verified on the Dash network. The QR code may be outdated.", comment: "DashPay Contacts: scanned username doesn't resolve to the scanned identity"),
+                        link.username)
+                    return
+                }
+                checkEligibilityIfNeeded(match)
+                previewTarget = match
+            } catch {
+                errorMessage = error.localizedDescription
             }
         }
     }
@@ -524,5 +647,78 @@ struct AddContactPreviewSheet: View {
         .foregroundColor(color)
         .frame(maxWidth: .infinity)
         .frame(height: 48)
+    }
+}
+
+// MARK: - MyDashPayUserQRSheet
+
+/// "My QR" — the counterpart of the scan button: renders the current
+/// user's `DashPayUserLink` (identity id + preferred username) as a
+/// Dash-branded QR code (`QRCodeGenerator.dashStyledImage`) another
+/// Dash Wallet can scan to open the send-request confirmation for
+/// this user.
+struct MyDashPayUserQRSheet: View {
+    let link: DashPayUserLink
+    let displayName: String?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var qrImage: UIImage?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.dash.primaryBackground.ignoresSafeArea()
+                VStack(spacing: 6) {
+                    Text(displayName ?? link.username)
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundColor(.dash.primaryText)
+                        .padding(.top, 20)
+                    if displayName != nil {
+                        Text(link.username)
+                            .font(.system(size: 14))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    Group {
+                        if let qrImage {
+                            Image(uiImage: qrImage)
+                                .resizable()
+                                .scaledToFit()
+                        } else {
+                            SwiftUI.ProgressView()
+                        }
+                    }
+                    .frame(width: 240, height: 240)
+                    .padding(20)
+                    // The branded QR draws Dash-blue modules on a
+                    // transparent background — keep the card white in
+                    // dark mode so camera scanners keep their contrast.
+                    .background(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .fill(Color.white)
+                            .shadow(color: Color.dash.shadow, radius: 16, x: 0, y: 4))
+                    .padding(.top, 14)
+                    Text(NSLocalizedString("Let another Dash Wallet user scan this code to add you as a contact.", comment: "DashPay Contacts: caption under the user's own QR code"))
+                        .font(.system(size: 14))
+                        .foregroundColor(.dash.tertiaryText)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.horizontal, 32)
+                        .padding(.top, 14)
+                    Spacer()
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(NSLocalizedString("Close", comment: "")) { dismiss() }
+                        .foregroundColor(.dash.blue)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .onAppear {
+            if qrImage == nil {
+                qrImage = QRCodeGenerator.dashStyledImage(for: link.uriString, size: 240)
+            }
+        }
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -56,6 +56,10 @@ struct AddContactScreen: View {
     /// A scanned user QR is being verified against Platform (DPNS
     /// lookup + identity id match) — drives the blocking spinner.
     @State private var isVerifyingScan = false
+    /// The in-flight verification. Canceled by the next scan and on
+    /// screen dismissal so a stale lookup can never overwrite the
+    /// newer one's `previewTarget`/`errorMessage`/spinner state.
+    @State private var scanVerifyTask: Task<Void, Never>? = nil
 
     @ObservedObject private var service = SwiftDashSDKContactsService.shared
 
@@ -103,6 +107,11 @@ struct AddContactScreen: View {
                 if !trimmedQuery.isEmpty {
                     scheduleSearch()
                 }
+            }
+            .onDisappear {
+                scanVerifyTask?.cancel()
+                scanVerifyTask = nil
+                isVerifyingScan = false
             }
             .alert(
                 NSLocalizedString("Error", comment: ""),
@@ -373,6 +382,11 @@ struct AddContactScreen: View {
     /// is an exact-username DPNS search whose result must carry the
     /// scanned identity id — the sheet then renders a Platform-backed
     /// `DpnsSearchResult`, never the QR's own unproven claim.
+    ///
+    /// Every UI-state write happens on the main actor after a
+    /// cancellation check, and a new scan cancels the previous task
+    /// first, so a slow stale lookup can neither clear the newer
+    /// scan's spinner nor overwrite its result.
     private func handleScannedCode(_ value: String) {
         showScanner = false
         guard let link = DashPayUserLink.parse(value) else {
@@ -382,11 +396,18 @@ struct AddContactScreen: View {
         // Mirror the scanned name into the search field so the results
         // list behind the confirmation sheet shows the same user.
         query = link.username
+        scanVerifyTask?.cancel()
         isVerifyingScan = true
-        Task {
-            defer { isVerifyingScan = false }
+        scanVerifyTask = Task {
+            defer {
+                // A canceled task's replacement owns the spinner now.
+                if !Task.isCancelled {
+                    isVerifyingScan = false
+                }
+            }
             do {
                 let matches = try await service.searchUsernames(prefix: link.username)
+                guard !Task.isCancelled else { return }
                 guard let match = matches.first(where: {
                     $0.identityId == link.identityId
                         && $0.fullName.withoutDashSuffix.lowercased() == link.username.lowercased()
@@ -399,6 +420,7 @@ struct AddContactScreen: View {
                 checkEligibilityIfNeeded(match)
                 previewTarget = match
             } catch {
+                guard !Task.isCancelled else { return }
                 errorMessage = error.localizedDescription
             }
         }

--- a/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/QRCodeGenerator.swift
@@ -23,4 +23,161 @@ enum QRCodeGenerator {
         }
         return UIImage(cgImage: cgImage)
     }
+
+    // MARK: - Dash-branded rendering
+
+    /// Dash-branded QR code: round modules under a Dash-blue gradient,
+    /// rounded finder eyes, and the Dash logo on a white disc in the
+    /// center. Encoded at error-correction level H, so the ~9% of
+    /// modules the logo disc hides stay well inside the 30% recovery
+    /// budget. Modules are drawn in Dash blue on a transparent
+    /// background — present on a white/light surface for contrast.
+    static func dashStyledImage(for string: String, size: CGFloat) -> UIImage? {
+        guard let matrix = moduleMatrix(for: string), matrix.count >= 21 else { return nil }
+        let moduleCount = matrix.count
+        let module = size / CGFloat(moduleCount)
+        let imageCenter = CGPoint(x: size / 2, y: size / 2)
+        // Modules whose center falls inside this radius are skipped to
+        // clear a landing zone for the logo disc (π·0.16² ≈ 8% of area).
+        let clearRadius = size * 0.16
+
+        // (col, row) of the three 7×7 finder patterns; they are drawn
+        // as custom rounded eyes instead of dots.
+        let finderOrigins = [(0, 0), (moduleCount - 7, 0), (0, moduleCount - 7)]
+        func isInFinder(col: Int, row: Int) -> Bool {
+            finderOrigins.contains { col >= $0.0 && col < $0.0 + 7 && row >= $0.1 && row < $0.1 + 7 }
+        }
+
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: size, height: size), format: format)
+        return renderer.image { rendererContext in
+            let context = rendererContext.cgContext
+            let path = CGMutablePath()
+
+            // Data modules as circles.
+            let dotDiameter = module * 0.86
+            for row in 0..<moduleCount {
+                for col in 0..<moduleCount where matrix[row][col] {
+                    if isInFinder(col: col, row: row) { continue }
+                    let dotCenter = CGPoint(
+                        x: (CGFloat(col) + 0.5) * module,
+                        y: (CGFloat(row) + 0.5) * module)
+                    if hypot(dotCenter.x - imageCenter.x, dotCenter.y - imageCenter.y) < clearRadius {
+                        continue
+                    }
+                    path.addEllipse(in: CGRect(
+                        x: dotCenter.x - dotDiameter / 2,
+                        y: dotCenter.y - dotDiameter / 2,
+                        width: dotDiameter,
+                        height: dotDiameter))
+                }
+            }
+
+            // Finder eyes: a rounded ring (7×7 outer, 5×5 hole via the
+            // even-odd rule) plus a rounded 3×3 pupil.
+            for origin in finderOrigins {
+                let box = CGRect(
+                    x: CGFloat(origin.0) * module,
+                    y: CGFloat(origin.1) * module,
+                    width: 7 * module,
+                    height: 7 * module)
+                path.addRoundedRect(in: box, cornerWidth: module * 2.4, cornerHeight: module * 2.4)
+                path.addRoundedRect(
+                    in: box.insetBy(dx: module, dy: module),
+                    cornerWidth: module * 1.7, cornerHeight: module * 1.7)
+                path.addRoundedRect(
+                    in: box.insetBy(dx: 2 * module, dy: 2 * module),
+                    cornerWidth: module * 1.1, cornerHeight: module * 1.1)
+            }
+
+            // One gradient across all modules. Both stops stay dark
+            // enough against white for scanner binarization.
+            context.saveGState()
+            context.addPath(path)
+            context.clip(using: .evenOdd)
+            let dashBlue = UIColor(red: 0x00 / 255.0, green: 0x8D / 255.0, blue: 0xE4 / 255.0, alpha: 1)
+            let deepBlue = UIColor(red: 0x01 / 255.0, green: 0x2C / 255.0, blue: 0x7A / 255.0, alpha: 1)
+            if let gradient = CGGradient(
+                colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                colors: [dashBlue.cgColor, deepBlue.cgColor] as CFArray,
+                locations: [0, 1]) {
+                context.drawLinearGradient(
+                    gradient,
+                    start: .zero,
+                    end: CGPoint(x: size, y: size),
+                    options: [])
+            }
+            context.restoreGState()
+
+            // Center: white backing disc, then the Dash logo disc with
+            // a white ring of breathing room between it and the dots.
+            let discRadius = size * 0.155
+            UIColor.white.setFill()
+            context.fillEllipse(in: CGRect(
+                x: imageCenter.x - discRadius,
+                y: imageCenter.y - discRadius,
+                width: discRadius * 2,
+                height: discRadius * 2))
+            if let logo = UIImage(named: "dashCircleFilled") {
+                let logoDiameter = size * 0.25
+                logo.draw(in: CGRect(
+                    x: imageCenter.x - logoDiameter / 2,
+                    y: imageCenter.y - logoDiameter / 2,
+                    width: logoDiameter,
+                    height: logoDiameter))
+            }
+        }
+    }
+
+    /// Decode the CIQRCodeGenerator bitmap (1 pixel per module) into a
+    /// square bool matrix, quiet zone stripped. `true` = dark module.
+    /// Row 0 is the top of the symbol.
+    private static func moduleMatrix(for string: String) -> [[Bool]]? {
+        let data = Data(string.utf8)
+        let filter = CIFilter.qrCodeGenerator()
+        filter.setValue(data, forKey: "inputMessage")
+        filter.setValue("H", forKey: "inputCorrectionLevel")
+        guard let output = filter.outputImage else { return nil }
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(output, from: output.extent) else { return nil }
+
+        let width = cgImage.width
+        let height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height)
+        guard let bitmap = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue)
+        else { return nil }
+        bitmap.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        func isDark(_ x: Int, _ y: Int) -> Bool {
+            pixels[y * width + x] < 128
+        }
+
+        // The bounding box of dark pixels is the symbol; anything
+        // outside is the generator's quiet border.
+        var minX = width, minY = height, maxX = -1, maxY = -1
+        for y in 0..<height {
+            for x in 0..<width where isDark(x, y) {
+                minX = min(minX, x)
+                minY = min(minY, y)
+                maxX = max(maxX, x)
+                maxY = max(maxY, y)
+            }
+        }
+        let side = maxX - minX + 1
+        guard side > 0, side == maxY - minY + 1 else { return nil }
+
+        return (0..<side).map { row in
+            (0..<side).map { col in
+                isDark(minX + col, minY + row)
+            }
+        }
+    }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -19,6 +19,9 @@
 /* DashPay Invitations */
 "%@ couldn't be found on the Dash network to send them a contact request." = "%@ couldn't be found on the Dash network to send them a contact request.";
 
+/* DashPay Contacts: scanned username doesn't resolve to the scanned identity */
+"%@ couldn't be verified on the Dash network. The QR code may be outdated." = "%@ couldn't be verified on the Dash network. The QR code may be outdated.";
+
 /* Usernames */
 "%@ Dash available" = "%@ Dash available";
 
@@ -2022,6 +2025,9 @@
 /* CrowdNode */
 "Leaving the pool" = "Leaving the pool";
 
+/* DashPay Contacts: caption under the user's own QR code */
+"Let another Dash Wallet user scan this code to add you as a contact." = "Let another Dash Wallet user scan this code to add you as a contact.";
+
 /* No comment provided by engineer. */
 "Let me know when it’s done" = "Let me know when it’s done";
 
@@ -2359,6 +2365,9 @@
 /* DashPay: body of the Enable DashPay confirmation */
 "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event." = "This adds two keys to your identity so other users can send you contact requests, and so you can accept theirs. This is a one time event.";
 
+/* DashPay Contacts: scanned QR is a payment/invitation/foreign code */
+"This isn't a DashPay user QR code." = "This isn't a DashPay user QR code.";
+
 /* SDK identity profile sheet — explains the identity credit balance */
 "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits." = "This balance pays Dash Platform network fees — usernames, contact requests, profile updates. It belongs to your identity, not your wallet: unlike your Transparent, Platform, and Shielded balances it can't be spent as regular Dash. Topping up converts Dash from a balance you choose — Shielded by default — into identity credits.";
 
@@ -2427,6 +2436,9 @@
 
 /* SDK identity profile sheet — title */
 "My Profile" = "My Profile";
+
+/* DashPay Contacts: shows the user's own contact QR code */
+"My QR" = "My QR";
 
 /* No comment provided by engineer. */
 "Name" = "Name";
@@ -4367,6 +4379,9 @@
 
 /* No comment provided by engineer. */
 "Verified Successfully" = "Verified Successfully";
+
+/* DashPay Contacts: spinner after scanning a user QR code */
+"Verifying user…" = "Verifying user…";
 
 /* No comment provided by engineer. */
 "Verify" = "Verify";

--- a/DashWalletTests/DashPayUserLinkTests.swift
+++ b/DashWalletTests/DashPayUserLinkTests.swift
@@ -46,6 +46,23 @@ final class DashPayUserLinkTests: XCTestCase {
         XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=\(base58)&username=.dash"))
     }
 
+    func testParseRejectsNonCanonicalURIShapes() {
+        let base58 = identityId.toBase58String()
+        let canonicalQuery = "id=\(base58)&username=alice"
+        // Userinfo, port, path, and fragment are not part of the wire
+        // contract.
+        XCTAssertNil(DashPayUserLink.parse("dashpay://someone@user?\(canonicalQuery)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://someone:secret@user?\(canonicalQuery)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user:1234?\(canonicalQuery)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user/profile?\(canonicalQuery)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?\(canonicalQuery)#fragment"))
+        // Each parameter exactly once, and nothing but id + username.
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?\(canonicalQuery)&id=\(base58)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?\(canonicalQuery)&username=bob"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=invalid&ID=\(base58)&username=alice"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?\(canonicalQuery)&amount=1"))
+    }
+
     func testParseRejectsInvalidIdentityIds() {
         // Base58 alphabet excludes 0, O, I, l.
         XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=0OIl&username=alice"))

--- a/DashWalletTests/DashPayUserLinkTests.swift
+++ b/DashWalletTests/DashPayUserLinkTests.swift
@@ -1,0 +1,56 @@
+//
+//  DashPayUserLinkTests.swift
+//  DashWalletTests
+//
+//  Pure-parsing tests for the `dashpay://user` QR payload codec.
+//
+
+import Foundation
+import XCTest
+@testable import dashwallet
+
+final class DashPayUserLinkTests: XCTestCase {
+
+    /// Any 32 bytes round-trip through base58 in the QR URI.
+    private let identityId = Data((0..<32).map { UInt8($0 &* 7 &+ 3) })
+
+    func testEncodeParseRoundTrip() {
+        let link = DashPayUserLink(identityId: identityId, username: "alice")
+        let parsed = DashPayUserLink.parse(link.uriString)
+        XCTAssertEqual(parsed, link)
+    }
+
+    func testParseStripsDashSuffixAndWhitespace() {
+        let base58 = identityId.toBase58String()
+        let parsed = DashPayUserLink.parse("  dashpay://user?id=\(base58)&username=alice.dash\n")
+        XCTAssertEqual(parsed?.username, "alice")
+        XCTAssertEqual(parsed?.identityId, identityId)
+    }
+
+    func testParseIsCaseInsensitiveOnSchemeHostAndParamNames() {
+        let base58 = identityId.toBase58String()
+        let parsed = DashPayUserLink.parse("DASHPAY://USER?ID=\(base58)&USERNAME=alice")
+        XCTAssertEqual(parsed?.username, "alice")
+    }
+
+    func testParseRejectsForeignPayloads() {
+        let base58 = identityId.toBase58String()
+        XCTAssertNil(DashPayUserLink.parse("dash:XoyzY6j9wkYp1yPe9GHmBdqSwSCmDHb2y7?amount=1"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://invite?du=alice&cftx=abc"))
+        XCTAssertNil(DashPayUserLink.parse("alice"))
+        XCTAssertNil(DashPayUserLink.parse(""))
+        // Missing either parameter.
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=\(base58)"))
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?username=alice"))
+        // `.dash`-only label collapses to empty.
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=\(base58)&username=.dash"))
+    }
+
+    func testParseRejectsInvalidIdentityIds() {
+        // Base58 alphabet excludes 0, O, I, l.
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=0OIl&username=alice"))
+        // Valid base58 but not 32 bytes.
+        let short = Data([1, 2, 3]).toBase58String()
+        XCTAssertNil(DashPayUserLink.parse("dashpay://user?id=\(short)&username=alice"))
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Add a New Contact screen only supported typing a username. In person, the natural flow is to show a code and scan one: this adds "My QR" (identity id + preferred username) and "Scan QR", with a confirmation asking whether to send a contact request to the scanned user.

## What was done?

- **`DashPayUserLink`** (new): codec for the canonical QR payload `dashpay://user?id=<base58-identity-id>&username=<label>`. Parsing is pure/offline and strict — payment URIs, invitation links, bare usernames, bad base58, and non-32-byte ids are all rejected; a trailing `.dash` is tolerated and stripped. Android will need to adopt the same shape for cross-platform scanning.
- **"Scan QR"** (labeled button under the search field): opens the existing `GenericQRScannerView`. A scanned code is never trusted as-is — the username is resolved on Platform via exact DPNS search and the result must carry the scanned identity id. Only then does the existing `AddContactPreviewSheet` open ("Send Contact Request" confirmation), which brings along all collision states for free (already a contact / pending / they-asked-us → Accept / self / missing DashPay keys). Mismatched or outdated codes and foreign QRs surface explicit errors; a "Verifying user…" overlay covers the lookup.
- **"My QR"** (labeled button, shown only once the identity owns a DPNS name — the QR encodes both): sheet with the username and a Dash-branded QR via the new `QRCodeGenerator.dashStyledImage` — round modules under a Dash-blue gradient, rounded finder eyes, and the Dash logo disc in the center. Encoded at ECC level H so the ~9% of modules the logo hides stay well inside the 30% recovery budget; modules render on a white card in both themes so camera binarization keeps its contrast.
- Compile-ready parser tests in `DashWalletTests/DashPayUserLinkTests.swift` (unit-test target is currently broken repo-wide; tests are written ready to run once repaired).

## How Has This Been Tested?

- Clean `dashpay` scheme build (`ARCHS=arm64`, iOS simulator).
- Manual smoke on a mainnet wallet with a registered identity (iPhone 16 Pro simulator, iOS 26.5): buttons render under the search field; "My QR" sheet shows the branded code for the identity's username; button hidden for wallets without a DPNS name by construction. Scanner flow exercised up to the camera boundary (simulator has no camera); the verify-then-confirm path shares its code with the search-result tap flow, which was exercised.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR code sharing and scanning for DashPay contacts.
  * Display your personal DashPay QR code for others to scan.
  * Scan, validate, and verify DashPay contact links before opening contact details.
  * Added branded QR code styling and clear progress and error messages.
  * Improved contact verification by matching usernames with identity details.

* **Tests**
  * Added coverage for valid, normalized, and invalid DashPay links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->