### PR TITLE
fix(coinjoin): dust never prompts the sweep, and Later is remembered

### DIFF
--- a/DashWallet/Sources/Models/CoinJoin/CoinJoinRecovery.swift
+++ b/DashWallet/Sources/Models/CoinJoin/CoinJoinRecovery.swift
@@ -77,6 +77,12 @@ final class CoinJoinRecovery: NSObject {
         "coinJoinRecovery.v1.recovered.\(networkTag(network))"
     }
 
+    /// CoinJoin balance (duffs) at the moment the user last chose "Later" on
+    /// the post-sync sweep prompt. Absent = never dismissed.
+    private func sweepPromptDismissedBalanceKey(_ network: Network) -> String {
+        "coinJoinRecovery.v1.sweepPromptDismissedBalance.\(networkTag(network))"
+    }
+
     // MARK: - API
 
     /// Whether the one-time wide CoinJoin recovery gap should be applied for
@@ -102,6 +108,29 @@ final class CoinJoinRecovery: NSObject {
             "🪙 CJRECOV :: recovery complete for \(self.networkTag(network), privacy: .public) — reverting to default gap")
     }
 
+    /// Record that the user chose "Later" on the post-sync sweep prompt while
+    /// holding `balanceDuffs`. The prompt stays suppressed while the CoinJoin
+    /// balance sits at or below this value; mixing new coins (the balance
+    /// rising above it) re-arms the prompt. The Tools / Settings
+    /// "Move CoinJoin Funds" rows stay available throughout. Thread-safe.
+    func recordSweepPromptDismissal(balanceDuffs: UInt64, for network: Network) {
+        lock.lock(); defer { lock.unlock() }
+        defaults.set(balanceDuffs, forKey: sweepPromptDismissedBalanceKey(network))
+        Self.logger.info(
+            "🪙 CJRECOV :: sweep prompt deferred at \(balanceDuffs, privacy: .public) duffs on \(self.networkTag(network), privacy: .public)")
+    }
+
+    /// Whether an earlier "Later" suppresses the sweep prompt at the current
+    /// balance. False once the balance exceeds the dismissed amount (new
+    /// mixed coins arrived since the dismissal). Thread-safe.
+    func isSweepPromptSuppressed(currentBalanceDuffs: UInt64, for network: Network) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard let stored = defaults.object(forKey: sweepPromptDismissedBalanceKey(network)) as? UInt64 else {
+            return false
+        }
+        return currentBalanceDuffs <= stored
+    }
+
     /// Clear the terminal per-network recovery flags on a wallet wipe so a
     /// wallet restored afterwards re-runs the one-time wide CoinJoin scan. The
     /// flag is app-level (UserDefaults), not per-wallet, and a wipe deletes the
@@ -114,6 +143,8 @@ final class CoinJoinRecovery: NSObject {
         lock.lock(); defer { lock.unlock() }
         defaults.removeObject(forKey: recoveredKey(.mainnet))
         defaults.removeObject(forKey: recoveredKey(.testnet))
+        defaults.removeObject(forKey: sweepPromptDismissedBalanceKey(.mainnet))
+        defaults.removeObject(forKey: sweepPromptDismissedBalanceKey(.testnet))
         Self.logger.info(
             "🪙 CJRECOV :: recovery flags cleared on wipe — next wallet re-runs the one-time wide scan")
     }

--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -556,7 +556,9 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
             },
             negativeButtonText: NSLocalizedString("Later", comment: "CoinJoin"),
             negativeButtonAction: {
-                self.viewModel.showCoinJoinSweepDialog = false
+                // Persisted: stops the per-launch re-prompt until new mixed
+                // coins arrive; the Tools/Settings row stays available.
+                self.viewModel.deferCoinJoinSweep()
             }
         )
     }

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -494,7 +494,13 @@ struct HomeViewContent<Content: View>: View {
                 pendingShieldedRecovery = nil
             }
         }
-        .sheet(isPresented: $viewModel.showCoinJoinMoveFundsSheet) {
+        .sheet(
+            isPresented: $viewModel.showCoinJoinMoveFundsSheet,
+            // Any dismissal (close button or swipe) counts as "Later": persist
+            // it so the prompt stops re-arming every launch. After a completed
+            // move the recorded balance is moot — the leftover is gone.
+            onDismiss: { viewModel.deferCoinJoinSweep() }
+        ) {
             CoinJoinMoveFundsSheet(amountDuffs: viewModel.coinJoinSweepAmountDuffs) {
                 viewModel.showCoinJoinMoveFundsSheet = false
             }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -1215,16 +1215,39 @@ extension HomeViewModel {
     /// sheet (`CoinJoinMoveFundsSheet`) is shown instead of the BIP44-only
     /// dialog.
     func maybeShowCoinJoinSweepDialog() {
-        DWLogger.log("HomeViewModel: sweep dialog check — \(coinJoinSweepAmountDuffs) duffs (\(String(format: "%.6f", Double(coinJoinSweepAmountDuffs) / Double(kOneDash))) DASH), threshold \(CoinJoinRecovery.recoveryDustThresholdDuffs), above=\(coinJoinSweepAmountDuffs > CoinJoinRecovery.recoveryDustThresholdDuffs), syncDone=\(syncModel.state == .syncDone), alreadyShown=\(coinJoinSweepDialogShown)")
+        let balance = coinJoinSweepAmountDuffs
+        // Economic floor: below the L1-fee allowance a drain of many tiny
+        // mixed inputs cannot pay its own fee — prompting would offer a sweep
+        // that can never succeed. Dust leftovers stay visible (and manually
+        // sweepable) via the Tools / Settings "Move CoinJoin Funds" rows,
+        // which keep the lower `recoveryDustThresholdDuffs` floor.
+        let viableFloor = max(WalletBalance.sendFeeReserveDuffs, CoinJoinRecovery.recoveryDustThresholdDuffs)
+        let suppressed = WalletEnvironment.network.map {
+            CoinJoinRecovery.shared.isSweepPromptSuppressed(currentBalanceDuffs: balance, for: $0)
+        } ?? false
+        DWLogger.log("HomeViewModel: sweep dialog check — \(balance) duffs (\(String(format: "%.6f", Double(balance) / Double(kOneDash))) DASH), viableFloor \(viableFloor), above=\(balance > viableFloor), suppressed=\(suppressed), syncDone=\(syncModel.state == .syncDone), alreadyShown=\(coinJoinSweepDialogShown)")
         guard !coinJoinSweepDialogShown,
               syncModel.state == .syncDone,
-              coinJoinSweepAmountDuffs > CoinJoinRecovery.recoveryDustThresholdDuffs else { return }
+              balance > viableFloor,
+              !suppressed else { return }
         coinJoinSweepDialogShown = true
         if coinJoinShieldDestinationAvailable {
             showCoinJoinMoveFundsSheet = true
         } else {
             showCoinJoinSweepDialog = true
         }
+    }
+
+    /// "Later" on either sweep surface: persist the dismissal (keyed to the
+    /// current balance, so newly mixed coins re-arm the prompt) and close the
+    /// surface. The Tools / Settings rows remain the durable entry points.
+    func deferCoinJoinSweep() {
+        if let network = WalletEnvironment.network {
+            CoinJoinRecovery.shared.recordSweepPromptDismissal(
+                balanceDuffs: coinJoinSweepAmountDuffs, for: network)
+        }
+        showCoinJoinSweepDialog = false
+        showCoinJoinMoveFundsSheet = false
     }
 
     /// Sweep the leftover CoinJoin balance into the user's spendable balance


### PR DESCRIPTION
Follow-up to #978.

## Problem

The post-sync "move your CoinJoin funds" prompt re-armed on **every launch** for any leftover above 1000 duffs — including dust a drain transaction can never sweep (the L1 fee of spending many tiny mixed inputs exceeds their value). A forever-nag offering an action that cannot succeed.

## Fix

- **Economic floor**: the prompt now requires the leftover to clear `WalletBalance.sendFeeReserveDuffs` (the same L1-fee allowance the drain itself budgets) instead of the bare dust threshold. Dust leftovers stay visible — and manually sweepable — via the existing Tools and Settings "Move CoinJoin Funds" rows, which keep the lower floor.
- **Persistent "Later"**: any dismissal (dialog button, sheet close, sheet swipe-down) is stored per network, keyed to the balance at that moment. The prompt stays quiet until newly mixed coins raise the balance above the dismissed mark, and the flag clears on wallet wipe alongside the other recovery flags.

## Verification

Clean `dashpay` scheme build (arm64 sim) against platform `v4.2-dev` @ `e0b8baa8`. Repro wallet on hand (mainnet recovery with CoinJoin dust that re-prompted each launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CoinJoin sweep prompt behavior by remembering when it was dismissed.
  - Sweep prompts now reappear when new mixed funds increase the balance.
  - Dismissing the move-funds sheet—using a button or swipe—now consistently defers the prompt.
  - Dismissal settings are cleared when the wallet is wiped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->