### PR TITLE
fix(ui): keep Max transfer amount exact in fiat mode

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -151,14 +151,21 @@ final class InternalTransferViewModel: ObservableObject {
     /// remainder, or why it could not produce one at all. Surfaced through
     /// `amountValidationMessage` so tapping Max is never a silent no-op.
     @Published private(set) var maxNotice: String?
+    /// Exact duff amount selected by Max. Fiat text is presentation-only and
+    /// may round to two decimals, so reparsing it must never move the transfer
+    /// above (or below) the source's real spendable ceiling.
+    private var maxAmountDuffs: UInt64?
     private var shieldedSweepAmountCredits: UInt64?
     @Published var unit: InternalTransferUnit = .dash {
         didSet {
             guard oldValue != unit else { return }
-            let preserveMax = isFullShieldedSweep
-            isApplyingMax = preserveMax
-            defer { isApplyingMax = false }
-            convertAmountText(from: oldValue, to: unit)
+            if let maxAmountDuffs {
+                isApplyingMax = true
+                defer { isApplyingMax = false }
+                applyMaxAmountText(maxAmountDuffs)
+            } else {
+                convertAmountText(from: oldValue, to: unit)
+            }
         }
     }
 
@@ -419,6 +426,9 @@ final class InternalTransferViewModel: ObservableObject {
     }
 
     var parsedDashAmount: Decimal {
+        if let maxAmountDuffs {
+            return maxAmountDuffs.dashAmount
+        }
         let raw = rawTypedDecimal
         switch unit {
         case .dash:
@@ -823,24 +833,37 @@ final class InternalTransferViewModel: ObservableObject {
 
         isApplyingMax = true
         defer { isApplyingMax = false }
+        applyMaxAmountText(sourceDuffs)
+    }
+
+    /// Render Max in the selected input unit while retaining `duffs` as the
+    /// executable amount. In fiat mode the visible cents are approximate;
+    /// converting those rounded cents back to DASH caused Max to exceed the
+    /// balance and disabled Continue.
+    private func applyMaxAmountText(_ duffs: UInt64) {
+        guard duffs > 0 else {
+            maxAmountDuffs = nil
+            amountText = "0"
+            return
+        }
+
+        maxAmountDuffs = duffs
         switch unit {
         case .dash:
-            amountText = sourceDuffs.formattedDashAmountWithoutCurrencySymbol
+            amountText = duffs.formattedDashAmountWithoutCurrencySymbol
         case .fiat:
-            let dashDecimal = sourceDuffs.dashAmount
-            guard dashDecimal > 0 else {
-                amountText = "0"
-                return
-            }
+            let dashDecimal = duffs.dashAmount
             if let fiat = try? CurrencyExchanger.shared.convertDash(amount: dashDecimal, to: App.fiatCurrency) {
                 amountText = Self.formatTyped(fiat, fractionDigits: 2)
             } else {
+                maxAmountDuffs = nil
                 amountText = "0"
             }
         }
     }
 
     private func clearMaxSelection() {
+        maxAmountDuffs = nil
         isFullShieldedSweep = false
         shieldedSweepAmountCredits = nil
         maxNotice = nil

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -53,23 +53,29 @@ final class SendViewModel: ObservableObject {
     @Published var source: ChainNetwork = .core {
         didSet { sourceDidChange() }
     }
-    private var isApplyingShieldedMax = false
+    private var isApplyingMax = false
     @Published var amountText: String = "0" {
         didSet {
-            guard !isApplyingShieldedMax else { return }
+            guard !isApplyingMax else { return }
             clearShieldedMaxSelection()
         }
     }
     @Published private(set) var isFullShieldedSweep = false
     @Published private(set) var shieldedMaxNotice: String?
+    /// Exact duff amount selected by Max. The two-decimal fiat value is only
+    /// its display representation and must not be converted back for sending.
+    private var maxAmountDuffs: UInt64?
     private var shieldedSweepAmountCredits: UInt64?
     @Published var unit: InternalTransferUnit = .dash {
         didSet {
             guard oldValue != unit else { return }
-            let preserveShieldedMax = isFullShieldedSweep
-            isApplyingShieldedMax = preserveShieldedMax
-            defer { isApplyingShieldedMax = false }
-            convertAmountText(from: oldValue, to: unit)
+            if let maxAmountDuffs {
+                isApplyingMax = true
+                defer { isApplyingMax = false }
+                applyMaxAmountText(maxAmountDuffs)
+            } else {
+                convertAmountText(from: oldValue, to: unit)
+            }
         }
     }
     @Published private(set) var clipboardSuggestion: ClipboardSuggestion? = nil
@@ -328,6 +334,9 @@ final class SendViewModel: ObservableObject {
     }
 
     var parsedDashAmount: Decimal {
+        if let maxAmountDuffs {
+            return maxAmountDuffs.dashAmount
+        }
         let raw = rawTypedDecimal
         switch unit {
         case .dash:
@@ -658,26 +667,37 @@ final class SendViewModel: ObservableObject {
             sourceDuffs = creditsMinusFeeReserve(shieldedBalance) / 1000
         }
 
-        isApplyingShieldedMax = true
-        defer { isApplyingShieldedMax = false }
+        isApplyingMax = true
+        defer { isApplyingMax = false }
+        applyMaxAmountText(sourceDuffs)
+    }
+
+    /// Keep the selected Max amount exact in duffs while rendering either
+    /// DASH or an approximate two-decimal fiat value.
+    private func applyMaxAmountText(_ duffs: UInt64) {
+        guard duffs > 0 else {
+            maxAmountDuffs = nil
+            amountText = "0"
+            return
+        }
+
+        maxAmountDuffs = duffs
         switch unit {
         case .dash:
-            amountText = sourceDuffs.formattedDashAmountWithoutCurrencySymbol
+            amountText = duffs.formattedDashAmountWithoutCurrencySymbol
         case .fiat:
-            let dashDecimal = sourceDuffs.dashAmount
-            guard dashDecimal > 0 else {
-                amountText = "0"
-                return
-            }
+            let dashDecimal = duffs.dashAmount
             if let fiat = try? CurrencyExchanger.shared.convertDash(amount: dashDecimal, to: App.fiatCurrency) {
                 amountText = InternalTransferViewModel.formatTyped(fiat, fractionDigits: 2)
             } else {
+                maxAmountDuffs = nil
                 amountText = "0"
             }
         }
     }
 
     private func clearShieldedMaxSelection() {
+        maxAmountDuffs = nil
         isFullShieldedSweep = false
         shieldedSweepAmountCredits = nil
         shieldedMaxNotice = nil


### PR DESCRIPTION
## Summary
- preserve the exact spendable amount in duffs after selecting Max
- treat the rounded fiat amount as display-only
- keep the exact Max value when switching units and clear it after manual edits

## Verification
- xcodebuild dashpay Debug arm64 simulator build succeeded
- no automated tests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Max amount selections now retain the exact payment amount when switching between DASH and fiat.
  - Prevented rounding in displayed values from changing the actual amount sent.
  - Editing the amount now correctly clears the previous Max selection.
  - Max selections are cleared when the amount is zero or fiat conversion is unavailable.
  - Improved amount parsing and display consistency across regular payments and internal transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->