### PR TITLE
fix: unsatisfiable Enter PIN lock when a wallet exists without a PIN record

### DIFF
--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -128,6 +128,12 @@ NS_ASSUME_NONNULL_BEGIN
     
     [[DWVersionManager sharedInstance] migrateUserDefaults];
     [[DWAuthenticationService shared] enableAuthenticationIfNeeded];
+#ifdef DEBUG
+    // QA fixture: fabricate the wallet-without-PIN keychain state (partial
+    // restore / interrupted setup) to exercise the lock screen's Set PIN
+    // routing. No-op unless QA_DROP_PIN_RECORDS=1 is in the environment.
+    [DWAuthenticationService debugDropPinRecordsIfRequested];
+#endif
 
     // Advance the PIN-lockout clock to the wall clock at every launch, so a
     // lockout keeps elapsing even fully offline (Bug #2 — DashSync's own

--- a/DashWallet/Sources/Infrastructure/Authentication/AuthenticationService.swift
+++ b/DashWallet/Sources/Infrastructure/Authentication/AuthenticationService.swift
@@ -183,6 +183,21 @@ final class AuthenticationService: NSObject, AuthenticationServiceProtocol {
         didAuthenticate = false
     }
 
+    #if DEBUG
+    /// QA fixture: fabricate the "wallet exists, no PIN record" keychain
+    /// state (partial iCloud/device-transfer restore, interrupted setup) by
+    /// deleting the PIN records at launch, leaving the wallet mnemonic in
+    /// place. With a wallet on the device,
+    /// `SIMCTL_CHILD_QA_DROP_PIN_RECORDS=1 simctl launch …` reproduces the
+    /// lock screen's no-PIN routing. Called from the AppDelegate before the
+    /// root controller is built.
+    @objc static func debugDropPinRecordsIfRequested() {
+        guard ProcessInfo.processInfo.environment["QA_DROP_PIN_RECORDS"] == "1" else { return }
+        shared.removePin()
+        logger.warning("🔑 QA fixture: PIN records dropped (QA_DROP_PIN_RECORDS)")
+    }
+    #endif
+
     // MARK: Verification
 
     /// Result shape of the pod's 4-flag verification completion, minus the

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenModel.h
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenModel.h
@@ -36,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic, assign, getter=isBiometricAuthenticationAllowed) BOOL biometricAuthenticationAllowed;
 @property (readonly, nonatomic, assign) LABiometryType biometryType;
+/// Whether a PIN record exists in the keychain. NO means "Enter PIN" can
+/// never succeed (partial keychain restore, interrupted setup) — the lock
+/// screen must route to the phrase-gated Set PIN flow instead.
+@property (readonly, nonatomic, assign) BOOL hasPinSet;
 @property (nullable, nonatomic, weak) id<DWLockScreenModelDelegate> delegate;
 
 - (void)authenticateUsingBiometricsOnlyCompletion:(void (^)(BOOL authenticated))completion;

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenModel.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenModel.m
@@ -40,6 +40,10 @@ static NSTimeInterval const CHECK_INTERVAL = 1.0;
            [DWAuthenticationService shared].isBiometricAuthenticationAllowed;
 }
 
+- (BOOL)hasPinSet {
+    return [[DWAuthenticationService shared] hasPin];
+}
+
 - (LABiometryType)biometryType {
 #if (TARGET_OS_SIMULATOR && SHOULD_SIMULATE_BIOMETRICS)
     return LABiometryTypeTouchID;

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -343,8 +343,11 @@ static CGFloat ActionButtonsHeight(void) {
         self.scanToPayButton.enabled = NO;
         [self hideLoginButtonIfNeeded];
         [self.pinInputView setTitleText:NSLocalizedString(@"PIN Not Set", nil)];
+        // Keep this to one action phrase: the pin-input container is centered
+        // without a width cap (LockScreen.storyboard), so an overlong single
+        // line renders past the screen edges instead of wrapping.
         [self.pinInputView setAttemptsText:nil
-                                 errorText:NSLocalizedString(@"This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet.", nil)];
+                                 errorText:NSLocalizedString(@"Verify your recovery phrase to set a new PIN.", nil)];
         return;
     }
 

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -154,6 +154,16 @@ static CGFloat ActionButtonsHeight(void) {
 - (IBAction)forgotPinButtonAction:(UIButton *)sender {
     [self.model stopCheckingAuthState];
 
+    // No PIN record at all (partial keychain restore, interrupted setup):
+    // there is nothing to forget and no fail counter can ever advance, so go
+    // straight to the ownership proof. The phrase gate stays mandatory — the
+    // PIN is the spending protection, so a missing record must not become a
+    // free takeover of the wallet.
+    if (!self.model.hasPinSet) {
+        [self presentPinResetRecovery];
+        return;
+    }
+
     // Everyday forgot-PIN: prove ownership with the recovery phrase, then set a
     // new PIN and keep the wallet (app-owned DWRecoverViewController in
     // ResetPin mode). Only past the wipe threshold do we also offer a wipe —
@@ -262,8 +272,12 @@ static CGFloat ActionButtonsHeight(void) {
 #pragma mark - DWSetPinViewControllerDelegate
 
 - (void)presentSetNewPin {
+    // Forgot-PIN changes an existing PIN; the no-PIN-record path sets the
+    // first one — same screen, honest title.
+    const DWSetPinIntent intent =
+        self.model.hasPinSet ? DWSetPinIntent_ChangePin : DWSetPinIntent_SetPin;
     DWSetPinViewController *controller =
-        [DWSetPinViewController controllerWithIntent:DWSetPinIntent_ChangePin];
+        [DWSetPinViewController controllerWithIntent:intent];
     controller.delegate = self;
 
     DWNavigationController *navigationController =
@@ -280,8 +294,10 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (void)setPinViewControllerDidCancel:(DWSetPinViewController *)controller {
-    // Phrase was proven but the user backed out of setting a new PIN; the old
-    // PIN still works, so return to the lock screen.
+    // Phrase was proven but the user backed out of setting a new PIN — return
+    // to the lock screen in whatever state the keychain is in: the old PIN
+    // still works on the forgot-PIN path, and the no-PIN-record path re-renders
+    // its Set PIN routing.
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  [self.model startCheckingAuthState];
@@ -316,6 +332,22 @@ static CGFloat ActionButtonsHeight(void) {
                    authenticated:(BOOL)authenticated
                    shouldLockout:(BOOL)shouldLockout
                  attemptsMessage:(nullable NSString *)attemptsMessage {
+    // A wallet without a PIN record (partial keychain restore, interrupted
+    // setup) can never satisfy "Enter PIN" — every entry would fail as a
+    // store error, permanently locking the user out. Present the honest
+    // state instead and route to the phrase-gated Set PIN flow. This wins
+    // over a stale lockout counter too: with no PIN there is nothing to
+    // brute-force, and setting the new PIN zeroes the counters.
+    if (!model.hasPinSet) {
+        self.keyboarView.isEnabled = NO;
+        self.scanToPayButton.enabled = NO;
+        [self hideLoginButtonIfNeeded];
+        [self.pinInputView setTitleText:NSLocalizedString(@"PIN Not Set", nil)];
+        [self.pinInputView setAttemptsText:nil
+                                 errorText:NSLocalizedString(@"This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet.", nil)];
+        return;
+    }
+
     self.keyboarView.isEnabled = shouldContinueAuthentication;
     self.scanToPayButton.enabled = shouldContinueAuthentication;
 
@@ -391,7 +423,14 @@ static CGFloat ActionButtonsHeight(void) {
     self.pinInputView.delegate = self;
     [self.pinInputView configureWithKeyboard:self.keyboarView];
 
-    [self.forgotPinButton setTitle:NSLocalizedString(@"Forgot PIN?", nil) forState:UIControlStateNormal];
+    // The button is the single escape hatch in both states; with no PIN
+    // record "Forgot PIN?" would be a lie — nothing was forgotten. A PIN
+    // set while this screen is alive immediately unlocks (delegate), so the
+    // title never needs to flip back.
+    NSString *escapeTitle = self.model.hasPinSet
+                                ? NSLocalizedString(@"Forgot PIN?", nil)
+                                : NSLocalizedString(@"Set PIN", nil);
+    [self.forgotPinButton setTitle:escapeTitle forState:UIControlStateNormal];
 
     self.quickReceiveButton.title = NSLocalizedString(@"Quick Receive", nil);
     self.quickReceiveButton.image = [UIImage imageNamed:@"icon_lock_receive"];
@@ -428,6 +467,13 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (void)performBiometricAuthentication {
+    // No biometric unlock while no PIN record exists: it would bypass the
+    // missing PIN into a wallet where every downstream auth gate (spend,
+    // change-PIN) is unsatisfiable. The Set PIN route repairs the state first.
+    if (!self.model.hasPinSet) {
+        return;
+    }
+
     if (self.model.isBiometricAuthenticationAllowed) {
         [self.model authenticateUsingBiometricsOnlyCompletion:^(BOOL authenticated) {
             if (authenticated) {
@@ -441,7 +487,7 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (void)hideLoginButtonIfNeeded {
-    self.loginButton.hidden = !self.model.isBiometricAuthenticationAllowed;
+    self.loginButton.hidden = !self.model.hasPinSet || !self.model.isBiometricAuthenticationAllowed;
 }
 
 @end

--- a/DashWallet/Sources/UI/LockScreen/Views/DWLockPinInputView.m
+++ b/DashWallet/Sources/UI/LockScreen/Views/DWLockPinInputView.m
@@ -116,6 +116,10 @@ static CGFloat const SPACING = 8.0;
         [titleLabel.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
 
         [stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+        // Cap the stack at the view's width so multi-line attempts/error text
+        // wraps (numberOfLines = 0) instead of extending past the screen edges.
+        [stackView.leadingAnchor constraintGreaterThanOrEqualToAnchor:self.leadingAnchor],
+        [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:self.trailingAnchor],
         [stackView.topAnchor constraintEqualToAnchor:titleLabel.bottomAnchor
                                             constant:VERTICAL_PADDING],
         [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.h
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.h
@@ -33,6 +33,11 @@ extern NSInteger const DW_PHRASE_MULTIPLE;
 
 - (BOOL)hasWallet;
 
+/// Whether a PIN record exists in the keychain. In ResetPin mode the screen's
+/// copy depends on it: an existing PIN is "reset", a missing record (partial
+/// keychain restore, interrupted setup) is "set".
+- (BOOL)hasPinSet;
+
 // `isWalletEmpty`, `canWipeWithPhrase:`, `cleanupPhrase:`, `normalizePhrase:`,
 // `wordIsLocal:`, `wordIsValid:` are provided by the Swift extension
 // `DWRecoverModel+Mnemonic.swift` (SwiftDashSDK) and reach Obj-C callers

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
@@ -45,6 +45,10 @@ NSInteger const DW_PHRASE_MULTIPLE = 3;
     return DWWalletEnvironment.hasWallet;
 }
 
+- (BOOL)hasPinSet {
+    return [[DWAuthenticationService shared] hasPin];
+}
+
 // `isWalletEmpty` and `canWipeWithPhrase:` live in DWRecoverModel+Mnemonic.swift
 // (SDK balance + sync-done gate; normalized-phrase comparison) — C6-D.
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
@@ -240,6 +240,12 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Private
 
 - (void)setupView {
+    self.model = [[DWRecoverModel alloc] initWithAction:self.action];
+
+    // ResetPin mode proves ownership before (re)setting the PIN; when no PIN
+    // record exists (partial keychain restore, interrupted setup) there is
+    // nothing to "reset", so the copy says "set".
+    const BOOL hasPinSet = self.model.hasPinSet;
     switch (self.action) {
         case DWRecoverAction_Recover:
             self.title = NSLocalizedString(@"Recover Wallet", nil);
@@ -248,11 +254,11 @@ NS_ASSUME_NONNULL_BEGIN
             self.title = NSLocalizedString(@"Wipe Wallet", nil);
             break;
         case DWRecoverAction_ResetPin:
-            self.title = NSLocalizedString(@"Reset PIN", nil);
+            self.title = hasPinSet
+                             ? NSLocalizedString(@"Reset PIN", nil)
+                             : NSLocalizedString(@"Set PIN", nil);
             break;
     }
-
-    self.model = [[DWRecoverModel alloc] initWithAction:self.action];
 
     self.actionButton.enabled = NO;
 
@@ -260,9 +266,14 @@ NS_ASSUME_NONNULL_BEGIN
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
     contentView.model = self.model;
     contentView.delegate = self;
-    contentView.title = (self.action == DWRecoverAction_ResetPin)
-                            ? NSLocalizedString(@"Enter your recovery phrase to reset your PIN", nil)
-                            : NSLocalizedString(@"Enter Recovery Phrase", nil);
+    if (self.action == DWRecoverAction_ResetPin) {
+        contentView.title = hasPinSet
+                                ? NSLocalizedString(@"Enter your recovery phrase to reset your PIN", nil)
+                                : NSLocalizedString(@"Enter your recovery phrase to set a new PIN", nil);
+    }
+    else {
+        contentView.title = NSLocalizedString(@"Enter Recovery Phrase", nil);
+    }
     [self.scrollView addSubview:contentView];
     self.contentView = contentView;
 

--- a/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.h
+++ b/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.h
@@ -22,6 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, DWSetPinIntent) {
     DWSetPinIntent_CreateNewWallet,
     DWSetPinIntent_ChangePin,
+    /// A wallet exists but no PIN record does (partial keychain restore,
+    /// interrupted setup) — there is no PIN to "change".
+    DWSetPinIntent_SetPin,
 };
 
 @class DWSetPinViewController;

--- a/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.m
+++ b/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.m
@@ -49,6 +49,10 @@ NS_ASSUME_NONNULL_BEGIN
             controller.title = NSLocalizedString(@"Change PIN", nil);
             break;
         }
+        case DWSetPinIntent_SetPin: {
+            controller.title = NSLocalizedString(@"Set PIN", nil);
+            break;
+        }
     }
 
     controller.model = [[DWSetPinModel alloc] init];

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -4477,9 +4477,6 @@
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
 
-/* No comment provided by engineer. */
-"This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet." = "This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet.";
-
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";
 
@@ -4855,6 +4852,9 @@
 
 /* CrowdNode */
 "Verify your API Dash address" = "Verify your API Dash address";
+
+/* No comment provided by engineer. */
+"Verify your recovery phrase to set a new PIN." = "Verify your recovery phrase to set a new PIN.";
 
 /* Usernames */
 "Verify your identity" = "Verify your identity";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1516,6 +1516,9 @@
 /* No comment provided by engineer. */
 "Enter your recovery phrase to reset your PIN" = "Enter your recovery phrase to reset your PIN";
 
+/* No comment provided by engineer. */
+"Enter your recovery phrase to set a new PIN" = "Enter your recovery phrase to set a new PIN";
+
 /* Voting */
 "Enter your voting key" = "Enter your voting key";
 
@@ -3249,6 +3252,9 @@
 /* No comment provided by engineer. */
 "PIN is always required to make a payment" = "PIN is always required to make a payment";
 
+/* No comment provided by engineer. */
+"PIN Not Set" = "PIN Not Set";
+
 /* Dash Platform chain */
 "Platform" = "Platform";
 
@@ -4470,6 +4476,9 @@
 
 /* DashPay Contacts */
 "This user hasn't set up the keys needed to receive contact requests yet." = "This user hasn't set up the keys needed to receive contact requests yet.";
+
+/* No comment provided by engineer. */
+"This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet." = "This wallet has no PIN. Verify your recovery phrase to set a new PIN and unlock your wallet.";
 
 /* Wallets */
 "This wallet is already on this device." = "This wallet is already on this device.";


### PR DESCRIPTION
## Issue being fixed or feature implemented

A wallet present in the SDK keychain with **no PIN record** presented the lock screen in "Enter PIN" mode — which no input can satisfy (`verifyPin` fails with a store error on every entry), permanently locking the user out. The only escape was the misleading "Forgot PIN?" button. Observed 2026-08-12 on a simulator with a planted mnemonic and no PIN; reachable in production via partial keychain states — e.g. an iCloud/device-transfer restore that drops ThisDeviceOnly PIN items but keeps synchronizable ones, or setup interrupted between wallet creation and PIN entry.

Root cause: `DWLockScreenModel`'s auth-state loop drives the lock UI purely from `AuthenticationService.authenticationPrecheck()`, which reads fail counters but never `hasPin()` — the screen had no notion of "no PIN exists".

## What was done?

- Added a `hasPinSet` facade to `DWLockScreenModel` (and `DWRecoverModel`) over `AuthenticationService.hasPin()`.
- `DWLockScreenViewController` now branches first on the missing PIN record:
  - keypad and Scan-to-Send disabled; PIN dots hidden; title **"PIN Not Set"** with explanatory copy;
  - biometric unlock suppressed (a restored `PIN_UNLOCK_TIME` in UserDefaults could otherwise let Face ID bypass into a wallet whose every downstream auth gate — spend, change-PIN — is unsatisfiable);
  - the escape button, retitled **"Set PIN"**, routes into the **existing ownership-gated flow**: `DWRecoverViewController` (ResetPin mode) verifies the typed recovery phrase against the persisted SDK mnemonic, then `DWSetPinViewController` sets the new PIN and the screen unlocks. The phrase gate stays mandatory — the PIN is the spending protection, so a missing record must not become a free wallet takeover. The no-PIN state also wins over a stale lockout counter (nothing to brute-force; `setupNewPin` zeroes the counters).
- Honest copy end to end: new `DWSetPinIntent_SetPin` titles the PIN screen "Set PIN" (not "Change PIN"); the recovery screen says "Enter your recovery phrase to **set a new** PIN" when none exists. New strings added to the en catalog.
- **DEBUG repro fixture** (same pattern as #985's legacy fixture): `QA_DROP_PIN_RECORDS=1` in the environment deletes the PIN records at launch while leaving the wallet in place:
  ```
  SIMCTL_CHILD_QA_DROP_PIN_RECORDS=1 xcrun simctl launch <udid> org.dashfoundation.dashpay.devnet
  ```
  (Equivalent to running #985's `LEGACY_KEYCHAIN_MNEMONIC` fixture without its PIN planting, but self-contained on develop.)

## How Has This Been Tested?

- `dashpay` scheme simulator build.
- Simulator smoke of the touched flow (unit-test target is broken pre-existing): create/recover wallet with a PIN → relaunch with `QA_DROP_PIN_RECORDS=1` → lock screen shows the "PIN Not Set" state (keypad disabled, no biometric button) → **Set PIN** → recovery phrase verifies → new PIN set → app unlocks → subsequent relaunch requires the new PIN normally.

## Breaking Changes

None. Wallets with a PIN record see the exact previous behavior; the new branch is reachable only when the PIN record is absent (previously a hard lockout).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works — unit-test target is currently broken (pre-existing); verified via simulator smoke instead
- [x] I have made corresponding changes to the documentation — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)