### PR TITLE
feat(wallet): remove a never-accepted transaction from the tx detail sheet

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		2EFDEC7DCA624B16DBBB482D /* SwiftDashSDKWalletCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B697D56A525CBF142F4401FE /* SwiftDashSDKWalletCreator.swift */; };
 		30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */; };
 		A1FA10C00000000000000002 /* AssetLockRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */; };
+		UTR0B0002FA0000000000002 /* UnconfirmedTransactionRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */; };
 		3116F910F54D310002090CBB /* PinPromptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D385FC174E5B887CF3398CCD /* PinPromptPresenter.swift */; };
 		35BFE3D1C0B8999FBC8AB180 /* PaymentRequestVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59D5720437F8A4137605940 /* PaymentRequestVerifier.swift */; };
 		3705C73F15BCD91AF70940B9 /* PlatformCreditsFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C830DD6D63115525925F75 /* PlatformCreditsFormatter.swift */; };
@@ -930,6 +931,7 @@
 		8E3AF21ED19AEC0FD89A63FC /* IdentitiesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528594007157A56ABDEAD552 /* IdentitiesScreen.swift */; };
 		8EAA05FA797008525050A2A7 /* PlatformAddressSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */; };
 		A1FA10C00000000000000003 /* AssetLockRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */; };
+		UTR0B0002FA0000000000003 /* UnconfirmedTransactionRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */; };
 		8F0B3AA027F569D8D2E1F900 /* PaymentRequestVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59D5720437F8A4137605940 /* PaymentRequestVerifier.swift */; };
 		8FCE113ECEA4B9781B24922C /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE3302C1C5DF898D1A0F915 /* AuthenticationService.swift */; };
 		908AB7EFCC69D3828BBD70A8 /* PaymentsLandingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B401E660599FEF6B18087F91 /* PaymentsLandingHostingController.swift */; };
@@ -3584,6 +3586,7 @@
 		E66B030D4B574621DA2C5816 /* PaymentProtocolWireFormat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentProtocolWireFormat.swift; sourceTree = "<group>"; };
 		E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformAddressSyncCoordinator.swift; sourceTree = "<group>"; };
 		A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetLockRecoveryService.swift; sourceTree = "<group>"; };
+		UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnconfirmedTransactionRemover.swift; sourceTree = "<group>"; };
 		E7333F2D05D0DD2D4373FF9B /* StorageExplorerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageExplorerView.swift; sourceTree = "<group>"; };
 		E735446F9E918618E97EDD38 /* PaymentsLandingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentsLandingScreen.swift; sourceTree = "<group>"; };
 		E83D8CEAFF69B6D666C02116 /* Pods-WatchApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WatchApp.release.xcconfig"; path = "Target Support Files/Pods-WatchApp/Pods-WatchApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -7124,6 +7127,7 @@
 				E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */,
 				UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */,
 				A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */,
+				UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */,
 				51AA000D2F97000D005A000D /* ShieldedSyncMonitor.swift */,
 				43C830DD6D63115525925F75 /* PlatformCreditsFormatter.swift */,
 				44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */,
@@ -10152,6 +10156,7 @@
 				85448D7537BBD0AE40682EC8 /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				8EAA05FA797008525050A2A7 /* PlatformAddressSyncCoordinator.swift in Sources */,
 				A1FA10C00000000000000003 /* AssetLockRecoveryService.swift in Sources */,
+				UTR0B0002FA0000000000003 /* UnconfirmedTransactionRemover.swift in Sources */,
 				2D354A4D6053027CA27F02CB /* PlatformSyncStatusScreen.swift in Sources */,
 				51AA00222F970022005A0022 /* MasternodesScreen.swift in Sources */,
 				51AA00022F970002005A0002 /* SyncInfoMenuScreen.swift in Sources */,
@@ -11158,6 +11163,7 @@
 				87AC92AAD9DF8CBF271609AC /* SwiftDashSDKSPVStatusScreen.swift in Sources */,
 				30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */,
 				A1FA10C00000000000000002 /* AssetLockRecoveryService.swift in Sources */,
+				UTR0B0002FA0000000000002 /* UnconfirmedTransactionRemover.swift in Sources */,
 				0308E777B29CC6DE1DB30FDD /* PlatformSyncStatusScreen.swift in Sources */,
 				51AA00212F970021005A0021 /* MasternodesScreen.swift in Sources */,
 				51AA00032F970003005A0003 /* SyncInfoMenuScreen.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -1,0 +1,214 @@
+//
+//  UnconfirmedTransactionRemover.swift
+//  DashWallet
+//
+//  Removes a never-accepted transaction from local wallet state — the
+//  tx-detail "Remove if not on Blockchain" action for a stuck asset
+//  lock the network keeps rejecting (rebroadcasts end "outcome
+//  uncertain", the tx is on no explorer, and the coins it tried to
+//  spend stay locked forever).
+//
+//  There is no removal API at any FFI layer (verified against the
+//  pinned rust-dashcore/platform revs: key-wallet has no
+//  reorg/rollback/remove path at all, and `untrack_asset_lock` is
+//  `pub(crate)` + Built-only). What DOES exist is the restore path:
+//  on wallet load the Rust side rehydrates its entire core state from
+//  the SwiftData rows (`loadWalletList` → UTXO/tx-record restore
+//  buffers), and `spent_outpoints` is documented as "rebuilt from
+//  `transactions` during deserialization". So removal is performed on
+//  the persistence layer — delete the transaction row, un-mark the
+//  TXOs it spent, drop its asset-lock bookmark — followed by a full
+//  runtime reload, after which the Rust wallet has never heard of the
+//  transaction and its inputs are spendable again.
+//  TODO(sdk-remove-tx): replace the persistence surgery with a
+//  first-class SDK call once one exists upstream.
+//
+//  Ordered safety rails:
+//    1. The row must exist locally and be unconfirmed (mempool
+//       context, no block) — an IS/CL-locked or mined tx is never
+//       touched.
+//    2. A block explorer is consulted first; if it KNOWS the tx, the
+//       removal is refused (the wallet just needs to catch up). If
+//       the explorer can't be reached, the removal is refused too —
+//       "if not on Blockchain" is a checked claim, never a guess.
+//    3. After the reload, the wallet's compact-filter checkpoint is
+//       rewound past the transaction's first-seen time
+//       (`spvRescanFilters`), so if the explorer was wrong the
+//       rescan re-discovers the transaction on-chain and restores it.
+//
+//  dashpay + dashwallet targets.
+//
+
+import Foundation
+import OSLog
+import SwiftDashSDK
+import SwiftData
+
+@MainActor
+struct UnconfirmedTransactionRemover {
+
+    private static let logger = Logger(
+        subsystem: "org.dashfoundation.dash",
+        category: "swift-sdk-migration.unconfirmed-tx-remover")
+
+    enum RemovalError: LocalizedError {
+        case notReady
+        case transactionNotFound
+        case confirmedLocally
+        case transactionOnChain
+        case verificationUnavailable
+
+        var errorDescription: String? {
+            switch self {
+            case .notReady:
+                return NSLocalizedString("Wallet is not ready", comment: "DashPay")
+            case .transactionNotFound:
+                return NSLocalizedString("This transaction is not in the local wallet.", comment: "Remove never-accepted transaction: no local row")
+            case .confirmedLocally:
+                return NSLocalizedString("This transaction is confirmed and can't be removed.", comment: "Remove never-accepted transaction: local state says it's on-chain")
+            case .transactionOnChain:
+                return NSLocalizedString("Transaction is on the blockchain", comment: "Remove never-accepted transaction: refused because the explorer found it")
+            case .verificationUnavailable:
+                return NSLocalizedString("Couldn't reach a block explorer to verify the transaction isn't on the blockchain. Check your connection and try again.", comment: "Remove never-accepted transaction: explorer unreachable")
+            }
+        }
+    }
+
+    /// Compact-filter rescan window bounds, in blocks (~2.5 min each):
+    /// at least ~30 hours even for a fresh transaction, at most ~5 weeks
+    /// for a long-stuck one.
+    private static let minRescanBlocks: UInt32 = 720
+    private static let maxRescanBlocks: UInt32 = 20_000
+    /// Extra rewind margin below the transaction's first-seen height
+    /// estimate (~1 day), covering clock skew and variable block times.
+    private static let rescanMarginBlocks: UInt32 = 576
+
+    func remove(txidWire: Data) async throws {
+        guard let container = SwiftDashSDKHost.shared.modelContainer,
+              let network = WalletEnvironment.network,
+              let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
+            throw RemovalError.notReady
+        }
+        let displayTxid = Transaction.displayHex(txidWire)
+
+        // 1. Local sanity — refuse anything the local store believes is
+        //    past the mempool (context 0 = mempool; 1…3 = IS/inBlock/CL).
+        let context = container.mainContext
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { $0.txid == txidWire })
+        descriptor.fetchLimit = 1
+        guard let row = try context.fetch(descriptor).first else {
+            throw RemovalError.transactionNotFound
+        }
+        guard row.context == 0, row.blockHeight == 0 else {
+            throw RemovalError.confirmedLocally
+        }
+        let firstSeen: UInt64 = row.firstSeen
+
+        // 2. The claim in the button title is checked, not assumed: a
+        //    transaction the explorer knows (mempool or mined) is never
+        //    removed, and an unreachable explorer refuses the removal.
+        if try await Self.explorerKnowsTransaction(displayTxid: displayTxid, network: network) {
+            Self.logger.notice("🗑️ TX-REMOVE :: refused — explorer reports \(displayTxid, privacy: .public) on the network")
+            throw RemovalError.transactionOnChain
+        }
+
+        // 3. Persistence surgery. Inputs first: the `.nullify` inverse on
+        //    `PersistentTransaction.inputs` only clears the relationship —
+        //    the denormalized `isSpent` column must be flipped explicitly
+        //    or the restore buffer would keep excluding these TXOs from
+        //    the spendable set.
+        let unspentInputCount = row.inputs.count
+        for spent in row.inputs {
+            spent.isSpent = false
+            spent.spendingTransaction = nil
+            spent.spendingInputIndex = nil
+            spent.lastUpdated = Date()
+        }
+        // Deleting the row cascades its own outputs and unresolved
+        // pending-input placeholders.
+        context.delete(row)
+        // The asset-lock bookmark (any vout of this txid): the row that
+        // makes launch-time recovery re-track and re-broadcast the lock.
+        // Tiny table — fetch by wallet and filter in Swift, same as
+        // ShieldedTxLookup.
+        let lockPrefix = displayTxid.lowercased() + ":"
+        let locks = try context.fetch(FetchDescriptor<PersistentAssetLock>(
+            predicate: PersistentAssetLock.predicate(walletId: walletId)))
+        for lock in locks where lock.outPointHex.lowercased().hasPrefix(lockPrefix) {
+            context.delete(lock)
+        }
+        try context.save()
+        Self.logger.notice("🗑️ TX-REMOVE :: deleted \(displayTxid, privacy: .public) — \(unspentInputCount, privacy: .public) input(s) unspent")
+
+        // App-side metadata (tax category override) keyed by the same
+        // hash — a fresh install knows nothing about a removed tx, and
+        // neither should this one.
+        if let metadata = TransactionMetadataDAOImpl.shared.get(by: txidWire) {
+            TransactionMetadataDAOImpl.shared.delete(dto: metadata)
+        }
+
+        // 4. Full runtime reload — the same serialized stop → load →
+        //    start lifecycle a network switch runs. The reloaded Rust
+        //    wallet rebuilds its tx set, UTXOs and spent_outpoints from
+        //    the rows as they now are, and dash-spv's mempool tracker
+        //    (which kept rebroadcasting) restarts without the tx.
+        await SwiftDashSDKWalletRuntime.shared.rearmPlatformSync()
+
+        // 5. Rescan recent compact filters, reaching back past the
+        //    removed transaction's first appearance: if the explorer was
+        //    wrong and the tx IS mined, the re-match finds it and the
+        //    wallet state repairs itself. Best-effort — the removal
+        //    already verified off-chain status; a failed arm is logged,
+        //    not surfaced as a failed removal.
+        let tip = SwiftDashSDKSPVCoordinator.shared.tipHeight
+        if tip > 0, let manager = SwiftDashSDKHost.shared.manager {
+            let ageSeconds = max(0, Date().timeIntervalSince1970 - TimeInterval(firstSeen))
+            let ageBlocks = UInt32(clamping: Int(ageSeconds / 150)) + Self.rescanMarginBlocks
+            let blocksBack = min(Self.maxRescanBlocks, max(Self.minRescanBlocks, ageBlocks))
+            let fromHeight = tip > blocksBack ? tip - blocksBack : 1
+            do {
+                try manager.spvRescanFilters(walletId: walletId, fromHeight: fromHeight)
+                Self.logger.notice("🗑️ TX-REMOVE :: filter rescan armed from height \(fromHeight, privacy: .public) (tip \(tip, privacy: .public))")
+            } catch {
+                Self.logger.error("🗑️ TX-REMOVE :: filter rescan arm failed: \(String(describing: error), privacy: .public)")
+            }
+        } else {
+            Self.logger.error("🗑️ TX-REMOVE :: filter rescan skipped — SPV not running after reload")
+        }
+
+        // 6. App caches that mirror the deleted rows.
+        ShieldedTxLookup.shared.refresh()
+    }
+
+    /// One GET against the network's Insight API. 200 = the explorer
+    /// knows the tx (mempool or mined); 404 = it doesn't; anything else
+    /// (including transport failure) refuses the removal rather than
+    /// guessing.
+    private static func explorerKnowsTransaction(displayTxid: String, network: Network) async throws -> Bool {
+        let base = network == .mainnet
+            ? "https://insight.dash.org/insight-api"
+            : "https://insight.testnet.networks.dash.org/insight-api"
+        guard let url = URL(string: "\(base)/tx/\(displayTxid)") else {
+            throw RemovalError.verificationUnavailable
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let http: HTTPURLResponse
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw RemovalError.verificationUnavailable
+            }
+            http = httpResponse
+        } catch {
+            throw RemovalError.verificationUnavailable
+        }
+        switch http.statusCode {
+        case 200: return true
+        case 404: return false
+        default: throw RemovalError.verificationUnavailable
+        }
+    }
+}

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -318,6 +318,17 @@ class Transaction: TransactionDataItem, Identifiable {
         return (1...3).contains(status)
     }
 
+    /// The subset of pending identity fundings whose recovery lives in the
+    /// Join DashPay registration flow (types 0 registration / 3 invitation —
+    /// the ones `AssetLockRecoveryService` deliberately does NOT handle).
+    /// Only these get the home row's "tap to finish" routing into that flow;
+    /// a pending top-up (1/2) recovers from the tx detail sheet instead.
+    var isPendingIdentityRegistration: Bool {
+        guard isPendingIdentityFunding,
+              let type = identityFundingLockInfo?.fundingTypeRaw else { return false }
+        return type == 0 || type == 3
+    }
+
     /// True when this incoming tx is the L1 payout of a Shielded → Core
     /// withdrawal the app performed — matched by destination address via
     /// `ShieldedWithdrawalStore` (the SDK's opaque withdraw call returns no

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -774,9 +774,11 @@ struct HomeViewContent<Content: View>: View {
                 subtitle: txItem.shortTimeString,
                 details: txItem.isPendingShieldedTransfer
                     ? NSLocalizedString("Pending — tap to finish", comment: "InternalTransfer recovery")
-                    : txItem.isPendingIdentityFunding
+                    : txItem.isPendingIdentityRegistration
                         ? NSLocalizedString("Pending — tap to finish", comment: "DashPay registration recovery")
-                    : txItem.isPendingPlatformFunding
+                    // A pending top-up has nothing to "finish" in another
+                    // flow — it recovers from the tx detail sheet.
+                    : txItem.isPendingIdentityFunding || txItem.isPendingPlatformFunding
                         ? NSLocalizedString("Pending", comment: "")
                         : (metadata?.details?.isEmpty == false
                             ? metadata?.details
@@ -795,7 +797,7 @@ struct HomeViewContent<Content: View>: View {
                 // instead of the read-only detail/gift-card sheets.
                 if txItem.isPendingShieldedTransfer {
                     self.pendingShieldedRecovery = txItem
-                } else if txItem.isPendingIdentityFunding {
+                } else if txItem.isPendingIdentityRegistration {
                     #if DASHPAY
                     delegate?.homeViewRequestUsername()
                     #else

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -501,6 +501,11 @@ extension TxDetailModel {
                 ? NSLocalizedString("Rebroadcast", comment: "Retry a stuck balance transfer whose transaction never confirmed")
                 : NSLocalizedString("Complete Transfer", comment: "Retry a stuck balance transfer whose transaction confirmed but whose Platform side never finished")
         }
+
+        /// Local removal is offered only while the network has shown no
+        /// acceptance at all (built/broadcast). An IS/CL-locked lock is
+        /// proven on-chain — removing it locally could only corrupt state.
+        var supportsRemoval: Bool { statusRaw <= 1 }
     }
 
     /// Non-nil when this transaction is a funding asset lock parked in a

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -132,6 +132,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case taxCategory(DWTitleDetailItem)
         case shieldedInfo(DWTitleDetailItem)
         case rebroadcast(String)
+        case removeUnconfirmed
         case viewTransaction
         case copyRawTransaction
         case explorer
@@ -155,6 +156,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
             case .taxCategory(let item): return ["TaxCategory"] + Self.identity(of: [item])
             case .shieldedInfo(let item): return ["ShieldedInfo"] + Self.identity(of: [item])
             case .rebroadcast(let title): return ["Rebroadcast", title]
+            case .removeUnconfirmed: return ["RemoveUnconfirmed"]
             case .viewTransaction: return ["ViewTransaction"]
             case .copyRawTransaction: return ["CopyRawTransaction"]
             case .explorer: return ["Explorer"]
@@ -299,6 +301,64 @@ extension TXDetailViewController {
         present(alert, animated: true)
     }
 
+    /// Spell out exactly what removal does before anything is touched:
+    /// a block-explorer check first, local-only deletion, and the
+    /// rescan safety net that restores the transaction if the explorer
+    /// was wrong.
+    private func confirmRemoveUnconfirmed() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Remove this transaction?", comment: "Remove never-accepted transaction: confirmation title"),
+            message: NSLocalizedString("The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network.", comment: "Remove never-accepted transaction: confirmation body"),
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(
+            title: NSLocalizedString("Remove Transaction", comment: "Remove never-accepted transaction: destructive confirm button"),
+            style: .destructive) { [weak self] _ in
+                self?.performRemoveUnconfirmed()
+            })
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        present(alert, animated: true)
+    }
+
+    private func performRemoveUnconfirmed() {
+        guard !isRetryingAssetLock else { return }
+        isRetryingAssetLock = true
+        let txidWire = model.transaction.txHashData
+        view.dw_showProgressHUD(withMessage: NSLocalizedString("Removing transaction…", comment: "Remove never-accepted transaction: progress"))
+        Task { [weak self] in
+            defer {
+                self?.isRetryingAssetLock = false
+                self?.view.dw_hideProgressHUD()
+            }
+            do {
+                try await UnconfirmedTransactionRemover().remove(txidWire: txidWire)
+                self?.view.dw_showInfoHUD(withText: NSLocalizedString("Transaction removed", comment: "Remove never-accepted transaction: success"))
+                // The row this sheet describes no longer exists.
+                self?.closeAction()
+            } catch UnconfirmedTransactionRemover.RemovalError.transactionOnChain {
+                self?.presentRemovalRefused()
+            } catch {
+                let alert = UIAlertController(
+                    title: NSLocalizedString("Couldn't remove the transaction", comment: "Remove never-accepted transaction: failure title"),
+                    message: error.localizedDescription,
+                    preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
+                self?.present(alert, animated: true)
+            }
+        }
+    }
+
+    /// The explorer says the transaction IS on the blockchain — removal
+    /// is refused and the wallet just needs to catch up.
+    private func presentRemovalRefused() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Transaction is on the blockchain", comment: "Remove never-accepted transaction: refused because the explorer found it"),
+            message: NSLocalizedString("A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own.", comment: "Remove never-accepted transaction: refusal body"),
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
+        present(alert, animated: true)
+        reloadDataSource()
+    }
+
     /// Copies the serialized transaction hex. A missing row (bytes not
     /// stored on this device) reports itself rather than copying nothing.
     private func copyRawTransaction() {
@@ -350,6 +410,10 @@ extension TXDetailViewController {
                                                              for: indexPath) as! TxDetailActionCell
                     if case .rebroadcast(let title) = item {
                         cell.titleLabel.text = title
+                        cell.titleLabel.textColor = .dw_label()
+                    } else if item == .removeUnconfirmed {
+                        cell.titleLabel.text = NSLocalizedString("Remove if not on Blockchain", comment: "Delete a never-accepted transaction from local wallet state")
+                        cell.titleLabel.textColor = .systemRed
                     }
                     return cell
 
@@ -435,6 +499,9 @@ extension TXDetailViewController {
         if let retry = model.stuckAssetLockRetry {
             currentSnapshot.insertSections([.recovery], afterSection: .taxCategory)
             currentSnapshot.appendItems([.rebroadcast(retry.actionTitle)], toSection: .recovery)
+            if retry.supportsRemoval {
+                currentSnapshot.appendItems([.removeUnconfirmed], toSection: .recovery)
+            }
         }
         currentSnapshot.appendItems([.viewTransaction, .copyRawTransaction], toSection: .rawTransaction)
         currentSnapshot.appendItems([.explorer], toSection: .explorer)
@@ -461,7 +528,11 @@ extension TXDetailViewController {
             reloadDataSource()
             break
         case .recovery:
-            retryStuckAssetLock()
+            if dataSource.itemIdentifier(for: indexPath) == .removeUnconfirmed {
+                confirmRemoveUnconfirmed()
+            } else {
+                retryStuckAssetLock()
+            }
         case .rawTransaction:
             if let item = dataSource.itemIdentifier(for: indexPath) {
                 switch item {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2449,6 +2449,15 @@
 /* Retry a stuck balance transfer whose transaction never confirmed */
 "Rebroadcast" = "Rebroadcast";
 
+/* Delete a never-accepted transaction from local wallet state */
+"Remove if not on Blockchain" = "Remove if not on Blockchain";
+
+/* Remove never-accepted transaction: confirmation title */
+"Remove this transaction?" = "Remove this transaction?";
+
+/* Remove never-accepted transaction: destructive confirm button */
+"Remove Transaction" = "Remove Transaction";
+
 /* Username marketplace: transfer recipient placeholder */
 "Recipient username or identity ID" = "Recipient username or identity ID";
 
@@ -2464,6 +2473,9 @@
 /* Username marketplace */
 "Remove From Sale" = "Remove From Sale";
 
+/* Remove never-accepted transaction: progress */
+"Removing transaction…" = "Removing transaction…";
+
 /* Username marketplace: delist confirmation title */
 "Remove “%@” from sale?" = "Remove “%@” from sale?";
 
@@ -2472,6 +2484,30 @@
 
 /* Username marketplace: delist confirmation body */
 "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name." = "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.";
+
+/* Remove never-accepted transaction: refused because the explorer found it */
+"Transaction is on the blockchain" = "Transaction is on the blockchain";
+
+/* Remove never-accepted transaction: refusal body */
+"A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own." = "A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own.";
+
+/* Remove never-accepted transaction: success */
+"Transaction removed" = "Transaction removed";
+
+/* Remove never-accepted transaction: confirmation body */
+"The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network." = "The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network.";
+
+/* Remove never-accepted transaction: failure title */
+"Couldn't remove the transaction" = "Couldn't remove the transaction";
+
+/* Remove never-accepted transaction: no local row */
+"This transaction is not in the local wallet." = "This transaction is not in the local wallet.";
+
+/* Remove never-accepted transaction: local state says it's on-chain */
+"This transaction is confirmed and can't be removed." = "This transaction is confirmed and can't be removed.";
+
+/* Remove never-accepted transaction: explorer unreachable */
+"Couldn't reach a block explorer to verify the transaction isn't on the blockchain. Check your connection and try again." = "Couldn't reach a block explorer to verify the transaction isn't on the blockchain. Check your connection and try again.";
 
 /* Username marketplace: contested request cost row */
 "Request cost" = "Request cost";


### PR DESCRIPTION
## Issue being fixed or feature implemented

A stuck asset lock the network keeps rejecting had no way out. Concrete case from testnet QA: an identity top-up whose every Rebroadcast reached 2/3 peers and ended **"outcome uncertain: no acceptance signal within 60s"**, absent from the testnet Insight explorer in both txid byte orders. The row sat in history forever ("Broadcasting"), the coins it tried to spend stayed locked, and the launch-time asset-lock resume kept rebroadcasting it on every start.

Also fixes the adjacent mislabel this QA surfaced: a pending identity **top-up** row read "Pending — tap to finish" and the tap opened the **Create Username flow** — the registration-recovery treatment applied to all identity funding types 0–3.

## What was done

**"Remove if not on Blockchain"** (red, under Rebroadcast; only for locks that never reached IS/CL — a locked transaction is proven on-chain and never removable). The confirmation dialog states the exact contract, and the flow implements it in order:

1. Refuse if local state says the transaction is confirmed.
2. Ask the network's Insight explorer. A known transaction (mempool or mined) refuses the removal with "Transaction is on the blockchain"; an **unreachable explorer also refuses** — the button's claim is checked, never guessed.
3. Delete the `PersistentTransaction` row (outputs + pending-input placeholders cascade), flip the input TXOs it spent back to unspent (the denormalized `isSpent` column doesn't follow the relationship nullify on its own), delete the `PersistentAssetLock` bookmark that drove the launch-time rebroadcasts, and the app-side tax-category metadata.
4. **Full runtime reload** (`rearmPlatformSync` — the same serialized stop → load → start a network switch runs). The Rust side rehydrates its entire core state from the SwiftData rows on load, and `spent_outpoints` is rebuilt from the transaction set — so after reload the wallet has never heard of the transaction, in all places: history, UTXO set, balance, and dash-spv's mempool tracker.
5. Arm `spvRescanFilters` back past the transaction's first-seen time (age-scaled window, clamped ~30h…~5w, +1 day margin): if the explorer was wrong, the compact-filter re-match rediscovers the transaction on-chain and state self-heals.

**Why the persistence-layer route:** there is no transaction-removal API at any reachable FFI layer — verified against the pinned revs: key-wallet has no reorg/rollback/remove path at all, `abandonTransaction` only covers pre-broadcast handles, and `untrack_asset_lock` (the exact primitive wanted) is `pub(crate)` with a `status == Built` guard. `TODO(sdk-remove-tx)` marks the seam for a first-class SDK call once one exists upstream.

**Pending-label fix:** new `isPendingIdentityRegistration` narrows the "Pending — tap to finish" + Create-Username routing to funding types 0/3 (exactly the ones `AssetLockRecoveryService` documents as registration-flow recovery). A pending top-up now reads plain "Pending" and opens the detail sheet, where Rebroadcast and the new Remove action actually live.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build; installed on the testnet QA simulator with the real stuck top-up present. In-app verification of the end-to-end removal (explorer check → delete → reload → rescan) is in progress on that simulator and results will be posted on this PR. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to remove eligible unconfirmed asset-lock transactions that were not accepted on-chain.
  * Added confirmation, progress, success, and failure feedback during transaction removal.
  * Wallet state and transaction data refresh automatically after successful removal.

* **Improvements**
  * Pending identity registration transactions now display clearer status messaging.
  * Tapping a pending identity registration opens the DashPay username setup flow.
  * Pending identity and platform funding transactions now use consistent “Pending” labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->