### PR TITLE
fix(dashsync): stop stranding App Store upgraders without their wallet

### DIFF
--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -147,6 +147,12 @@ NS_ASSUME_NONNULL_BEGIN
     // Kick off the SwiftDashSDK key migration and app-owned runtime early.
     // The runtime wallet is restored from app-owned Keychain state,
     // not from a SwiftData wallet store.
+#ifdef DEBUG
+    // QA fixture: fabricate DashSync's legacy keychain layout when the
+    // LEGACY_KEYCHAIN_MNEMONIC env var is set (simulator upgrade-path
+    // testing). No-op otherwise; DEBUG builds only.
+    [DWSwiftDashSDKKeyMigrator debugInstallLegacyFixtureIfRequested];
+#endif
     [DWSwiftDashSDKKeyMigrator migrateIfNeeded];
     [DWSwiftDashSDKWalletRuntime startObservingNetworkChanges];
     [DWSwiftDashSDKWalletRuntime startIfReady];

--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -148,9 +148,10 @@ NS_ASSUME_NONNULL_BEGIN
     // The runtime wallet is restored from app-owned Keychain state,
     // not from a SwiftData wallet store.
 #ifdef DEBUG
-    // QA fixture: fabricate DashSync's legacy keychain layout when the
-    // LEGACY_KEYCHAIN_MNEMONIC env var is set (simulator upgrade-path
-    // testing). No-op otherwise; DEBUG builds only.
+    // QA fixture: fabricate DashSync's legacy keychain layout when either
+    // LEGACY_KEYCHAIN_MNEMONIC or LEGACY_KEYCHAIN_INVALID=1 is set in the
+    // environment (simulator upgrade-path testing). No-op otherwise;
+    // DEBUG builds only.
     [DWSwiftDashSDKKeyMigrator debugInstallLegacyFixtureIfRequested];
 #endif
     [DWSwiftDashSDKKeyMigrator migrateIfNeeded];

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
@@ -88,7 +88,7 @@ final class SwiftDashSDKKeyMigrator: NSObject {
     /// (the runtime's 30s poll, the root controller's launch decision) timed
     /// out on every launch while the migrator kept failing — stranding a
     /// restored wallet behind a permanently stopped runtime.
-    private static let deferredFailureKey       = "swiftSDKKeyMigration.v1.deferredFailure"
+    private static let deferredFailureKey = "swiftSDKKeyMigration.v1.deferredFailure"
 
     /// Per-wallet success ledger — DashSync walletIDs that already round-tripped
     /// through `createOrImportWallet`. Lets a partial-failure run resume on next
@@ -216,7 +216,8 @@ final class SwiftDashSDKKeyMigrator: NSObject {
     /// inside the async migration window showed Create/Recover to upgrading
     /// users whose wallet was milliseconds from landing (and routed their
     /// typed phrase into the recover screen's wipe branch).
-    @objc static func legacyWalletMaterialPendingMigration() -> Bool {
+    @objc
+    static func legacyWalletMaterialPendingMigration() -> Bool {
         guard UserDefaults.standard.string(forKey: doneKey) == nil else { return false }
         return !enumerateDashSyncMnemonicAccounts().isEmpty
     }
@@ -224,7 +225,8 @@ final class SwiftDashSDKKeyMigrator: NSObject {
     /// True once the migrator reached a terminal state for this launch:
     /// completed, or recorded any deferral/failure flag (each of which every
     /// waiter treats as "stop waiting").
-    @objc static func migrationSettled() -> Bool {
+    @objc
+    static func migrationSettled() -> Bool {
         let defaults = UserDefaults.standard
         if defaults.string(forKey: doneKey) != nil { return true }
         return [deferredMultiWalletKey, deferredUnknownChainKey, deferredFailureKey]
@@ -377,12 +379,18 @@ final class SwiftDashSDKKeyMigrator: NSObject {
 
     /// Fabricate DashSync's keychain layout so the App Store → SDK upgrade
     /// path can be exercised on a simulator without a real legacy install.
-    /// Env: `LEGACY_KEYCHAIN_MNEMONIC` = BIP39 phrase to plant; optional
-    /// `LEGACY_KEYCHAIN_ORPHAN=1` skips the chain-wallets list (exercises
-    /// the unknown-chain defer path). Also clears the migration sentinel and
-    /// per-wallet ledger so the migrator re-runs. Call before
-    /// `migrateIfNeeded`.
-    @objc static func debugInstallLegacyFixtureIfRequested() {
+    /// Two mutually exclusive triggers, each clearing the migration
+    /// sentinel so the migrator re-runs:
+    /// - `LEGACY_KEYCHAIN_INVALID=1` plants one never-valid mnemonic entry
+    ///   (the perpetually-failing-migration state) and nothing else.
+    /// - `LEGACY_KEYCHAIN_MNEMONIC` = BIP39 phrase to plant, with a legacy
+    ///   PIN (`LEGACY_KEYCHAIN_PIN`, default 1111); optional
+    ///   `LEGACY_KEYCHAIN_ORPHAN=1` skips the chain-wallets list (the
+    ///   unknown-chain defer path). This variant also clears the per-wallet
+    ///   ledger and removes any previously planted invalid entry.
+    /// Call before `migrateIfNeeded`.
+    @objc
+    static func debugInstallLegacyFixtureIfRequested() {
         let env = ProcessInfo.processInfo.environment
         // Variant: a DashSync entry whose phrase can never validate — the
         // migrator fails every run (deferredFailure), reproducing the
@@ -403,6 +411,14 @@ final class SwiftDashSDKKeyMigrator: NSObject {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: doneKey)
         defaults.removeObject(forKey: migratedDashSyncWalletIdsKey)
+        // Drop any invalid entry a previous LEGACY_KEYCHAIN_INVALID run
+        // planted — otherwise this run's migration sees both accounts,
+        // fails on the invalid one, and can never mark itself done.
+        _ = KeychainStore.set(
+            data: nil,
+            service: dashSyncService,
+            account: dashSyncMnemonicAccountPrefix + "deadbeefdeadbeef",
+            accessibility: .whenUnlockedThisDeviceOnly)
 
         // The legacy install had a PIN (PinStore reads DashSync's records
         // in place) — plant one so the post-migration lock screen is

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKKeyMigrator.swift
@@ -83,6 +83,12 @@ final class SwiftDashSDKKeyMigrator: NSObject {
 
     private static let deferredMultiWalletKey   = "swiftSDKKeyMigration.v1.deferredMultiWallet"
     private static let deferredUnknownChainKey  = "swiftSDKKeyMigration.v1.deferredUnknownChain"
+    /// Set when a run ended with a read/validate/import failure. Without a
+    /// terminal flag for this case, every consumer waiting on the sentinel
+    /// (the runtime's 30s poll, the root controller's launch decision) timed
+    /// out on every launch while the migrator kept failing — stranding a
+    /// restored wallet behind a permanently stopped runtime.
+    private static let deferredFailureKey       = "swiftSDKKeyMigration.v1.deferredFailure"
 
     /// Per-wallet success ledger — DashSync walletIDs that already round-tripped
     /// through `createOrImportWallet`. Lets a partial-failure run resume on next
@@ -126,10 +132,11 @@ final class SwiftDashSDKKeyMigrator: NSObject {
         }
 
         // Clear stale defer flags before re-evaluating. The runtime reads
-        // either flag as permission to stop waiting for migration — leaving
+        // any flag as permission to stop waiting for migration — leaving
         // a stale value would race the loop below.
         defaults.removeObject(forKey: deferredMultiWalletKey)
         defaults.removeObject(forKey: deferredUnknownChainKey)
+        defaults.removeObject(forKey: deferredFailureKey)
 
         let mnemonicAccounts = enumerateDashSyncMnemonicAccounts()
         if mnemonicAccounts.isEmpty {
@@ -194,8 +201,34 @@ final class SwiftDashSDKKeyMigrator: NSObject {
             if hadUnknownChain {
                 defaults.set(true, forKey: deferredUnknownChainKey)
             }
+            if hadFailure {
+                defaults.set(true, forKey: deferredFailureKey)
+            }
             logger.warning("🔑 KEYMIG :: migration incomplete — will retry on next launch")
         }
+    }
+
+    // MARK: - Launch-decision probes
+
+    /// True while DashSync wallet material exists in the keychain and the
+    /// one-shot migration has not completed. The root controller holds its
+    /// initial-screen decision while this is true — deciding "no wallet"
+    /// inside the async migration window showed Create/Recover to upgrading
+    /// users whose wallet was milliseconds from landing (and routed their
+    /// typed phrase into the recover screen's wipe branch).
+    @objc static func legacyWalletMaterialPendingMigration() -> Bool {
+        guard UserDefaults.standard.string(forKey: doneKey) == nil else { return false }
+        return !enumerateDashSyncMnemonicAccounts().isEmpty
+    }
+
+    /// True once the migrator reached a terminal state for this launch:
+    /// completed, or recorded any deferral/failure flag (each of which every
+    /// waiter treats as "stop waiting").
+    @objc static func migrationSettled() -> Bool {
+        let defaults = UserDefaults.standard
+        if defaults.string(forKey: doneKey) != nil { return true }
+        return [deferredMultiWalletKey, deferredUnknownChainKey, deferredFailureKey]
+            .contains { defaults.object(forKey: $0) != nil }
     }
 
     private static func createWalletOnHost(
@@ -338,5 +371,69 @@ final class SwiftDashSDKKeyMigrator: NSObject {
         PinStore.readData(service: service, account: account)
             .flatMap { String(data: $0, encoding: .utf8) }
     }
+
+    #if DEBUG
+    // MARK: - QA fixture (DEBUG only)
+
+    /// Fabricate DashSync's keychain layout so the App Store → SDK upgrade
+    /// path can be exercised on a simulator without a real legacy install.
+    /// Env: `LEGACY_KEYCHAIN_MNEMONIC` = BIP39 phrase to plant; optional
+    /// `LEGACY_KEYCHAIN_ORPHAN=1` skips the chain-wallets list (exercises
+    /// the unknown-chain defer path). Also clears the migration sentinel and
+    /// per-wallet ledger so the migrator re-runs. Call before
+    /// `migrateIfNeeded`.
+    @objc static func debugInstallLegacyFixtureIfRequested() {
+        let env = ProcessInfo.processInfo.environment
+        // Variant: a DashSync entry whose phrase can never validate — the
+        // migrator fails every run (deferredFailure), reproducing the
+        // "stranded upgrader" state without touching any valid material
+        // already present.
+        if env["LEGACY_KEYCHAIN_INVALID"] == "1" {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: doneKey)
+            _ = KeychainStore.set(
+                data: Data("definitely not a valid bip39 phrase".utf8),
+                service: dashSyncService,
+                account: dashSyncMnemonicAccountPrefix + "deadbeefdeadbeef",
+                accessibility: .whenUnlockedThisDeviceOnly)
+            logger.warning("🔑 KEYMIG :: DEBUG invalid-mnemonic fixture installed")
+            return
+        }
+        guard let phrase = env["LEGACY_KEYCHAIN_MNEMONIC"], !phrase.isEmpty else { return }
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: doneKey)
+        defaults.removeObject(forKey: migratedDashSyncWalletIdsKey)
+
+        // The legacy install had a PIN (PinStore reads DashSync's records
+        // in place) — plant one so the post-migration lock screen is
+        // satisfiable, as it is on a real upgrade.
+        let pin = env["LEGACY_KEYCHAIN_PIN"] ?? "1111"
+        _ = PinStore.set(string: pin, for: .pin)
+        _ = PinStore.set(int64: 1, for: .usesAuthentication)
+
+        let walletID = "1122334455667788"
+        _ = KeychainStore.set(
+            data: Data(phrase.utf8),
+            service: dashSyncService,
+            account: dashSyncMnemonicAccountPrefix + walletID,
+            accessibility: .whenUnlockedThisDeviceOnly)
+        let orphan = env["LEGACY_KEYCHAIN_ORPHAN"] == "1"
+        if orphan {
+            _ = KeychainStore.set(
+                data: nil,
+                service: dashSyncService,
+                account: dashSyncChainWalletsKeyPrefix + mainnetGenesisShortHex,
+                accessibility: .whenUnlockedThisDeviceOnly)
+        } else if let archive = try? NSKeyedArchiver.archivedData(
+            withRootObject: [walletID] as NSArray, requiringSecureCoding: false) {
+            _ = KeychainStore.set(
+                data: archive,
+                service: dashSyncService,
+                account: dashSyncChainWalletsKeyPrefix + mainnetGenesisShortHex,
+                accessibility: .whenUnlockedThisDeviceOnly)
+        }
+        logger.warning("🔑 KEYMIG :: DEBUG legacy fixture installed (orphan=\(orphan, privacy: .public))")
+    }
+    #endif
 
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -50,6 +50,7 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     private static let seedMigratorDeferredKeys = [
         "swiftSDKKeyMigration.v1.deferredMultiWallet",
         "swiftSDKKeyMigration.v1.deferredUnknownChain",
+        "swiftSDKKeyMigration.v1.deferredFailure",
     ]
     private static let seedMigratorWaitTimeout: TimeInterval = 30.0
     private static let seedMigratorPollInterval: TimeInterval = 0.1
@@ -403,6 +404,18 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     private func waitForSeedMigratorIfNeeded() async -> Bool {
         let defaults = UserDefaults.standard
         if defaults.string(forKey: Self.seedMigratorDoneKey) != nil {
+            return true
+        }
+
+        // A persisted SDK wallet is runnable material regardless of the
+        // migrator's state. Gating on the sentinel here stranded users who
+        // restored a wallet while the migrator kept failing without a
+        // terminal flag: every refresh waited the full timeout, gave up,
+        // and left the runtime stopped — main UI with an empty Wallets
+        // screen and refused imports. A late successful migration still
+        // lands through `handleWalletMaterialChanged`.
+        if WalletEnvironment.hasSDKWallet {
+            Self.logger.info("🧭 RUNTIME :: SDK wallet already persisted; not blocking on key migrator")
             return true
         }
 

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -194,12 +194,26 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
             controller = [self mainController];
         }
     }
-    else {
+    // A DashSync-era wallet in the keychain with the async key migrator
+    // still running means "no wallet" is a lie about to become true.
+    // Deciding now would show Create/Recover to an upgrading user whose
+    // wallet is milliseconds from appearing — and route their typed
+    // phrase into the recover screen's wipe branch. Hold the launch
+    // background and decide once the migrator settles (typically well
+    // under a second; bounded fallback in the poller).
+    const BOOL keyMigrationPending =
+        !hasAWallet && [DWSwiftDashSDKKeyMigrator legacyWalletMaterialPendingMigration];
+    if (!hasAWallet && !keyMigrationPending) {
         controller = [self setupController];
     }
 
     if (controller) {
         [self transitionToController:controller];
+    }
+
+    if (keyMigrationPending) {
+        [self presentInitialControllerWhenKeyMigrationSettles:
+                  [NSDate dateWithTimeIntervalSinceNow:10.0]];
     }
 
     if (hasAWallet) {
@@ -269,6 +283,38 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
         self.launchingWasDeferred = NO;
 
         [self applicationDidBecomeActiveNotification];
+    }
+}
+
+#pragma mark - Key migration launch hold
+
+/// Poll the key migrator's terminal state, then present the initial
+/// controller the normal launch decision would have picked: main (behind
+/// the lock screen — `PinStore` reads DashSync's PIN records in place, so
+/// the migrated wallet keeps its old PIN) when the wallet landed, setup
+/// otherwise. Bounded by `deadline` so a wedged migrator degrades to the
+/// old behavior instead of a blank screen.
+- (void)presentInitialControllerWhenKeyMigrationSettles:(NSDate *)deadline {
+    if (![DWSwiftDashSDKKeyMigrator migrationSettled] && [deadline timeIntervalSinceNow] > 0) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
+                       dispatch_get_main_queue(), ^{
+                           [weakSelf presentInitialControllerWhenKeyMigrationSettles:deadline];
+                       });
+        return;
+    }
+
+    const BOOL hasAWallet = self.model.hasAWallet;
+    if (hasAWallet) {
+        if ([self.model shouldShowLockScreen]) {
+            [self showLockControllerIfNeeded];
+        }
+        else {
+            [self transitionToController:[self mainController]];
+        }
+    }
+    else {
+        [self transitionToController:[self setupController]];
     }
 }
 

--- a/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
@@ -184,6 +184,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Private
 
 - (BOOL)shouldDisplayOnboarding {
+    // The carousel is a new-user intro. An upgrader whose DashSync wallet
+    // is pending migration skips it: the root controller's migration hold
+    // presents their wallet (behind the lock screen) directly, instead of
+    // marketing playing while the wallet is milliseconds from appearing.
+    // The reinstall case (SDK wallet material with wiped defaults) keeps
+    // the carousel — its Keep/Delete prompt is wired to the carousel's
+    // completion.
+    if ([DWSwiftDashSDKKeyMigrator legacyWalletMaterialPendingMigration]) {
+        return NO;
+    }
     return [DWGlobalOptions sharedInstance].shouldDisplayOnboarding;
 }
 


### PR DESCRIPTION
Field report from a TestFlight upgrader (previous install: the App Store DashSync-era build, wallet with no transactions): after upgrading he got the Create/Recover screen instead of his wallet; restoring the phrase "let him in", but the Wallets screen was empty and importing another wallet was refused.

## Root causes (all three verified in code and reproduced in sim)

1. **Launch race — every upgrader hits it.** `AppDelegate` fires the async key migrator and builds the root UI in the same turn; `DWAppRootViewController` reads `hasAWallet` (SDK-keychain inventory) synchronously and never re-evaluates. For an App Store upgrade that inventory is empty at that instant, so onboarding shows even when migration succeeds ~500 ms later. Worse: once migration lands mid-entry, the recover screen's `hasWallet` branch routes the typed phrase into **wipe**, not import.
2. **Permanent strand.** A migrator run ending in `hadFailure` recorded **no terminal flag** — the runtime's sentinel wait timed out and full-reset on *every* refresh, even after the user restored a wallet into the SDK keychain: main UI up, `manager == nil` forever, Wallets list empty (it reads the live manager), imports refused with the misleading "No persisted SwiftDashSDK wallet found" (the host-not-ready guard). The empty list and the refused import are one condition.

## Fixes

- Root controller: when DashSync material is pending migration, hold the initial decision (0.1 s poll, 10 s bound), then present **main behind the lock screen** (`PinStore` reads DashSync's PIN records in place — the old PIN just works) or setup on genuine failure.
- Migrator: failures record a terminal `deferredFailure` flag, so no waiter ever polls a sentinel that cannot arrive.
- Runtime: `waitForSeedMigratorIfNeeded` short-circuits whenever an SDK wallet is already persisted — **this heals already-affected devices on update with no user action** (the restored wallet exists, so the runtime simply starts).
- DEBUG-only keychain fixture (`LEGACY_KEYCHAIN_MNEMONIC` / `_PIN` / `_ORPHAN` / `_INVALID` env) fabricating DashSync's frozen keychain layout for simulator testing of these paths.

## Verification (simulator, wiped device each run)

| Scenario | Result |
|---|---|
| Valid legacy fixture (mnemonic + chain list + PIN) | Migration lands; "Wallet found on this device" offer; **Keep Wallet** → wallet live with correct balance. No Create/Recover. |
| Orphan fixture (no chain list — genuinely unmigratable) | `deferredUnknownChain` settles; Create/Recover shown promptly (no blank hold). |
| Poisoned migration over an existing SDK wallet (the reporter's stranded state) | Runtime starts immediately (fresh SDK session dir on launch) instead of 30 s timeout → dead manager. |

Two pre-existing bugs observed during verification are filed separately: the first-launch reinstall flow's PIN screen ignores input until relaunch (lockWindow key-window ordering), and a `hasWallet`-without-PIN state presents an unsatisfiable Enter PIN instead of routing to Set PIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app launch handling when legacy wallet data requires migration.
  * Prevented setup screens from appearing prematurely while migration is still in progress.
  * Added fallback handling for failed or incomplete legacy wallet imports.
  * Preserved lock-screen behavior while determining the appropriate initial screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->