### PR TITLE
fix(ui): PIN prompt survives being launched from a dismissing sheet

### DIFF
--- a/DashWallet/Sources/UI/Auth/PinPromptPresenter.swift
+++ b/DashWallet/Sources/UI/Auth/PinPromptPresenter.swift
@@ -25,43 +25,71 @@ enum PinPromptPresenter {
 
         return await withCheckedContinuation { continuation in
             var didResume = false
-            func resume(_ result: PinPromptResult, dismiss host: UIViewController?) {
+            var hostRef: UIViewController?
+            func resume(_ result: PinPromptResult) {
                 guard !didResume else { return }
                 didResume = true
-                if let host {
-                    host.dismiss(animated: true) { continuation.resume(returning: result) }
+                // Dismiss the modal WE presented, addressed directly. Never
+                // route the dismissal through the original anchor: flows
+                // like the marketplace sheets dismiss themselves right after
+                // starting the gate, and a deallocated anchor used to leave
+                // the PIN card frozen on screen after a successful entry.
+                if let hostRef, hostRef.presentingViewController != nil {
+                    hostRef.dismiss(animated: true) { continuation.resume(returning: result) }
                 } else {
                     continuation.resume(returning: result)
                 }
             }
 
-            let viewModel = PinPromptViewModel(service: service) { [weak anchor] result in
-                // Capture the hosting controller lazily: the closure fires
-                // after presentation, so `anchor.presentedViewController` is
-                // the modal we put up.
-                resume(result, dismiss: anchor?.presentedViewController)
+            let viewModel = PinPromptViewModel(service: service) { result in
+                resume(result)
             }
             let host = UIHostingController(rootView: PinPromptView(viewModel: viewModel))
+            hostRef = host
             host.modalPresentationStyle = .overFullScreen
             host.modalTransitionStyle = .crossDissolve
             // Transparent so the SwiftUI dimmed backdrop is the only overlay
             // and the send screen stays visible behind the card.
             host.view.backgroundColor = .clear
-            anchor.present(host, animated: true)
 
-            // UIKit can reject a presentation without calling a completion
-            // handler (for example when a SwiftUI sheet is being replaced).
-            // Do not leak the continuation and leave AuthenticationGate
-            // waiting for its watchdog in that case.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                guard !didResume else { return }
-                guard host.presentingViewController != nil,
-                      host.viewIfLoaded?.window != nil else {
-                    NSLog("🔐 PINPROMPT :: presentation rejected — resolving .failed")
-                    resume(.failed, dismiss: nil)
-                    return
+            // A presentation can land AFTER the gate already resolved
+            // (UIKit queues it behind an in-flight sheet dismissal). Tear
+            // the late modal down from the presentation completion, or it
+            // sits orphaned on screen swallowing PIN digits forever.
+            func present(from presenter: UIViewController) {
+                presenter.present(host, animated: true) {
+                    if didResume {
+                        host.dismiss(animated: false)
+                    }
                 }
             }
+            present(from: anchor)
+
+            // UIKit can reject a presentation without calling a completion
+            // handler (for example when a SwiftUI sheet is being replaced —
+            // exactly what happens when the flow that asked for this gate
+            // dismissed its own sheet as it started). Verify the modal
+            // actually landed; re-anchor once on the post-dismissal top
+            // controller before giving up, and never leak the continuation.
+            func verifyPresented(retriesLeft: Int) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    guard !didResume else { return }
+                    if host.presentingViewController != nil, host.viewIfLoaded?.window != nil {
+                        return
+                    }
+                    guard retriesLeft > 0,
+                          host.presentingViewController == nil,
+                          let retryAnchor = topPresentedController() else {
+                        NSLog("🔐 PINPROMPT :: presentation rejected — resolving .failed")
+                        resume(.failed)
+                        return
+                    }
+                    NSLog("🔐 PINPROMPT :: presentation rejected — retrying on a fresh anchor")
+                    present(from: retryAnchor)
+                    verifyPresented(retriesLeft: retriesLeft - 1)
+                }
+            }
+            verifyPresented(retriesLeft: 1)
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Testnet QA: "Put Up For Sale" on a marketplace name → enter PIN → **stall**. The PIN card stayed on screen with the digits filled, swallowing input, Cancel dead; the log showed `IDENTITY-AUTH :: authentication failed` even though the user typed the correct PIN. Nothing was signed or listed.

Mechanism: the marketplace sheets dismiss themselves right as the auth gate starts, so `PinPromptPresenter` anchored the modal on a controller mid-dismissal. UIKit rejected the presentation without a callback, the 0.5 s guard resolved `.failed` — and the queued presentation then landed anyway once the sheets finished dismissing, leaving an **orphaned** PIN card whose continuation had already resumed. A second latent defect could strand the card even on success: dismissal was routed through the weak original anchor (`anchor?.presentedViewController`), which deallocates with the sheet.

## What was done

All in `PinPromptPresenter`, so every stacked-sheet flow is covered (send, shielded transfers, marketplace, contested requests):

- `resume()` dismisses the host it presented, addressed directly — never through the original anchor.
- The landed-check retries the presentation once on a freshly resolved top controller (by then the sheet dismissal has settled) before resolving `.failed`.
- `present()`'s completion handler tears down a modal that lands **after** the gate already resolved, closing the rejected-then-queued orphan window entirely.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build. The stall was reproduced live on the testnet QA simulator (marketplace Put Up For Sale, with the log line and orphaned card matching the mechanism above). In-app verification of the fix build (PIN presenting over the marketplace screen after the sheets dismiss) is in progress on that simulator; result to follow on this PR. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PIN prompt dismissal to reliably close the modal after authentication completes.
  - Prevented prompts from remaining visible when the original presentation context is no longer available.
  - Added recovery for delayed or rejected presentations using an updated presentation context.
  - Ensured failed presentation attempts complete with a failure result instead of remaining indefinitely pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->