### PR TITLE
Marketplace Browse tab + scoped wallet-source fetches

### DIFF
--- a/DashWallet/Sources/AppleWatch/DWPhoneWCSessionManager.m
+++ b/DashWallet/Sources/AppleWatch/DWPhoneWCSessionManager.m
@@ -41,6 +41,11 @@ static CGSize const LOGO_SIZE = {54.0, 54.0};
 
 @property WCSession *session;
 @property id balanceObserver;
+// Coalesces bursts of context sends (every balance tick fires one) into a
+// single delayed send — building the context is expensive (recent-tx
+// snapshot + CoreImage QR render) and `sendApplicationContext` runs on a
+// concurrent queue, so undamped bursts pile up overlapping builds.
+@property (atomic) BOOL contextSendScheduled;
 
 @end
 
@@ -70,7 +75,7 @@ static CGSize const LOGO_SIZE = {54.0, 54.0};
                                                                    queue:nil
                                                               usingBlock:^(NSNotification *_Nonnull note) {
                                                                   if ([SyncingActivityMonitor shared].state == SyncingActivityMonitorStateSyncDone)
-                                                                      [self sendApplicationContext];
+                                                                      [self scheduleApplicationContextSend];
                                                               }];
 
             [[SyncingActivityMonitor shared] addObserver:self];
@@ -93,8 +98,24 @@ static CGSize const LOGO_SIZE = {54.0, 54.0};
 
 - (void)syncingActivityMonitorStateDidChangeWithPreviousState:(enum SyncingActivityMonitorState)previousState state:(enum SyncingActivityMonitorState)state {
     if (state == SyncingActivityMonitorStateSyncDone || state == SyncingActivityMonitorStateSyncFailed) {
-        [self sendApplicationContext];
+        [self scheduleApplicationContextSend];
     }
+}
+
+// Coalesced entry point for runtime context sends: the first request arms a
+// 15s timer; requests landing while armed fold into that send (the context
+// is built at send time, so it always reflects the latest state). The watch
+// face doesn't need tighter freshness than this, and the damping keeps a
+// balance-tick storm during sync from queueing overlapping context builds.
+- (void)scheduleApplicationContextSend {
+    if (self.contextSendScheduled)
+        return;
+    self.contextSendScheduled = YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(15 * NSEC_PER_SEC)),
+                   dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                       self.contextSendScheduled = NO;
+                       [self sendApplicationContext];
+                   });
 }
 
 - (BOOL)reachable {

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -106,18 +106,32 @@ struct UsernameMarketplaceService {
     /// not with the size of the namespace.
     private static let documentHistoryContractId = "6voHRaoiPcfmMhbqCA9dixH98xcgPQ9UEcuaXjpVu3LD"
 
-    /// One DPNS `priceUpdate` history row: which domain document was
-    /// (re)listed and when. The recorded price is deliberately NOT
-    /// carried — the live document is the only honest price source
-    /// (later re-prices, delists, and purchases all invalidate it).
-    struct ListingEvent {
+    /// One DPNS trade event from the history trail — a `priceUpdate`
+    /// (listing / re-price) or a `purchase`. The event's own price and
+    /// time are historical FACTS and safe to show as such; only claims
+    /// about the PRESENT ("for sale now") require the live document.
+    struct MarketplaceEvent {
         let dpnsDocumentIdBase58: String
+        let priceCredits: UInt64
         let createdAtMs: UInt64
+        /// Purchase events only: buyer (`$ownerId`) and seller, base58.
+        let buyerIdBase58: String?
+        let sellerIdBase58: String?
     }
 
-    /// One page of DPNS listing events, newest first. `beforeMs` is the
-    /// pagination cursor: pass the previous page's last `createdAtMs`.
-    func listingEventsPage(beforeMs: UInt64?, limit: UInt32 = 100) async throws -> [ListingEvent] {
+    /// Newest-first page of DPNS listing / re-price events. `beforeMs`
+    /// is the pagination cursor (previous page's last `createdAtMs`).
+    func recentPriceChanges(beforeMs: UInt64?, limit: UInt32 = 25) async throws -> [MarketplaceEvent] {
+        try await eventsPage(documentType: "priceUpdate", beforeMs: beforeMs, limit: limit)
+    }
+
+    /// Newest-first page of DPNS purchase events, with price paid and
+    /// both counterparties.
+    func recentPurchases(beforeMs: UInt64?, limit: UInt32 = 25) async throws -> [MarketplaceEvent] {
+        try await eventsPage(documentType: "purchase", beforeMs: beforeMs, limit: limit)
+    }
+
+    private func eventsPage(documentType: String, beforeMs: UInt64?, limit: UInt32) async throws -> [MarketplaceEvent] {
         guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
         var conditions = "[[\"dataContractId\",\"==\",\"\(DPNSVotePoll.contractId)\"]"
         if let beforeMs {
@@ -126,7 +140,7 @@ struct UsernameMarketplaceService {
         conditions += "]"
         let result = try await sdk.documentList(
             dataContractId: Self.documentHistoryContractId,
-            documentType: "priceUpdate",
+            documentType: documentType,
             whereClause: conditions,
             // Order-by tuples here are [field, ascending-bool] — the FFI
             // rejects "asc"/"desc" strings. false = newest first.
@@ -141,17 +155,46 @@ struct UsernameMarketplaceService {
             docs = result.values.compactMap { $0 as? [String: Any] }
         }
         return docs.compactMap { doc in
-            guard let documentId = doc["documentId"] as? String,
+            guard let raw = doc["documentId"] as? String,
+                  let documentId = Self.identifier32(raw),
+                  let price = (doc["price"] as? NSNumber)?.uint64Value,
                   let createdAt = (doc["$createdAt"] as? NSNumber)?.uint64Value else { return nil }
-            return ListingEvent(dpnsDocumentIdBase58: documentId, createdAtMs: createdAt)
+            let buyer = (doc["$ownerId"] as? String).flatMap(Self.identifier32)
+            let seller = (doc["sellerId"] as? String).flatMap(Self.identifier32)
+            return MarketplaceEvent(
+                dpnsDocumentIdBase58: documentId.toBase58String(),
+                priceCredits: price,
+                createdAtMs: createdAt,
+                buyerIdBase58: documentType == "purchase" ? buyer?.toBase58String() : nil,
+                sellerIdBase58: documentType == "purchase" ? seller?.toBase58String() : nil)
         }
     }
 
-    /// Live marketplace state of the domain document behind a listing
-    /// event — nil when the document no longer exists. The caller checks
-    /// `isForSale`; an old event for a since-delisted or sold name
-    /// resolves to a live row without a price.
-    func liveName(forDomainDocumentId documentIdBase58: String) async throws -> DpnsMarketplaceName? {
+    /// Identifier-typed CUSTOM properties serialize as base64 in this
+    /// query path's JSON, while SYSTEM fields ($id, $ownerId) are base58.
+    /// Accept either, but only an exact 32-byte identifier — anything
+    /// else is nil, never a guess.
+    private static func identifier32(_ string: String) -> Data? {
+        if let data = Data(base64Encoded: string), data.count == 32 {
+            return data
+        }
+        if let data = Data.identifier(fromBase58: string), data.count == 32 {
+            return data
+        }
+        return nil
+    }
+
+    /// The name behind an event's domain document: its label plus its
+    /// live marketplace state. nil when the document is gone entirely;
+    /// `live` nil when the name currently resolves to no queryable
+    /// state. Only `live` may claim anything about the PRESENT — the
+    /// event's own price/time are already history.
+    struct EventName {
+        let label: String
+        let live: DpnsMarketplaceName?
+    }
+
+    func eventName(forDomainDocumentId documentIdBase58: String) async throws -> EventName? {
         guard let sdk = SwiftDashSDKHost.shared.sdk,
               let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
         let doc: [String: Any]
@@ -167,7 +210,9 @@ struct UsernameMarketplaceService {
         guard let label = (doc["label"] as? String) ?? (doc["normalizedLabel"] as? String) else {
             return nil
         }
-        return try await wallet.dpnsMarketplaceNameState(name: label)
+        return EventName(
+            label: label,
+            live: try await wallet.dpnsMarketplaceNameState(name: label))
     }
 
     /// The main identity's tracked names from the wallet's local rows —

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -111,6 +111,9 @@ struct UsernameMarketplaceService {
     /// time are historical FACTS and safe to show as such; only claims
     /// about the PRESENT ("for sale now") require the live document.
     struct MarketplaceEvent {
+        /// The history row's own `$id` — the dedupe key that makes the
+        /// overlap-tolerant pagination cursor safe (see `eventsPage`).
+        let eventIdBase58: String
         let dpnsDocumentIdBase58: String
         let priceCredits: UInt64
         let createdAtMs: UInt64
@@ -135,7 +138,12 @@ struct UsernameMarketplaceService {
         guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
         var conditions = "[[\"dataContractId\",\"==\",\"\(DPNSVotePoll.contractId)\"]"
         if let beforeMs {
-            conditions += ",[\"$createdAt\",\"<\",\(beforeMs)]"
+            // "<=", not "<": several events can share one block's
+            // $createdAt, and a strict cursor at a page boundary would
+            // silently drop the rest of that timestamp group. The
+            // deliberate overlap re-fetches the boundary rows; callers
+            // dedupe on `eventIdBase58`.
+            conditions += ",[\"$createdAt\",\"<=\",\(beforeMs)]"
         }
         conditions += "]"
         let result = try await sdk.documentList(
@@ -155,13 +163,16 @@ struct UsernameMarketplaceService {
             docs = result.values.compactMap { $0 as? [String: Any] }
         }
         return docs.compactMap { doc in
-            guard let raw = doc["documentId"] as? String,
+            guard let rawEventId = doc["$id"] as? String,
+                  let eventId = Self.identifier32(rawEventId),
+                  let raw = doc["documentId"] as? String,
                   let documentId = Self.identifier32(raw),
                   let price = (doc["price"] as? NSNumber)?.uint64Value,
                   let createdAt = (doc["$createdAt"] as? NSNumber)?.uint64Value else { return nil }
             let buyer = (doc["$ownerId"] as? String).flatMap(Self.identifier32)
             let seller = (doc["sellerId"] as? String).flatMap(Self.identifier32)
             return MarketplaceEvent(
+                eventIdBase58: eventId.toBase58String(),
                 dpnsDocumentIdBase58: documentId.toBase58String(),
                 priceCredits: price,
                 createdAtMs: createdAt,
@@ -219,12 +230,16 @@ struct UsernameMarketplaceService {
         }
         var out: [String: LiveDomainName] = [:]
         for doc in docs {
-            guard let id = doc["$id"] as? String,
-                  let ownerBase58 = doc["$ownerId"] as? String,
-                  let ownerId = Data.identifier(fromBase58: ownerBase58),
+            guard let rawId = doc["$id"] as? String,
+                  let id = Self.identifier32(rawId),
+                  let rawOwnerId = doc["$ownerId"] as? String,
+                  let ownerId = Self.identifier32(rawOwnerId),
                   let label = (doc["label"] as? String) ?? (doc["normalizedLabel"] as? String) else { continue }
-            out[id] = LiveDomainName(
-                documentIdBase58: id,
+            // Canonical base58 key — must byte-match the event side's
+            // dpnsDocumentIdBase58, which is produced the same way.
+            let documentIdBase58 = id.toBase58String()
+            out[documentIdBase58] = LiveDomainName(
+                documentIdBase58: documentIdBase58,
                 label: label,
                 ownerId: ownerId,
                 priceCredits: (doc["$price"] as? NSNumber)?.uint64Value)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -184,35 +184,52 @@ struct UsernameMarketplaceService {
         return nil
     }
 
-    /// The name behind an event's domain document: its label plus its
-    /// live marketplace state. nil when the document is gone entirely;
-    /// `live` nil when the name currently resolves to no queryable
-    /// state. Only `live` may claim anything about the PRESENT — the
-    /// event's own price/time are already history.
-    struct EventName {
+    /// Live DPNS state for a BATCH of domain document ids — one
+    /// `documentList` on the primary `$id` index (`in` clause) instead of
+    /// two round trips per name. The domain document itself carries the
+    /// entire live state a feed row claims about the present: label,
+    /// owner, and current `$price` (nil = not for sale). Ids absent from
+    /// the result no longer exist.
+    struct LiveDomainName {
+        let documentIdBase58: String
         let label: String
-        let live: DpnsMarketplaceName?
+        let ownerId: Data
+        let priceCredits: UInt64?
+
+        var isForSale: Bool { priceCredits != nil }
+        var priceDuffs: UInt64? { priceCredits.map { $0 / 1_000 } }
     }
 
-    func eventName(forDomainDocumentId documentIdBase58: String) async throws -> EventName? {
-        guard let sdk = SwiftDashSDKHost.shared.sdk,
-              let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
-        let doc: [String: Any]
-        do {
-            doc = try await sdk.documentGet(
-                dataContractId: DPNSVotePoll.contractId,
-                documentType: DPNSVotePoll.documentTypeName,
-                documentId: documentIdBase58)
-        } catch {
-            // Gone documents are an expected outcome for old events.
-            return nil
+    func liveDomainNames(forDocumentIds ids: [String]) async throws -> [String: LiveDomainName] {
+        guard let sdk = SwiftDashSDKHost.shared.sdk, !ids.isEmpty else { return [:] }
+        let idList = ids.map { "\"\($0)\"" }.joined(separator: ",")
+        let result = try await sdk.documentList(
+            dataContractId: DPNSVotePoll.contractId,
+            documentType: DPNSVotePoll.documentTypeName,
+            whereClause: "[[\"$id\",\"in\",[\(idList)]]]",
+            orderByClause: "[[\"$id\",true]]",
+            limit: UInt32(ids.count))
+        let docs: [[String: Any]]
+        if let array = result["documents"] as? [[String: Any]] {
+            docs = array
+        } else if let array = result["items"] as? [[String: Any]] {
+            docs = array
+        } else {
+            docs = result.values.compactMap { $0 as? [String: Any] }
         }
-        guard let label = (doc["label"] as? String) ?? (doc["normalizedLabel"] as? String) else {
-            return nil
+        var out: [String: LiveDomainName] = [:]
+        for doc in docs {
+            guard let id = doc["$id"] as? String,
+                  let ownerBase58 = doc["$ownerId"] as? String,
+                  let ownerId = Data.identifier(fromBase58: ownerBase58),
+                  let label = (doc["label"] as? String) ?? (doc["normalizedLabel"] as? String) else { continue }
+            out[id] = LiveDomainName(
+                documentIdBase58: id,
+                label: label,
+                ownerId: ownerId,
+                priceCredits: (doc["$price"] as? NSNumber)?.uint64Value)
         }
-        return EventName(
-            label: label,
-            live: try await wallet.dpnsMarketplaceNameState(name: label))
+        return out
     }
 
     /// The main identity's tracked names from the wallet's local rows —

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -97,6 +97,16 @@ struct UsernameMarketplaceService {
         return try await wallet.searchDpnsMarketplace(prefix: prefix, limit: limit)
     }
 
+    /// One alphabetical page of ALL names (the SDK's empty-prefix browse),
+    /// each with live sale state. `startAfter` is the cursor: the previous
+    /// page's last documentId. Powers the Browse tab's scan — there is no
+    /// server-side price filter or ordering to lean on ($price is not
+    /// indexable), so callers filter and sort what the scan returns.
+    func browsePage(startAfter: Data?, limit: UInt32 = 100) async throws -> [DpnsMarketplaceName] {
+        guard let wallet = SwiftDashSDKHost.shared.wallet else { return [] }
+        return try await wallet.searchDpnsMarketplace(prefix: "", limit: limit, startAfter: startAfter)
+    }
+
     /// The main identity's tracked names from the wallet's local rows —
     /// no network round-trip. Includes retained `.sold` / `.transferred`
     /// departures so the UI can show what left and to whom.

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -97,14 +97,75 @@ struct UsernameMarketplaceService {
         return try await wallet.searchDpnsMarketplace(prefix: prefix, limit: limit)
     }
 
-    /// One alphabetical page of ALL names (the SDK's empty-prefix browse),
-    /// each with live sale state. `startAfter` is the cursor: the previous
-    /// page's last documentId. Powers the Browse tab's scan — there is no
-    /// server-side price filter or ordering to lean on ($price is not
-    /// indexable), so callers filter and sort what the scan returns.
-    func browsePage(startAfter: Data?, limit: UInt32 = 100) async throws -> [DpnsMarketplaceName] {
-        guard let wallet = SwiftDashSDKHost.shared.wallet else { return [] }
-        return try await wallet.searchDpnsMarketplace(prefix: "", limit: limit, startAfter: startAfter)
+    /// The document-history system contract (platform #4348,
+    /// `document_history_contract::ID_BYTES`). Every `setDocumentPrice`
+    /// also writes a `priceUpdate` row here, indexed by
+    /// `[dataContractId, $createdAt]` — the queryable listing trail the
+    /// DPNS contract itself lacks ($price is not indexable). Browse
+    /// walks it newest-first, so its cost scales with LISTING EVENTS,
+    /// not with the size of the namespace.
+    private static let documentHistoryContractId = "6voHRaoiPcfmMhbqCA9dixH98xcgPQ9UEcuaXjpVu3LD"
+
+    /// One DPNS `priceUpdate` history row: which domain document was
+    /// (re)listed and when. The recorded price is deliberately NOT
+    /// carried — the live document is the only honest price source
+    /// (later re-prices, delists, and purchases all invalidate it).
+    struct ListingEvent {
+        let dpnsDocumentIdBase58: String
+        let createdAtMs: UInt64
+    }
+
+    /// One page of DPNS listing events, newest first. `beforeMs` is the
+    /// pagination cursor: pass the previous page's last `createdAtMs`.
+    func listingEventsPage(beforeMs: UInt64?, limit: UInt32 = 100) async throws -> [ListingEvent] {
+        guard let sdk = SwiftDashSDKHost.shared.sdk else { return [] }
+        var conditions = "[[\"dataContractId\",\"==\",\"\(DPNSVotePoll.contractId)\"]"
+        if let beforeMs {
+            conditions += ",[\"$createdAt\",\"<\",\(beforeMs)]"
+        }
+        conditions += "]"
+        let result = try await sdk.documentList(
+            dataContractId: Self.documentHistoryContractId,
+            documentType: "priceUpdate",
+            whereClause: conditions,
+            orderByClause: "[[\"$createdAt\",\"desc\"]]",
+            limit: limit)
+        let docs: [[String: Any]]
+        if let array = result["documents"] as? [[String: Any]] {
+            docs = array
+        } else if let array = result["items"] as? [[String: Any]] {
+            docs = array
+        } else {
+            docs = result.values.compactMap { $0 as? [String: Any] }
+        }
+        return docs.compactMap { doc in
+            guard let documentId = doc["documentId"] as? String,
+                  let createdAt = (doc["$createdAt"] as? NSNumber)?.uint64Value else { return nil }
+            return ListingEvent(dpnsDocumentIdBase58: documentId, createdAtMs: createdAt)
+        }
+    }
+
+    /// Live marketplace state of the domain document behind a listing
+    /// event — nil when the document no longer exists. The caller checks
+    /// `isForSale`; an old event for a since-delisted or sold name
+    /// resolves to a live row without a price.
+    func liveName(forDomainDocumentId documentIdBase58: String) async throws -> DpnsMarketplaceName? {
+        guard let sdk = SwiftDashSDKHost.shared.sdk,
+              let wallet = SwiftDashSDKHost.shared.wallet else { return nil }
+        let doc: [String: Any]
+        do {
+            doc = try await sdk.documentGet(
+                dataContractId: DPNSVotePoll.contractId,
+                documentType: DPNSVotePoll.documentTypeName,
+                documentId: documentIdBase58)
+        } catch {
+            // Gone documents are an expected outcome for old events.
+            return nil
+        }
+        guard let label = (doc["label"] as? String) ?? (doc["normalizedLabel"] as? String) else {
+            return nil
+        }
+        return try await wallet.dpnsMarketplaceNameState(name: label)
     }
 
     /// The main identity's tracked names from the wallet's local rows —

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UsernameMarketplaceService.swift
@@ -128,7 +128,9 @@ struct UsernameMarketplaceService {
             dataContractId: Self.documentHistoryContractId,
             documentType: "priceUpdate",
             whereClause: conditions,
-            orderByClause: "[[\"$createdAt\",\"desc\"]]",
+            // Order-by tuples here are [field, ascending-bool] — the FFI
+            // rejects "asc"/"desc" strings. false = newest first.
+            orderByClause: "[[\"$createdAt\",false]]",
             limit: limit)
         let docs: [[String: Any]]
         if let array = result["documents"] as? [[String: Any]] {

--- a/DashWallet/Sources/Models/Coinbase/Coinbase.swift
+++ b/DashWallet/Sources/Models/Coinbase/Coinbase.swift
@@ -359,12 +359,28 @@ struct CoinbaseWalletTransactionSnapshot {
     let walletId: Data
     let transactions: [CoinbaseWalletTransactionRecord]
 
-    static func current() -> CoinbaseWalletTransactionSnapshot? {
-        guard let snapshot = SwiftDashSDKWalletSource.fetchCurrentWalletSnapshot() else {
-            return nil
-        }
+    /// Only the wallet transactions whose wire-order txid is in `txids`
+    /// (the `TransactionMetadata.txHash` key convention) — point lookups,
+    /// so resolving stored metadata never materializes the whole wallet.
+    static func matching(txids: Set<Data>) -> CoinbaseWalletTransactionSnapshot? {
+        SwiftDashSDKWalletSource.fetch(txids: txids).map(Self.init(snapshot:))
+    }
 
-        return CoinbaseWalletTransactionSnapshot(
+    /// Only the wallet transactions first seen at/after `cutoff`, for
+    /// matchers that are time-bounded anyway (the pending-receive resolver
+    /// requires `timestamp >= minimumTimestamp`). Callers pad the cutoff
+    /// for the firstSeen-vs-display-date skew.
+    static func recent(since cutoff: Date) -> CoinbaseWalletTransactionSnapshot? {
+        SwiftDashSDKWalletSource.fetchRecent(firstSeenSince: cutoff).map(Self.init(snapshot:))
+    }
+}
+
+// The projection init lives in an extension so the struct keeps its
+// synthesized memberwise initializer (the resolver tests build snapshots
+// with it directly).
+extension CoinbaseWalletTransactionSnapshot {
+    fileprivate init(snapshot: SwiftDashSDKWalletTransactionSnapshot) {
+        self.init(
             walletId: snapshot.walletId,
             transactions: snapshot.transactions.map(CoinbaseWalletTransactionRecord.init(transaction:)))
     }
@@ -511,8 +527,13 @@ final class CoinbaseTransactionMetadataTagger {
     }
 
     private func resolvePendingReceiveTransfersOnQueue() {
-        guard !pendingReceiveTransfers.isEmpty,
-              let snapshot = CoinbaseWalletTransactionSnapshot.current() else {
+        guard !pendingReceiveTransfers.isEmpty else { return }
+        // The resolver only accepts rows at/after each transfer's
+        // `minimumTimestamp`; fetch from the oldest one, padded a day for
+        // the firstSeen-vs-display-date skew, instead of the whole wallet.
+        let oldestMinimum = pendingReceiveTransfers.map(\.minimumTimestamp).min() ?? 0
+        let cutoff = Date(timeIntervalSince1970: max(0, oldestMinimum - 86_400))
+        guard let snapshot = CoinbaseWalletTransactionSnapshot.recent(since: cutoff) else {
             return
         }
 

--- a/DashWallet/Sources/Models/Swap/SwapBuyTransactionMatcher.swift
+++ b/DashWallet/Sources/Models/Swap/SwapBuyTransactionMatcher.swift
@@ -35,6 +35,18 @@ enum SwapBuyTransactionMatcher {
     /// still far tighter than the address + amount checks, which do the real disambiguation.
     private static let timestampSlack: TimeInterval = 2 * 60 * 60
 
+    /// The `firstSeen` fetch cutoff for matching `order`: order time minus
+    /// `timestampSlack` (the matcher's own below-order-time allowance on the
+    /// display date) minus a day for the firstSeen-vs-display-date skew
+    /// (block timestamps trail the wall clock; restores re-stamp old rows).
+    /// Callers hand this to `SwiftDashSDKWalletSource.fetchRecent(firstSeenSince:)`
+    /// so the matcher's candidate pool is a ranged index scan, not the
+    /// wallet's full history.
+    static func fetchCutoff(for order: SwapOrder) -> Date {
+        let orderTimestamp = TimeInterval(order.timestamp) / 1000.0
+        return Date(timeIntervalSince1970: max(0, orderTimestamp - timestampSlack - 24 * 60 * 60))
+    }
+
     static func matchedTransaction(
         for order: SwapOrder,
         in transactions: [Transaction]

--- a/DashWallet/Sources/Models/Swap/SwapTrackingService.swift
+++ b/DashWallet/Sources/Models/Swap/SwapTrackingService.swift
@@ -213,7 +213,11 @@ final class SwapTrackingService {
     private func completedWalletTxHash(for order: SwapOrder) -> String? {
         // Read the wallet's transactions from SwiftDashSDK; DashSync's allTransactions is frozen
         // (empty) post-migration, so a buy's incoming DASH would never match.
-        let transactions = SwiftDashSDKWalletSource.fetchAll()
+        // The matcher only considers rows around the order's own time, so
+        // range the fetch by `firstSeen` instead of walking the wallet.
+        let transactions = SwiftDashSDKWalletSource
+            .fetchRecent(firstSeenSince: SwapBuyTransactionMatcher.fetchCutoff(for: order))?
+            .transactions ?? []
         return SwapBuyTransactionMatcher.walletTxHashHexString(for: order, in: transactions)
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -151,37 +151,56 @@ final class UsernameMarketplaceViewModel: ObservableObject {
             guard let self else { return }
             defer { self.isBrowseLoading = false }
             do {
-                let cursor = feed == .priceChanges ? priceChangesCursorMs : purchasesCursorMs
-                let events = feed == .priceChanges
-                    ? try await service.recentPriceChanges(beforeMs: cursor, limit: Self.browseEventsPerPage)
-                    : try await service.recentPurchases(beforeMs: cursor, limit: Self.browseEventsPerPage)
-                // One batched $id lookup covers every name this page
-                // mentions that we haven't resolved yet.
-                let unknownIds = Array(Set(events.map(\.dpnsDocumentIdBase58)
-                    .filter { browseNameCache[$0] == nil }))
-                if !unknownIds.isEmpty {
-                    for (id, live) in try await service.liveDomainNames(forDocumentIds: unknownIds) {
-                        browseNameCache[id] = live
+                // Price changes is a FOR-SALE feed: rows whose name was
+                // since delisted or sold are dropped, and each name
+                // renders once (its newest event — whose price, by
+                // consensus, IS the live price of a still-listed name).
+                // Dropped rows can leave a page thin, so keep paging
+                // within a bounded pass until something showed.
+                var pagesLeft = feed == .priceChanges ? 4 : 1
+                while pagesLeft > 0 {
+                    pagesLeft -= 1
+                    let cursor = feed == .priceChanges ? priceChangesCursorMs : purchasesCursorMs
+                    let events = feed == .priceChanges
+                        ? try await service.recentPriceChanges(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                        : try await service.recentPurchases(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                    // One batched $id lookup covers every name this page
+                    // mentions that we haven't resolved yet.
+                    let unknownIds = Array(Set(events.map(\.dpnsDocumentIdBase58)
+                        .filter { browseNameCache[$0] == nil }))
+                    if !unknownIds.isEmpty {
+                        for (id, live) in try await service.liveDomainNames(forDocumentIds: unknownIds) {
+                            browseNameCache[id] = live
+                        }
                     }
-                }
-                var rows: [BrowseEventRow] = []
-                for event in events {
-                    // Absent from the batch = the document is gone.
-                    guard let live = browseNameCache[event.dpnsDocumentIdBase58] else { continue }
-                    rows.append(BrowseEventRow(
-                        id: "\(event.dpnsDocumentIdBase58)-\(event.createdAtMs)",
-                        label: live.label,
-                        event: event,
-                        live: live))
-                }
-                if feed == .priceChanges {
-                    browsePriceChanges.append(contentsOf: rows)
-                    priceChangesCursorMs = events.last?.createdAtMs
-                    if events.count < Int(Self.browseEventsPerPage) { browsePriceChangesExhausted = true }
-                } else {
-                    browsePurchases.append(contentsOf: rows)
-                    purchasesCursorMs = events.last?.createdAtMs
-                    if events.count < Int(Self.browseEventsPerPage) { browsePurchasesExhausted = true }
+                    var rows: [BrowseEventRow] = []
+                    for event in events {
+                        // Absent from the batch = the document is gone.
+                        guard let live = browseNameCache[event.dpnsDocumentIdBase58] else { continue }
+                        let row = BrowseEventRow(
+                            id: "\(event.dpnsDocumentIdBase58)-\(event.createdAtMs)",
+                            label: live.label,
+                            event: event,
+                            live: live)
+                        if feed == .priceChanges {
+                            guard live.isForSale,
+                                  !browsePriceChanges.contains(where: { $0.event.dpnsDocumentIdBase58 == event.dpnsDocumentIdBase58 }),
+                                  !rows.contains(where: { $0.event.dpnsDocumentIdBase58 == event.dpnsDocumentIdBase58 })
+                            else { continue }
+                        }
+                        rows.append(row)
+                    }
+                    let exhausted = events.count < Int(Self.browseEventsPerPage)
+                    if feed == .priceChanges {
+                        browsePriceChanges.append(contentsOf: rows)
+                        priceChangesCursorMs = events.last?.createdAtMs
+                        if exhausted { browsePriceChangesExhausted = true }
+                    } else {
+                        browsePurchases.append(contentsOf: rows)
+                        purchasesCursorMs = events.last?.createdAtMs
+                        if exhausted { browsePurchasesExhausted = true }
+                    }
+                    if exhausted || !rows.isEmpty { break }
                 }
             } catch {
                 errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
@@ -542,7 +561,7 @@ struct UsernameMarketplaceScreen: View {
                     }
                     if viewModel.browseRows.isEmpty && !viewModel.isBrowseLoading {
                         emptyHint(viewModel.browseFeed == .priceChanges
-                            ? NSLocalizedString("No price changes on the network yet.", comment: "Username marketplace: empty price-changes feed")
+                            ? NSLocalizedString("No names are for sale in the recent listing activity. Show more reaches further back.", comment: "Username marketplace: price-changes feed found no live listings yet")
                             : NSLocalizedString("No purchases on the network yet.", comment: "Username marketplace: empty purchases feed"))
                     }
                     if viewModel.isBrowseLoading {

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -114,12 +114,21 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     @Published var browsePurchasesExhausted = false
 
     /// Per-feed pagination cursors: oldest $createdAt fetched so far.
+    /// The service pages with "<=" (a timestamp can span many events),
+    /// so pages overlap at the boundary; `browseSeenEventIds` dedupes.
     private var priceChangesCursorMs: UInt64?
     private var purchasesCursorMs: UInt64?
+    private var browseSeenEventIds: Set<String> = []
     /// documentId → live domain state, shared across both feeds and
     /// filled by ONE batched read per page — a page costs exactly two
     /// platform queries (events + batched $id lookup) regardless of size.
     private var browseNameCache: [String: UsernameMarketplaceService.LiveDomainName] = [:]
+    /// In-flight load — cancelled by a reset so pull-to-refresh can
+    /// always restart, never silently bounce off the busy guard. The
+    /// generation counter keeps a cancelled task's cleanup from clearing
+    /// the loading flag of the load that replaced it.
+    private var browseTask: Task<Void, Never>?
+    private var browseLoadGeneration = 0
     private static let browseEventsPerPage: UInt32 = 25
 
     var browseRows: [BrowseEventRow] {
@@ -130,26 +139,35 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         browseFeed == .priceChanges ? browsePriceChangesExhausted : browsePurchasesExhausted
     }
 
-    /// Load the next page of the CURRENT feed. `reset` restarts both
-    /// feeds from the newest event (pull-to-refresh) so live states and
-    /// prices re-read fresh.
+    /// Load the next page of the CURRENT feed. `reset` cancels any
+    /// in-flight load and restarts both feeds from the newest event
+    /// (pull-to-refresh) so live states and prices re-read fresh.
     func loadBrowse(reset: Bool = false) {
-        guard !isBrowseLoading else { return }
         if reset {
+            browseTask?.cancel()
             browsePriceChanges = []
             browsePurchases = []
             priceChangesCursorMs = nil
             purchasesCursorMs = nil
             browsePriceChangesExhausted = false
             browsePurchasesExhausted = false
+            browseSeenEventIds = []
             browseNameCache = [:]
+        } else {
+            guard !isBrowseLoading else { return }
         }
         let feed = browseFeed
         guard !browseFeedExhausted else { return }
         isBrowseLoading = true
-        Task { [weak self] in
+        browseLoadGeneration += 1
+        let generation = browseLoadGeneration
+        browseTask = Task { [weak self] in
             guard let self else { return }
-            defer { self.isBrowseLoading = false }
+            defer {
+                if self.browseLoadGeneration == generation {
+                    self.isBrowseLoading = false
+                }
+            }
             do {
                 // Price changes is a FOR-SALE feed: rows whose name was
                 // since delisted or sold are dropped, and each name
@@ -161,9 +179,14 @@ final class UsernameMarketplaceViewModel: ObservableObject {
                 while pagesLeft > 0 {
                     pagesLeft -= 1
                     let cursor = feed == .priceChanges ? priceChangesCursorMs : purchasesCursorMs
-                    let events = feed == .priceChanges
+                    let rawEvents = feed == .priceChanges
                         ? try await service.recentPriceChanges(beforeMs: cursor, limit: Self.browseEventsPerPage)
                         : try await service.recentPurchases(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                    guard !Task.isCancelled else { return }
+                    // Boundary rows reappear by design (the "<=" cursor);
+                    // the event-id set drops what was already consumed.
+                    let events = rawEvents.filter { !browseSeenEventIds.contains($0.eventIdBase58) }
+                    events.forEach { browseSeenEventIds.insert($0.eventIdBase58) }
                     // One batched $id lookup covers every name this page
                     // mentions that we haven't resolved yet.
                     let unknownIds = Array(Set(events.map(\.dpnsDocumentIdBase58)
@@ -173,12 +196,13 @@ final class UsernameMarketplaceViewModel: ObservableObject {
                             browseNameCache[id] = live
                         }
                     }
+                    guard !Task.isCancelled else { return }
                     var rows: [BrowseEventRow] = []
                     for event in events {
                         // Absent from the batch = the document is gone.
                         guard let live = browseNameCache[event.dpnsDocumentIdBase58] else { continue }
                         let row = BrowseEventRow(
-                            id: "\(event.dpnsDocumentIdBase58)-\(event.createdAtMs)",
+                            id: event.eventIdBase58,
                             label: live.label,
                             event: event,
                             live: live)
@@ -190,22 +214,35 @@ final class UsernameMarketplaceViewModel: ObservableObject {
                         }
                         rows.append(row)
                     }
-                    let exhausted = events.count < Int(Self.browseEventsPerPage)
+                    // Exhaustion reads the RAW page: a short page means the
+                    // trail ended. A full page of only-seen rows means the
+                    // cursor cannot advance (>page-size events sharing one
+                    // timestamp) — stop rather than spin.
+                    let exhausted = rawEvents.count < Int(Self.browseEventsPerPage)
+                        || (events.isEmpty && rawEvents.count == Int(Self.browseEventsPerPage))
                     if feed == .priceChanges {
                         browsePriceChanges.append(contentsOf: rows)
-                        priceChangesCursorMs = events.last?.createdAtMs
+                        priceChangesCursorMs = rawEvents.last?.createdAtMs ?? cursor
                         if exhausted { browsePriceChangesExhausted = true }
                     } else {
                         browsePurchases.append(contentsOf: rows)
-                        purchasesCursorMs = events.last?.createdAtMs
+                        purchasesCursorMs = rawEvents.last?.createdAtMs ?? cursor
                         if exhausted { browsePurchasesExhausted = true }
                     }
                     if exhausted || !rows.isEmpty { break }
                 }
             } catch {
+                guard !Task.isCancelled else { return }
                 errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
         }
+    }
+
+    /// Awaitable refresh for `.refreshable` — the spinner stays until
+    /// the restarted load actually finishes.
+    func refreshBrowse() async {
+        loadBrowse(reset: true)
+        await browseTask?.value
     }
 
     let service = UsernameMarketplaceService()
@@ -591,7 +628,7 @@ struct UsernameMarketplaceScreen: View {
                 .padding(.bottom, 24)
             }
             .refreshable {
-                viewModel.loadBrowse(reset: true)
+                await viewModel.refreshBrowse()
             }
         }
         .onAppear {
@@ -605,13 +642,20 @@ struct UsernameMarketplaceScreen: View {
         let eventDash = (row.event.priceCredits / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol
         let eventDate = DWDateFormatter.sharedInstance.shortStringFromDate(
             Date(timeIntervalSince1970: Double(row.event.createdAtMs) / 1000))
-        let subtitle = viewModel.browseFeed == .priceChanges
-            ? String.localizedStringWithFormat(
+        let subtitle: String
+        if viewModel.browseFeed == .priceChanges {
+            subtitle = String.localizedStringWithFormat(
                 NSLocalizedString("Listed for %1$@ DASH · %2$@", comment: "Username marketplace: price-change feed row — event price, then date"),
                 eventDash, eventDate)
-            : String.localizedStringWithFormat(
+        } else if let seller = row.event.sellerIdBase58, let buyer = row.event.buyerIdBase58 {
+            subtitle = String.localizedStringWithFormat(
+                NSLocalizedString("Sold for %1$@ DASH · %2$@ · %3$@ → %4$@", comment: "Username marketplace: purchases feed row — price paid, date, then seller → buyer short ids"),
+                eventDash, eventDate, shortBase58(seller), shortBase58(buyer))
+        } else {
+            subtitle = String.localizedStringWithFormat(
                 NSLocalizedString("Sold for %1$@ DASH · %2$@", comment: "Username marketplace: purchases feed row — price paid, then date"),
                 eventDash, eventDate)
+        }
         return Button {
             selectedLabel = SelectedMarketplaceLabel(label: row.label)
         } label: {
@@ -923,6 +967,10 @@ struct UsernameMarketplaceScreen: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    private func shortBase58(_ base58: String) -> String {
+        String(base58.prefix(8)) + "…" + String(base58.suffix(4))
     }
 
     private func sectionHeader(_ text: String) -> some View {

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -82,27 +82,34 @@ final class UsernameMarketplaceViewModel: ObservableObject {
 
     // MARK: Browse (for-sale) state
     //
-    // `$price` is not an indexable property on Dash Platform, so there is
-    // no server-side "everything for sale, ordered by price" query at any
-    // layer. Browse is an honest client-side pass instead: page through
-    // ALL names alphabetically (empty-prefix search with a documentId
-    // cursor), keep the listed ones, and sort locally. The coverage label
-    // says how much of the network the sort currently reflects.
+    // `$price` is not indexable on Dash Platform, so the DPNS contract
+    // has no server-side "everything for sale, ordered by price" query.
+    // What DOES exist is the document-history system contract: every
+    // listing writes a `priceUpdate` event queryable newest-first by
+    // [dataContractId, $createdAt]. Browse walks that trail — every
+    // listed name necessarily has such an event, so exhausting the trail
+    // yields the COMPLETE current listing set at a cost proportional to
+    // listing activity, not namespace size — then verifies each
+    // candidate's LIVE document (events say nothing about later
+    // re-prices, delists, or purchases) and sorts locally.
 
-    /// For-sale names accumulated by the alphabetical scan.
+    /// Live for-sale names, verified against the current documents.
     @Published var browseForSale: [DpnsMarketplaceName] = []
-    /// Total names scanned so far (listed or not) — the coverage label.
+    /// Listing events checked so far — the coverage label.
     @Published var browseScannedCount = 0
     /// True while a scan pass is fetching pages.
     @Published var isBrowseScanning = false
-    /// True once the alphabetical scan has walked every name.
+    /// True once the whole listing-event trail was walked.
     @Published var browseExhausted = false
     @Published var browseSort: BrowseSort = .priceHighFirst
 
-    /// Cursor: last page's final documentId; nil = scan from the start.
-    private var browseCursor: Data?
-    /// Pages per scan pass — bounds one tap's network cost (100 names each).
-    private static let browsePagesPerPass = 5
+    /// Pagination cursor: the oldest event's $createdAt seen so far.
+    private var browseCursorMs: UInt64?
+    /// Domain documents already resolved this scan — a re-listed name has
+    /// many events; one live check answers them all.
+    private var browseSeenDocumentIds: Set<String> = []
+    /// Event pages per scan pass (100 events each) — bounds one tap's cost.
+    private static let browsePagesPerPass = 3
 
     var sortedBrowseForSale: [DpnsMarketplaceName] {
         browseForSale.sorted {
@@ -112,14 +119,15 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         }
     }
 
-    /// Scan another batch of pages. `reset` restarts from the top
-    /// (pull-to-refresh) so re-listed/delisted names re-read fresh.
+    /// Walk another batch of listing events. `reset` restarts from the
+    /// newest (pull-to-refresh) so prices and delists re-read fresh.
     func scanBrowsePages(reset: Bool = false) {
         guard !isBrowseScanning else { return }
         if reset {
-            browseCursor = nil
+            browseCursorMs = nil
             browseForSale = []
             browseScannedCount = 0
+            browseSeenDocumentIds = []
             browseExhausted = false
         }
         guard !browseExhausted else { return }
@@ -130,11 +138,18 @@ final class UsernameMarketplaceViewModel: ObservableObject {
             let pageSize: UInt32 = 100
             for _ in 0..<Self.browsePagesPerPass {
                 do {
-                    let page = try await service.browsePage(startAfter: browseCursor, limit: pageSize)
-                    browseScannedCount += page.count
-                    browseForSale.append(contentsOf: page.filter(\.isForSale))
-                    browseCursor = page.last?.documentId
-                    if page.count < Int(pageSize) {
+                    let events = try await service.listingEventsPage(beforeMs: browseCursorMs, limit: pageSize)
+                    browseScannedCount += events.count
+                    browseCursorMs = events.last?.createdAtMs
+                    for event in events where !browseSeenDocumentIds.contains(event.dpnsDocumentIdBase58) {
+                        browseSeenDocumentIds.insert(event.dpnsDocumentIdBase58)
+                        if let live = try await service.liveName(forDomainDocumentId: event.dpnsDocumentIdBase58),
+                           live.isForSale,
+                           !browseForSale.contains(where: { $0.documentId == live.documentId }) {
+                            browseForSale.append(live)
+                        }
+                    }
+                    if events.count < Int(pageSize) {
                         browseExhausted = true
                         break
                     }
@@ -479,10 +494,10 @@ struct UsernameMarketplaceScreen: View {
             HStack {
                 Text(viewModel.browseExhausted
                     ? String.localizedStringWithFormat(
-                        NSLocalizedString("All %1$d names scanned · %2$d for sale", comment: "Username marketplace: browse coverage line once the whole network was scanned"),
+                        NSLocalizedString("All %1$d listings checked · %2$d for sale now", comment: "Username marketplace: browse coverage line once the whole listing trail was walked"),
                         viewModel.browseScannedCount, viewModel.browseForSale.count)
                     : String.localizedStringWithFormat(
-                        NSLocalizedString("%1$d names scanned · %2$d for sale", comment: "Username marketplace: browse coverage line while the scan is partial"),
+                        NSLocalizedString("%1$d listings checked · %2$d for sale now", comment: "Username marketplace: browse coverage line while the scan is partial"),
                         viewModel.browseScannedCount, viewModel.browseForSale.count))
                     .font(.system(size: 12))
                     .foregroundColor(.dash.secondaryText)
@@ -521,13 +536,13 @@ struct UsernameMarketplaceScreen: View {
                     }
                     if viewModel.browseForSale.isEmpty && !viewModel.isBrowseScanning {
                         emptyHint(viewModel.browseExhausted
-                            ? NSLocalizedString("No names are for sale right now.", comment: "Username marketplace: browse scanned everything, nothing listed")
-                            : NSLocalizedString("No names for sale found yet — scan more of the network below.", comment: "Username marketplace: browse partial scan found nothing listed"))
+                            ? NSLocalizedString("No names are for sale right now.", comment: "Username marketplace: browse walked every listing event, nothing currently listed")
+                            : NSLocalizedString("No live listings found yet — check more of the listing history below.", comment: "Username marketplace: browse partial scan found nothing currently listed"))
                     }
                     if viewModel.isBrowseScanning {
                         HStack(spacing: 8) {
                             SwiftUI.ProgressView()
-                            Text(NSLocalizedString("Scanning names…", comment: "Username marketplace: browse scan in progress"))
+                            Text(NSLocalizedString("Checking listings…", comment: "Username marketplace: browse scan in progress"))
                                 .font(.system(size: 12))
                                 .foregroundColor(.dash.secondaryText)
                         }
@@ -537,7 +552,7 @@ struct UsernameMarketplaceScreen: View {
                         Button {
                             viewModel.scanBrowsePages()
                         } label: {
-                            Text(NSLocalizedString("Scan more names", comment: "Username marketplace: continue the browse scan"))
+                            Text(NSLocalizedString("Check more listings", comment: "Username marketplace: continue the browse scan"))
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundColor(.dash.blue)
                                 .frame(maxWidth: .infinity)

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -34,13 +34,20 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     enum Segment: Int, CaseIterable {
         case find
         case mine
+        case browse
 
         var title: String {
             switch self {
             case .find: return NSLocalizedString("Find Names", comment: "Username marketplace: search segment")
             case .mine: return NSLocalizedString("My Names", comment: "Username marketplace: owned names segment")
+            case .browse: return NSLocalizedString("Browse", comment: "Username marketplace: browse-for-sale segment")
             }
         }
+    }
+
+    enum BrowseSort {
+        case priceHighFirst
+        case priceLowFirst
     }
 
     @Published var segment: Segment = .find
@@ -72,6 +79,72 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     /// DPNS document can still be mid-vote — without this the row would
     /// claim "Available" for a name already being contested.
     @Published var queryContest: UsernameMarketplaceService.ContestPrecheck?
+
+    // MARK: Browse (for-sale) state
+    //
+    // `$price` is not an indexable property on Dash Platform, so there is
+    // no server-side "everything for sale, ordered by price" query at any
+    // layer. Browse is an honest client-side pass instead: page through
+    // ALL names alphabetically (empty-prefix search with a documentId
+    // cursor), keep the listed ones, and sort locally. The coverage label
+    // says how much of the network the sort currently reflects.
+
+    /// For-sale names accumulated by the alphabetical scan.
+    @Published var browseForSale: [DpnsMarketplaceName] = []
+    /// Total names scanned so far (listed or not) — the coverage label.
+    @Published var browseScannedCount = 0
+    /// True while a scan pass is fetching pages.
+    @Published var isBrowseScanning = false
+    /// True once the alphabetical scan has walked every name.
+    @Published var browseExhausted = false
+    @Published var browseSort: BrowseSort = .priceHighFirst
+
+    /// Cursor: last page's final documentId; nil = scan from the start.
+    private var browseCursor: Data?
+    /// Pages per scan pass — bounds one tap's network cost (100 names each).
+    private static let browsePagesPerPass = 5
+
+    var sortedBrowseForSale: [DpnsMarketplaceName] {
+        browseForSale.sorted {
+            let l = $0.priceCredits ?? 0
+            let r = $1.priceCredits ?? 0
+            return browseSort == .priceHighFirst ? l > r : l < r
+        }
+    }
+
+    /// Scan another batch of pages. `reset` restarts from the top
+    /// (pull-to-refresh) so re-listed/delisted names re-read fresh.
+    func scanBrowsePages(reset: Bool = false) {
+        guard !isBrowseScanning else { return }
+        if reset {
+            browseCursor = nil
+            browseForSale = []
+            browseScannedCount = 0
+            browseExhausted = false
+        }
+        guard !browseExhausted else { return }
+        isBrowseScanning = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.isBrowseScanning = false }
+            let pageSize: UInt32 = 100
+            for _ in 0..<Self.browsePagesPerPass {
+                do {
+                    let page = try await service.browsePage(startAfter: browseCursor, limit: pageSize)
+                    browseScannedCount += page.count
+                    browseForSale.append(contentsOf: page.filter(\.isForSale))
+                    browseCursor = page.last?.documentId
+                    if page.count < Int(pageSize) {
+                        browseExhausted = true
+                        break
+                    }
+                } catch {
+                    errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
+                    break
+                }
+            }
+        }
+    }
 
     let service = UsernameMarketplaceService()
     private var searchTask: Task<Void, Never>?
@@ -293,6 +366,8 @@ struct UsernameMarketplaceScreen: View {
                 findSection
             case .mine:
                 mySection
+            case .browse:
+                browseSection
             }
 
             Spacer(minLength: 0)
@@ -390,6 +465,98 @@ struct UsernameMarketplaceScreen: View {
                 .padding(.horizontal, 15)
                 .padding(.top, 12)
                 .padding(.bottom, 24)
+            }
+        }
+    }
+
+    // MARK: Browse segment
+
+    /// Names for sale across the network, sorted by price client-side.
+    /// The coverage line keeps the sort honest: Platform cannot order by
+    /// $price, so "most expensive" means "among the names scanned so far".
+    private var browseSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(viewModel.browseExhausted
+                    ? String.localizedStringWithFormat(
+                        NSLocalizedString("All %1$d names scanned · %2$d for sale", comment: "Username marketplace: browse coverage line once the whole network was scanned"),
+                        viewModel.browseScannedCount, viewModel.browseForSale.count)
+                    : String.localizedStringWithFormat(
+                        NSLocalizedString("%1$d names scanned · %2$d for sale", comment: "Username marketplace: browse coverage line while the scan is partial"),
+                        viewModel.browseScannedCount, viewModel.browseForSale.count))
+                    .font(.system(size: 12))
+                    .foregroundColor(.dash.secondaryText)
+                Spacer()
+                Menu {
+                    Button {
+                        viewModel.browseSort = .priceHighFirst
+                    } label: {
+                        Label(NSLocalizedString("Highest price first", comment: "Username marketplace: browse sort option"),
+                              systemImage: viewModel.browseSort == .priceHighFirst ? "checkmark" : "arrow.down")
+                    }
+                    Button {
+                        viewModel.browseSort = .priceLowFirst
+                    } label: {
+                        Label(NSLocalizedString("Lowest price first", comment: "Username marketplace: browse sort option"),
+                              systemImage: viewModel.browseSort == .priceLowFirst ? "checkmark" : "arrow.up")
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.up.arrow.down")
+                        Text(viewModel.browseSort == .priceHighFirst
+                            ? NSLocalizedString("Highest price", comment: "Username marketplace: current browse sort label")
+                            : NSLocalizedString("Lowest price", comment: "Username marketplace: current browse sort label"))
+                    }
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dash.blue)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 8)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(viewModel.sortedBrowseForSale) { name in
+                        searchRow(name)
+                    }
+                    if viewModel.browseForSale.isEmpty && !viewModel.isBrowseScanning {
+                        emptyHint(viewModel.browseExhausted
+                            ? NSLocalizedString("No names are for sale right now.", comment: "Username marketplace: browse scanned everything, nothing listed")
+                            : NSLocalizedString("No names for sale found yet — scan more of the network below.", comment: "Username marketplace: browse partial scan found nothing listed"))
+                    }
+                    if viewModel.isBrowseScanning {
+                        HStack(spacing: 8) {
+                            SwiftUI.ProgressView()
+                            Text(NSLocalizedString("Scanning names…", comment: "Username marketplace: browse scan in progress"))
+                                .font(.system(size: 12))
+                                .foregroundColor(.dash.secondaryText)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                    } else if !viewModel.browseExhausted {
+                        Button {
+                            viewModel.scanBrowsePages()
+                        } label: {
+                            Text(NSLocalizedString("Scan more names", comment: "Username marketplace: continue the browse scan"))
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundColor(.dash.blue)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 15)
+                .padding(.top, 4)
+                .padding(.bottom, 24)
+            }
+            .refreshable {
+                viewModel.scanBrowsePages(reset: true)
+            }
+        }
+        .onAppear {
+            if viewModel.browseScannedCount == 0 {
+                viewModel.scanBrowsePages()
             }
         }
     }

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -58,12 +58,12 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     }
 
     /// One rendered browse-feed row: the historical event plus the
-    /// name's label and (best-effort) live state.
+    /// name's label and live state (from the batched domain read).
     struct BrowseEventRow: Identifiable {
         let id: String
         let label: String
         let event: UsernameMarketplaceService.MarketplaceEvent
-        let live: DpnsMarketplaceName?
+        let live: UsernameMarketplaceService.LiveDomainName?
     }
 
     @Published var segment: Segment = .find
@@ -116,10 +116,10 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     /// Per-feed pagination cursors: oldest $createdAt fetched so far.
     private var priceChangesCursorMs: UInt64?
     private var purchasesCursorMs: UInt64?
-    /// documentId → resolved name, shared across both feeds — a name
-    /// with many events costs one resolution per refresh.
-    private var browseNameCache: [String: UsernameMarketplaceService.EventName] = [:]
-    /// Events per fetch — each new name costs up to 2 extra round trips.
+    /// documentId → live domain state, shared across both feeds and
+    /// filled by ONE batched read per page — a page costs exactly two
+    /// platform queries (events + batched $id lookup) regardless of size.
+    private var browseNameCache: [String: UsernameMarketplaceService.LiveDomainName] = [:]
     private static let browseEventsPerPage: UInt32 = 25
 
     var browseRows: [BrowseEventRow] {
@@ -155,21 +155,24 @@ final class UsernameMarketplaceViewModel: ObservableObject {
                 let events = feed == .priceChanges
                     ? try await service.recentPriceChanges(beforeMs: cursor, limit: Self.browseEventsPerPage)
                     : try await service.recentPurchases(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                // One batched $id lookup covers every name this page
+                // mentions that we haven't resolved yet.
+                let unknownIds = Array(Set(events.map(\.dpnsDocumentIdBase58)
+                    .filter { browseNameCache[$0] == nil }))
+                if !unknownIds.isEmpty {
+                    for (id, live) in try await service.liveDomainNames(forDocumentIds: unknownIds) {
+                        browseNameCache[id] = live
+                    }
+                }
                 var rows: [BrowseEventRow] = []
                 for event in events {
-                    let name: UsernameMarketplaceService.EventName?
-                    if let cached = browseNameCache[event.dpnsDocumentIdBase58] {
-                        name = cached
-                    } else {
-                        name = try await service.eventName(forDomainDocumentId: event.dpnsDocumentIdBase58)
-                        if let name { browseNameCache[event.dpnsDocumentIdBase58] = name }
-                    }
-                    guard let name else { continue } // document gone — nothing to show
+                    // Absent from the batch = the document is gone.
+                    guard let live = browseNameCache[event.dpnsDocumentIdBase58] else { continue }
                     rows.append(BrowseEventRow(
                         id: "\(event.dpnsDocumentIdBase58)-\(event.createdAtMs)",
-                        label: name.label,
+                        label: live.label,
                         event: event,
-                        live: name.live))
+                        live: live))
                 }
                 if feed == .priceChanges {
                     browsePriceChanges.append(contentsOf: rows)

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -45,9 +45,25 @@ final class UsernameMarketplaceViewModel: ObservableObject {
         }
     }
 
-    enum BrowseSort {
-        case priceHighFirst
-        case priceLowFirst
+    enum BrowseFeed: Int, CaseIterable {
+        case priceChanges
+        case purchases
+
+        var title: String {
+            switch self {
+            case .priceChanges: return NSLocalizedString("Price changes", comment: "Username marketplace: browse feed of recent listings and re-prices")
+            case .purchases: return NSLocalizedString("Purchases", comment: "Username marketplace: browse feed of recent sales")
+            }
+        }
+    }
+
+    /// One rendered browse-feed row: the historical event plus the
+    /// name's label and (best-effort) live state.
+    struct BrowseEventRow: Identifiable {
+        let id: String
+        let label: String
+        let event: UsernameMarketplaceService.MarketplaceEvent
+        let live: DpnsMarketplaceName?
     }
 
     @Published var segment: Segment = .find
@@ -80,83 +96,92 @@ final class UsernameMarketplaceViewModel: ObservableObject {
     /// claim "Available" for a name already being contested.
     @Published var queryContest: UsernameMarketplaceService.ContestPrecheck?
 
-    // MARK: Browse (for-sale) state
+    // MARK: Browse (recent activity) state
     //
-    // `$price` is not indexable on Dash Platform, so the DPNS contract
-    // has no server-side "everything for sale, ordered by price" query.
-    // What DOES exist is the document-history system contract: every
-    // listing writes a `priceUpdate` event queryable newest-first by
-    // [dataContractId, $createdAt]. Browse walks that trail — every
-    // listed name necessarily has such an event, so exhausting the trail
-    // yields the COMPLETE current listing set at a cost proportional to
-    // listing activity, not namespace size — then verifies each
-    // candidate's LIVE document (events say nothing about later
-    // re-prices, delists, or purchases) and sorts locally.
+    // `$price` is not indexable on Dash Platform, so no query at any
+    // layer can order names by price. What the document-history system
+    // contract DOES index is RECENCY ([dataContractId, $createdAt]) —
+    // so Browse is an honest activity feed: recent price changes
+    // (listings / re-prices) and recent purchases, newest first. Each
+    // event's price and time are historical facts shown as such; each
+    // row also resolves the name's LIVE state for what's true now.
 
-    /// Live for-sale names, verified against the current documents.
-    @Published var browseForSale: [DpnsMarketplaceName] = []
-    /// Listing events checked so far — the coverage label.
-    @Published var browseScannedCount = 0
-    /// True while a scan pass is fetching pages.
-    @Published var isBrowseScanning = false
-    /// True once the whole listing-event trail was walked.
-    @Published var browseExhausted = false
-    @Published var browseSort: BrowseSort = .priceHighFirst
+    @Published var browseFeed: BrowseFeed = .priceChanges
+    @Published var browsePriceChanges: [BrowseEventRow] = []
+    @Published var browsePurchases: [BrowseEventRow] = []
+    @Published var isBrowseLoading = false
+    @Published var browsePriceChangesExhausted = false
+    @Published var browsePurchasesExhausted = false
 
-    /// Pagination cursor: the oldest event's $createdAt seen so far.
-    private var browseCursorMs: UInt64?
-    /// Domain documents already resolved this scan — a re-listed name has
-    /// many events; one live check answers them all.
-    private var browseSeenDocumentIds: Set<String> = []
-    /// Event pages per scan pass (100 events each) — bounds one tap's cost.
-    private static let browsePagesPerPass = 3
+    /// Per-feed pagination cursors: oldest $createdAt fetched so far.
+    private var priceChangesCursorMs: UInt64?
+    private var purchasesCursorMs: UInt64?
+    /// documentId → resolved name, shared across both feeds — a name
+    /// with many events costs one resolution per refresh.
+    private var browseNameCache: [String: UsernameMarketplaceService.EventName] = [:]
+    /// Events per fetch — each new name costs up to 2 extra round trips.
+    private static let browseEventsPerPage: UInt32 = 25
 
-    var sortedBrowseForSale: [DpnsMarketplaceName] {
-        browseForSale.sorted {
-            let l = $0.priceCredits ?? 0
-            let r = $1.priceCredits ?? 0
-            return browseSort == .priceHighFirst ? l > r : l < r
-        }
+    var browseRows: [BrowseEventRow] {
+        browseFeed == .priceChanges ? browsePriceChanges : browsePurchases
     }
 
-    /// Walk another batch of listing events. `reset` restarts from the
-    /// newest (pull-to-refresh) so prices and delists re-read fresh.
-    func scanBrowsePages(reset: Bool = false) {
-        guard !isBrowseScanning else { return }
+    var browseFeedExhausted: Bool {
+        browseFeed == .priceChanges ? browsePriceChangesExhausted : browsePurchasesExhausted
+    }
+
+    /// Load the next page of the CURRENT feed. `reset` restarts both
+    /// feeds from the newest event (pull-to-refresh) so live states and
+    /// prices re-read fresh.
+    func loadBrowse(reset: Bool = false) {
+        guard !isBrowseLoading else { return }
         if reset {
-            browseCursorMs = nil
-            browseForSale = []
-            browseScannedCount = 0
-            browseSeenDocumentIds = []
-            browseExhausted = false
+            browsePriceChanges = []
+            browsePurchases = []
+            priceChangesCursorMs = nil
+            purchasesCursorMs = nil
+            browsePriceChangesExhausted = false
+            browsePurchasesExhausted = false
+            browseNameCache = [:]
         }
-        guard !browseExhausted else { return }
-        isBrowseScanning = true
+        let feed = browseFeed
+        guard !browseFeedExhausted else { return }
+        isBrowseLoading = true
         Task { [weak self] in
             guard let self else { return }
-            defer { self.isBrowseScanning = false }
-            let pageSize: UInt32 = 100
-            for _ in 0..<Self.browsePagesPerPass {
-                do {
-                    let events = try await service.listingEventsPage(beforeMs: browseCursorMs, limit: pageSize)
-                    browseScannedCount += events.count
-                    browseCursorMs = events.last?.createdAtMs
-                    for event in events where !browseSeenDocumentIds.contains(event.dpnsDocumentIdBase58) {
-                        browseSeenDocumentIds.insert(event.dpnsDocumentIdBase58)
-                        if let live = try await service.liveName(forDomainDocumentId: event.dpnsDocumentIdBase58),
-                           live.isForSale,
-                           !browseForSale.contains(where: { $0.documentId == live.documentId }) {
-                            browseForSale.append(live)
-                        }
+            defer { self.isBrowseLoading = false }
+            do {
+                let cursor = feed == .priceChanges ? priceChangesCursorMs : purchasesCursorMs
+                let events = feed == .priceChanges
+                    ? try await service.recentPriceChanges(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                    : try await service.recentPurchases(beforeMs: cursor, limit: Self.browseEventsPerPage)
+                var rows: [BrowseEventRow] = []
+                for event in events {
+                    let name: UsernameMarketplaceService.EventName?
+                    if let cached = browseNameCache[event.dpnsDocumentIdBase58] {
+                        name = cached
+                    } else {
+                        name = try await service.eventName(forDomainDocumentId: event.dpnsDocumentIdBase58)
+                        if let name { browseNameCache[event.dpnsDocumentIdBase58] = name }
                     }
-                    if events.count < Int(pageSize) {
-                        browseExhausted = true
-                        break
-                    }
-                } catch {
-                    errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
-                    break
+                    guard let name else { continue } // document gone — nothing to show
+                    rows.append(BrowseEventRow(
+                        id: "\(event.dpnsDocumentIdBase58)-\(event.createdAtMs)",
+                        label: name.label,
+                        event: event,
+                        live: name.live))
                 }
+                if feed == .priceChanges {
+                    browsePriceChanges.append(contentsOf: rows)
+                    priceChangesCursorMs = events.last?.createdAtMs
+                    if events.count < Int(Self.browseEventsPerPage) { browsePriceChangesExhausted = true }
+                } else {
+                    browsePurchases.append(contentsOf: rows)
+                    purchasesCursorMs = events.last?.createdAtMs
+                    if events.count < Int(Self.browseEventsPerPage) { browsePurchasesExhausted = true }
+                }
+            } catch {
+                errorMessage = UsernameMarketplaceService.userFacingMessage(for: error)
             }
         }
     }
@@ -486,73 +511,51 @@ struct UsernameMarketplaceScreen: View {
 
     // MARK: Browse segment
 
-    /// Names for sale across the network, sorted by price client-side.
-    /// The coverage line keeps the sort honest: Platform cannot order by
-    /// $price, so "most expensive" means "among the names scanned so far".
+    /// Recent marketplace activity, newest first: price changes
+    /// (listings / re-prices) and purchases, straight off the
+    /// document-history trail's [dataContractId, $createdAt] index.
+    /// Event price and time are historical facts; the trailing badge is
+    /// the name's LIVE state, so a stale listing can't read as an offer.
     private var browseSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(viewModel.browseExhausted
-                    ? String.localizedStringWithFormat(
-                        NSLocalizedString("All %1$d listings checked · %2$d for sale now", comment: "Username marketplace: browse coverage line once the whole listing trail was walked"),
-                        viewModel.browseScannedCount, viewModel.browseForSale.count)
-                    : String.localizedStringWithFormat(
-                        NSLocalizedString("%1$d listings checked · %2$d for sale now", comment: "Username marketplace: browse coverage line while the scan is partial"),
-                        viewModel.browseScannedCount, viewModel.browseForSale.count))
-                    .font(.system(size: 12))
-                    .foregroundColor(.dash.secondaryText)
-                Spacer()
-                Menu {
-                    Button {
-                        viewModel.browseSort = .priceHighFirst
-                    } label: {
-                        Label(NSLocalizedString("Highest price first", comment: "Username marketplace: browse sort option"),
-                              systemImage: viewModel.browseSort == .priceHighFirst ? "checkmark" : "arrow.down")
-                    }
-                    Button {
-                        viewModel.browseSort = .priceLowFirst
-                    } label: {
-                        Label(NSLocalizedString("Lowest price first", comment: "Username marketplace: browse sort option"),
-                              systemImage: viewModel.browseSort == .priceLowFirst ? "checkmark" : "arrow.up")
-                    }
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.up.arrow.down")
-                        Text(viewModel.browseSort == .priceHighFirst
-                            ? NSLocalizedString("Highest price", comment: "Username marketplace: current browse sort label")
-                            : NSLocalizedString("Lowest price", comment: "Username marketplace: current browse sort label"))
-                    }
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(.dash.blue)
+            Picker("", selection: $viewModel.browseFeed) {
+                ForEach(UsernameMarketplaceViewModel.BrowseFeed.allCases, id: \.self) { feed in
+                    Text(feed.title).tag(feed)
                 }
             }
+            .pickerStyle(.segmented)
             .padding(.horizontal, 20)
             .padding(.bottom, 8)
+            .onChange(of: viewModel.browseFeed) { _, _ in
+                if viewModel.browseRows.isEmpty {
+                    viewModel.loadBrowse()
+                }
+            }
 
             ScrollView {
                 LazyVStack(spacing: 6) {
-                    ForEach(viewModel.sortedBrowseForSale) { name in
-                        searchRow(name)
+                    ForEach(viewModel.browseRows) { row in
+                        browseEventRow(row)
                     }
-                    if viewModel.browseForSale.isEmpty && !viewModel.isBrowseScanning {
-                        emptyHint(viewModel.browseExhausted
-                            ? NSLocalizedString("No names are for sale right now.", comment: "Username marketplace: browse walked every listing event, nothing currently listed")
-                            : NSLocalizedString("No live listings found yet — check more of the listing history below.", comment: "Username marketplace: browse partial scan found nothing currently listed"))
+                    if viewModel.browseRows.isEmpty && !viewModel.isBrowseLoading {
+                        emptyHint(viewModel.browseFeed == .priceChanges
+                            ? NSLocalizedString("No price changes on the network yet.", comment: "Username marketplace: empty price-changes feed")
+                            : NSLocalizedString("No purchases on the network yet.", comment: "Username marketplace: empty purchases feed"))
                     }
-                    if viewModel.isBrowseScanning {
+                    if viewModel.isBrowseLoading {
                         HStack(spacing: 8) {
                             SwiftUI.ProgressView()
-                            Text(NSLocalizedString("Checking listings…", comment: "Username marketplace: browse scan in progress"))
+                            Text(NSLocalizedString("Loading activity…", comment: "Username marketplace: browse feed loading"))
                                 .font(.system(size: 12))
                                 .foregroundColor(.dash.secondaryText)
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
-                    } else if !viewModel.browseExhausted {
+                    } else if !viewModel.browseFeedExhausted && !viewModel.browseRows.isEmpty {
                         Button {
-                            viewModel.scanBrowsePages()
+                            viewModel.loadBrowse()
                         } label: {
-                            Text(NSLocalizedString("Check more listings", comment: "Username marketplace: continue the browse scan"))
+                            Text(NSLocalizedString("Show more", comment: "Username marketplace: load older browse activity"))
                                 .font(.system(size: 14, weight: .semibold))
                                 .foregroundColor(.dash.blue)
                                 .frame(maxWidth: .infinity)
@@ -566,14 +569,71 @@ struct UsernameMarketplaceScreen: View {
                 .padding(.bottom, 24)
             }
             .refreshable {
-                viewModel.scanBrowsePages(reset: true)
+                viewModel.loadBrowse(reset: true)
             }
         }
         .onAppear {
-            if viewModel.browseScannedCount == 0 {
-                viewModel.scanBrowsePages()
+            if viewModel.browseRows.isEmpty {
+                viewModel.loadBrowse()
             }
         }
+    }
+
+    private func browseEventRow(_ row: UsernameMarketplaceViewModel.BrowseEventRow) -> some View {
+        let eventDash = (row.event.priceCredits / 1000).dashAmount.formattedDashAmountWithoutCurrencySymbol
+        let eventDate = DWDateFormatter.sharedInstance.shortStringFromDate(
+            Date(timeIntervalSince1970: Double(row.event.createdAtMs) / 1000))
+        let subtitle = viewModel.browseFeed == .priceChanges
+            ? String.localizedStringWithFormat(
+                NSLocalizedString("Listed for %1$@ DASH · %2$@", comment: "Username marketplace: price-change feed row — event price, then date"),
+                eventDash, eventDate)
+            : String.localizedStringWithFormat(
+                NSLocalizedString("Sold for %1$@ DASH · %2$@", comment: "Username marketplace: purchases feed row — price paid, then date"),
+                eventDash, eventDate)
+        return Button {
+            selectedLabel = SelectedMarketplaceLabel(label: row.label)
+        } label: {
+            HStack(spacing: 10) {
+                ContactAvatarView(
+                    title: row.label,
+                    avatarURL: nil,
+                    identitySeed: row.live?.ownerId ?? Data())
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(row.label)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.dash.primaryText)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(.dash.tertiaryText)
+                        .lineLimit(1)
+                }
+                Spacer()
+                if let live = row.live, live.isForSale, let priceDuffs = live.priceDuffs {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(NSLocalizedString("For sale", comment: "Username marketplace: listed badge"))
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(.dashGolden)
+                        Text("\(priceDuffs.dashAmount.formattedDashAmountWithoutCurrencySymbol) DASH")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.dash.primaryText)
+                    }
+                } else {
+                    Text(NSLocalizedString("Not for sale now", comment: "Username marketplace: browse row whose name is no longer listed"))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.dash.tertiaryText)
+                }
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.dash.secondaryBackground))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: My Names segment

--- a/DashWallet/Sources/UI/Home/Tx Metadata/CoinbaseMetadataProvider.swift
+++ b/DashWallet/Sources/UI/Home/Tx Metadata/CoinbaseMetadataProvider.swift
@@ -35,10 +35,18 @@ final class CoinbaseMetadataProvider: MetadataProvider, @unchecked Sendable {
 
     let metadataUpdated = PassthroughSubject<Data, Never>()
 
+    /// Single-flight guard for `refreshMetadata()` — both fields guarded by
+    /// `metadataQueue`. Every trigger (SwiftData save, wallet switch, DAO
+    /// change) funnels through `requestRefresh()`; requests landing while a
+    /// refresh runs collapse into one trailing rerun. Without this,
+    /// save-storms during initial sync queue unbounded concurrent refreshes
+    /// (this pegged 7 cores and 4.6GB after a mainnet recovery back when
+    /// each refresh also fetched the full wallet snapshot).
+    private var refreshInFlight = false
+    private var refreshQueued = false
+
     private init() {
-        Task {
-            await refreshMetadata()
-        }
+        requestRefresh()
 
         metadataDao.$lastChange
             .receive(on: DispatchQueue.main)
@@ -46,10 +54,8 @@ final class CoinbaseMetadataProvider: MetadataProvider, @unchecked Sendable {
                 guard let self, let change = change else { return }
 
                 switch change {
-                case .created(let metadata), .updated(let metadata, _):
-                    Task {
-                        await self.refreshMetadata()
-                    }
+                case .created, .updated:
+                    self.requestRefresh()
 
                 case .deleted(let metadata):
                     metadataQueue.sync {
@@ -74,9 +80,7 @@ final class CoinbaseMetadataProvider: MetadataProvider, @unchecked Sendable {
             .receive(on: DispatchQueue.main)
             .throttle(for: .seconds(1), scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] _ in
-                Task {
-                    await self?.refreshMetadata()
-                }
+                self?.requestRefresh()
             }
             .store(in: &cancellableBag)
 
@@ -84,19 +88,56 @@ final class CoinbaseMetadataProvider: MetadataProvider, @unchecked Sendable {
             for: SwiftDashSDKWalletState.activeWalletDidChangeNotification)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                Task {
-                    await self?.refreshMetadata()
-                }
+                self?.requestRefresh()
             }
             .store(in: &cancellableBag)
     }
 
+    /// Coalescing entry point for all refresh triggers — see the guard
+    /// fields' doc for why triggers must not spawn refreshes directly.
+    private func requestRefresh() {
+        let shouldStart: Bool = metadataQueue.sync {
+            if refreshInFlight {
+                refreshQueued = true
+                return false
+            }
+            refreshInFlight = true
+            return true
+        }
+        guard shouldStart else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            var runAgain = true
+            while runAgain {
+                await self.refreshMetadata()
+                runAgain = self.metadataQueue.sync {
+                    if self.refreshQueued {
+                        self.refreshQueued = false
+                        return true
+                    }
+                    self.refreshInFlight = false
+                    return false
+                }
+            }
+        }
+    }
+
     private func refreshMetadata() async {
         let coinbaseMetadata = metadataDao.all().filter { $0.service == ServiceName.coinbase.rawValue }
-        let current = Self.resolveMetadata(
-            storedMetadata: coinbaseMetadata,
-            walletSnapshot: CoinbaseWalletTransactionSnapshot.current(),
-            icon: coinbaseIcon())
+        // Resolve against only the rows the stored metadata points at —
+        // point lookups on the txid index. With no stored Coinbase metadata
+        // (most wallets, and every save tick during initial sync) the
+        // refresh doesn't touch the transaction store at all.
+        let current: [Data: TxRowMetadata]
+        if coinbaseMetadata.isEmpty {
+            current = [:]
+        } else {
+            current = Self.resolveMetadata(
+                storedMetadata: coinbaseMetadata,
+                walletSnapshot: CoinbaseWalletTransactionSnapshot.matching(
+                    txids: Set(coinbaseMetadata.map(\.txHash))),
+                icon: coinbaseIcon())
+        }
 
         metadataQueue.async { [weak self] in
             guard let self else { return }

--- a/DashWallet/Sources/UI/Home/Tx Metadata/SwapOrderMetadataProvider.swift
+++ b/DashWallet/Sources/UI/Home/Tx Metadata/SwapOrderMetadataProvider.swift
@@ -65,9 +65,13 @@ class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
     // MARK: - Private
 
     private func updateMetadata(from orders: [SwapOrder]) {
+        // One shared, `firstSeen`-ranged fetch feeds every order that needs
+        // the address+time buy matcher (the previous shape walked the ENTIRE
+        // wallet once per order, on every balance tick).
+        let matcherTransactions = buyMatcherTransactions(for: orders)
         var current: [Data: TxRowMetadata] = [:]
         for order in orders {
-            if let key = metadataKey(for: order) {
+            if let key = metadataKey(for: order, matcherTransactions: matcherTransactions) {
                 current[key] = makeMetadata(for: order)
             }
         }
@@ -85,28 +89,35 @@ class SwapOrderMetadataProvider: MetadataProvider, @unchecked Sendable {
         }
     }
 
-    private func metadataKey(for order: SwapOrder) -> Data? {
+    private func metadataKey(for order: SwapOrder, matcherTransactions: [Transaction]) -> Data? {
         if order.direction == "sell" {
             return Data(hex: order.id).map { Data($0.reversed()) }
         } else {
+            // `outboundTxHash` is display-order hex; the row lives under its
+            // wire-order reversal — a point lookup on the txid index (the
+            // previous shape scanned the whole wallet for the hex match).
             if let outboundTxHash = order.outboundTxHash?.trimmingCharacters(in: .whitespacesAndNewlines),
                !outboundTxHash.isEmpty,
                let txHashData = Data(hex: outboundTxHash),
-               let matchingTx = SwiftDashSDKWalletSource.fetchAll().first(
-                    where: { $0.txHashHexString.caseInsensitiveCompare(outboundTxHash) == .orderedSame }
-               ),
+               let matchingTx = SwiftDashSDKWalletSource.fetch(txid: Data(txHashData.reversed())),
                SwapBuyTransactionMatcher.matchedTransaction(for: order, in: [matchingTx]) != nil {
                 return Data(txHashData.reversed())
             }
 
-            return walletTxHashData(for: order)
+            return SwapBuyTransactionMatcher.walletTxHashData(for: order, in: matcherTransactions)
         }
     }
 
-    private func walletTxHashData(for order: SwapOrder) -> Data? {
-        // SwiftDashSDK tx set; DashSync's allTransactions is frozen (empty) post-migration.
-        let transactions = SwiftDashSDKWalletSource.fetchAll()
-        return SwapBuyTransactionMatcher.walletTxHashData(for: order, in: transactions)
+    /// Candidate pool for the buy matcher: wallet transactions first seen at/
+    /// after the oldest buy order's fetch cutoff. Empty (and fetch-free) when
+    /// no order needs matching. SwiftDashSDK tx set; DashSync's
+    /// allTransactions is frozen (empty) post-migration.
+    private func buyMatcherTransactions(for orders: [SwapOrder]) -> [Transaction] {
+        let cutoffs = orders
+            .filter { $0.direction != "sell" }
+            .map(SwapBuyTransactionMatcher.fetchCutoff(for:))
+        guard let oldest = cutoffs.min() else { return [] }
+        return SwiftDashSDKWalletSource.fetchRecent(firstSeenSince: oldest)?.transactions ?? []
     }
 
     private func refreshMetadata() {

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1316,21 +1316,26 @@ final class DWAppleWatchSnapshotProvider: NSObject {
 
     @objc
     static func hasWallet() -> Bool {
-        SwiftDashSDKWalletSource.fetchCurrentWalletSnapshot() != nil
+        SwiftDashSDKWalletSource.hasActiveWallet
     }
 
     /// The legacy bridge sent at most the account's 100 newest Core
     /// transactions. Keep that limit and ordering so existing watches receive
     /// the same archive shape and list semantics.
+    ///
+    /// The page is picked by `firstSeen` (the store's indexed timeline) and
+    /// then displayed in `date` order like before; the two only diverge by
+    /// the mempool→block timestamp skew, and never inside a 100-row window
+    /// that matters to a watch face. Scoping the fetch is what keeps a
+    /// context send from materializing a many-thousand-tx wallet.
     @objc
     static func recentTransactions() -> [DWAppleWatchTransactionSnapshot] {
-        guard let snapshot = SwiftDashSDKWalletSource.fetchCurrentWalletSnapshot() else {
+        guard let snapshot = SwiftDashSDKWalletSource.fetchRecent(limit: 100) else {
             return []
         }
 
         return snapshot.transactions
             .sorted { $0.date > $1.date }
-            .prefix(100)
             .map(makeSnapshot)
     }
 
@@ -1404,6 +1409,59 @@ class SwiftDashSDKWalletSource: TransactionSource {
     static func fetch(txid: Data) -> Transaction? {
         guard let (container, walletId) = hostHandles() else { return nil }
         return fetchOne(txid: txid, in: ModelContext(container), walletId: walletId)
+    }
+
+    /// The newest `limit` wallet transactions (`firstSeen` desc — the same
+    /// timeline the full snapshot is sorted by). Safe from any thread.
+    ///
+    /// Wallet-scoped in SQL against the `firstSeen` index (see
+    /// `scopedNewestFirst`), so callers that need a page of recent rows no
+    /// longer materialize the entire wallet the way
+    /// `fetchCurrentWalletSnapshot()` does.
+    static func fetchRecent(limit: Int) -> SwiftDashSDKWalletTransactionSnapshot? {
+        guard let (container, walletId) = hostHandles() else { return nil }
+        let transactions = scopedNewestFirst(
+            in: ModelContext(container), walletId: walletId,
+            minFirstSeen: 0, limit: limit)
+        return SwiftDashSDKWalletTransactionSnapshot(walletId: walletId, transactions: transactions)
+    }
+
+    /// Wallet transactions first seen at/after `cutoff` (`firstSeen` desc).
+    /// Safe from any thread.
+    ///
+    /// `firstSeen` is the SDK's observation stamp (wall clock when the tx
+    /// enters the mempool; the block timestamp once mined/restored), while
+    /// `Transaction.date` prefers the block timestamp — so callers matching
+    /// on the display date must pad `cutoff` with generous slack for that
+    /// skew rather than pass an exact bound (e.g.
+    /// `SwapBuyTransactionMatcher.fetchCutoff(for:)`).
+    static func fetchRecent(firstSeenSince cutoff: Date) -> SwiftDashSDKWalletTransactionSnapshot? {
+        guard let (container, walletId) = hostHandles() else { return nil }
+        let transactions = scopedNewestFirst(
+            in: ModelContext(container), walletId: walletId,
+            minFirstSeen: UInt64(max(0, cutoff.timeIntervalSince1970)), limit: nil)
+        return SwiftDashSDKWalletTransactionSnapshot(walletId: walletId, transactions: transactions)
+    }
+
+    /// The subset of wallet transactions whose txid (wire order) is in
+    /// `txids`, `firstSeen` desc. Safe from any thread. Point lookups on the
+    /// unique txid index — cost scales with `txids.count`, not with the
+    /// wallet's history size.
+    static func fetch(txids: Set<Data>) -> SwiftDashSDKWalletTransactionSnapshot? {
+        guard let (container, walletId) = hostHandles() else { return nil }
+        guard !txids.isEmpty else {
+            return SwiftDashSDKWalletTransactionSnapshot(walletId: walletId, transactions: [])
+        }
+        let context = ModelContext(container)
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { txids.contains($0.txid) },
+            sortBy: [SortDescriptor(\.firstSeen, order: .reverse)])
+        descriptor.relationshipKeyPathsForPrefetching = [\.outputs, \.inputs]
+        let rows = (try? context.fetch(descriptor)) ?? []
+        let transactions = rows
+            .filter { isWalletMember($0, walletId: walletId) }
+            .map { wrap($0, walletId: walletId) }
+        return SwiftDashSDKWalletTransactionSnapshot(walletId: walletId, transactions: transactions)
     }
 
     /// The active wallet's shielded operations as history items, for
@@ -1847,6 +1905,11 @@ class SwiftDashSDKWalletSource: TransactionSource {
         return row.account?.wallet.walletId == walletId
     }
 
+    /// Whether an active wallet is configured — the same truth
+    /// `fetchCurrentWalletSnapshot() != nil` reports, without materializing
+    /// every wallet transaction to learn it.
+    static var hasActiveWallet: Bool { hostHandles() != nil }
+
     /// The host is `@MainActor`-isolated; grab its container + active-wallet
     /// id in one brief main hop (two property reads — unlike the fetches,
     /// cheap enough to block a worker queue on). `ModelContainer` is
@@ -1878,59 +1941,160 @@ class SwiftDashSDKWalletSource: TransactionSource {
         var descriptor = FetchDescriptor<PersistentTransaction>(
             predicate: #Predicate { $0.txid == txid })
         descriptor.fetchLimit = 1
-        guard let row = (try? context.fetch(descriptor))?.first else {
+        guard let row = (try? context.fetch(descriptor))?.first,
+              isWalletMember(row, walletId: walletId) else {
             return nil
         }
-        // Membership can arrive through either side of the SDK's documented
-        // union: wallet-scoped TXOs or an account's involved-transactions
-        // relation. Accept both so an out-of-order receipt is not discarded.
-        guard row.outputs.contains(where: { $0.walletId == walletId })
+        return wrap(row, walletId: walletId)
+    }
+
+    /// Membership can arrive through either side of the SDK's documented
+    /// union: wallet-scoped TXOs or an account's involved-transactions
+    /// relation. Accept both so an out-of-order receipt is not discarded.
+    /// Reads relationships — call on the row's fetch thread.
+    private static func isWalletMember(_ row: PersistentTransaction, walletId: Data) -> Bool {
+        row.outputs.contains(where: { $0.walletId == walletId })
             || row.inputs.contains(where: { $0.walletId == walletId })
-            || row.involvedAccounts.contains(where: { $0.wallet.walletId == walletId }) else {
-            return nil
-        }
+            || row.involvedAccounts.contains(where: { $0.wallet.walletId == walletId })
+    }
+
+    /// Wrap a fetched row on its fetch thread, stamping the CoinJoin-mixing
+    /// classification (cached — see `cachedIsCoinJoinMixingTx`).
+    private static func wrap(_ row: PersistentTransaction, walletId: Data) -> Transaction {
         let tx = Transaction(persistentTransaction: row, walletId: walletId)
-        tx.sdkCoinJoinMixing = isCoinJoinMixingTx(row)
+        tx.sdkCoinJoinMixing = cachedIsCoinJoinMixingTx(row)
         return tx
     }
 
-    /// Every txid the active wallet participates in. Union the canonical TXO
-    /// membership with `PersistentAccount.involvedTransactions`, as required
-    /// by the SDK model: the latter closes out-of-order/payload-only indexing
-    /// gaps where the transaction record is saved before its TXO relationship
-    /// is available to the home timeline.
-    private static func activeWalletTxids(
+    /// SQL-scoped timeline fetch: wallet membership is evaluated inside the
+    /// store (EXISTS subqueries over the indexed `PersistentTxo.walletId`
+    /// denorm and the `involvedAccounts` join) while scanning the `firstSeen`
+    /// index newest-first, so only the returned rows are ever materialized —
+    /// unlike the full-wallet pass, whose cost is the whole history no matter
+    /// how few rows the caller needs.
+    ///
+    /// If SwiftData fails to translate the membership predicate (an OS
+    /// regression, not a data state), the fetch throws and we fall back to
+    /// the full-wallet pass — same results, old cost — and log it so the
+    /// regression is visible instead of silent.
+    private static func scopedNewestFirst(
         in context: ModelContext,
-        walletId: Data
-    ) -> Set<Data> {
-        let txoDescriptor = FetchDescriptor<PersistentTxo>(
-            predicate: #Predicate { $0.walletId == walletId })
-        let txos = (try? context.fetch(txoDescriptor)) ?? []
-        var txids = Set<Data>()
-        for txo in txos {
-            if let producing = txo.transaction { txids.insert(producing.txid) }
-            if let spending = txo.spendingTransaction { txids.insert(spending.txid) }
+        walletId: Data,
+        minFirstSeen: UInt64,
+        limit: Int?
+    ) -> [Transaction] {
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { tx in
+                tx.firstSeen >= minFirstSeen
+                    && (tx.outputs.contains(where: { $0.walletId == walletId })
+                        || tx.inputs.contains(where: { $0.walletId == walletId })
+                        || tx.involvedAccounts.contains(where: { $0.wallet.walletId == walletId }))
+            },
+            sortBy: [SortDescriptor(\.firstSeen, order: .reverse)])
+        if let limit { descriptor.fetchLimit = limit }
+        descriptor.relationshipKeyPathsForPrefetching = [\.outputs, \.inputs]
+        do {
+            return try context.fetch(descriptor).map { wrap($0, walletId: walletId) }
+        } catch {
+            DWLogger.log("SwiftDashSDKWalletSource: scoped fetch failed (\(error)); falling back to the full wallet pass")
+            return fetchAndWrap(in: context, walletId: walletId, minFirstSeen: minFirstSeen, limit: limit)
         }
+    }
 
+    /// Everything a wallet-wide wrap needs from the TXO table, computed in
+    /// one indexed scan with relationships prefetched: the member-txid union
+    /// AND the per-tx CoinJoin-account roles. Replaces the previous shape —
+    /// a txid walk plus a per-row `isCoinJoinMixingTx` traversal — whose
+    /// per-row relationship faults each cost a separate store round-trip
+    /// (multiple seconds of SwiftData CPU on a CoinJoin-heavy wallet).
+    private struct WalletTxRollup {
+        /// Every txid the wallet participates in: the canonical TXO union
+        /// plus `PersistentAccount.involvedTransactions` (payload-only
+        /// membership — see the SDK model doc on `PersistentTransaction`).
+        var txids: Set<Data> = []
+        /// Txids classified as CoinJoin mixing operations — the same rules
+        /// as `isCoinJoinMixingTx`, evaluated from the wallet's own TXO
+        /// roles (matching DashSync's per-wallet-account grouping; another
+        /// on-device wallet's stake in a shared tx doesn't classify ours).
+        var mixingTxids: Set<Data> = []
+    }
+
+    private static func walletTxRollup(in context: ModelContext, walletId: Data) -> WalletTxRollup {
+        var txoDescriptor = FetchDescriptor<PersistentTxo>(
+            predicate: #Predicate { $0.walletId == walletId })
+        txoDescriptor.relationshipKeyPathsForPrefetching = [
+            \.transaction, \.spendingTransaction, \.coreAddress, \.account,
+        ]
+        let txos = (try? context.fetch(txoDescriptor)) ?? []
+
+        var rollup = WalletTxRollup()
+        // The three classification ingredients (rules 1–3 of
+        // `isCoinJoinMixingTx`), accumulated per txid.
+        var kindOrDepositMixing: Set<Data> = []
+        var spendsCoinJoin: Set<Data> = []
+        var depositsToStandard: Set<Data> = []
+        for txo in txos {
+            let ownerType = ownerAccountType(txo)
+            if let producing = txo.transaction {
+                rollup.txids.insert(producing.txid)
+                if producing.typedKind == .coinJoin || ownerType == coinJoinAccountType {
+                    kindOrDepositMixing.insert(producing.txid)
+                }
+                if ownerType == standardAccountType {
+                    depositsToStandard.insert(producing.txid)
+                }
+            }
+            if let spending = txo.spendingTransaction {
+                rollup.txids.insert(spending.txid)
+                if spending.typedKind == .coinJoin {
+                    kindOrDepositMixing.insert(spending.txid)
+                }
+                if ownerType == coinJoinAccountType {
+                    spendsCoinJoin.insert(spending.txid)
+                }
+            }
+        }
+        rollup.mixingTxids = kindOrDepositMixing
+            .union(spendsCoinJoin.subtracting(depositsToStandard))
+
+        // Payload-only membership (e.g. a ProRegTx matched purely through
+        // its payload keys) is only representable via
+        // `PersistentAccount.involvedTransactions`; union it in, as the SDK
+        // model requires. Nearly every row here is already realized by the
+        // TXO prefetch above, so this walk no longer faults the store per tx.
         var walletDescriptor = FetchDescriptor<PersistentWallet>(
             predicate: #Predicate { $0.walletId == walletId })
         walletDescriptor.fetchLimit = 1
         if let wallet = (try? context.fetch(walletDescriptor))?.first {
             for account in wallet.accounts {
                 for transaction in account.involvedTransactions {
-                    txids.insert(transaction.txid)
+                    rollup.txids.insert(transaction.txid)
+                    if transaction.typedKind == .coinJoin {
+                        rollup.mixingTxids.insert(transaction.txid)
+                    }
                 }
             }
         }
-        return txids
+        return rollup
     }
 
-    private static func fetchAndWrap(in context: ModelContext, walletId: Data) -> [Transaction] {
-        let txids = activeWalletTxids(in: context, walletId: walletId)
-        guard !txids.isEmpty else { return [] }
-        let descriptor = FetchDescriptor<PersistentTransaction>(
-            predicate: #Predicate { txids.contains($0.txid) },
+    private static func fetchAndWrap(
+        in context: ModelContext,
+        walletId: Data,
+        minFirstSeen: UInt64 = 0,
+        limit: Int? = nil
+    ) -> [Transaction] {
+        let rollup = walletTxRollup(in: context, walletId: walletId)
+        guard !rollup.txids.isEmpty else { return [] }
+        let txids = rollup.txids
+        var descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { txids.contains($0.txid) && $0.firstSeen >= minFirstSeen },
             sortBy: [SortDescriptor(\.firstSeen, order: .reverse)])
+        if let limit { descriptor.fetchLimit = limit }
+        // Prefetch what the wrap reads (`SDKSnapshot` walks `outputs` +
+        // `inputs`) — without this every wrapped row costs two more store
+        // round-trips.
+        descriptor.relationshipKeyPathsForPrefetching = [\.outputs, \.inputs]
         let rows: [PersistentTransaction]
         do {
             rows = try context.fetch(descriptor)
@@ -1940,7 +2104,11 @@ class SwiftDashSDKWalletSource: TransactionSource {
         }
         return rows.map { row -> Transaction in
             let tx = Transaction(persistentTransaction: row, walletId: walletId)
-            tx.sdkCoinJoinMixing = Self.isCoinJoinMixingTx(row)
+            let isMixing = rollup.mixingTxids.contains(row.txid)
+            tx.sdkCoinJoinMixing = isMixing
+            // Seed the per-row cache so subsequent scoped fetches skip the
+            // relationship traversal for rows this pass already classified.
+            storeMixingClassification(txid: row.txid, stamp: row.lastUpdated, isMixing: isMixing)
             return tx
         }
     }
@@ -1948,6 +2116,43 @@ class SwiftDashSDKWalletSource: TransactionSource {
     // PersistentAccount.accountType discriminants (stable across releases).
     private static let coinJoinAccountType: UInt32 = 1 // 0=Standard(BIP44/BIP32), 1=CoinJoin
     private static let standardAccountType: UInt32 = 0
+
+    /// CoinJoin-mixing classification cache for the per-row (scoped) fetch
+    /// paths, keyed by txid and stamped with the row's `lastUpdated` — the
+    /// persistence handler bumps that on every re-upsert, so an entry
+    /// self-invalidates the next time the SDK actually rewrites the row.
+    /// Guarded by `mixingCacheLock` (entries are written from whichever
+    /// thread fetched the row). Capacity-bounded: population tracks wallet
+    /// size, and blowing the bound just resets to a cold cache.
+    private static let mixingCacheLock = NSLock()
+    private static var mixingCache: [Data: (stamp: Date, isMixing: Bool)] = [:]
+    private static let mixingCacheCapacity = 20_000
+
+    private static func storeMixingClassification(txid: Data, stamp: Date, isMixing: Bool) {
+        mixingCacheLock.lock()
+        defer { mixingCacheLock.unlock() }
+        if mixingCache.count >= mixingCacheCapacity, mixingCache[txid] == nil {
+            mixingCache.removeAll(keepingCapacity: true)
+        }
+        mixingCache[txid] = (stamp, isMixing)
+    }
+
+    /// Cached front for `isCoinJoinMixingTx` on the scoped fetch paths: a
+    /// hit skips the relationship traversal entirely; a miss computes and
+    /// seeds. Must run on the row's fetch thread (the compute path traverses
+    /// relationships). The full-wallet pass doesn't call this — it derives
+    /// every classification from its single TXO scan and seeds the cache.
+    private static func cachedIsCoinJoinMixingTx(_ row: PersistentTransaction) -> Bool {
+        let txid = row.txid
+        let stamp = row.lastUpdated
+        mixingCacheLock.lock()
+        let hit = mixingCache[txid]
+        mixingCacheLock.unlock()
+        if let hit, hit.stamp == stamp { return hit.isMixing }
+        let isMixing = isCoinJoinMixingTx(row)
+        storeMixingClassification(txid: txid, stamp: stamp, isMixing: isMixing)
+        return isMixing
+    }
 
     /// Account type owning a TXO — canonical path is `coreAddress?.account`;
     /// `account` is the fallback used before the address row is linked.
@@ -1957,7 +2162,10 @@ class SwiftDashSDKWalletSource: TransactionSource {
 
     /// CoinJoin mixing-operation detection. Traverses SwiftData relationships,
     /// so it must run on the thread that owns the row's `ModelContext` (the
-    /// fetch thread). DashSync grouped by CoinJoin-account *role*, not tx
+    /// fetch thread). Called per row only on scoped-fetch cache misses (see
+    /// `cachedIsCoinJoinMixingTx`); the full-wallet pass evaluates these same
+    /// rules set-wise in `walletTxRollup` — keep the two in lockstep.
+    /// DashSync grouped by CoinJoin-account *role*, not tx
     /// structure, so the SDK's structural `typedKind` (mixing rounds only) is
     /// too narrow. We classify a tx as a mixing operation when:
     ///   1. it DEPOSITS into the CoinJoin account (≥1 CoinJoin output) — covers

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -803,6 +803,39 @@
 /* Username marketplace: activity overlay while the contested request transition runs */
 "Submitting your username request…" = "Submitting your username request…";
 
+/* Username marketplace: browse-for-sale segment */
+"Browse" = "Browse";
+
+/* Username marketplace: browse coverage line while the scan is partial */
+"%1$d names scanned · %2$d for sale" = "%1$d names scanned · %2$d for sale";
+
+/* Username marketplace: browse coverage line once the whole network was scanned */
+"All %1$d names scanned · %2$d for sale" = "All %1$d names scanned · %2$d for sale";
+
+/* Username marketplace: browse sort option */
+"Highest price first" = "Highest price first";
+
+/* Username marketplace: browse sort option */
+"Lowest price first" = "Lowest price first";
+
+/* Username marketplace: current browse sort label */
+"Highest price" = "Highest price";
+
+/* Username marketplace: current browse sort label */
+"Lowest price" = "Lowest price";
+
+/* Username marketplace: browse scanned everything, nothing listed */
+"No names are for sale right now." = "No names are for sale right now.";
+
+/* Username marketplace: browse partial scan found nothing listed */
+"No names for sale found yet — scan more of the network below." = "No names for sale found yet — scan more of the network below.";
+
+/* Username marketplace: browse scan in progress */
+"Scanning names…" = "Scanning names…";
+
+/* Username marketplace: continue the browse scan */
+"Scan more names" = "Scan more names";
+
 /* Username marketplace: contest tallies card title */
 "Network vote so far" = "Network vote so far";
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -821,8 +821,8 @@
 /* Username marketplace: browse row whose name is no longer listed */
 "Not for sale now" = "Not for sale now";
 
-/* Username marketplace: empty price-changes feed */
-"No price changes on the network yet." = "No price changes on the network yet.";
+/* Username marketplace: price-changes feed found no live listings yet */
+"No names are for sale in the recent listing activity. Show more reaches further back." = "No names are for sale in the recent listing activity. Show more reaches further back.";
 
 /* Username marketplace: empty purchases feed */
 "No purchases on the network yet." = "No purchases on the network yet.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -806,35 +806,32 @@
 /* Username marketplace: browse-for-sale segment */
 "Browse" = "Browse";
 
-/* Username marketplace: browse coverage line while the scan is partial */
-"%1$d listings checked · %2$d for sale now" = "%1$d listings checked · %2$d for sale now";
+/* Username marketplace: browse feed of recent listings and re-prices */
+"Price changes" = "Price changes";
 
-/* Username marketplace: browse coverage line once the whole listing trail was walked */
-"All %1$d listings checked · %2$d for sale now" = "All %1$d listings checked · %2$d for sale now";
+/* Username marketplace: browse feed of recent sales */
+"Purchases" = "Purchases";
 
-/* Username marketplace: browse sort option */
-"Highest price first" = "Highest price first";
+/* Username marketplace: price-change feed row — event price, then date */
+"Listed for %1$@ DASH · %2$@" = "Listed for %1$@ DASH · %2$@";
 
-/* Username marketplace: browse sort option */
-"Lowest price first" = "Lowest price first";
+/* Username marketplace: purchases feed row — price paid, then date */
+"Sold for %1$@ DASH · %2$@" = "Sold for %1$@ DASH · %2$@";
 
-/* Username marketplace: current browse sort label */
-"Highest price" = "Highest price";
+/* Username marketplace: browse row whose name is no longer listed */
+"Not for sale now" = "Not for sale now";
 
-/* Username marketplace: current browse sort label */
-"Lowest price" = "Lowest price";
+/* Username marketplace: empty price-changes feed */
+"No price changes on the network yet." = "No price changes on the network yet.";
 
-/* Username marketplace: browse walked every listing event, nothing currently listed */
-"No names are for sale right now." = "No names are for sale right now.";
+/* Username marketplace: empty purchases feed */
+"No purchases on the network yet." = "No purchases on the network yet.";
 
-/* Username marketplace: browse partial scan found nothing currently listed */
-"No live listings found yet — check more of the listing history below." = "No live listings found yet — check more of the listing history below.";
+/* Username marketplace: browse feed loading */
+"Loading activity…" = "Loading activity…";
 
-/* Username marketplace: browse scan in progress */
-"Checking listings…" = "Checking listings…";
-
-/* Username marketplace: continue the browse scan */
-"Check more listings" = "Check more listings";
+/* Username marketplace: load older browse activity */
+"Show more" = "Show more";
 
 /* Username marketplace: contest tallies card title */
 "Network vote so far" = "Network vote so far";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -818,6 +818,9 @@
 /* Username marketplace: purchases feed row — price paid, then date */
 "Sold for %1$@ DASH · %2$@" = "Sold for %1$@ DASH · %2$@";
 
+/* Username marketplace: purchases feed row — price paid, date, then seller → buyer short ids */
+"Sold for %1$@ DASH · %2$@ · %3$@ → %4$@" = "Sold for %1$@ DASH · %2$@ · %3$@ → %4$@";
+
 /* Username marketplace: browse row whose name is no longer listed */
 "Not for sale now" = "Not for sale now";
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -807,10 +807,10 @@
 "Browse" = "Browse";
 
 /* Username marketplace: browse coverage line while the scan is partial */
-"%1$d names scanned · %2$d for sale" = "%1$d names scanned · %2$d for sale";
+"%1$d listings checked · %2$d for sale now" = "%1$d listings checked · %2$d for sale now";
 
-/* Username marketplace: browse coverage line once the whole network was scanned */
-"All %1$d names scanned · %2$d for sale" = "All %1$d names scanned · %2$d for sale";
+/* Username marketplace: browse coverage line once the whole listing trail was walked */
+"All %1$d listings checked · %2$d for sale now" = "All %1$d listings checked · %2$d for sale now";
 
 /* Username marketplace: browse sort option */
 "Highest price first" = "Highest price first";
@@ -824,17 +824,17 @@
 /* Username marketplace: current browse sort label */
 "Lowest price" = "Lowest price";
 
-/* Username marketplace: browse scanned everything, nothing listed */
+/* Username marketplace: browse walked every listing event, nothing currently listed */
 "No names are for sale right now." = "No names are for sale right now.";
 
-/* Username marketplace: browse partial scan found nothing listed */
-"No names for sale found yet — scan more of the network below." = "No names for sale found yet — scan more of the network below.";
+/* Username marketplace: browse partial scan found nothing currently listed */
+"No live listings found yet — check more of the listing history below." = "No live listings found yet — check more of the listing history below.";
 
 /* Username marketplace: browse scan in progress */
-"Scanning names…" = "Scanning names…";
+"Checking listings…" = "Checking listings…";
 
 /* Username marketplace: continue the browse scan */
-"Scan more names" = "Scan more names";
+"Check more listings" = "Check more listings";
 
 /* Username marketplace: contest tallies card title */
 "Network vote so far" = "Network vote so far";


### PR DESCRIPTION
## What

Two bodies of work that landed on this branch:

### Username-marketplace Browse tab (`f4a74b1`…`1e0d641`)
A Browse surface for names listed for sale across the network: recent-activity feed (price changes and purchases) driven by the document-history contract's listing trail, costing exactly 2 platform queries per page, with the price-changes feed filtered to names actually still for sale. Includes review-feedback fixes (cursor overlap, cancellable refresh, id validation, purchase counterparties) and the `documentList` orderBy ascending-BOOL fix.

### Scoped wallet-source fetches (`93c370a`)
`SwiftDashSDKWalletSource` previously had one shape — materialize the ENTIRE wallet (TXO walk with two relationship faults per row, giant IN-refetch, per-tx CoinJoin classification traversals) — and every consumer paid it, including the Watch bridge (needs 100 rows), Coinbase metadata (needs stored hashes only), and swap matchers (need a time window). On a CoinJoin-heavy wallet one snapshot cost multiple seconds of SwiftData CPU; diagnosed at 700% CPU / 4.6GB during a mainnet recovery sync.

- New scoped API: `fetchRecent(limit:)` / `fetchRecent(firstSeenSince:)` (firstSeen-index scan, membership as SQL EXISTS over the indexed `PersistentTxo.walletId` denorm + the `involvedAccounts` join, `fetchLimit` in the store, logged full-pass fallback if predicate translation ever regresses) and `fetch(txids:)` (unique-index point lookups).
- Full pass restructured: one prefetched TXO scan yields membership + set-wise CoinJoin classification; no per-row faults. Scoped paths use a `(txid, lastUpdated)`-stamped classification cache seeded by full passes.
- Callers migrated: Watch snapshot (newest 100 + cheap `hasActiveWallet`), `CoinbaseMetadataProvider` (stored-hash lookups + single-flight refresh), Coinbase pending-receive resolver and swap matchers (time-ranged), swap outbound-hash check (point lookup). Watch context sends coalesced to 15s.

## Why

The Browse tab is the marketplace feature itself; the perf commit removes the SwiftData meltdown that made large (CoinJoin-heavy / recovered) wallets peg the CPU on every Watch context send, Coinbase refresh, and balance tick.

## Verification

- Clean `dashpay` arm64 simulator build; testnet smoke on the QA sim (restored-wallet state, relaunched cleanly).
- Perf measured in-process on a synthetic 7,007-tx / 12,223-TXO CoinJoin-heavy mainnet store: Watch payload build 0.47–0.68s (was multi-second-plus), 8-txid metadata resolve 11ms, scoped SQL predicate translated with zero fallbacks, CoinJoin classification exactly matches the previous per-row rules (3,500/3,500 vs SQL ground truth), 526MB footprint.

## Reviewer notes

- The scoped EXISTS predicate shape is already shipped by `TransactionObserver.scan` (CrowdNode); the new code adds the `involvedAccounts` leg for payload-only membership (e.g. ProRegTx), verified translating on iOS 18.
- Mixing classification is now evaluated from the wallet's OWN TXO roles (matches DashSync's per-wallet-account grouping); a cross-wallet tx no longer classifies from another on-device wallet's stake.
- Follow-ups deliberately out of scope (tracked separately): paging the home list's full reload (still O(wallet), ~8.6s at 7k txs), and CrowdNode's doubled 6.5s restore scan at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Browse experience for username marketplace activity, including recent price changes and purchases.
  * Added pagination, pull-to-refresh, loading and empty states, sale-status details, and navigation to username details.
  * Added support for displaying historical marketplace events and current ownership information.

* **Bug Fixes**
  * Improved transaction matching for swaps and pending Coinbase transfers.
  * Reduced duplicate wallet synchronization and metadata refresh operations.

* **Performance**
  * Limited transaction searches to relevant time ranges and IDs for faster wallet activity loading.
  * Improved handling of CoinJoin transaction classification and marketplace data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->