### PR TITLE
fix(wallet): handle reported-consumed asset-lock recovery

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -1483,10 +1483,11 @@ final class ShieldedTxLookup {
     /// Snapshot value for one shielded funding tx: the locked amount plus the
     /// asset lock's current status and funding output index. `statusRaw`
     /// distinguishes a still-pending/stuck shield (1…3 — Broadcast/IS/CL) from
-    /// a consumed, successful one (4) and from a restore-scan recovery whose
-    /// Platform-side consumption is unknown (5 — RecoveredFromChain, neither
-    /// pending nor done); `vout` + the txid form the outpoint a recovery
-    /// resume needs.
+    /// a consumed, successful one (4) and from a chain-final lock whose
+    /// Platform-side consumption is unknown (5 — RecoveredFromChain, either
+    /// reconstructed during restore or reconciled from an unauthenticated
+    /// already-consumed report; neither pending nor done); `vout` + the txid
+    /// form the outpoint a recovery resume needs.
     struct ShieldedLockInfo: Sendable {
         let amountDuffs: UInt64
         let statusRaw: Int

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -707,8 +707,8 @@ struct ShieldedRecoverySheet: View {
                 alreadyComplete = true
                 return
             }
-            // statusRaw 1...3 (still pending), 5 (restored from chain — consumption
-            // unknown; a resume either completes it or Platform rejects the spent
+            // statusRaw 1...3 (still pending), 5 (Core-final — consumption
+            // unknown; a resume either completes it or Platform reports the spent
             // outpoint with a typed error), or nil/0 (status unavailable, e.g. a
             // failed refresh): attempt the resume. A genuinely gone/consumed lock
             // surfaces a real SDK error rather than a false "complete".

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -708,10 +708,9 @@ struct ShieldedRecoverySheet: View {
                 return
             }
             // statusRaw 1...3 (still pending), 5 (Core-final — consumption
-            // unknown; a resume either completes it or Platform reports the spent
-            // outpoint with a typed error), or nil/0 (status unavailable, e.g. a
-            // failed refresh): attempt the resume. A genuinely gone/consumed lock
-            // surfaces a real SDK error rather than a false "complete".
+            // unknown), or nil/0 (status unavailable, e.g. a failed refresh):
+            // attempt the resume. Both a local Consumed tombstone and a remote
+            // already-consumed report map to unconfirmed rather than false success.
             await coordinator.resumeAssetLock(outPointTxidWire: op.txidWire, outPointVout: op.vout)
             // On success the shield ST consumed the lock; refresh the snapshot so
             // the history row flips pending → completed even before the next

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -464,6 +464,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
         stopAssetLockPolling()
         Self.logger.info("🛡️ SHIELD-TX :: asset-lock route completed")
         phase = .success
+        ShieldedTxLookup.shared.refresh()
+        NotificationCenter.default.post(
+            name: .swiftDashSDKTransactionProjectionDidChange,
+            object: nil)
         scheduleShieldedResync(manager: env.manager)
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -505,6 +505,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // no asset-lock polling: there's no new lock to track).
         phase = .proving
 
+        let terminalPhase: Phase
         do {
             let recipient = ShieldedFundFromAssetLockRecipient(
                 recipientRaw43: recipientOverride ?? env.shieldedRecipient,
@@ -514,16 +515,18 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 outPointTxid: outPointTxidWire,
                 outPointVout: outPointVout,
                 recipients: [recipient])
+            terminalPhase = .success
         } catch {
-            guard Self.idempotentAssetLockResumePhase(for: error) == .success else {
+            guard let mappedPhase = Self.alreadyConsumedAssetLockResumePhase(for: error) else {
                 handleSpendError(error, manager: env.manager)
                 return
             }
-            // Platform confirmed this exact outpoint was already consumed by
-            // an earlier attempt. Rust reconciled its tracked lock to the
-            // terminal Consumed status before returning the typed error, so
-            // recovery is complete rather than retryable.
-            Self.logger.info("🛡️ SHIELD-TX :: resume found asset lock already consumed — treating as complete")
+            // A DAPI endpoint reported this exact outpoint as consumed, but
+            // rejection responses are not quorum-authenticated. Rust retains
+            // the ChainLock proof and records nonterminal consumption-unknown
+            // state, so suppress retries without claiming verified success.
+            terminalPhase = mappedPhase
+            Self.logger.info("🛡️ SHIELD-TX :: resume found asset lock reported consumed — completion remains unconfirmed")
         }
 
         Self.logger.info("🛡️ SHIELD-TX :: resume completed")
@@ -531,7 +534,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // .broadcasting so the step checklist completes naturally (mirrors
         // `performShield`). No intermediate signal exists for this opaque call.
         phase = .broadcasting
-        phase = .success
+        phase = terminalPhase
         ShieldedTxLookup.shared.refresh()
         NotificationCenter.default.post(
             name: .swiftDashSDKTransactionProjectionDidChange,
@@ -539,12 +542,12 @@ final class ShieldedTransferCoordinator: ObservableObject {
         scheduleShieldedResync(manager: env.manager)
     }
 
-    /// An exact-outpoint resume is idempotently complete when Platform says
-    /// that lock was already consumed. The SDK persists status 4 before
-    /// returning this typed error; every other error remains a real failure.
-    static func idempotentAssetLockResumePhase(for error: Error) -> Phase? {
+    /// An already-consumed report suppresses a potentially destructive retry,
+    /// but is not authenticated proof of completion. Every other error remains
+    /// a normal failure.
+    static func alreadyConsumedAssetLockResumePhase(for error: Error) -> Phase? {
         if case PlatformWalletError.assetLockAlreadyConsumed = error {
-            return .success
+            return .submittedUnconfirmed
         }
         return nil
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -515,8 +515,15 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 outPointVout: outPointVout,
                 recipients: [recipient])
         } catch {
-            handleSpendError(error, manager: env.manager)
-            return
+            guard Self.idempotentAssetLockResumePhase(for: error) == .success else {
+                handleSpendError(error, manager: env.manager)
+                return
+            }
+            // Platform confirmed this exact outpoint was already consumed by
+            // an earlier attempt. Rust reconciled its tracked lock to the
+            // terminal Consumed status before returning the typed error, so
+            // recovery is complete rather than retryable.
+            Self.logger.info("🛡️ SHIELD-TX :: resume found asset lock already consumed — treating as complete")
         }
 
         Self.logger.info("🛡️ SHIELD-TX :: resume completed")
@@ -525,7 +532,21 @@ final class ShieldedTransferCoordinator: ObservableObject {
         // `performShield`). No intermediate signal exists for this opaque call.
         phase = .broadcasting
         phase = .success
+        ShieldedTxLookup.shared.refresh()
+        NotificationCenter.default.post(
+            name: .swiftDashSDKTransactionProjectionDidChange,
+            object: nil)
         scheduleShieldedResync(manager: env.manager)
+    }
+
+    /// An exact-outpoint resume is idempotently complete when Platform says
+    /// that lock was already consumed. The SDK persists status 4 before
+    /// returning this typed error; every other error remains a real failure.
+    static func idempotentAssetLockResumePhase(for error: Error) -> Phase? {
+        if case PlatformWalletError.assetLockAlreadyConsumed = error {
+            return .success
+        }
+        return nil
     }
 
     /// Parse a `PersistentAssetLock.outPointHex` ("<txid display hex>:<vout>")

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -546,9 +546,9 @@ final class ShieldedTransferCoordinator: ObservableObject {
         scheduleShieldedResync(manager: env.manager)
     }
 
-    /// An already-consumed report suppresses a potentially destructive retry,
-    /// but is not authenticated proof of completion. Every other error remains
-    /// a normal failure.
+    /// Both a local `Consumed` tombstone and a remote already-consumed report
+    /// arrive through this typed error. Neither proves that this particular
+    /// shield completed, so both suppress retry without claiming success.
     static func alreadyConsumedAssetLockResumePhase(for error: Error) -> Phase? {
         if case PlatformWalletError.assetLockAlreadyConsumed = error {
             return .submittedUnconfirmed

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -502,9 +502,10 @@ extension TxDetailModel {
             return NSLocalizedString("Completed", comment: "Shielded transfer status")
         case 5:
             // RecoveredFromChain: the lock is final on Core, but whether it
-            // completed on Platform is unknown after a restore — claiming
-            // neither "Pending" nor "Completed" is deliberate.
-            return NSLocalizedString("Restored — completion unknown", comment: "Status of an asset lock recovered from on-chain data after a wallet restore; whether the transfer finished cannot be determined")
+            // completed on Platform is unknown after a restore or an
+            // unauthenticated already-consumed report. Claiming neither
+            // "Pending" nor "Completed" is deliberate.
+            return NSLocalizedString("Completion unknown", comment: "Status of a chain-locked asset lock whose Platform-side consumption cannot be authenticated")
         default:
             return nil
         }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -3583,7 +3583,7 @@
 /* Wallets */
 "Restore an existing wallet" = "Restore an existing wallet";
 
-"Restored — completion unknown" = "Restored — completion unknown";
+"Completion unknown" = "Completion unknown";
 
 /* Location Service Status */
 

--- a/DashWalletTests/PassiveWalletStateUITailTests.swift
+++ b/DashWalletTests/PassiveWalletStateUITailTests.swift
@@ -6,11 +6,23 @@
 //
 
 import Combine
+import SwiftDashSDK
 import XCTest
 @testable import dashwallet
 
 @MainActor
 final class PassiveWalletStateUITailTests: XCTestCase {
+
+    func testAlreadyConsumedAssetLockMapsToSuccessfulResume() {
+        let error = PlatformWalletError.assetLockAlreadyConsumed("test outpoint")
+
+        XCTAssertEqual(
+            ShieldedTransferCoordinator.idempotentAssetLockResumePhase(for: error),
+            .success)
+        XCTAssertNil(
+            ShieldedTransferCoordinator.idempotentAssetLockResumePhase(
+                for: PlatformWalletError.invalidParameter("unrelated")))
+    }
 
     func testHomeBalanceChangesSkipInitialAndDuplicateSnapshots() {
         let balances = CurrentValueSubject<WalletBalance?, Never>(nil)

--- a/DashWalletTests/PassiveWalletStateUITailTests.swift
+++ b/DashWalletTests/PassiveWalletStateUITailTests.swift
@@ -5,22 +5,22 @@
 //  Copyright © 2026 Dash Core Group. All rights reserved.
 //
 
+@testable import dashwallet
 import Combine
 import SwiftDashSDK
 import XCTest
-@testable import dashwallet
 
 @MainActor
 final class PassiveWalletStateUITailTests: XCTestCase {
 
-    func testAlreadyConsumedAssetLockMapsToSuccessfulResume() {
+    func testAlreadyConsumedAssetLockMapsToUnconfirmedResume() {
         let error = PlatformWalletError.assetLockAlreadyConsumed("test outpoint")
 
         XCTAssertEqual(
-            ShieldedTransferCoordinator.idempotentAssetLockResumePhase(for: error),
-            .success)
+            ShieldedTransferCoordinator.alreadyConsumedAssetLockResumePhase(for: error),
+            .submittedUnconfirmed)
         XCTAssertNil(
-            ShieldedTransferCoordinator.idempotentAssetLockResumePhase(
+            ShieldedTransferCoordinator.alreadyConsumedAssetLockResumePhase(
                 for: PlatformWalletError.invalidParameter("unrelated")))
     }
 


### PR DESCRIPTION
Depends on dashpay/platform#4357.

## Summary

- map the typed `assetLockAlreadyConsumed` report to `submittedUnconfirmed`, not verified success
- refresh `ShieldedTxLookup`, publish the transaction-projection notification, and schedule shielded sync after recovery
- stop advertising `Pending — tap to finish` once Rust has durably retained the lock as Core-final with Platform consumption unknown
- refresh the projection after the normal fresh asset-lock success path as well
- show `Completion unknown` for status 5 and add a unit-level mapping regression test
- fix the test import order required by `sorted_imports`

## Testing

- `dashpay` simulator build succeeded after rebasing onto current `develop`
- focused Rust wallet and FFI tests pass in dashpay/platform#4357
- focused `DashWalletTests` execution remains locally blocked because the `dashwallet` scheme embeds a Watch app and the required watchOS 26.5 runtime is not installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming a shielded transfer whose asset lock was already consumed now shows it as submitted and awaiting confirmation.
  * Transaction details refresh automatically after transfer recovery, with shielded synchronization scheduled afterward.
  * Recovered transfers now display “Completion unknown” for clearer status information.
  * Other transfer recovery errors continue to be handled normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->