### PR TITLE
fix(db): fresh installs abort migrations at SeedDB's duplicated version

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -356,7 +356,6 @@
 		47081197298CF20C003FCA3D /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47081196298CF20B003FCA3D /* Transaction.swift */; };
 		4708119F2990F56F003FCA3D /* TransactionDataItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4708119E2990F56F003FCA3D /* TransactionDataItem.swift */; };
 		4709C30F287E787700B4BD48 /* Migrations.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4709C30E287E787700B4BD48 /* Migrations.bundle */; };
-		4709C312287E78BD00B4BD48 /* SeedDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C311287E78BD00B4BD48 /* SeedDB.swift */; };
 		4709C315287EA11900B4BD48 /* TransactionMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C314287EA11900B4BD48 /* TransactionMetadata.swift */; };
 		4709C318287EA23000B4BD48 /* TransactionMetadataDAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C317287EA23000B4BD48 /* TransactionMetadataDAO.swift */; };
 		4709C31F28818BAE00B4BD48 /* TxDetailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C31A288020DE00B4BD48 /* TxDetailModel.swift */; };
@@ -1566,7 +1565,6 @@
 		C9D2C80D2A320AA000D15901 /* MainTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F451E42A0B986E00825057 /* MainTabbarController.swift */; };
 		C9D2C80E2A320AA000D15901 /* NumberFormatter+DashWallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B30D77290BFCA60080C326 /* NumberFormatter+DashWallet.swift */; };
 		C9D2C8102A320AA000D15901 /* BaseAmountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47AF18072907B7880025803E /* BaseAmountModel.swift */; };
-		C9D2C8122A320AA000D15901 /* SeedDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4709C311287E78BD00B4BD48 /* SeedDB.swift */; };
 		C9D2C8132A320AA000D15901 /* DWPinField.m in Sources */ = {isa = PBXBuildFile; fileRef = 2ACCD8EF231ECDE000A96B62 /* DWPinField.m */; };
 		C9D2C8142A320AA000D15901 /* DWCenteredScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AD1CEA122DFC80900C99324 /* DWCenteredScrollView.m */; };
 		C9D2C8162A320AA000D15901 /* DWPhraseRepairViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A9172C325233DC50024B4C5 /* DWPhraseRepairViewController.m */; };
@@ -2585,7 +2583,6 @@
 		47081196298CF20B003FCA3D /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		4708119E2990F56F003FCA3D /* TransactionDataItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDataItem.swift; sourceTree = "<group>"; };
 		4709C30E287E787700B4BD48 /* Migrations.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Migrations.bundle; sourceTree = "<group>"; };
-		4709C311287E78BD00B4BD48 /* SeedDB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeedDB.swift; sourceTree = "<group>"; };
 		4709C314287EA11900B4BD48 /* TransactionMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMetadata.swift; sourceTree = "<group>"; };
 		4709C317287EA23000B4BD48 /* TransactionMetadataDAO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionMetadataDAO.swift; sourceTree = "<group>"; };
 		4709C31A288020DE00B4BD48 /* TxDetailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailModel.swift; sourceTree = "<group>"; };
@@ -5705,7 +5702,6 @@
 				AA0000032DUMMYID001234567 /* AddProviderToGiftCardsTable.swift */,
 				F4C406090000000100000003 /* AddRedeemUrlChallengeToGiftCardsTable.swift */,
 				AA00300B2FD000000000000B /* AddSwapOrdersTable.swift */,
-				4709C311287E78BD00B4BD48 /* SeedDB.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -9856,7 +9852,6 @@
 				C9F451E52A0B986E00825057 /* MainTabbarController.swift in Sources */,
 				47B30D78290BFCA60080C326 /* NumberFormatter+DashWallet.swift in Sources */,
 				47AF18082907B7880025803E /* BaseAmountModel.swift in Sources */,
-				4709C312287E78BD00B4BD48 /* SeedDB.swift in Sources */,
 				2ACCD8F0231ECDE000A96B62 /* DWPinField.m in Sources */,
 				75050CD22DF2FCC200F586D6 /* ServiceName.swift in Sources */,
 				2AD1CEA222DFC80900C99324 /* DWCenteredScrollView.m in Sources */,
@@ -10832,7 +10827,6 @@
 				751C05DB2D3D0E8C00475E52 /* JoinDashPayViewModel.swift in Sources */,
 				C9D2C80E2A320AA000D15901 /* NumberFormatter+DashWallet.swift in Sources */,
 				C9D2C8102A320AA000D15901 /* BaseAmountModel.swift in Sources */,
-				C9D2C8122A320AA000D15901 /* SeedDB.swift in Sources */,
 				C9D2C8132A320AA000D15901 /* DWPinField.m in Sources */,
 				C943B3252A408CED00AF23C5 /* DWEditProfileViewController.m in Sources */,
 				75D9EBBC2DE5CD8B009416A2 /* GiftCard.swift in Sources */,

--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -115,7 +115,6 @@ NS_ASSUME_NONNULL_BEGIN
     [CurrencyExchangerObjcWrapper startExchangeRateFetching];
     [CoinbaseObjcWrapper start];
     [CrowdNodeObjcWrapper start];
-    [SwapTrackingServiceObjcWrapper start];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(applicationTerminationRequestNotification:)
@@ -136,7 +135,14 @@ NS_ASSUME_NONNULL_BEGIN
     // continuously via HTTPClient).
     [[DWSecureTimeService shared] ratchetToWallClock];
 
-    [[DatabaseConnection shared] migrateIfNeededAndReturnError:nil];
+    NSError *databaseMigrationError = nil;
+    if (![[DatabaseConnection shared] migrateIfNeededAndReturnError:&databaseMigrationError]) {
+        DWLog(@"Database migration failed: %@", databaseMigrationError);
+    }
+
+    // After migrateIfNeeded: the tracking service reads `swap_orders` as soon as it starts,
+    // so on a fresh install it must not race the migration that creates the table.
+    [SwapTrackingServiceObjcWrapper start];
 
     // Kick off the SwiftDashSDK key migration and app-owned runtime early.
     // The runtime wallet is restored from app-owned Keychain state,

--- a/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
+++ b/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
@@ -51,6 +51,14 @@ class DatabaseConnection: NSObject {
             ])
         }
 
+        // `schema_migrations.version` is UNIQUE: if two migrations share a version, the second
+        // one's bookkeeping insert throws mid-chain and every later migration is skipped.
+        // (Shipped once: a no-op `SeedDB` duplicating 20250418145536 left fresh installs
+        // without any table added after that version, e.g. `swap_orders`.)
+        let versions = migrationManager.migrations.map(\.version)
+        assert(Set(versions).count == versions.count,
+               "Duplicate migration versions: \(versions.sorted())")
+
         if !migrationManager.hasMigrationsTable() {
             try migrationManager.createMigrationsTable()
         }
@@ -75,7 +83,6 @@ extension DatabaseConnection {
 
     static func migrations() -> [Migration] {
         return [
-            SeedDB(),
             AddGiftCardsTable(),
             AddIconBitmapsTable(),
             AddProviderToGiftCardsTable(),

--- a/DashWallet/Sources/Infrastructure/Database/Migrations/SeedDB.swift
+++ b/DashWallet/Sources/Infrastructure/Database/Migrations/SeedDB.swift
@@ -1,9 +1,0 @@
-import Foundation
-import SQLite
-import SQLiteMigrationManager
-
-struct SeedDB: Migration {
-    var version: Int64 = 20250418145536
-
-    func migrateDatabase(_ db: Connection) throws { }
-}


### PR DESCRIPTION
## Problem

On a fresh install, the app log floods with `SwapOrdersDAO: all failed: no such table: swap_orders (code: 1)` for the entire first run (1,969 lines in one observed session).

The `swap_orders` migration (`AddSwapOrdersTable`, version `20260710100000`) exists — it just never ran. The no-op `SeedDB` code migration carried version `20250418145536`, the same version as the bundled `20250418145536_more_metadata_tx_userinfo.sql`. SQLiteMigrationManager records each applied migration in `schema_migrations`, whose `version` column is UNIQUE: on a fresh database both duplicates are pending, the first inserts the version, the second throws a UNIQUE-constraint error mid-chain, and **every migration sorted after the collision is skipped** — `swap_orders`, `platform_address_activity`/`platform_address_baseline`, and `masternode_vote_history` were never created. AppDelegate passed `nil` for the error, so the failure was silent.

The bug self-heals on the second launch (the recorded version filters both duplicates out as applied, and the remaining chain completes), which is why it only ever showed on a fresh install's first run and kept slipping by. `SeedDB`'s version has mirrored the newest SQL file for years — the previous value `20241130210940` was also a duplicate.

## Fix

- Delete `SeedDB` entirely (no-op; its version is carried by the SQL twin). Upgraded installs are unaffected; installs already stuck in the broken state heal on next launch exactly as before.
- Debug `assert` in `migrateIfNeeded()` that no two migrations across the combined SQL + code set share a version, so this class of bug fails loudly in dev instead of shipping again.
- Log the migration error in AppDelegate instead of discarding it.
- Start `SwapTrackingService` after `migrateIfNeeded` — its first `swap_orders` read raced table creation on first launch (2 residual error lines before the move).

No new timestamped migration is needed: `AddSwapOrdersTable` is correct and now runs.

## Verification

Canonical `dashpay` simulator build, then fresh install (app deleted first) on a wiped simulator: first launch applies all 15 migration versions, `store.db` contains `swap_orders`, and after three 30-second poll cycles the log shows `SwapTrackingService: polling 0 active order(s)` with zero `no such table` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)