### PR TITLE
feat: recovery actions for network-dropped unconfirmed transactions

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -83,12 +83,17 @@ struct UnconfirmedTransactionRemover {
     /// at least ~30 hours even for a fresh transaction, at most ~5 weeks
     /// for a long-stuck one.
     private static let minRescanBlocks: UInt32 = 720
-    private static let maxRescanBlocks: UInt32 = 20_000
     /// Extra rewind margin below the transaction's first-seen height
     /// estimate (~1 day), covering clock skew and variable block times.
     private static let rescanMarginBlocks: UInt32 = 576
 
-    func remove(txidWire: Data) async throws {
+    /// - Returns: whether the recovery filter rescan was armed. `false`
+    ///   means the removal itself succeeded but the rescan didn't start
+    ///   (SPV not running / arm threw) — the caller should tell the user
+    ///   to run Rescan Filters manually so the safety net isn't silently
+    ///   skipped.
+    @discardableResult
+    func remove(txidWire: Data) async throws -> Bool {
         guard let container = SwiftDashSDKHost.shared.modelContainer,
               let network = WalletEnvironment.network,
               let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
@@ -108,7 +113,6 @@ struct UnconfirmedTransactionRemover {
         guard row.context == 0, row.blockHeight == 0 else {
             throw RemovalError.confirmedLocally
         }
-        let firstSeen: UInt64 = row.firstSeen
 
         // 2. The claim in the button title is checked, not assumed: a
         //    transaction the explorer knows (mempool or mined) is never
@@ -118,14 +122,32 @@ struct UnconfirmedTransactionRemover {
             throw RemovalError.transactionOnChain
         }
 
-        // 3. Persistence surgery, then the shared reload + rescan +
+        // 3. The explorer check suspended the main actor, so nothing from
+        //    step 1 is trusted anymore: a filter match can have confirmed
+        //    the transaction, or the active wallet can have switched.
+        //    Re-resolve and re-validate everything before touching rows.
+        guard WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) == walletId else {
+            throw RemovalError.notReady
+        }
+        guard let freshRow = try context.fetch(descriptor).first else {
+            throw RemovalError.transactionNotFound
+        }
+        guard freshRow.context == 0, freshRow.blockHeight == 0 else {
+            throw RemovalError.confirmedLocally
+        }
+        guard SwiftDashSDKWalletSource.isWalletMember(freshRow, walletId: walletId) else {
+            throw RemovalError.transactionNotFound
+        }
+        let firstSeen: UInt64 = freshRow.firstSeen
+
+        // 4. Persistence surgery, then the shared reload + rescan +
         //    cache-refresh tail.
-        Self.excise(row, in: context)
+        Self.excise(freshRow, in: context)
         try Self.deleteAssetLockBookmarks(forDisplayTxids: [displayTxid], walletId: walletId, in: context)
         try context.save()
         Self.logger.notice("🗑️ TX-REMOVE :: deleted \(displayTxid, privacy: .public)")
 
-        try await Self.finishRemoval(
+        return await Self.finishRemoval(
             txidsWire: [txidWire], walletId: walletId, oldestFirstSeen: firstSeen)
     }
 
@@ -137,16 +159,18 @@ struct UnconfirmedTransactionRemover {
     /// a dropped transaction that IS on the blockchain is re-matched and
     /// restored by it. Nothing is sent to the network.
     ///
-    /// - Returns: how many transactions were dropped. 0 means there was
-    ///   nothing to drop; no reload or rescan runs in that case.
-    func dropAllUnconfirmedAndRescan() async throws -> Int {
+    /// - Returns: how many transactions were dropped (0 = nothing to
+    ///   drop; no reload or rescan runs), and whether the recovery
+    ///   rescan was armed — `false` after a successful drop means the
+    ///   caller must tell the user to run Rescan Filters manually.
+    func dropAllUnconfirmedAndRescan() async throws -> (dropped: Int, rescanArmed: Bool) {
         guard let container = SwiftDashSDKHost.shared.modelContainer,
               let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
             throw RemovalError.notReady
         }
         let context = container.mainContext
         let rows = try Self.unconfirmedRows(in: context, walletId: walletId)
-        guard !rows.isEmpty else { return 0 }
+        guard !rows.isEmpty else { return (dropped: 0, rescanArmed: true) }
 
         var oldestFirstSeen = UInt64.max
         var displayTxids: [String] = []
@@ -161,9 +185,9 @@ struct UnconfirmedTransactionRemover {
         try context.save()
         Self.logger.notice("🗑️ TX-REMOVE :: bulk-dropped \(rows.count, privacy: .public) unconfirmed tx(s): \(displayTxids.joined(separator: ","), privacy: .public)")
 
-        try await Self.finishRemoval(
+        let rescanArmed = await Self.finishRemoval(
             txidsWire: txidsWire, walletId: walletId, oldestFirstSeen: oldestFirstSeen)
-        return rows.count
+        return (dropped: rows.count, rescanArmed: rescanArmed)
     }
 
     /// The active wallet's unconfirmed (mempool-context, no block) rows —
@@ -223,10 +247,13 @@ struct UnconfirmedTransactionRemover {
 
     /// Shared removal tail, after the rows are deleted and saved:
     /// app-side metadata cleanup, full runtime reload, filter rescan,
-    /// and cache refresh.
+    /// and cache refresh. Returns whether the rescan was armed — the
+    /// rescan is the recovery step that restores a wrongly-removed
+    /// on-chain transaction, so callers surface `false` to the user
+    /// instead of claiming a complete recovery.
     private static func finishRemoval(
         txidsWire: [Data], walletId: Data, oldestFirstSeen: UInt64
-    ) async throws {
+    ) async -> Bool {
         // App-side metadata (tax category override) keyed by the same
         // hash — a fresh install knows nothing about a removed tx, and
         // neither should this one.
@@ -243,19 +270,23 @@ struct UnconfirmedTransactionRemover {
         // rebroadcasting) restarts without the removed transactions.
         await SwiftDashSDKWalletRuntime.shared.rearmPlatformSync()
 
-        // Rescan recent compact filters, reaching back past the oldest
-        // removed transaction's first appearance: if a removed tx IS
-        // mined, the re-match finds it and the wallet state repairs
-        // itself. Best-effort — a failed arm is logged, not surfaced as
-        // a failed removal.
+        // Rescan compact filters, reaching back past the OLDEST removed
+        // transaction's first appearance — uncapped in depth, because
+        // this is the step that restores a removed tx that actually IS
+        // mined (the bulk path never explorer-checked, and the single
+        // path's explorer can be wrong). The SDK floors the rescan at
+        // the wallet's birth height and the locally stored chain data;
+        // a row with no usable first-seen time rescans from the floor.
+        var rescanArmed = false
         let tip = SwiftDashSDKSPVCoordinator.shared.tipHeight
         if tip > 0, let manager = SwiftDashSDKHost.shared.manager {
             let ageSeconds = max(0, Date().timeIntervalSince1970 - TimeInterval(oldestFirstSeen))
             let ageBlocks = UInt32(clamping: Int(ageSeconds / 150)) + rescanMarginBlocks
-            let blocksBack = min(maxRescanBlocks, max(minRescanBlocks, ageBlocks))
+            let blocksBack = max(minRescanBlocks, ageBlocks)
             let fromHeight = tip > blocksBack ? tip - blocksBack : 1
             do {
                 try manager.spvRescanFilters(walletId: walletId, fromHeight: fromHeight)
+                rescanArmed = true
                 logger.notice("🗑️ TX-REMOVE :: filter rescan armed from height \(fromHeight, privacy: .public) (tip \(tip, privacy: .public))")
             } catch {
                 logger.error("🗑️ TX-REMOVE :: filter rescan arm failed: \(String(describing: error), privacy: .public)")
@@ -266,6 +297,7 @@ struct UnconfirmedTransactionRemover {
 
         // App caches that mirror the deleted rows.
         ShieldedTxLookup.shared.refresh()
+        return rescanArmed
     }
 
     /// One GET against the network's Insight API. 200 = the explorer

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -79,9 +79,11 @@ struct UnconfirmedTransactionRemover {
         }
     }
 
-    /// Compact-filter rescan window bounds, in blocks (~2.5 min each):
-    /// at least ~30 hours even for a fresh transaction, at most ~5 weeks
-    /// for a long-stuck one.
+    /// Minimum compact-filter rescan window, in blocks (~2.5 min each):
+    /// at least ~30 hours even for a fresh transaction. There is no
+    /// maximum — recovery depth is uncapped and reaches back past the
+    /// oldest removed transaction's first appearance, bounded only by
+    /// the SDK's wallet birth-height / stored-chain-data floors.
     private static let minRescanBlocks: UInt32 = 720
     /// Extra rewind margin below the transaction's first-seen height
     /// estimate (~1 day), covering clock skew and variable block times.
@@ -160,9 +162,10 @@ struct UnconfirmedTransactionRemover {
     /// restored by it. Nothing is sent to the network.
     ///
     /// - Returns: how many transactions were dropped (0 = nothing to
-    ///   drop; no reload or rescan runs), and whether the recovery
-    ///   rescan was armed — `false` after a successful drop means the
-    ///   caller must tell the user to run Rescan Filters manually.
+    ///   drop; no reload or rescan runs, so `rescanArmed` is `false`),
+    ///   and whether the recovery rescan was armed — `false` after a
+    ///   non-zero drop means the caller must tell the user to run
+    ///   Rescan Filters manually.
     func dropAllUnconfirmedAndRescan() async throws -> (dropped: Int, rescanArmed: Bool) {
         guard let container = SwiftDashSDKHost.shared.modelContainer,
               let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
@@ -170,7 +173,7 @@ struct UnconfirmedTransactionRemover {
         }
         let context = container.mainContext
         let rows = try Self.unconfirmedRows(in: context, walletId: walletId)
-        guard !rows.isEmpty else { return (dropped: 0, rescanArmed: true) }
+        guard !rows.isEmpty else { return (dropped: 0, rescanArmed: false) }
 
         var oldestFirstSeen = UInt64.max
         var displayTxids: [String] = []

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -2,11 +2,16 @@
 //  UnconfirmedTransactionRemover.swift
 //  DashWallet
 //
-//  Removes a never-accepted transaction from local wallet state — the
-//  tx-detail "Remove if not on Blockchain" action for a stuck asset
-//  lock the network keeps rejecting (rebroadcasts end "outcome
-//  uncertain", the tx is on no explorer, and the coins it tried to
-//  spend stay locked forever).
+//  Removes never-accepted transactions from local wallet state. Two
+//  entry points share the surgery:
+//  - `remove(txidWire:)` — the tx-detail "Remove if not on Blockchain"
+//    action for one stuck transaction (a parked asset lock, or any
+//    network-dropped send such as a stalled CoinJoin sweep chunk);
+//    explorer-checked per the rails below.
+//  - `dropAllUnconfirmedAndRescan()` — the Core Sync screen's bulk
+//    variant over every mempool-context row of the active wallet; it
+//    skips the per-tx explorer check and relies on the filter rescan
+//    to restore anything that was actually on-chain.
 //
 //  There is no removal API at any FFI layer (verified against the
 //  pinned rust-dashcore/platform revs: key-wallet has no
@@ -113,71 +118,153 @@ struct UnconfirmedTransactionRemover {
             throw RemovalError.transactionOnChain
         }
 
-        // 3. Persistence surgery. Inputs first: the `.nullify` inverse on
-        //    `PersistentTransaction.inputs` only clears the relationship —
-        //    the denormalized `isSpent` column must be flipped explicitly
-        //    or the restore buffer would keep excluding these TXOs from
-        //    the spendable set.
-        let unspentInputCount = row.inputs.count
+        // 3. Persistence surgery, then the shared reload + rescan +
+        //    cache-refresh tail.
+        Self.excise(row, in: context)
+        try Self.deleteAssetLockBookmarks(forDisplayTxids: [displayTxid], walletId: walletId, in: context)
+        try context.save()
+        Self.logger.notice("🗑️ TX-REMOVE :: deleted \(displayTxid, privacy: .public)")
+
+        try await Self.finishRemoval(
+            txidsWire: [txidWire], walletId: walletId, oldestFirstSeen: firstSeen)
+    }
+
+    /// Bulk diagnostic for the Core Sync screen: drop EVERY unconfirmed
+    /// (mempool-context, no block) transaction of the active wallet, free
+    /// the TXOs they tried to spend, and rescan recent filters back past
+    /// the oldest dropped transaction. Unlike `remove(txidWire:)` there is
+    /// no per-transaction explorer check — the rescan is the safety rail:
+    /// a dropped transaction that IS on the blockchain is re-matched and
+    /// restored by it. Nothing is sent to the network.
+    ///
+    /// - Returns: how many transactions were dropped. 0 means there was
+    ///   nothing to drop; no reload or rescan runs in that case.
+    func dropAllUnconfirmedAndRescan() async throws -> Int {
+        guard let container = SwiftDashSDKHost.shared.modelContainer,
+              let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
+            throw RemovalError.notReady
+        }
+        let context = container.mainContext
+        let rows = try Self.unconfirmedRows(in: context, walletId: walletId)
+        guard !rows.isEmpty else { return 0 }
+
+        var oldestFirstSeen = UInt64.max
+        var displayTxids: [String] = []
+        var txidsWire: [Data] = []
+        for row in rows {
+            oldestFirstSeen = min(oldestFirstSeen, row.firstSeen)
+            displayTxids.append(Transaction.displayHex(row.txid))
+            txidsWire.append(row.txid)
+            Self.excise(row, in: context)
+        }
+        try Self.deleteAssetLockBookmarks(forDisplayTxids: displayTxids, walletId: walletId, in: context)
+        try context.save()
+        Self.logger.notice("🗑️ TX-REMOVE :: bulk-dropped \(rows.count, privacy: .public) unconfirmed tx(s): \(displayTxids.joined(separator: ","), privacy: .public)")
+
+        try await Self.finishRemoval(
+            txidsWire: txidsWire, walletId: walletId, oldestFirstSeen: oldestFirstSeen)
+        return rows.count
+    }
+
+    /// The active wallet's unconfirmed (mempool-context, no block) rows —
+    /// exactly what `dropAllUnconfirmedAndRescan` would remove. Membership
+    /// is relationship-based (`SwiftDashSDKWalletSource.isWalletMember`),
+    /// so call on the main context's thread.
+    static func unconfirmedRows(in context: ModelContext, walletId: Data) throws -> [PersistentTransaction] {
+        try context.fetch(FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate { $0.context == 0 && $0.blockHeight == 0 }))
+            .filter { SwiftDashSDKWalletSource.isWalletMember($0, walletId: walletId) }
+    }
+
+    /// Count variant of `unconfirmedRows` for UI display; 0 when no wallet
+    /// is bound or the fetch fails.
+    static func unconfirmedCount() -> Int {
+        guard let container = SwiftDashSDKHost.shared.modelContainer,
+              let walletId = WalletEnvironment.activeWalletId(for: WalletEnvironment.networkKind) else {
+            return 0
+        }
+        return (try? unconfirmedRows(in: container.mainContext, walletId: walletId).count) ?? 0
+    }
+
+    /// Persistence surgery for one row. Inputs first: the `.nullify`
+    /// inverse on `PersistentTransaction.inputs` only clears the
+    /// relationship — the denormalized `isSpent` column must be flipped
+    /// explicitly or the restore buffer would keep excluding these TXOs
+    /// from the spendable set. Deleting the row then cascades its own
+    /// outputs and unresolved pending-input placeholders. The caller
+    /// saves the context.
+    private static func excise(_ row: PersistentTransaction, in context: ModelContext) {
         for spent in row.inputs {
             spent.isSpent = false
             spent.spendingTransaction = nil
             spent.spendingInputIndex = nil
             spent.lastUpdated = Date()
         }
-        // Deleting the row cascades its own outputs and unresolved
-        // pending-input placeholders.
         context.delete(row)
-        // The asset-lock bookmark (any vout of this txid): the row that
-        // makes launch-time recovery re-track and re-broadcast the lock.
-        // Tiny table — fetch by wallet and filter in Swift, same as
-        // ShieldedTxLookup.
-        let lockPrefix = displayTxid.lowercased() + ":"
+    }
+
+    /// Delete the asset-lock bookmarks (any vout of the given txids): the
+    /// rows that make launch-time recovery re-track and re-broadcast a
+    /// lock. Tiny table — fetch by wallet and filter in Swift, same as
+    /// ShieldedTxLookup. The caller saves the context.
+    private static func deleteAssetLockBookmarks(
+        forDisplayTxids displayTxids: [String], walletId: Data, in context: ModelContext
+    ) throws {
+        let prefixes = displayTxids.map { $0.lowercased() + ":" }
         let locks = try context.fetch(FetchDescriptor<PersistentAssetLock>(
             predicate: PersistentAssetLock.predicate(walletId: walletId)))
-        for lock in locks where lock.outPointHex.lowercased().hasPrefix(lockPrefix) {
-            context.delete(lock)
+        for lock in locks {
+            let outPoint = lock.outPointHex.lowercased()
+            if prefixes.contains(where: { outPoint.hasPrefix($0) }) {
+                context.delete(lock)
+            }
         }
-        try context.save()
-        Self.logger.notice("🗑️ TX-REMOVE :: deleted \(displayTxid, privacy: .public) — \(unspentInputCount, privacy: .public) input(s) unspent")
+    }
 
+    /// Shared removal tail, after the rows are deleted and saved:
+    /// app-side metadata cleanup, full runtime reload, filter rescan,
+    /// and cache refresh.
+    private static func finishRemoval(
+        txidsWire: [Data], walletId: Data, oldestFirstSeen: UInt64
+    ) async throws {
         // App-side metadata (tax category override) keyed by the same
         // hash — a fresh install knows nothing about a removed tx, and
         // neither should this one.
-        if let metadata = TransactionMetadataDAOImpl.shared.get(by: txidWire) {
-            TransactionMetadataDAOImpl.shared.delete(dto: metadata)
+        for txidWire in txidsWire {
+            if let metadata = TransactionMetadataDAOImpl.shared.get(by: txidWire) {
+                TransactionMetadataDAOImpl.shared.delete(dto: metadata)
+            }
         }
 
-        // 4. Full runtime reload — the same serialized stop → load →
-        //    start lifecycle a network switch runs. The reloaded Rust
-        //    wallet rebuilds its tx set, UTXOs and spent_outpoints from
-        //    the rows as they now are, and dash-spv's mempool tracker
-        //    (which kept rebroadcasting) restarts without the tx.
+        // Full runtime reload — the same serialized stop → load → start
+        // lifecycle a network switch runs. The reloaded Rust wallet
+        // rebuilds its tx set, UTXOs and spent_outpoints from the rows as
+        // they now are, and dash-spv's mempool tracker (which kept
+        // rebroadcasting) restarts without the removed transactions.
         await SwiftDashSDKWalletRuntime.shared.rearmPlatformSync()
 
-        // 5. Rescan recent compact filters, reaching back past the
-        //    removed transaction's first appearance: if the explorer was
-        //    wrong and the tx IS mined, the re-match finds it and the
-        //    wallet state repairs itself. Best-effort — the removal
-        //    already verified off-chain status; a failed arm is logged,
-        //    not surfaced as a failed removal.
+        // Rescan recent compact filters, reaching back past the oldest
+        // removed transaction's first appearance: if a removed tx IS
+        // mined, the re-match finds it and the wallet state repairs
+        // itself. Best-effort — a failed arm is logged, not surfaced as
+        // a failed removal.
         let tip = SwiftDashSDKSPVCoordinator.shared.tipHeight
         if tip > 0, let manager = SwiftDashSDKHost.shared.manager {
-            let ageSeconds = max(0, Date().timeIntervalSince1970 - TimeInterval(firstSeen))
-            let ageBlocks = UInt32(clamping: Int(ageSeconds / 150)) + Self.rescanMarginBlocks
-            let blocksBack = min(Self.maxRescanBlocks, max(Self.minRescanBlocks, ageBlocks))
+            let ageSeconds = max(0, Date().timeIntervalSince1970 - TimeInterval(oldestFirstSeen))
+            let ageBlocks = UInt32(clamping: Int(ageSeconds / 150)) + rescanMarginBlocks
+            let blocksBack = min(maxRescanBlocks, max(minRescanBlocks, ageBlocks))
             let fromHeight = tip > blocksBack ? tip - blocksBack : 1
             do {
                 try manager.spvRescanFilters(walletId: walletId, fromHeight: fromHeight)
-                Self.logger.notice("🗑️ TX-REMOVE :: filter rescan armed from height \(fromHeight, privacy: .public) (tip \(tip, privacy: .public))")
+                logger.notice("🗑️ TX-REMOVE :: filter rescan armed from height \(fromHeight, privacy: .public) (tip \(tip, privacy: .public))")
             } catch {
-                Self.logger.error("🗑️ TX-REMOVE :: filter rescan arm failed: \(String(describing: error), privacy: .public)")
+                logger.error("🗑️ TX-REMOVE :: filter rescan arm failed: \(String(describing: error), privacy: .public)")
             }
         } else {
-            Self.logger.error("🗑️ TX-REMOVE :: filter rescan skipped — SPV not running after reload")
+            logger.error("🗑️ TX-REMOVE :: filter rescan skipped — SPV not running after reload")
         }
 
-        // 6. App caches that mirror the deleted rows.
+        // App caches that mirror the deleted rows.
         ShieldedTxLookup.shared.refresh()
     }
 

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -2407,7 +2407,9 @@ class SwiftDashSDKWalletSource: TransactionSource {
     /// union: wallet-scoped TXOs or an account's involved-transactions
     /// relation. Accept both so an out-of-order receipt is not discarded.
     /// Reads relationships — call on the row's fetch thread.
-    private static func isWalletMember(_ row: PersistentTransaction, walletId: Data) -> Bool {
+    /// Internal: also the membership test for the bulk unconfirmed-tx
+    /// drop (`UnconfirmedTransactionRemover`).
+    static func isWalletMember(_ row: PersistentTransaction, walletId: Data) -> Bool {
         row.outputs.contains(where: { $0.walletId == walletId })
             || row.inputs.contains(where: { $0.walletId == walletId })
             || row.involvedAccounts.contains(where: { $0.wallet.walletId == walletId })

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
@@ -66,6 +66,15 @@ struct SwiftDashSDKSPVStatusScreen: View {
     /// the current height is the only way to express that in this UI.
     @State private var pendingResyncConfirmHeight: UInt32?
 
+    /// Presents the drop-unconfirmed confirmation dialog.
+    @State private var showDropUnconfirmedConfirm = false
+    /// True while the bulk drop + runtime reload + rescan runs; disables
+    /// the button and shows its progress spinner.
+    @State private var isDroppingUnconfirmed = false
+    /// Result banner under the drop button; coloured via `dropResultIsError`.
+    @State private var dropResultMessage: String?
+    @State private var dropResultIsError = false
+
     init(vc: UINavigationController) {
         self.vc = vc
     }
@@ -108,6 +117,7 @@ struct SwiftDashSDKSPVStatusScreen: View {
                     heightsCard
                     perPhaseCard
                     rescanFiltersCard
+                    dropUnconfirmedCard
                     connectedPeersCard
                     if let lastError = coordinator.lastError {
                         errorCard(message: lastError)
@@ -178,6 +188,23 @@ struct SwiftDashSDKSPVStatusScreen: View {
         } message: {
             Text(NSLocalizedString(
                 "The wallet's creation height — the floor for filter scans and \"From wallet creation\" rescans. Set it at or below the wallet's first funding; imports default to 200000 on mainnet and 0 on testnet. Saving a height at or below the current one clears this network's chain data at the next launch and rescans from it.",
+                comment: "SPV diagnostics"))
+        }
+        .confirmationDialog(
+            NSLocalizedString("Drop unconfirmed transactions?", comment: "SPV diagnostics"),
+            isPresented: $showDropUnconfirmedConfirm,
+            titleVisibility: .visible
+        ) {
+            Button(
+                NSLocalizedString("Drop & rescan", comment: "SPV diagnostics"),
+                role: .destructive
+            ) {
+                dropUnconfirmedAndRescan()
+            }
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) {}
+        } message: {
+            Text(NSLocalizedString(
+                "Deletes this wallet's unconfirmed transactions from this device only and frees the coins they tried to spend. The filter rescan restores any of them that is actually on the blockchain. Nothing is sent to the network.",
                 comment: "SPV diagnostics"))
         }
         .alert(
@@ -441,6 +468,66 @@ struct SwiftDashSDKSPVStatusScreen: View {
         .cornerRadius(12)
     }
 
+    private var dropUnconfirmedCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(NSLocalizedString("Unconfirmed Transactions", comment: "SPV diagnostics"))
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.dash.primaryText)
+
+            Text(NSLocalizedString(
+                "Drop this wallet's transactions still waiting for the network (never locked or mined) from this device, make the coins they tried to spend available again, and rescan recent filters. A dropped transaction that is actually on the blockchain comes back on its own during the rescan. Nothing is sent to the network.",
+                comment: "SPV diagnostics"))
+                .font(.system(size: 12))
+                .foregroundColor(Color.dash.secondaryText)
+                .fixedSize(horizontal: false, vertical: true)
+
+            row(
+                title: NSLocalizedString("Unconfirmed now", comment: "SPV diagnostics"),
+                value: "\(UnconfirmedTransactionRemover.unconfirmedCount())")
+
+            Button(action: {
+                dropResultMessage = nil
+                showDropUnconfirmedConfirm = true
+            }) {
+                HStack(spacing: 8) {
+                    if isDroppingUnconfirmed {
+                        SwiftUI.ProgressView()
+                            .controlSize(.small)
+                    }
+                    Text(isDroppingUnconfirmed
+                        ? NSLocalizedString("Dropping…", comment: "SPV diagnostics")
+                        : NSLocalizedString("Drop Unconfirmed & Rescan", comment: "SPV diagnostics"))
+                        .font(.system(size: 14, weight: .semibold))
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.dash.gray300.opacity(0.3))
+                .foregroundColor(rescanEnabled && !isDroppingUnconfirmed ? .red : .secondary)
+                .cornerRadius(8)
+            }
+            .disabled(!rescanEnabled || isDroppingUnconfirmed)
+
+            if !rescanEnabled {
+                Text(NSLocalizedString(
+                    "Available only while SPV is running with a wallet bound.",
+                    comment: "SPV diagnostics"))
+                    .font(.system(size: 12))
+                    .foregroundColor(Color.dash.secondaryText)
+            }
+
+            if let message = dropResultMessage {
+                Text(message)
+                    .font(.system(size: 12))
+                    .foregroundColor(dropResultIsError ? .red : .green)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(Color.dash.secondaryBackground)
+        .cornerRadius(12)
+    }
+
     private func errorCard(message: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Last Error")
@@ -687,6 +774,35 @@ extension SwiftDashSDKSPVStatusScreen {
             rescanResultIsError = true
             rescanResultMessage = error.localizedDescription
             Self.logger.error("🛰️ SPV-STATUS :: rescan filters failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Run the bulk unconfirmed-transaction drop + rescan. The await
+    /// spans the persistence surgery, the runtime reload, and the rescan
+    /// arm, so the button's spinner honestly covers the whole operation.
+    func dropUnconfirmedAndRescan() {
+        guard !isDroppingUnconfirmed else { return }
+        isDroppingUnconfirmed = true
+        Task { @MainActor in
+            do {
+                let dropped = try await UnconfirmedTransactionRemover().dropAllUnconfirmedAndRescan()
+                dropResultIsError = false
+                dropResultMessage = dropped == 0
+                    ? NSLocalizedString(
+                        "No unconfirmed transactions to drop.",
+                        comment: "SPV diagnostics")
+                    : String(
+                        format: NSLocalizedString(
+                            "Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row.",
+                            comment: "SPV diagnostics"),
+                        dropped)
+                Self.logger.info("🛰️ SPV-STATUS :: bulk unconfirmed drop finished — \(dropped, privacy: .public) tx(s)")
+            } catch {
+                dropResultIsError = true
+                dropResultMessage = error.localizedDescription
+                Self.logger.error("🛰️ SPV-STATUS :: bulk unconfirmed drop failed: \(String(describing: error), privacy: .public)")
+            }
+            isDroppingUnconfirmed = false
         }
     }
 

--- a/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
+++ b/DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift
@@ -785,18 +785,30 @@ extension SwiftDashSDKSPVStatusScreen {
         isDroppingUnconfirmed = true
         Task { @MainActor in
             do {
-                let dropped = try await UnconfirmedTransactionRemover().dropAllUnconfirmedAndRescan()
-                dropResultIsError = false
-                dropResultMessage = dropped == 0
-                    ? NSLocalizedString(
+                let outcome = try await UnconfirmedTransactionRemover().dropAllUnconfirmedAndRescan()
+                if outcome.dropped == 0 {
+                    dropResultIsError = false
+                    dropResultMessage = NSLocalizedString(
                         "No unconfirmed transactions to drop.",
                         comment: "SPV diagnostics")
-                    : String(
+                } else if outcome.rescanArmed {
+                    dropResultIsError = false
+                    dropResultMessage = String(
                         format: NSLocalizedString(
-                            "Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row.",
+                            "Dropped %d unconfirmed transaction(s) — rescanning filters, watch the Filters row.",
                             comment: "SPV diagnostics"),
-                        dropped)
-                Self.logger.info("🛰️ SPV-STATUS :: bulk unconfirmed drop finished — \(dropped, privacy: .public) tx(s)")
+                        outcome.dropped)
+                } else {
+                    // The drop finished but the recovery rescan didn't
+                    // arm — flag it instead of claiming the safety net ran.
+                    dropResultIsError = true
+                    dropResultMessage = String(
+                        format: NSLocalizedString(
+                            "Dropped %d unconfirmed transaction(s), but the filter rescan couldn't start — run Rescan Filters above.",
+                            comment: "SPV diagnostics"),
+                        outcome.dropped)
+                }
+                Self.logger.info("🛰️ SPV-STATUS :: bulk unconfirmed drop finished — \(outcome.dropped, privacy: .public) tx(s), rescanArmed=\(outcome.rescanArmed, privacy: .public)")
             } catch {
                 dropResultIsError = true
                 dropResultMessage = error.localizedDescription

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -536,6 +536,17 @@ extension TxDetailModel {
         var supportsRemoval: Bool { statusRaw <= 1 }
     }
 
+    /// True when the "Remove if not on Blockchain" action applies outside
+    /// the asset-lock retry route: the local store still has this
+    /// transaction in mempool context (`.processing` — never IS-locked,
+    /// never mined), which is exactly the state a network-dropped send
+    /// (e.g. a stalled CoinJoin sweep chunk) is stuck in.
+    /// `UnconfirmedTransactionRemover` re-verifies the local state and
+    /// checks a block explorer before touching anything.
+    var supportsUnconfirmedRemoval: Bool {
+        transaction.state == .processing
+    }
+
     /// Non-nil when this transaction is a funding asset lock parked in a
     /// non-terminal state (built/broadcast/IS-locked/CL-locked but never
     /// consumed) on a route `AssetLockRecoveryService` can retry. Status

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -502,6 +502,13 @@ extension TXDetailViewController {
             if retry.supportsRemoval {
                 currentSnapshot.appendItems([.removeUnconfirmed], toSection: .recovery)
             }
+        } else if model.supportsUnconfirmedRemoval {
+            // Any other transaction stuck in mempool context (a
+            // network-dropped classic send — e.g. a stalled CoinJoin sweep
+            // chunk) gets the removal action alone: there is no retry
+            // route for it, but deleting the local row frees its inputs.
+            currentSnapshot.insertSections([.recovery], afterSection: .taxCategory)
+            currentSnapshot.appendItems([.removeUnconfirmed], toSection: .recovery)
         }
         currentSnapshot.appendItems([.viewTransaction, .copyRawTransaction], toSection: .rawTransaction)
         currentSnapshot.appendItems([.explorer], toSection: .explorer)

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -330,8 +330,12 @@ extension TXDetailViewController {
                 self?.view.dw_hideProgressHUD()
             }
             do {
-                try await UnconfirmedTransactionRemover().remove(txidWire: txidWire)
-                self?.view.dw_showInfoHUD(withText: NSLocalizedString("Transaction removed", comment: "Remove never-accepted transaction: success"))
+                let rescanArmed = try await UnconfirmedTransactionRemover().remove(txidWire: txidWire)
+                // Never claim the rescan safety net ran when it didn't —
+                // point at the manual Rescan Filters action instead.
+                self?.view.dw_showInfoHUD(withText: rescanArmed
+                    ? NSLocalizedString("Transaction removed", comment: "Remove never-accepted transaction: success")
+                    : NSLocalizedString("Transaction removed — rescan couldn't start, run Rescan Filters in Core Sync Status", comment: "Remove never-accepted transaction: removed but the recovery rescan did not arm"))
                 // The row this sheet describes no longer exists.
                 self?.closeAction()
             } catch UnconfirmedTransactionRemover.RemovalError.transactionOnChain {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1303,6 +1303,9 @@
 /* No comment provided by engineer. */
 "Delete Wallet?" = "Delete Wallet?";
 
+/* SPV diagnostics */
+"Deletes this wallet's unconfirmed transactions from this device only and frees the coins they tried to spend. The filter rescan restores any of them that is actually on the blockchain. Nothing is sent to the network." = "Deletes this wallet's unconfirmed transactions from this device only and frees the coins they tried to spend. The filter rescan restores any of them that is actually on the blockchain. Nothing is sent to the network.";
+
 /* Location Service Status */
 "Denied" = "Denied";
 
@@ -1386,6 +1389,24 @@
 /* Edit profile — usernames list section header
    SDK identity profile sheet — usernames list */
 "DPNS Names" = "DPNS Names";
+
+/* SPV diagnostics */
+"Drop & rescan" = "Drop & rescan";
+
+/* SPV diagnostics */
+"Drop this wallet's transactions still waiting for the network (never locked or mined) from this device, make the coins they tried to spend available again, and rescan recent filters. A dropped transaction that is actually on the blockchain comes back on its own during the rescan. Nothing is sent to the network." = "Drop this wallet's transactions still waiting for the network (never locked or mined) from this device, make the coins they tried to spend available again, and rescan recent filters. A dropped transaction that is actually on the blockchain comes back on its own during the rescan. Nothing is sent to the network.";
+
+/* SPV diagnostics */
+"Drop Unconfirmed & Rescan" = "Drop Unconfirmed & Rescan";
+
+/* SPV diagnostics */
+"Drop unconfirmed transactions?" = "Drop unconfirmed transactions?";
+
+/* SPV diagnostics */
+"Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row." = "Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row.";
+
+/* SPV diagnostics */
+"Dropping…" = "Dropping…";
 
 /* CrowdNode */
 "Due to CrowdNode’s terms of service users can withdraw no more than:" = "Due to CrowdNode’s terms of service users can withdraw no more than:";
@@ -2843,6 +2864,9 @@
 
 /* (List of) New (notifications) */
 "New" = "New";
+
+/* SPV diagnostics */
+"No unconfirmed transactions to drop." = "No unconfirmed transactions to drop.";
 
 /* CrowdNode */
 "New CrowdNode Account" = "New CrowdNode Account";
@@ -4673,6 +4697,12 @@
 
 /* Voting */
 "Unblocked '%@' username" = "Unblocked '%@' username";
+
+/* SPV diagnostics */
+"Unconfirmed now" = "Unconfirmed now";
+
+/* SPV diagnostics */
+"Unconfirmed Transactions" = "Unconfirmed Transactions";
 
 /* DashPay Contacts */
 "Unhide Contact" = "Unhide Contact";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1403,7 +1403,10 @@
 "Drop unconfirmed transactions?" = "Drop unconfirmed transactions?";
 
 /* SPV diagnostics */
-"Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row." = "Dropped %d unconfirmed transaction(s) — rescanning recent filters, watch the Filters row.";
+"Dropped %d unconfirmed transaction(s) — rescanning filters, watch the Filters row." = "Dropped %d unconfirmed transaction(s) — rescanning filters, watch the Filters row.";
+
+/* SPV diagnostics */
+"Dropped %d unconfirmed transaction(s), but the filter rescan couldn't start — run Rescan Filters above." = "Dropped %d unconfirmed transaction(s), but the filter rescan couldn't start — run Rescan Filters above.";
 
 /* SPV diagnostics */
 "Dropping…" = "Dropping…";
@@ -2598,6 +2601,9 @@
 
 /* Remove never-accepted transaction: success */
 "Transaction removed" = "Transaction removed";
+
+/* Remove never-accepted transaction: removed but the recovery rescan did not arm */
+"Transaction removed — rescan couldn't start, run Rescan Filters in Core Sync Status" = "Transaction removed — rescan couldn't start, run Rescan Filters in Core Sync Status";
 
 /* Remove never-accepted transaction: confirmation body */
 "The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network." = "The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network.";


### PR DESCRIPTION
## What

Two user-facing recovery paths for transactions stuck in mempool state ("Sending" forever — never InstantSend-locked, never mined), e.g. CoinJoin sweep chunks whose broadcasts the network dropped:

1. **Tx detail — "Remove if not on Blockchain" for any stuck transaction.** Previously the recovery section only appeared for parked asset-lock transfers; a plain classic send stuck at mempool context had no action at all. Now any transaction in `.processing` state gets the removal action, with the existing rails unchanged: the local row must still be unconfirmed, a block explorer is consulted first (on-chain ⇒ removal refused), and a compact-filter rescan afterward restores the tx if the explorer was wrong. Since the CoinJoin Withdrawals group sheet already navigates into tx detail, each stuck sweep chunk is now individually recoverable.

2. **Core Sync Status — "Drop Unconfirmed & Rescan".** A new "Unconfirmed Transactions" card shows a live count of the active wallet's mempool-context transactions and offers a confirmed, destructive bulk action: drop them all in one pass, free the TXOs they tried to spend, do the full runtime reload, and arm a filter rescan reaching back past the oldest dropped transaction. The bulk path deliberately skips the per-tx explorer check — the rescan is the safety net that restores anything actually mined — and the confirmation dialog says exactly that. Nothing is ever sent to the network.

## Why

dash-spv rebroadcasts unconfirmed self-sent transactions every 10 minutes, but only in-memory for the session that broadcast them — after an app restart nothing resends them, so a dropped tx is permanently stalled and the coins it tried to spend stay locked. This shipped state was observed in the field: 10 CoinJoin sweep chunks (82 UTXOs, ~36.8 DASH) stuck at "Sending" with no recovery affordance.

## Implementation notes

- `UnconfirmedTransactionRemover` refactored so the single-tx and bulk paths share one surgery: un-spend inputs (explicit `isSpent` flip — the `.nullify` inverse alone isn't enough), delete rows, drop asset-lock bookmarks, metadata cleanup, runtime reload, rescan arm.
- `SwiftDashSDKWalletSource.isWalletMember` promoted from `private` to internal and reused for the wallet-scoped bulk fetch (no copy-then-adapt).
- New strings registered in `DashWallet/en.lproj/Localizable.strings`.

## Verification

- Clean `dashpay` scheme build (`ARCHS=arm64`, iphonesimulator). Unit-test target is pre-existing-broken per CLAUDE.md.
- Not yet smoke-tested on a simulator with stuck txs; the drop path reuses the already-shipped single-tx removal surgery.

## Follow-up (not in this PR)

The durable upstream fix is for dash-spv to repopulate its rebroadcast set from persisted unconfirmed self-authored transactions on wallet load, so stalls of this class stop happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove unconfirmed transactions individually from transaction details.
  - Added a bulk cleanup option in SPV diagnostics with confirmation prompts, progress updates, and transaction counts.
  - Automatically refreshes wallet data and rescans after bulk removal when applicable.
  - Displays success or failure states, including guidance when recovery scanning cannot be started.

- **Bug Fixes**
  - Improved cleanup of related wallet data when unconfirmed transactions are removed.

- **Documentation**
  - Added English text for cleanup actions, statuses, progress, failures, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->