### PR TITLE
feat(taxes): dedicated Internal Transfer tax category for own-fund transfers

### DIFF
--- a/DashWallet/Sources/Models/Taxes/Services/TaxReportGenerator.swift
+++ b/DashWallet/Sources/Models/Taxes/Services/TaxReportGenerator.swift
@@ -130,8 +130,13 @@ enum TaxReportGenerator {
         case .dateAndTime:
             return DWDateFormatter.sharedInstance.iso8601String(from: transaction.date)
         case .txType:
-            let taxCategoryString = userInfo?.taxCategoryString() ?? transaction.defaultTaxCategoryString()
-            return taxCategoryString
+            // Same rule as Taxes.taxCategory(for:): a stored .unknown means
+            // the row was never classified, so it must not shadow the
+            // transaction-derived default.
+            if let stored = userInfo?.taxCategory, stored != .unknown {
+                return stored.stringValue
+            }
+            return transaction.defaultTaxCategoryString()
         case .sentQuantity:
             let fee = transactionDirection == .sent ? transaction.feeUsed : 0
             guard transaction.dashAmount != UInt64.max else { return "" }

--- a/DashWallet/Sources/Models/Taxes/Taxes.swift
+++ b/DashWallet/Sources/Models/Taxes/Taxes.swift
@@ -36,6 +36,12 @@ enum TxMetadataTaxCategory: Int {
     /// Expense
     case expense
 
+    /// Internal Transfer — movement between the wallet's own balances
+    /// (Core ↔ Shielded/Platform/identity funding, or a plain self-send).
+    /// Appended last so the persisted raw values of the older cases keep
+    /// their meaning.
+    case internalTransfer
+
     var isIncoming: Bool {
         self == .income || self == .transferIn
     }
@@ -59,14 +65,15 @@ class Taxes: NSObject {
     }
 
     func taxCategory(for tx: Transaction) -> TxMetadataTaxCategory {
-        // A stored .unknown means the user never classified the tx (rows
-        // persisted before the direction default existed), so it must not
-        // shadow the direction-derived default.
+        // A stored .unknown means the user never classified the tx (rate
+        // stamping and rows persisted before the direction default existed
+        // both leave it .unknown), so it must not shadow the live
+        // transaction-derived default.
         if let stored = txUserInfos.get(by: tx.txHashData)?.taxCategory, stored != .unknown {
             return stored
         }
 
-        return tx.direction.defaultTaxCategory
+        return tx.defaultTaxCategory
     }
 
     func taxCategory(for address: String) -> TxMetadataTaxCategory? {

--- a/DashWallet/Sources/Models/Tx Metadata/TransactionMetadata.swift
+++ b/DashWallet/Sources/Models/Tx Metadata/TransactionMetadata.swift
@@ -32,6 +32,8 @@ extension TxMetadataTaxCategory {
             return NSLocalizedString("Expense", comment: "")
         case .income:
             return NSLocalizedString("Income", comment: "")
+        case .internalTransfer:
+            return NSLocalizedString("Internal Transfer", comment: "Transaction within the wallet, transfer of own funds")
         }
     }
 
@@ -48,6 +50,11 @@ extension TxMetadataTaxCategory {
             return .transferOut
         case .transferOut:
             return .expense
+        case .internalTransfer:
+            // Direction-blind fallback; the detail sheet cycles internal
+            // transfers with direction context instead
+            // (TxDetailModel.nextTaxCategory(after:)).
+            return .transferOut
         }
     }
 }
@@ -151,8 +158,16 @@ extension TransactionDirection {
 }
 
 extension Transaction {
+    /// Fallback tax category when the user hasn't classified the
+    /// transaction. A transfer between the wallet's own balances is
+    /// `.internalTransfer` regardless of direction; everything else keeps
+    /// the direction default.
+    var defaultTaxCategory: TxMetadataTaxCategory {
+        internalTransferRoute != nil ? .internalTransfer : direction.defaultTaxCategory
+    }
+
     func defaultTaxCategoryString() -> String {
-        direction.defaultTaxCategory.stringValue
+        defaultTaxCategory.stringValue
     }
 }
 

--- a/DashWallet/Sources/Models/Tx/Transactions.swift
+++ b/DashWallet/Sources/Models/Tx/Transactions.swift
@@ -38,8 +38,13 @@ final class Tx: NSObject {
         let rate = (decimalRate*pow(10, maximumFractionDigits) as NSDecimalNumber).intValue
 
         guard let userInfo = txUserInfos.get(by: transaction.txHashData) else {
+            // Stamp the rate only — the tax category stays .unknown
+            // (unclassified) so readers keep deriving the live default.
+            // Persisting the default here would freeze it before
+            // internal-transfer detection settles (restore-scan asset-lock
+            // reconstruction lags first observation).
             set(rate: rate, currency: App.fiatCurrency, maximumFractionDigits: maximumFractionDigits,
-                for: TransactionMetadata(txHash: transaction.txHashData, taxCategory: transaction.direction.defaultTaxCategory))
+                for: TransactionMetadata(txHash: transaction.txHashData))
             return
         }
 

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -101,10 +101,10 @@ class TxDetailModel: NSObject {
 
     func toggleTaxCategoryOnCurrentTransaction() {
         if txTaxCategory == .unknown {
-            txTaxCategory = transaction.direction.defaultTaxCategory
+            txTaxCategory = transaction.defaultTaxCategory
         }
 
-        txTaxCategory = txTaxCategory.nextTaxCategory
+        txTaxCategory = nextTaxCategory(after: txTaxCategory)
         let txHash = transaction.txHashData
 
         var txUserInfo = transaction.userInfo ?? TransactionMetadata(txHash: txHash, taxCategory: txTaxCategory)
@@ -112,6 +112,30 @@ class TxDetailModel: NSObject {
 
         // TODO: Move it to Domain layer
         TransactionMetadataDAOImpl.shared.update(dto: txUserInfo)
+    }
+
+    /// The category a tap on the Tax Category row moves to. Regular
+    /// transactions keep the two-state direction pair (Income ↔ Transfer In,
+    /// Expense ↔ Transfer Out); an internal transfer cycles through its
+    /// direction pair plus the Internal Transfer default, so a reclassified
+    /// transfer can be put back.
+    private func nextTaxCategory(after category: TxMetadataTaxCategory) -> TxMetadataTaxCategory {
+        guard transaction.internalTransferRoute != nil else {
+            // A stored Internal Transfer on a transaction no longer detected
+            // as one steps back to its direction default.
+            return category == .internalTransfer
+                ? transaction.direction.defaultTaxCategory
+                : category.nextTaxCategory
+        }
+        // Only the Shielded → Core payout leg is `.received`; every other
+        // route is an outgoing/moved leg.
+        let cycle: [TxMetadataTaxCategory] = transaction.direction == .received
+            ? [.internalTransfer, .transferIn, .income]
+            : [.internalTransfer, .transferOut, .expense]
+        guard let index = cycle.firstIndex(of: category) else {
+            return .internalTransfer
+        }
+        return cycle[(index + 1) % cycle.count]
     }
 
     func copyTransactionIdToPasteboard() -> Bool {

--- a/DashWalletTests/TransactionDirectionTests.swift
+++ b/DashWalletTests/TransactionDirectionTests.swift
@@ -66,6 +66,22 @@ final class TransactionDirectionTests: XCTestCase {
             taxCategory: .unknown)
     }
 
+    func testInternalTransferDefaultTaxCategory() {
+        // A plain self-send (`.moved` ⇒ coreToCore route) defaults to the
+        // dedicated Internal Transfer category instead of the direction's
+        // Expense fallback.
+        let selfSend = makeTransaction(directionRaw: 2, netAmount: 0)
+        XCTAssertEqual(selfSend.internalTransferRoute, .coreToCore)
+        XCTAssertEqual(selfSend.defaultTaxCategory, .internalTransfer)
+
+        // External sends/receives carry no internal route and keep the
+        // direction defaults.
+        let sent = makeTransaction(directionRaw: 1, netAmount: -110, fee: 10)
+        XCTAssertNil(sent.internalTransferRoute)
+        XCTAssertEqual(sent.defaultTaxCategory, .transferOut)
+        XCTAssertEqual(makeTransaction(directionRaw: 0, netAmount: 100).defaultTaxCategory, .transferIn)
+    }
+
     func testCrowdNodeTopUpStillRequiresMovedDirection() {
         let address = "Xcrowdnode"
         let output = ObservedTransaction.Output(


### PR DESCRIPTION
## Summary
- Adds a dedicated **Internal Transfer** tax category and makes it the default for every internal-transfer route — Core → Shielded / Platform / identity funding, the Shielded → Core payout, and plain self-sends — so moves between the wallet's own balances are distinguishable from exchange transfers in the tx detail sheet and the CSV tax report.
- The new `TxMetadataTaxCategory.internalTransfer` case is appended after the existing cases, so persisted raw values keep their meaning and no DB migration is needed.
- `Transaction.defaultTaxCategory` overrides the direction fallback whenever `internalTransferRoute` is set; direction-level defaults (and their tests) are unchanged. Notably this fixes plain self-sends, whose direction default was **Expense**.
- The detail sheet's tax-category tap cycles internal transfers through the direction pair plus Internal Transfer (`Internal Transfer → Transfer Out → Expense → …`, or the In/Income pair for the withdrawal payout leg), so a reclassified transfer can be put back. Regular transactions keep the two-state toggle.
- Rate stamping no longer persists a machine-derived category (rows stay `.unknown` until the user classifies), so the live default isn't frozen before internal-transfer detection settles (restore-scan asset-lock reconstruction lags first observation). The CSV report now applies the same stored-`.unknown` guard as `Taxes.taxCategory(for:)`.

## Behavior notes
- Rows already stamped by older builds keep their stored category (indistinguishable from a deliberate user choice) and can be re-toggled manually; unclassified and new transactions pick up the new default.
- The CSV report continues to exclude `.moved` transactions; asset-lock and withdrawal-payout legs that do appear now export as "Internal Transfer".

## Verification
- Clean `dashpay` scheme simulator build (ARCHS=arm64).
- `TransactionDirectionTests.testInternalTransferDefaultTaxCategory` added (compile-ready; unit-test target is still broken pre-existing).
- Installed on the QA-iPhone16 sim for a manual look — the wallet UI sits behind the user-held PIN, so on-device category display needs a human glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)