### PR TITLE
fix(ui): CoinJoin-funded shielded transfers render as Internal Transfer, not Mixing

### DIFF
--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -161,7 +161,23 @@ class Transaction: TransactionDataItem, Identifiable {
     /// account — see `SwiftDashSDKWalletSource.isCoinJoinMixingTx`), NOT just
     /// the SDK's structural `typedKind`, which only tags the mixing *rounds*
     /// and misses create-denomination / collateral / mixing-fee txs.
-    var isCoinJoinMixing: Bool { sdkCoinJoinMixing }
+    ///
+    /// Asset-lock funding transfers (Shielded / Platform / identity) are
+    /// excluded even when they draw on the CoinJoin account: draining mixed
+    /// funds is a transfer *out of* mixing, not a mixing operation, and must
+    /// render as its own Internal Transfer row instead of folding into the
+    /// "Mixing Transactions" group.
+    var isCoinJoinMixing: Bool { sdkCoinJoinMixing && !isCoinJoinFundedTransfer }
+
+    /// True when this asset-lock funding transfer drew on the CoinJoin
+    /// account (mixed funds moving out) rather than the Standard account.
+    /// Rides the role-computed mixing flag: for an asset-lock funding tx that
+    /// flag is set exactly when its inputs or change touch the CoinJoin
+    /// account — a BIP44/BIP32-funded transfer never sets it.
+    var isCoinJoinFundedTransfer: Bool {
+        sdkCoinJoinMixing
+            && (isShieldedTransfer || isPlatformFundingTransfer || isIdentityFundingTransfer)
+    }
 
     /// Raw signed wallet net change (duffs). Used to total a CoinJoin mixing
     /// group's cost: summing this across the group yields the net wallet

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -701,6 +701,9 @@ struct HomeViewContent<Content: View>: View {
     private func transferRouteDetails(txItem: Transaction) -> String? {
         switch txItem.internalTransferRoute {
         case .coreToShielded:
+            if txItem.isCoinJoinFundedTransfer {
+                return NSLocalizedString("CoinJoin → Shielded", comment: "Transfer of own mixed funds into the private shielded balance")
+            }
             return NSLocalizedString("Transparent → Shielded", comment: "Transfer of own funds into the private shielded balance")
         case .shieldedToCore:
             return NSLocalizedString("Shielded → Transparent", comment: "Transfer of own funds from the private shielded balance back to the transparent wallet")

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -423,8 +423,11 @@ extension TxDetailModel {
         let transparent = NSLocalizedString("Transparent balance", comment: "The transparent (Core) balance of the Dash Wallet")
         let shielded = NSLocalizedString("Shielded balance", comment: "")
         if transaction.isShieldedTransfer {
+            let source = transaction.isCoinJoinFundedTransfer
+                ? NSLocalizedString("CoinJoin balance", comment: "The wallet's mixed (CoinJoin) funds as the source of an internal transfer")
+                : transparent
             var rows: [DWTitleDetailItem] = [
-                DWTitleDetailCellModel(style: .default, title: NSLocalizedString("From", comment: ""), plainDetail: transparent),
+                DWTitleDetailCellModel(style: .default, title: NSLocalizedString("From", comment: ""), plainDetail: source),
                 DWTitleDetailCellModel(style: .default, title: NSLocalizedString("To", comment: ""), plainDetail: shielded),
             ]
             if let status = shieldedStatusText {


### PR DESCRIPTION
## Problem

Moving CoinJoin funds to the Shielded balance (the post-recovery sweep, or any CoinJoin-funded shield) produced a history row grouped under **"Mixing Transactions"**. The drain's asset-lock funding tx spends CoinJoin-account inputs and deposits nothing into a Standard account, so the role-based mixing classifier's rule 2 (mixing-fee / collateral spends) claimed it.

Draining mixed funds is a transfer *out of* mixing, not a mixing operation — it should stand as its own Internal Transfer row.

## Fix

- `Transaction.isCoinJoinMixing` excludes asset-lock funding transfers (Shielded / Platform / identity — same bug class) via a new `isCoinJoinFundedTransfer` property. Filtering at the computed property covers both the paged and full fetch paths without touching the classifier internals.
- Home-row route pill: **"CoinJoin → Shielded"** when the transfer drew on mixed funds.
- Details sheet From row: **"CoinJoin balance"** for CoinJoin-funded shielded transfers.

(The dust-aware sweep prompt + persistent "Later" change that briefly appeared in this description was pushed after this PR merged — it lives in its own follow-up PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)