### PR TITLE
feat(dashpay): pick the displayed username on the identity detail page

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -507,6 +507,26 @@ public final class DWCurrentUserIdentityInfo: NSObject {
             }
         }
 
+        // The user's picked display label (Identities → detail →
+        // Usernames card, stored as `PersistentIdentity.mainDpnsName`).
+        // Promote it to the front so `username` / `usernames.first` —
+        // and every mirror written from them — render the pick instead
+        // of DPNS-cache order. Only an owned label qualifies: it must
+        // appear in the managed cache or the SwiftData label cache, so
+        // a stale pick (name transferred away) can't resurface.
+        if let mainName = Self.nilIfEmpty(persisted.mainDpnsName), !isPending(mainName) {
+            if let index = usernames.firstIndex(where: {
+                DWContestedNameStatusService.labelsMatch($0, mainName)
+            }) {
+                usernames.insert(usernames.remove(at: index), at: 0)
+            } else if persisted.dpnsNames.contains(where: {
+                DWContestedNameStatusService.labelsMatch($0.label, mainName)
+            }) {
+                usernames.insert(mainName, at: 0)
+            }
+            username = usernames.first ?? username
+        }
+
         // Post-register fallback: SwiftDashSDK's DPNS cache is empty
         // immediately after `registerDpnsName` returns until the next
         // `syncDpnsNames` round, but the coordinator writes

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -350,6 +350,13 @@ struct IdentityDetailScreen: View {
             && row.walletId == SwiftDashSDKHost.shared.wallet?.walletId
     }
 
+    /// Live projection of this identity from the shared view model —
+    /// `row` is the push-time capture, so name-pick changes (which
+    /// reload the view model) re-render through this instead.
+    private var currentRow: IdentityRowModel {
+        viewModel.rows.first(where: { $0.identityId == row.identityId }) ?? row
+    }
+
     var body: some View {
         ZStack {
             Color.dash.primaryBackground.ignoresSafeArea()
@@ -364,7 +371,7 @@ struct IdentityDetailScreen: View {
                         if row.pendingContestedName != nil {
                             pendingNameCard
                         }
-                        if !row.dpnsNames.isEmpty {
+                        if !currentRow.dpnsNames.isEmpty {
                             namesCard
                         }
                         mainIdentityCard
@@ -418,7 +425,7 @@ struct IdentityDetailScreen: View {
             .padding(.top, 10)
 
             HStack(spacing: 6) {
-                Text(row.title)
+                Text(currentRow.title)
                     .font(.title)
                     .fontWeight(.bold)
                     .foregroundColor(.dash.primaryText)
@@ -573,15 +580,41 @@ struct IdentityDetailScreen: View {
         vc.pushViewController(controller, animated: true)
     }
 
+    /// Owned DPNS names as a radio-style picker: the checked row is the
+    /// name the identity displays everywhere (`mainDpnsName` pick, with
+    /// the same fallback the row title uses); tapping another row
+    /// persists it via `IdentitiesViewModel.setMainName`.
     private var namesCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(NSLocalizedString("Usernames", comment: "Identities"))
                 .font(.caption)
                 .foregroundColor(.dash.secondaryText)
-            ForEach(row.dpnsNames, id: \.self) { name in
-                Text(name)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.dash.primaryText)
+            ForEach(currentRow.dpnsNames, id: \.self) { name in
+                let isDisplayed = currentRow.displayedDpnsName.map {
+                    DWContestedNameStatusService.labelsMatch(name, $0)
+                } ?? false
+                Button(action: { viewModel.setMainName(name, for: currentRow) }) {
+                    HStack {
+                        Text(name)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(.dash.primaryText)
+                        Spacer()
+                        Image(systemName: isDisplayed ? "checkmark.circle.fill" : "circle")
+                            .font(.system(size: 18))
+                            .foregroundColor(isDisplayed ? .dash.blue : Color.dash.gray300.opacity(0.6))
+                    }
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(isDisplayed ? [.isSelected] : [])
+            }
+            if currentRow.dpnsNames.count > 1 {
+                Text(NSLocalizedString(
+                    "Select the username to display for this identity.",
+                    comment: "Identities"))
+                    .font(.caption)
+                    .foregroundColor(.dash.secondaryText)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -85,6 +85,12 @@ struct IdentityRowModel: Identifiable {
     let publicKeys: [IdentityKeyRowModel]
     /// Every DPNS label owned by this identity (detail sheet list).
     let dpnsNames: [String]
+    /// The label the identity currently displays: the stored
+    /// `mainDpnsName` pick when set, else the same fallback the title
+    /// uses (`dpnsName` → first owned label). Drives the selection
+    /// indicator on the detail page's Usernames card. Nil when the
+    /// identity owns no names.
+    let displayedDpnsName: String?
     /// Contested label submitted by this wallet but not owned yet.
     /// Kept separate from `dpnsNames` so every identities surface can
     /// render it explicitly as voting rather than as a confirmed name.
@@ -154,6 +160,32 @@ final class IdentitiesViewModel: ObservableObject {
 
         DWCurrentUserIdentityInfo.setMainIdentityId(row.identityId, walletId: activeWalletId)
         _ = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
+        reload()
+    }
+
+    /// Persist `name` as the identity's main DPNS name — the label every
+    /// display surface prefers (`alias → mainDpnsName → dpnsName → first
+    /// owned label`). When the identity is the wallet's main identity,
+    /// drive the same reconcile cascade `setMainIdentity` uses so the
+    /// app-wide username mirror and live DashPay surfaces re-render with
+    /// the new pick immediately.
+    func setMainName(_ name: String, for row: IdentityRowModel) {
+        guard let container = SwiftDashSDKHost.shared.modelContainer else {
+            errorMessage = NSLocalizedString("Wallet is not ready", comment: "Identities")
+            return
+        }
+        // Only an owned (non-pending) label can be displayed.
+        guard row.dpnsNames.contains(where: { DWContestedNameStatusService.labelsMatch($0, name) }) else {
+            return
+        }
+        PersistentIdentity.updateMainDpnsName(
+            in: container.mainContext,
+            identityId: row.identityId,
+            mainDpnsName: name)
+        try? container.mainContext.save()
+        if row.isMainIdentity {
+            _ = DWCurrentUserIdentityInfo.shared.reconcileRecoveredIdentity()
+        }
         reload()
     }
 
@@ -278,10 +310,9 @@ final class IdentitiesViewModel: ObservableObject {
         let preferredName = isPending(identity.dpnsName)
             ? nil
             : identity.dpnsName?.nonEmptyString
+        let displayedName = mainName ?? preferredName ?? ownedNames.first
         let title = alias
-            ?? mainName
-            ?? preferredName
-            ?? ownedNames.first
+            ?? displayedName
             ?? (pendingBelongsToIdentity ? pendingLabel : nil)
             ?? (String(identity.identityIdString.prefix(12)) + "...")
         let hasName = alias != nil || mainName != nil || preferredName != nil || !ownedNames.isEmpty
@@ -305,6 +336,7 @@ final class IdentitiesViewModel: ObservableObject {
                 .sorted { $0.keyId < $1.keyId }
                 .map(keyRowModel(for:)),
             dpnsNames: ownedNames,
+            displayedDpnsName: displayedName,
             pendingContestedName: pendingBelongsToIdentity ? pendingLabel : nil,
             pendingVotingEndTime: pendingBelongsToIdentity
                 ? DWContestedNameStatusService.shared.pendingVotingEndTime

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -3714,6 +3714,9 @@
 /* Coinbase */
 "Select the coin" = "Select the coin";
 
+/* Identities */
+"Select the username to display for this identity." = "Select the username to display for this identity.";
+
 /* No comment provided by engineer. */
 "Self-checkout" = "Self-checkout";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

An identity can own several DPNS usernames, but the Identities detail page only listed them — there was no way to choose which one the identity displays. The app-wide username (`DWCurrentUserIdentityInfo.username`) was whatever came first in DPNS-cache order.

## What was done?

- **IdentitiesScreen** — the Usernames card is now a radio-style picker: each owned name is a tappable row with a checkmark on the currently displayed one, plus a hint line when there's more than one name. The detail page re-renders live from the shared view model, so the header title flips immediately on selection.
- **IdentitiesViewModel** — new `setMainName(_:for:)` persists the pick through the SDK's existing `PersistentIdentity.updateMainDpnsName` helper (`mainDpnsName` is the SDK's "show this one" hint, already first in the row-title priority). When the identity is the wallet's main identity, it drives the same reconcile cascade `setMainIdentity` uses, so the username mirror and live DashPay surfaces re-key right away. Only owned, non-pending labels are selectable — a still-voting contested name can't be picked.
- **DWCurrentUserIdentityInfo** — the snapshot used to take `usernames.first` in DPNS-cache order, ignoring `mainDpnsName`. It now promotes the picked label to the front (so `username`, `displayTitle`, and every mirror written from them honor the pick), but only when the label is actually owned per the managed or SwiftData caches — a stale pick can't resurface a transferred-away name.
- Added the one new user-facing string to the en `Localizable.strings` catalog.

## How Has This Been Tested?

Clean `dashpay` scheme build (arm64 simulator). Installed on the testnet QA simulator holding a five-username identity; interactive smoke of the picker flow is pending (wallet PIN is user-held). The unit-test target is broken pre-existing on this branch line, per repo verification standard.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)