### PR TITLE
fix(dashpay): remove duplicated contenderJoinDeadline after parallel merges

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -514,20 +514,6 @@ struct UsernameMarketplaceService {
     /// (20_000_000_000 credits = 0.2 DASH).
     static let contestedFundCredits: UInt64 = 20_000_000_000
 
-    /// Until when NEW contenders may join a contest, derived from its
-    /// authoritative voting end time. Mirrors rs-platform-version
-    /// `VotingValidationVersions` (v3): contenders may join for
-    /// `allow_other_contenders_time` after the FIRST request — mainnet
-    /// 1 week of the 2-week poll, testing environments 45 minutes of the
-    /// 90-minute poll. In both, joining closes (poll − join window)
-    /// before the end: 1 week on mainnet, 45 minutes on testnet.
-    static func contenderJoinDeadline(voteEnd: Date) -> Date {
-        let closedBeforeEnd: TimeInterval = WalletEnvironment.isMainnet
-            ? 7 * 24 * 60 * 60
-            : 45 * 60
-        return voteEnd.addingTimeInterval(-closedBeforeEnd)
-    }
-
     /// Buyer identity's credit balance from the persisted row — for the
     /// affordability hint; the SDK re-checks authoritatively at purchase.
     static func identityBalanceCredits(identityId: Data, container: ModelContainer) -> UInt64 {


### PR DESCRIPTION
## Issue being fixed or feature implemented

**develop does not compile** after the last two merges: #958's branch and #965 each added an identical `contenderJoinDeadline(voteEnd:)` to `UsernameMarketplaceService`, and the squash merges landed both — "invalid redeclaration of 'contenderJoinDeadline(voteEnd:)'".

## What was done

Removed one of the two byte-identical copies. No behavior change.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build on develop + this commit (develop alone fails). (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have added or updated relevant unit/integration/functional/e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)