### PR TITLE
fix(crowdnode): single history scan per restore pass instead of two

### DIFF
--- a/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
+++ b/DashWallet/Sources/Models/CrowdNode/CrowdNode.swift
@@ -223,7 +223,17 @@ extension CrowdNode {
         signUpState = SignUpState.notStarted
         validatePrefs()
 
-        if tryRestoreSignUp() {
+        // One snapshot serves the whole restore. The signup reconstruction and
+        // the linked-account confirmation lookup consume the same window —
+        // floored at 2022 because CrowdNode protocol traffic cannot predate
+        // CrowdNode — and each running the identical fetch is what doubled the
+        // multi-second scan on large wallets. No fetchLimit: a signup can sit
+        // anywhere in the post-2022 history, so a newest-first cap would drop
+        // real accounts.
+        let observed = TransactionObserver
+            .fetchObserved(firstSeenAtOrAfter: FullCrowdNodeSignUpTxSet.januaryFirst2022Epoch)
+
+        if tryRestoreSignUp(observed) {
             refreshWithdrawalLimits()
             refreshFees()
             restoreCreatedOnlineAccount(accountAddress)
@@ -232,7 +242,7 @@ extension CrowdNode {
 
         var onlineState = prefs.savedOnlineAccountState
 
-        if let address = getOnlineAccountAddress(state: onlineState) {
+        if let address = getOnlineAccountAddress(state: onlineState, observed: observed) {
             prefs.accountAddress = address
 
             if onlineState == .none {
@@ -263,11 +273,9 @@ extension CrowdNode {
         }
     }
 
-    private func tryRestoreSignUp() -> Bool {
+    private func tryRestoreSignUp(_ observed: [ObservedTransaction]) -> Bool {
         let fullSet = FullCrowdNodeSignUpTxSet()
-        TransactionObserver
-            .fetchObserved(firstSeenAtOrAfter: FullCrowdNodeSignUpTxSet.januaryFirst2022Epoch)
-            .forEach { fullSet.tryInclude($0) }
+        observed.forEach { fullSet.tryInclude($0) }
 
         if let welcomeResponse = fullSet.welcomeToApiResponse {
             precondition(welcomeResponse.toAddress != nil)
@@ -1028,12 +1036,12 @@ extension CrowdNode {
         return TransactionObserver.fetchObserved().contains { filter.matches($0) }
     }
 
-    private func getOnlineAccountAddress(state: OnlineAccountState) -> String? {
+    private func getOnlineAccountAddress(state: OnlineAccountState, observed: [ObservedTransaction]) -> String? {
         let savedAddress = prefs.accountAddress
 
         if savedAddress != nil && state != .none {
             return savedAddress
-        } else if let confirmationTx = getApiAddressConfirmationTx(),
+        } else if let confirmationTx = getApiAddressConfirmationTx(in: observed),
                   let apiAddress = confirmationTx.ownOutputAddresses.first {
             prefs.accountAddress = apiAddress
             signUpState = .linkedOnline
@@ -1045,16 +1053,11 @@ extension CrowdNode {
         return nil
     }
 
-    private func getApiAddressConfirmationTx() -> ObservedTransaction? {
+    /// `observed` is `restoreState()`'s shared snapshot of the post-2022
+    /// history — this lookup runs against it rather than fetching its own.
+    private func getApiAddressConfirmationTx(in observed: [ObservedTransaction]) -> ObservedTransaction? {
         let filter = CoinsToAddressTxFilter(coins: CrowdNode.apiConfirmationDashAmount, address: nil) // account address is unknown at this point
         let forwardedConfirmationFilter = CrowdNodeAPIConfirmationTxForwarded()
-        // Same floor the signup scan uses: an API-address confirmation is
-        // CrowdNode protocol traffic, so it cannot predate CrowdNode. Without
-        // it this walked and decoded the wallet's entire history on the main
-        // thread during restore — the more expensive of the restore's two
-        // scans, on a wallet that has no CrowdNode account at all.
-        let observed = TransactionObserver.fetchObserved(
-            firstSeenAtOrAfter: FullCrowdNodeSignUpTxSet.januaryFirst2022Epoch)
 
         // There might be several matching transactions. The real one is the
         // one whose destination CrowdNode forwarded from.

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/FullCrowdNodeSignUpTxSet.swift
@@ -36,7 +36,7 @@ final class FullCrowdNodeSignUpTxSet: GroupedTransactions, TransactionWrapper {
     static let id = "FullCrowdNodeSignUpTxSet"
     private let savedAccountAddress = CrowdNodeDefaults.shared.accountAddress
     /// Safe to assume there weren't any CrowdNode accounts before this point.
-    /// Also reused as the SwiftData fetch floor by `tryRestoreSignUp`.
+    /// Also reused as the SwiftData fetch floor by `CrowdNode.restoreState`.
     static let januaryFirst2022Epoch: UInt64 = 1_640_995_200
     private static let januaryFirst2022 = TimeInterval(januaryFirst2022Epoch)
     private var matchedFilters: [CoinsToAddressTxFilter] = []


### PR DESCRIPTION
## Issue being fixed or feature implemented

App startup on a large wallet logged "restoring CrowdNode state" followed by two identical full-history scans (`CrowdNode scan: fetch 5940 rows in 6496ms` / `6474ms` on a 7k-tx mainnet wallet — up to 38s per scan under concurrent sync load). One `restoreState()` pass ran the same SwiftData fetch twice: once in `tryRestoreSignUp()`, and — when no signup was found, i.e. on every wallet that never used CrowdNode — again in `getApiAddressConfirmationTx()` via `getOnlineAccountAddress()`. Each fetch materializes every post-2022 row (~1.1ms/row), so the common case paid the multi-second cost twice at every launch sync-done.

## What was done?

- `restoreState()` now fetches one shared snapshot (`fetchObserved(firstSeenAtOrAfter: januaryFirst2022Epoch)`) and passes it to both consumers: `tryRestoreSignUp(_:)` and `getOnlineAccountAddress(state:observed:)` → `getApiAddressConfirmationTx(in:)`.
- Every restore path now performs exactly one scan (previously one or two); no consumer sees fewer rows than it needs. The existing in-session fruitless-scan memo is unchanged and still suppresses repeat scans.
- Deliberately no `fetchLimit`: the fetch is newest-first, so a cap would silently drop old signup transactions and fail to restore real accounts — now documented at the fetch site.
- Doc-comment fix in `FullCrowdNodeSignUpTxSet` (the floor constant is applied by `restoreState`, not `tryRestoreSignUp`).

Reviewer note: skipping the restore scan outright under the CrowdNode-suspension release posture was considered and rejected for now — the suspension is not implemented on this branch (Explore menu, shortcuts, balance reminder, and interrupted-signup resume all still consume restored CrowdNode state). If/when the hide lands, gating `checkCrowdNodeState()` behind the same flag can zero this cost entirely.

## How Has This Been Tested?

- Clean `dashpay` scheme build (arm64 simulator).
- Smoke on the QA-iPhone16 simulator against a synthetic 7,007-tx mainnet store: pre-fix log shows `restoring CrowdNode state` followed by two `CrowdNode scan` lines (12,005ms + 38,585ms in the worst observed launch); with this fix the same launch logs exactly one scan (`fetch 5944 rows in 11035ms`) followed by `CrowdNode: account not found`, and the in-session memo still prevents any further scans.
- Unit-test target is currently broken repo-wide (pre-existing), so no new tests were added.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CrowdNode account and linked-account restoration by using a consistent transaction history snapshot.
  * Reduced redundant transaction-history retrieval during state restoration.
* **Documentation**
  * Updated the signup transaction timestamp guidance to reference the current restoration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->