### PR TITLE
fix(wallet): stop dumping every HTTP response body in debug builds

### DIFF
--- a/DashWallet/Sources/Infrastructure/Networking/HTTPClient.swift
+++ b/DashWallet/Sources/Infrastructure/Networking/HTTPClient.swift
@@ -173,7 +173,14 @@ extension HTTPClient {
             switch result {
             case .success(let response):
                 #if DEBUG
-                print(try? JSONSerialization.jsonObject(with: response.data, options: .allowFragments))
+                // Body left unprinted on purpose: the CTX rates response alone
+                // is ~3000 lines of pretty-printed pairs, and dumping it
+                // synchronously here stalls the UI for about a second and
+                // buries every other line in a diagnostic log. Print the size
+                // instead; uncomment the body when debugging a specific
+                // endpoint's payload.
+                print("HTTP \(response.statusCode) \(target.path) — \(response.data.count) bytes")
+                // print(try? JSONSerialization.jsonObject(with: response.data, options: .allowFragments))
                 #endif
 
                 // Feed the auth stack's monotone clock from the TLS-protected


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`HTTPClient` pretty-printed the parsed JSON body of **every** response in debug builds:

```swift
#if DEBUG
print(try? JSONSerialization.jsonObject(with: response.data, options: .allowFragments))
#endif
```

The CTX rates payload (`rates.ctx.com/rates`) is a few hundred currency pairs, which `JSONSerialization` + `print` expand to roughly 3000 lines — emitted synchronously inside the response callback.

Found while diagnosing something else: a tester reported the app freezing on the "Backup your recovery phrase" screen, and the log showed 3053 lines written in a single second at exactly that moment, all of them entries like

```
{
    baseCurrency = BTC;
    price = "327452.9462";
    quoteCurrency = BRL;
    source = "ctx-average";
    symbol = BTCBRL;
},
```

The second cost is diagnostic: a 15-minute session produced 111k lines, the large majority of them rate dumps, which makes reading the log for anything else painful. The same session after this change is 42k lines.

## What was done?
<!--- Describe your changes in detail -->

Print one line — status, path, byte count — instead of the decoded body:

```
HTTP 200 /rates — 48213 bytes
```

The body print is kept commented directly above it. Inspecting a specific endpoint's payload is a real need; it just cannot be the default for every call the app makes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Clean `dashpay` build, then a full testnet session on the iOS 26.5 simulator: restore, sync, contact payment history.

- No `quoteCurrency` lines remain in the log (0, from ~3000 per fetch).
- Session log went from 111k lines to 42k.
- The freeze on the backup screen did not reproduce.

No tests added — this is a debug-only log statement.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. Debug-only, and no behaviour outside logging changes.

Worth knowing: this affects every endpoint, not just rates — Coinbase, Uphold, DEX response bodies no longer appear either. If you were relying on that while debugging, uncomment the line below the new one.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug network logging to show HTTP status, endpoint path, and response size.
  * Reduced verbose output by no longer printing complete response bodies by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->