### PR TITLE
feat(dashpay): live vote details in the contested request sheet

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -345,6 +345,20 @@ struct UsernameMarketplaceService {
     /// (20_000_000_000 credits = 0.2 DASH).
     static let contestedFundCredits: UInt64 = 20_000_000_000
 
+    /// Until when NEW contenders may join a contest, derived from its
+    /// authoritative voting end time. Mirrors rs-platform-version
+    /// `VotingValidationVersions` (v3): contenders may join for
+    /// `allow_other_contenders_time` after the FIRST request — mainnet
+    /// 1 week of the 2-week poll, testing environments 45 minutes of the
+    /// 90-minute poll. In both, joining closes (poll − join window)
+    /// before the end: 1 week on mainnet, 45 minutes on testnet.
+    static func contenderJoinDeadline(voteEnd: Date) -> Date {
+        let closedBeforeEnd: TimeInterval = WalletEnvironment.isMainnet
+            ? 7 * 24 * 60 * 60
+            : 45 * 60
+        return voteEnd.addingTimeInterval(-closedBeforeEnd)
+    }
+
     /// Buyer identity's credit balance from the persisted row — for the
     /// affordability hint; the SDK re-checks authoritatively at purchase.
     static func identityBalanceCredits(identityId: Data, container: ModelContainer) -> UInt64 {

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -1273,6 +1273,9 @@ private struct RegisterNameSheet: View {
 
     /// Pre-submit network state for contested labels; nil while loading.
     @State private var precheck: UsernameMarketplaceService.ContestPrecheck?
+    /// Live vote tallies for an active contest on this label (yours or
+    /// anyone's); nil while loading, unavailable, or no contest exists.
+    @State private var voteState: ContestVoteState?
 
     private var isContested: Bool {
         UsernameMarketplaceService.isContested(label)
@@ -1362,8 +1365,13 @@ private struct RegisterNameSheet: View {
         }
         .background(Color.dash.primaryBackground)
         .task {
-            guard isContested, precheck == nil else { return }
-            precheck = await viewModel.service.contestPrecheck(label: label)
+            guard isContested else { return }
+            if precheck == nil {
+                precheck = await viewModel.service.contestPrecheck(label: label)
+            }
+            if voteState == nil {
+                voteState = await viewModel.service.contestState(label: label)
+            }
         }
     }
 
@@ -1382,6 +1390,7 @@ private struct RegisterNameSheet: View {
             statusCallout(
                 icon: "hourglass",
                 text: NSLocalizedString("You already requested this name — the network vote is in progress. You'll find it under My Names.", comment: "Username marketplace: contested request already submitted by this identity"))
+            contestVotesCard
         } else if let pending = pendingOtherContestLabel {
             statusCallout(
                 icon: "hourglass",
@@ -1409,6 +1418,7 @@ private struct RegisterNameSheet: View {
                 statusCallout(
                     icon: "person.2",
                     text: NSLocalizedString("This name is already in an active network vote. Your request joins it as another contender.", comment: "Username marketplace: contested label already has an active vote"))
+                contestVotesCard
             }
 
             requestCostCard
@@ -1483,6 +1493,102 @@ private struct RegisterNameSheet: View {
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color.dash.secondaryBackground))
+    }
+
+    /// Live state of the vote: every contender with their tally (own
+    /// identity labeled), abstain and lock counts, the voting deadline,
+    /// and until when new contenders can still join. Renders nothing
+    /// while the state is loading or Platform hasn't indexed the
+    /// contest — never a fabricated zero-tally.
+    @ViewBuilder private var contestVotesCard: some View {
+        if let state = voteState, case .none = state.winner {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(NSLocalizedString("Network vote so far", comment: "Username marketplace: contest tallies card title"))
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.dash.secondaryText)
+                    .padding(.horizontal, 14)
+                    .padding(.top, 12)
+                    .padding(.bottom, 4)
+                if state.totalVotes == 0 {
+                    Text(NSLocalizedString("No votes cast yet", comment: "Username marketplace: contest with zero masternode votes so far"))
+                        .font(.system(size: 12))
+                        .foregroundColor(.dash.tertiaryText)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 6)
+                }
+                ForEach(state.contenders.sorted { $0.voteTally > $1.voteTally }) { contender in
+                    voteRow(
+                        contender.identityId == viewModel.ownIdentityId
+                            ? NSLocalizedString("You", comment: "Username marketplace: owner is the current user")
+                            : shortId(contender.identityId),
+                        tally: contender.voteTally,
+                        emphasized: contender.identityId == viewModel.ownIdentityId)
+                }
+                voteRow(NSLocalizedString("Abstain", comment: "Username marketplace: masternode abstain votes"), tally: state.abstainVotes, emphasized: false)
+                voteRow(NSLocalizedString("Lock the name", comment: "Username marketplace: masternode votes to lock the name so nobody wins"), tally: state.lockVotes, emphasized: false)
+                Divider().padding(.horizontal, 14).padding(.vertical, 4)
+                deadlineRow(
+                    NSLocalizedString("Vote ends", comment: "Username marketplace: contest voting deadline row"),
+                    value: Self.deadlineText(state.endTime))
+                let joinDeadline = UsernameMarketplaceService.contenderJoinDeadline(voteEnd: state.endTime)
+                deadlineRow(
+                    NSLocalizedString("New contenders", comment: "Username marketplace: until when other identities can join the contest"),
+                    value: joinDeadline > Date()
+                        ? String.localizedStringWithFormat(
+                            NSLocalizedString("can join until %@", comment: "Username marketplace: join deadline still open — value of the New contenders row"),
+                            Self.deadlineText(joinDeadline))
+                        : NSLocalizedString("joining closed", comment: "Username marketplace: the contest's join window has passed — value of the New contenders row"))
+                    .padding(.bottom, 8)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.dash.secondaryBackground))
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+        }
+    }
+
+    private func voteRow(_ title: String, tally: UInt32, emphasized: Bool) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 13, weight: emphasized ? .semibold : .regular))
+                .foregroundColor(.dash.primaryText)
+            Spacer()
+            Text(String.localizedStringWithFormat(
+                NSLocalizedString("%d votes", comment: "Username marketplace: masternode vote tally for one contest row"),
+                Int(tally)))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.dash.primaryText)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+    }
+
+    private func deadlineRow(_ title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 13))
+                .foregroundColor(.dash.secondaryText)
+            Spacer()
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(.dash.primaryText)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+    }
+
+    /// Date + time — contest windows on testnet are minutes long, so a
+    /// date alone ("Today") wouldn't say anything actionable.
+    private static func deadlineText(_ date: Date) -> String {
+        let formatter = DWDateFormatter.sharedInstance
+        return "\(formatter.shortStringFromDate(date)) \(formatter.timeOnly(from: date))"
+    }
+
+    private func shortId(_ id: Data) -> String {
+        let base58 = id.toBase58String()
+        return String(base58.prefix(8)) + "…" + String(base58.suffix(4))
     }
 
     private func statusCallout(icon: String, text: String) -> some View {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -785,6 +785,33 @@
 /* Username marketplace: contested request line — voting deadline */
 "Network vote ends %@" = "Network vote ends %@";
 
+/* Username marketplace: contest tallies card title */
+"Network vote so far" = "Network vote so far";
+
+/* Username marketplace: contest with zero masternode votes so far */
+"No votes cast yet" = "No votes cast yet";
+
+/* Username marketplace: masternode abstain votes */
+"Abstain" = "Abstain";
+
+/* Username marketplace: masternode votes to lock the name so nobody wins */
+"Lock the name" = "Lock the name";
+
+/* Username marketplace: contest voting deadline row */
+"Vote ends" = "Vote ends";
+
+/* Username marketplace: until when other identities can join the contest */
+"New contenders" = "New contenders";
+
+/* Username marketplace: join deadline still open — value of the New contenders row */
+"can join until %@" = "can join until %@";
+
+/* Username marketplace: the contest's join window has passed — value of the New contenders row */
+"joining closed" = "joining closed";
+
+/* Username marketplace: masternode vote tally for one contest row */
+"%d votes" = "%d votes";
+
 /* Username marketplace: unresolvable transfer recipient */
 "No identity owns that username." = "No identity owns that username.";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Testnet QA follow-up to #955: the contested request sheet only said "you already requested this name" — no tallies, no deadline, no join window. (This commit was originally pushed to #955's branch minutes after that PR merged, so it never landed; re-based here onto current develop.)

## What was done

A **"Network vote so far"** card in `RegisterNameSheet`, shown whenever an active contest exists on the label — both for a request of your own and for a contest you'd join as a contender:

- every contender with their masternode vote tally, sorted descending, own identity labeled "You"
- **Abstain** and **Lock the name** counts
- **Vote ends** with the time of day (testnet polls are minutes long — a bare "Today" says nothing actionable)
- **New contenders** — "can join until ⟨date time⟩", or "joining closed" once the window passed. Derived from the authoritative end time via rs-platform-version's `allow_other_contenders_time`: mainnet joins are open the first week of the two-week poll, testing environments the first 45 minutes of the 90-minute poll (`UsernameMarketplaceService.contenderJoinDeadline`, constants documented against their source).

Data comes from the existing `fetchContestVoteState` (`ContestVoteState`: contender tallies, abstain/lock votes, end time, winner). The card renders nothing while vote state is unavailable or Platform hasn't indexed the contest — never fabricated zero-tallies.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build on top of current develop. Installed on the testnet QA simulator carrying a live in-flight contest ("greg"); sheet verification ongoing in the same QA session. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)