### PR TITLE
feat(dashpay): show the requested variant next to a normalized contested label

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -154,6 +154,25 @@ final class UsernameMarketplaceViewModel: ObservableObject {
             || DWContestedNameStatusService.shared.isPendingLabel(label)
     }
 
+    /// The variant the user actually typed for a contested label the
+    /// network reports in NORMALIZED form — DPNS folds look-alike
+    /// characters (i/l → 1, o → 0), so requesting "quiet" registers
+    /// "qu1et". Recovered from the submission bookmarks by normalizing
+    /// each through the SDK; nil when no bookmark differs from the
+    /// normalized form (nothing worth showing twice).
+    func requestedVariant(forNormalized label: String) -> String? {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return nil }
+        let target = label.lowercased()
+        for pending in DWContestedNameStatusService.shared.pendingLabels {
+            guard pending.lowercased() != target else { continue }
+            let normalized = (try? sdk.dpnsNormalizeLabel(pending)) ?? pending.lowercased()
+            if normalized == target {
+                return pending
+            }
+        }
+        return nil
+    }
+
     /// Local read — the wallet's own tracked rows plus the contested
     /// labels cache, no network. Vote states for contested labels are
     /// filled in best-effort afterward (those are live queries).
@@ -536,19 +555,31 @@ struct UsernameMarketplaceScreen: View {
     }
 
     /// A contested request awaiting the masternode vote. Not tappable —
-    /// there is no document to act on until the vote resolves.
+    /// there is no document to act on until the vote resolves. When the
+    /// requested variant normalizes differently ("quiet" → "qu1et"),
+    /// both are shown: the variant is what the user asked for, the
+    /// normalized form is what the network actually registers.
     private func contestedRow(_ label: String) -> some View {
-        HStack(spacing: 10) {
+        let variant = viewModel.requestedVariant(forNormalized: label)
+        return HStack(spacing: 10) {
             Image(systemName: "hourglass")
                 .font(.system(size: 20, weight: .medium))
                 .foregroundColor(.dashGolden)
                 .frame(width: 36, height: 36)
                 .background(Circle().fill(Color.dashGolden.opacity(0.12)))
             VStack(alignment: .leading, spacing: 2) {
-                Text(label)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.dash.primaryText)
-                    .lineLimit(1)
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(variant ?? label)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                        .lineLimit(1)
+                    if variant != nil {
+                        Text(label)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.dash.tertiaryText)
+                            .lineLimit(1)
+                    }
+                }
                 Text(contestedLine(for: label))
                     .font(.system(size: 11))
                     .foregroundColor(.dash.tertiaryText)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Testnet QA: requesting "quiet" shows up under My Names → In network vote as **"qu1et"** — DPNS normalization folds look-alike characters (i/l → 1, o → 0), and the row only displayed the network's normalized label, not what the user typed.

## What was done

`contestedRow` now shows both forms when they differ: the **requested variant** ("quiet") as the title — recovered by running each submission bookmark through `dpnsNormalizeLabel` and matching it to the SDK cache's normalized label — with the **normalized form** ("qu1et") beside it in the tertiary tone. The variant is what the user asked for; the normalized form is what the network actually registers. Rows whose typed form already equals the normalized form are unchanged.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build; installed on the testnet QA simulator carrying a live "quiet"→"qu1et" contest among four in-flight requests — screenshot verification in the same QA session. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contested-name entries now show the exact label variant you requested when it differs from the network-normalized version.
  * Improved display accuracy for pending username marketplace requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->