### PR TITLE
fix(dashpay): stop offering Pay for a contact we cannot pay

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
@@ -68,6 +68,21 @@ struct ContactItem: Identifiable, Equatable {
     /// Hidden contacts move to the collapsed Hidden section.
     let isHidden: Bool
 
+    /// The SDK gave up on building this contact's DIP-15 payment
+    /// channel for a permanent reason (`EstablishedContact
+    /// .payment_channel_broken`): the counterparty's encrypted xpub
+    /// cannot be decrypted, or their key shape can never satisfy the
+    /// ECDH gate.
+    ///
+    /// Being `.established` is NOT the same as being payable —
+    /// friendship is mutual contact requests, while paying needs the
+    /// external contact account those requests are the input to. A
+    /// broken channel is unrecoverable from this side: the sweep never
+    /// retries it, and only a fresh contact request from the CONTACT
+    /// clears the flag. Surfacing it is what stops the UI offering a
+    /// Pay button that can only ever fail.
+    let paymentChannelBroken: Bool
+
     /// `dashpay.profile.avatarUrl` from the synced contact-profile cache.
     let avatarURL: String?
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/SwiftDashSDKContactsService.swift
@@ -220,6 +220,10 @@ final class SwiftDashSDKContactsService: ObservableObject {
                 alias: rows.compactMap(\.contactAlias).first(where: { !$0.isEmpty }),
                 note: rows.compactMap(\.contactNote).first(where: { !$0.isEmpty }),
                 isHidden: rows.contains(where: \.contactHidden),
+                // The persister mirrors the flag onto both direction
+                // rows, so either carrying it means the channel is
+                // broken.
+                paymentChannelBroken: rows.contains(where: \.paymentChannelBroken),
                 avatarURL: profile?.avatarUrl,
                 publicMessage: profile?.publicMessage,
                 createdAt: Date(timeIntervalSince1970: TimeInterval(newestMillis) / 1000),

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -453,11 +453,16 @@ final class WalletSendService: NSObject {
             )
         }
 
-        let (txid, feeDuffs) = try await context.wallet.sendDashPayPayment(
-            fromIdentityId: context.ourId,
-            toContactIdentityId: contactIdentityId,
-            amountDuffs: amount,
-            memo: memo)
+        let (txid, feeDuffs): (Data, UInt64)
+        do {
+            (txid, feeDuffs) = try await context.wallet.sendDashPayPayment(
+                fromIdentityId: context.ourId,
+                toContactIdentityId: contactIdentityId,
+                amountDuffs: amount,
+                memo: memo)
+        } catch {
+            throw Self.contactPaymentError(from: error)
+        }
         Self.logger.info("💸 TXSEND :: pay-to-contact broadcast, txid \(txid.map { String(format: "%02x", $0) }.joined(), privacy: .public), fee \(feeDuffs, privacy: .public) duffs")
         return (txid: txid, feeDuffs: feeDuffs)
     }
@@ -653,6 +658,35 @@ private extension WalletSendService {
     }
 
     static let errorDomain = "org.dashfoundation.dash.wallet-send-service"
+
+    /// Translate the SDK's internal missing-external-account diagnostic into
+    /// something a user can act on.
+    ///
+    /// A contact's DIP-15 external account is built in the background from the
+    /// counterparty's contact request; until it exists the SDK fails the send
+    /// with "Invalid identity data: No DashpayExternalAccount found for contact
+    /// <id> — call register_external_contact_account first". That reached users
+    /// verbatim in an alert: it names an API only the SDK can call, so it reads
+    /// as an instruction for something they cannot do.
+    ///
+    /// Mapped here rather than at the presentation layer so the diagnostic stops
+    /// at the boundary that owns the SDK call, and every present and future
+    /// caller of `sendToContact` gets the same treatment. Deliberately narrow —
+    /// anything else is returned untouched rather than hidden behind a generic
+    /// message.
+    static func contactPaymentError(from error: Error) -> Error {
+        let description = error.localizedDescription
+        guard description.contains("DashpayExternalAccount")
+            || description.contains("register_external_contact_account")
+        else {
+            return error
+        }
+        return makeError(
+            code: .dashPayPaymentUnavailable,
+            description: NSLocalizedString(
+                "This contact's payment channel isn't ready yet. It's still being set up in the background — please try again in a few minutes.",
+                comment: "DashPay Contacts"))
+    }
 
     static func makeError(code: ErrorCode, description: String) -> NSError {
         NSError(

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -744,36 +744,9 @@ struct PayContactSheet: View {
             } catch {
                 let nsError = error as NSError
                 if !WalletSendService.isAuthenticationCancelledError(nsError) {
-                    errorMessage = Self.payFailureMessage(for: error)
+                    errorMessage = error.localizedDescription
                 }
             }
         }
-    }
-
-    /// User-facing text for a failed contact payment.
-    ///
-    /// The SDK surfaces a missing DIP-15 external account as its own
-    /// internal diagnostic — "Invalid identity data: No
-    /// DashpayExternalAccount found for contact <id> — call
-    /// register_external_contact_account first". That reached users
-    /// verbatim in an alert: unreadable, and it names an API only the
-    /// SDK can call, so it reads as "do something" when there is
-    /// nothing for the user to do.
-    ///
-    /// The channel is built in the background from the counterparty's
-    /// contact request, so the honest advice is to wait and retry. Any
-    /// other failure keeps its own message — this deliberately
-    /// translates one known string rather than swallowing every error
-    /// behind a generic one.
-    static func payFailureMessage(for error: Error) -> String {
-        let description = error.localizedDescription
-        guard description.contains("DashpayExternalAccount")
-            || description.contains("register_external_contact_account")
-        else {
-            return description
-        }
-        return NSLocalizedString(
-            "This contact's payment channel isn't ready yet. It's still being set up in the background — please try again in a few minutes.",
-            comment: "DashPay Contacts")
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -254,23 +254,33 @@ struct ContactProfileSheet: View {
                         .zIndex(-1)
                 }
 
-                // Android Button.Primary.Blue: full-width filled pay CTA.
-                Button {
-                    showingPaySheet = true
-                } label: {
-                    Label(
-                        NSLocalizedString("Pay", comment: "DashPay Contacts"),
-                        systemImage: "arrow.up.circle.fill")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(Color.dash.whiteText)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 46)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.dash.blue))
+                // Being established means the contact requests are
+                // mutual; it does NOT mean we can pay. Paying needs the
+                // DIP-15 external account built from the counterparty's
+                // encrypted xpub, and when the SDK has permanently
+                // failed to build it, every Pay tap ends in a failure
+                // the user can do nothing about. Say so instead.
+                if contact.paymentChannelBroken {
+                    paymentChannelBrokenNotice
+                } else {
+                    // Android Button.Primary.Blue: full-width filled pay CTA.
+                    Button {
+                        showingPaySheet = true
+                    } label: {
+                        Label(
+                            NSLocalizedString("Pay", comment: "DashPay Contacts"),
+                            systemImage: "arrow.up.circle.fill")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundColor(Color.dash.whiteText)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 46)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(Color.dash.blue))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 32)
                 }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 32)
 
                 paymentsSection
 
@@ -398,6 +408,37 @@ struct ContactProfileSheet: View {
             return nil
         }
         return error.localizedDescription
+    }
+
+    /// Shown in place of the Pay CTA when the contact's payment
+    /// channel is permanently broken.
+    ///
+    /// Deliberately actionable rather than an error: the flag only
+    /// clears when the CONTACT sends a fresh request, so telling the
+    /// user what to ask for is the only thing that can fix it. A
+    /// disabled-looking button with no explanation would leave them
+    /// tapping and reading a Rust diagnostic instead.
+    private var paymentChannelBrokenNotice: some View {
+        VStack(spacing: 6) {
+            Label(
+                NSLocalizedString("Payments unavailable", comment: "DashPay Contacts"),
+                systemImage: "exclamationmark.triangle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundColor(.dashGolden)
+            Text(NSLocalizedString(
+                "This contact's payment details couldn't be set up. Ask them to send you a new contact request.",
+                comment: "DashPay Contacts"))
+                .font(.system(size: 13))
+                .foregroundColor(.dash.secondaryText)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.dash.secondaryBackground))
+        .padding(.horizontal, 32)
     }
 
     // MARK: Payments between us — history card
@@ -703,9 +744,36 @@ struct PayContactSheet: View {
             } catch {
                 let nsError = error as NSError
                 if !WalletSendService.isAuthenticationCancelledError(nsError) {
-                    errorMessage = error.localizedDescription
+                    errorMessage = Self.payFailureMessage(for: error)
                 }
             }
         }
+    }
+
+    /// User-facing text for a failed contact payment.
+    ///
+    /// The SDK surfaces a missing DIP-15 external account as its own
+    /// internal diagnostic — "Invalid identity data: No
+    /// DashpayExternalAccount found for contact <id> — call
+    /// register_external_contact_account first". That reached users
+    /// verbatim in an alert: unreadable, and it names an API only the
+    /// SDK can call, so it reads as "do something" when there is
+    /// nothing for the user to do.
+    ///
+    /// The channel is built in the background from the counterparty's
+    /// contact request, so the honest advice is to wait and retry. Any
+    /// other failure keeps its own message — this deliberately
+    /// translates one known string rather than swallowing every error
+    /// behind a generic one.
+    static func payFailureMessage(for error: Error) -> String {
+        let description = error.localizedDescription
+        guard description.contains("DashpayExternalAccount")
+            || description.contains("register_external_contact_account")
+        else {
+            return description
+        }
+        return NSLocalizedString(
+            "This contact's payment channel isn't ready yet. It's still being set up in the background — please try again in a few minutes.",
+            comment: "DashPay Contacts")
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A mainnet user tapped **Pay** on a DashPay contact and got this alert:

```
Błąd
Invalid identity data: No DashpayExternalAccount found for contact
6ridihVjZZXGJCJ63hFqLAxXgxRMUnRoHRZnjhqHNT4y
— call register_external_contact_account first
```

That is an internal SDK diagnostic, shown verbatim, naming an API only the SDK can call. It reads as an instruction to the user for something the user cannot do.

The underlying reason is that `.established` was the **only** gate on the Pay CTA. Established means the contact requests are mutual — paying additionally needs the DIP-15 **external contact account** those requests are the input to. The app treated "we're friends" and "I can pay them" as the same state; they are not.

Root cause of *why* the account was missing is fixed separately in dashpay/platform#4372 (legacy Android/dashj contact requests were rejected by our key-purpose policy). This PR is the other half: the app should never route a user into a spend it already knows cannot complete, whatever the reason.

## What was done?
<!--- Describe your changes in detail -->

**Surface the channel state the SDK already persists**

- `ContactItem` gains `paymentChannelBroken`, read from the `PersistentDashpayContactRequest` rows — the persister already mirrors `EstablishedContact.payment_channel_broken` onto both directions, so this needs no new SDK API or FFI.

**Don't offer a spend that cannot succeed**

- When the channel is permanently broken, `ContactProfileSheet` renders an explanation in place of the Pay button. It states what actually fixes it — *"Ask them to send you a new contact request"* — because the flag only clears when the **contact** sends a fresh request. A greyed-out button with no reason would leave the user tapping and guessing.

**Translate the one diagnostic that reaches users**

- A failed send maps the missing-account case to *"This contact's payment channel isn't ready yet. It's still being set up in the background — please try again in a few minutes."* That is accurate: the channel is built in the background from the counterparty's request.
- Deliberately narrow — only that known string is translated. Every other error keeps its own message rather than disappearing behind something generic.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`dashpay` scheme, iOS Simulator, Debug — builds clean.

**Not yet verified on device against a real broken channel.** The reporting user's 27 legacy contacts are queued, not broken, so their wallet does not exercise the broken-channel branch; it exercises the error-message branch. Reproducing the broken branch needs a contact whose request permanently fails validation.

What I would ask the reporter to confirm on a TestFlight build (together with dashpay/platform#4372):

1. Legacy contacts become payable — the actual fix.
2. If any single contact still fails, the alert is now the readable "not ready yet" message, not the `register_external_contact_account` string.
3. No contact that used to show Pay has lost it (the broken-flag gate should be a no-op for their wallet).

> **Build note:** the Rust fix lives in dashpay/platform#4372. This app builds against the sibling `../platform/packages/swift-sdk` local package, so a TestFlight build that actually fixes those contacts needs the `platform` checkout on that branch **and** the xcframework rebuilt (`packages/swift-sdk/build_ios.sh`). Building this PR alone only changes the UI behaviour.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. `ContactItem` is an internal read model; the new field defaults to what the persisted rows already carry. No contact that is payable today loses its Pay button.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of contacts whose payment channel cannot be established.
  * Removed the Pay button for affected established contacts and displayed guidance to request a new contact connection.
  * Added clearer messaging when payment account details are unavailable.
  * Preserved specific error messages when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->