### PR TITLE
fix(dashpay): rekey isLocal consumers to the restored wallet-ownership semantics

### DIFF
--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -282,11 +282,14 @@ private struct IdentityRowView: View {
                     icon: "server.rack",
                     color: .indigo)
             }
-            if row.isLocal {
+            // `isLocal` = mine-or-tracked: wallet-derived identities
+            // are always local, manual adds too. Badge only the rare
+            // incidental rows (observed identities nobody tracks).
+            if !row.isLocal {
                 IdentityBadge(
-                    text: NSLocalizedString("Local Only", comment: "Identities"),
-                    icon: "location",
-                    color: .orange)
+                    text: NSLocalizedString("Observed", comment: "Identities"),
+                    icon: "eye",
+                    color: .gray)
             }
             if row.pendingContestedName != nil {
                 IdentityBadge(
@@ -530,12 +533,16 @@ struct IdentityDetailScreen: View {
             detailRow(
                 label: NSLocalizedString("Type", comment: "Identities"),
                 value: typeName)
-            divider
-            detailRow(
-                label: NSLocalizedString("Status", comment: ""),
-                value: row.isLocal
-                    ? NSLocalizedString("Local Only", comment: "Identities")
-                    : NSLocalizedString("On Network", comment: "Identities"))
+            // A Status row only for the rare incidental case — every
+            // wallet identity is local, so an always-on "Local" row
+            // would be noise; the Wallet row below already names the
+            // owner when there is one.
+            if !row.isLocal {
+                divider
+                detailRow(
+                    label: NSLocalizedString("Status", comment: ""),
+                    value: NSLocalizedString("Observed", comment: "Identities"))
+            }
             if let walletName = row.walletName {
                 divider
                 detailRow(

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -229,7 +229,11 @@ final class IdentitiesViewModel: ObservableObject {
         }
 
         var failures = 0
-        for row in rows where !row.isLocal {
+        // Refresh every row — the old `!row.isLocal` filter dates from
+        // when the flag was misread as an on-network badge; under the
+        // real semantics (mine-or-tracked) it would skip exactly the
+        // wallet's own identities.
+        for row in rows {
             do {
                 let fetched = try await sdk.identityGet(identityId: row.idBase58)
                 if let balance = Self.uint64(from: fetched["balance"]) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #981. The SDK defines `isLocal` as **mine-or-tracked** (owner-decided semantics, dashpay/platform#4375): wallet-derived identities are always local, manual adds are local, and only incidental observed rows are `false` — promote-only, with a startup heal for stores written by the constant-`false` era that caused the original field bug (the wallet's own identity showing as not-local, hiding the key-refresh affordances).

This PR updates the three remaining app-side `isLocal` readers, written against the old dead "Local Only / On Network" badge reading:

- **Identities list badge** — the orange "Local Only" badge (which would now appear on every wallet identity) becomes an "Observed" badge on the rare incidental rows.
- **Identity detail sheet** — the always-on Status row is replaced by an "Observed" row shown only for incidental rows; the Wallet row already names the owner otherwise.
- **`refreshFromNetwork`** — the `!row.isLocal` filter is dropped; it would have skipped exactly the wallet's own identities.

The key-refresh gates stay on the wallet relationship (#981) — that operation needs the wallet's DIP-9 tree specifically, which `isLocal` deliberately does not claim.

## Ordering

Land/pull dashpay/platform#4375 first: until the SDK fix is in `../platform`, rows still carry the constant `false` and every identity would show the "Observed" badge.

## How Has This Been Tested?

Clean `dashpay` scheme simulator build (`ARCHS=arm64`). SDK-side behavior (promotion, promote-only discipline, heal, observed-entry mislink fixes) is covered by `IdentityIsLocalPersistenceTests` in the platform PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Identity details now clearly indicate when an identity is observed.
  * Identity lists display an “Observed” badge for identities detected from the network.

* **Bug Fixes**
  * Active-wallet identities are now refreshed correctly from the network.
  * Local identities no longer display misleading status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->