### PR TITLE
feat(ui): internal transfers render a circulating-arrows amount, not a sign

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -13303,7 +13303,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dashpay/DashUIKit";
 			requirement = {
-				branch = "feat/amount-accessory-icon";
+				branch = master;
 				kind = branch;
 			};
 		};

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -13303,7 +13303,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dashpay/DashUIKit";
 			requirement = {
-				branch = master;
+				branch = "feat/amount-accessory-icon";
 				kind = branch;
 			};
 		};

--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,15 @@
 {
-  "originHash" : "c249ed8d75daf51cf5f1467a120fdeaf4cb1d396e8e7721de5bd30aa8b713ba4",
-  "pins" : [
+  "originHash": "cecc72572cc422aa0d68b46e2be53c36997e822a15e2da6434836b8dda9e4934",
+  "pins": [
     {
-      "identity" : "dashuikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dashpay/DashUIKit",
-      "state" : {
-        "branch" : "master",
-        "revision" : "046f087514e12f01087ba20efd5e73c682172ebf"
+      "identity": "dashuikit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/dashpay/DashUIKit",
+      "state": {
+        "branch": "feat/amount-accessory-icon",
+        "revision": "499abc26b4e10b7f7f12d67d58c3e3b0486ec26d"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/dashpay/DashUIKit",
       "state": {
-        "branch": "feat/amount-accessory-icon",
-        "revision": "499abc26b4e10b7f7f12d67d58c3e3b0486ec26d"
+        "branch": "master",
+        "revision": "88bf41f3c3e8c66bf7ac653841643d4a4bed2444"
       }
     }
   ],

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -721,7 +721,8 @@ struct HomeViewContent<Content: View>: View {
                 title: NSLocalizedString("Mixing Transactions", comment: "CoinJoin"),
                 subtitle: firstTx?.shortTimeString ?? "",
                 dashAmount: set.amount,
-                amountSign: .none
+                amountSign: .none,
+                amountAccessorySystemImage: "arrow.triangle.2.circlepath"
             )
             .onTapGesture { self.selectedTxDataItem = txDataItem }
             .frame(height: 80)
@@ -780,7 +781,10 @@ struct HomeViewContent<Content: View>: View {
                             // counterparty's actual name underneath.
                             : transferRouteDetails(txItem: txItem) ?? txItem.dashPayPaymentDetailsName),
                 dashAmount: txItem.signedDashAmount,
-                amountSign: .always,
+                // Internal moves carry no direction: no +/- sign, a
+                // circulating-arrows glyph qualifies the amount instead.
+                amountSign: txItem.internalTransferRoute == nil ? .always : .none,
+                amountAccessorySystemImage: txItem.internalTransferRoute == nil ? nil : "arrow.triangle.2.circlepath",
                 fiat: txItem.fiatAmount,
                 trailingStatusText: txItem.state == .locked ? NSLocalizedString("Locked", comment: "Transaction state: coinbase reward locked until 100 confirmations") : nil
             ) {
@@ -812,6 +816,7 @@ struct HomeViewContent<Content: View>: View {
                 details: item.detailsText,
                 dashAmount: item.signedDashAmount,
                 amountSign: item.showsDirectionSign ? .always : .none,
+                amountAccessorySystemImage: item.showsDirectionSign ? nil : "arrow.triangle.2.circlepath",
                 fiat: item.fiatAmount,
                 trailingStatusText: item.trailingStatusText
             ) {

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -745,6 +745,9 @@ struct HomeViewContent<Content: View>: View {
             // Service/merchant metadata wins over the route pair — such rows
             // are external payments, not transfers of own funds.
             let routeSymbols = metadata == nil ? transferRouteSymbols(txItem: txItem) : nil
+            // Same precedence for the amount treatment: only a metadata-less
+            // internal move drops the +/- sign for the circulating-arrows glyph.
+            let isInternalAmount = metadata == nil && txItem.internalTransferRoute != nil
             // A DashPay contact payment shows the counterparty's avatar
             // (profile image, or the deterministic initial placeholder the
             // contacts screens use).
@@ -783,8 +786,8 @@ struct HomeViewContent<Content: View>: View {
                 dashAmount: txItem.signedDashAmount,
                 // Internal moves carry no direction: no +/- sign, a
                 // circulating-arrows glyph qualifies the amount instead.
-                amountSign: txItem.internalTransferRoute == nil ? .always : .none,
-                amountAccessorySystemImage: txItem.internalTransferRoute == nil ? nil : "arrow.triangle.2.circlepath",
+                amountSign: isInternalAmount ? .none : .always,
+                amountAccessorySystemImage: isInternalAmount ? "arrow.triangle.2.circlepath" : nil,
                 fiat: txItem.fiatAmount,
                 trailingStatusText: txItem.state == .locked ? NSLocalizedString("Locked", comment: "Transaction state: coinbase reward locked until 100 confirmations") : nil
             ) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

An identity top-up row read **"+2 Đ"** — styled like an external receive — when the transaction only moved the wallet's own funds. Wallet-internal rows shouldn't claim a direction.

## What was done

Every internal history row now renders its amount **signless, with a circulating-arrows glyph (⟳) before it**:

- main-feed rows with an `internalTransferRoute`: identity top-up / registration / invitation asset locks, to-Shielded transfers, Shielded → Transparent payouts, to-Platform fundings, and plain self-sends
- internal shielded-activity rows (already signless — now carry the glyph too)
- the CoinJoin "Mixing Transactions" group row

External sends and receives keep their `+`/`-` signs; Platform-address receives (external senders) are untouched.

The glyph is a new `TransactionView.amountAccessorySystemImage` in DashUIKit (dashpay/DashUIKit#10) — an optional SF Symbol before the trailing amount, secondary tone. dashpay/DashUIKit#10 has merged, and the package pin points at `master` (88bf41f), which carries both the new API and the `fix/textfield-prompt-type` compile fix iOS consumers need.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build. Installed on the testnet QA simulator: the "Identity top-up" row shows "⟳ 2 Đ" (no sign), while an external "Sent to …" row keeps "-1 Đ". (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated transaction rows with a circulating-arrows indicator for CoinJoin, internal transfers, and shielded activity.
  * Preserved directional signs for transactions that include transaction metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
