### PR TITLE
fix(ui): an untracked asset lock shows its locked amount, not 0

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -514,20 +514,6 @@ struct UsernameMarketplaceService {
     /// (20_000_000_000 credits = 0.2 DASH).
     static let contestedFundCredits: UInt64 = 20_000_000_000
 
-    /// Until when NEW contenders may join a contest, derived from its
-    /// authoritative voting end time. Mirrors rs-platform-version
-    /// `VotingValidationVersions` (v3): contenders may join for
-    /// `allow_other_contenders_time` after the FIRST request — mainnet
-    /// 1 week of the 2-week poll, testing environments 45 minutes of the
-    /// 90-minute poll. In both, joining closes (poll − join window)
-    /// before the end: 1 week on mainnet, 45 minutes on testnet.
-    static func contenderJoinDeadline(voteEnd: Date) -> Date {
-        let closedBeforeEnd: TimeInterval = WalletEnvironment.isMainnet
-            ? 7 * 24 * 60 * 60
-            : 45 * 60
-        return voteEnd.addingTimeInterval(-closedBeforeEnd)
-    }
-
     /// Buyer identity's credit balance from the persisted row — for the
     /// affordability hint; the SDK re-checks authoritatively at purchase.
     static func identityBalanceCredits(identityId: Data, container: ModelContainer) -> UInt64 {

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -434,26 +434,29 @@ class Transaction: TransactionDataItem, Identifiable {
             ?? _dashAmount
     }
 
-    /// The amount a plain Core→Core self-send actually moved — the
-    /// net-change model deliberately derives 0 for a move (every input
-    /// and output is the wallet's own), which read as "0 DASH" on the
-    /// history row and detail sheet. Same reconstruction the Watch
-    /// payload has always used, but fee-EXCLUSIVE to match how `.sent`
-    /// rows display: for a self-send every output is owned, so the
-    /// owned-output total IS the moved amount; owned inputs minus fee
-    /// are the fallback while the TXO join hasn't reconciled. CoinJoin
-    /// mixing rows keep their deliberate net semantics, and an
-    /// unreconstructable amount stays 0 rather than guessing.
+    /// The amount an UNTRACKED asset lock moved out of the transparent
+    /// UTXO set — the net-change model derives 0 for it (the credit
+    /// outputs live in the lock payload, not in the wallet's TXOs, so
+    /// everything visible is self change), which read as "0 DASH" on
+    /// the history row. The locked amount is exactly what left the
+    /// regular outputs: Σ(owned inputs) − Σ(owned outputs) − fee.
+    /// (Tracked funding locks — shielded / platform / identity — were
+    /// already overridden with their recorded amounts above.)
+    ///
+    /// Deliberately NOT applied to plain `.moved` self-sends: their
+    /// destination-vs-change split is not derivable from the owned
+    /// totals (change is owned too — reconstructing from owned outputs
+    /// showed a 1.2 DASH lock as its ~825 DASH change), so they keep
+    /// the honest net-change 0. CoinJoin mixing rows likewise keep
+    /// their net semantics.
     private var movedAmountDuffs: UInt64? {
-        guard direction == .moved, !isCoinJoinMixing, _dashAmount == 0 else { return nil }
-        if snapshot.ownedOutputAmount > 0 {
-            return snapshot.ownedOutputAmount
-        }
-        let fee = snapshot.fee ?? 0
-        if snapshot.ownedInputAmount > fee {
-            return snapshot.ownedInputAmount - fee
-        }
-        return nil
+        guard direction == .moved, !isCoinJoinMixing, _dashAmount == 0,
+              TransactionTypeKind(rawValue: snapshot.typeKind) == .assetLock,
+              snapshot.ownedInputAmount > 0 else { return nil }
+        let (nonLock, overflow) = snapshot.ownedOutputAmount
+            .addingReportingOverflow(snapshot.fee ?? 0)
+        guard !overflow, snapshot.ownedInputAmount > nonLock else { return nil }
+        return snapshot.ownedInputAmount - nonLock
     }
     var signedDashAmount: Int64 {
         if dashAmount == UInt64.max {

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -430,7 +430,30 @@ class Transaction: TransactionDataItem, Identifiable {
             ?? shieldedTransferAmountDuffs
             ?? platformFundingAmountDuffs
             ?? identityFundingAmountDuffs
+            ?? movedAmountDuffs
             ?? _dashAmount
+    }
+
+    /// The amount a plain Core→Core self-send actually moved — the
+    /// net-change model deliberately derives 0 for a move (every input
+    /// and output is the wallet's own), which read as "0 DASH" on the
+    /// history row and detail sheet. Same reconstruction the Watch
+    /// payload has always used, but fee-EXCLUSIVE to match how `.sent`
+    /// rows display: for a self-send every output is owned, so the
+    /// owned-output total IS the moved amount; owned inputs minus fee
+    /// are the fallback while the TXO join hasn't reconciled. CoinJoin
+    /// mixing rows keep their deliberate net semantics, and an
+    /// unreconstructable amount stays 0 rather than guessing.
+    private var movedAmountDuffs: UInt64? {
+        guard direction == .moved, !isCoinJoinMixing, _dashAmount == 0 else { return nil }
+        if snapshot.ownedOutputAmount > 0 {
+            return snapshot.ownedOutputAmount
+        }
+        let fee = snapshot.fee ?? 0
+        if snapshot.ownedInputAmount > fee {
+            return snapshot.ownedInputAmount - fee
+        }
+        return nil
     }
     var signedDashAmount: Int64 {
         if dashAmount == UInt64.max {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Testnet QA: a 1.2 DASH internal transfer between the wallet's own transparent addresses showed **"⟳ 0 Đ"** on the history row (and 0 in the detail sheet). The net-change model deliberately derives 0 for a `.moved` transaction — every input and output is the wallet's own — and unlike the to-Shielded / to-Platform / identity funding asset locks, a plain Core→Core self-send had no recorded amount overriding it.

## What was done

Added `movedAmountDuffs` to the display-amount override chain, scoped to **asset locks** (type kind check): the locked amount is exactly what left the regular UTXO set — Σ(owned inputs) − Σ(owned outputs) − fee. Tracked funding locks (to-Shielded / to-Platform / identity) already carried recorded-amount overrides; this covers locks the app-side store doesn't track.

QA falsified the first attempt (owned-output reconstruction) within minutes: the transaction was an asset lock whose credit outputs live in the payload, so owned outputs were its ~825 DASH *change* — displayed as the amount. Plain `.moved` self-sends therefore deliberately keep the net-change 0: destination-vs-change is not derivable from owned totals (change is owned too), and a wrong number is worse than a zero. CoinJoin mixing rows keep their net semantics.

## How Has This Been Tested?

Clean `dashpay` arm64 simulator build; installed on the testnet QA simulator carrying the real 1.2 DASH self-send — row verification in the same QA session. (Unit-test target pre-existing broken.)

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
