### PR TITLE
feat: embed internal transfer form in Send landing and block same-balance routes

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -48,15 +48,17 @@ struct InternalTransferScreen: View {
 
     @State private var confirmation: InternalTransferConfirmation?
 
-    /// Standalone screen: which endpoint group is currently expanded into
-    /// its three-row picker. `nil` = both collapsed to their selected card,
-    /// so the screen never shows all six rows at once. Presentation state
-    /// only — the selection itself lives in the view model.
-    @State private var expandedEndpointGroup: EndpointGroup?
+    /// Standalone screen: which endpoint's balance picker is presented as
+    /// the bottom sheet. `nil` = none — the form shows just the two
+    /// selected-endpoint cards, never all six rows at once. Presentation
+    /// state only — the selection itself lives in the view model.
+    @State private var endpointPicker: EndpointGroup?
 
-    private enum EndpointGroup {
+    private enum EndpointGroup: String, Identifiable {
         case from
         case to
+
+        var id: String { rawValue }
     }
 
     var body: some View {
@@ -252,51 +254,69 @@ struct InternalTransferScreen: View {
 
     private var swappableCards: some View {
         VStack(spacing: 12) {
-            endpointSelector(
-                group: .from,
-                caption: NSLocalizedString("From", comment: ""),
-                selected: viewModel.source,
-                conflictingWith: viewModel.resolvedSendTarget,
-                onSelect: viewModel.selectStandaloneSource)
-
-            endpointSelector(
-                group: .to,
-                caption: NSLocalizedString("To", comment: ""),
-                selected: viewModel.resolvedSendTarget,
-                conflictingWith: viewModel.source,
-                onSelect: viewModel.selectStandaloneTarget)
+            collapsedEndpointCard(viewModel.source, caption: NSLocalizedString("From", comment: "")) {
+                presentEndpointPicker(.from)
+            }
+            collapsedEndpointCard(viewModel.resolvedSendTarget, caption: NSLocalizedString("To", comment: "")) {
+                presentEndpointPicker(.to)
+            }
+        }
+        .sheet(item: $endpointPicker) { group in
+            endpointPickerSheet(for: group)
+                .presentationDetents([.height(400)])
+                .presentationDragIndicator(.visible)
         }
     }
 
-    /// Collapsed: one card showing the group's current selection, chevron
-    /// trailing; tapping expands it. Expanded: the three-row picker — a
-    /// valid pick collapses it again, a conflicting tap keeps it open with
-    /// the inline warning explaining the rejection.
-    @ViewBuilder
-    private func endpointSelector(
-        group: EndpointGroup,
-        caption: String,
-        selected: ChainNetwork,
-        conflictingWith conflict: ChainNetwork,
-        onSelect: @escaping (ChainNetwork) -> Void
-    ) -> some View {
-        if expandedEndpointGroup == group {
+    private func presentEndpointPicker(_ group: EndpointGroup) {
+        // A conflict notice from an earlier interaction must not open a
+        // fresh picker pre-scolded.
+        viewModel.clearEndpointConflictNotice()
+        endpointPicker = group
+    }
+
+    /// Bottom-sheet balance picker for one endpoint, sized to slide over
+    /// the keypad area. A valid pick applies and dismisses; a conflicting
+    /// pick keeps the sheet open with the inline warning explaining the
+    /// rejection.
+    private func endpointPickerSheet(for group: EndpointGroup) -> some View {
+        let isFrom = group == .from
+        let conflict = isFrom ? viewModel.resolvedSendTarget : viewModel.source
+        return VStack(alignment: .leading, spacing: 16) {
+            Text(isFrom
+                ? NSLocalizedString("Transfer from", comment: "Internal transfer source picker title")
+                : NSLocalizedString("Transfer to", comment: "Internal transfer destination picker title"))
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.dash.primaryText)
+
             selectionGroup(
-                caption: caption,
+                caption: isFrom
+                    ? NSLocalizedString("From", comment: "")
+                    : NSLocalizedString("To", comment: ""),
                 networks: ChainNetwork.allCases,
-                selected: selected,
+                selected: isFrom ? viewModel.source : viewModel.resolvedSendTarget,
                 conflictingWith: conflict,
                 onSelect: { network in
-                    onSelect(network)
+                    if isFrom {
+                        viewModel.selectStandaloneSource(network)
+                    } else {
+                        viewModel.selectStandaloneTarget(network)
+                    }
                     if network != conflict {
-                        withAnimation { expandedEndpointGroup = nil }
+                        endpointPicker = nil
                     }
                 })
-        } else {
-            collapsedEndpointCard(selected, caption: caption) {
-                withAnimation { expandedEndpointGroup = group }
+
+            if let notice = viewModel.endpointConflictNotice {
+                TransferAmountValidationNote(message: notice)
             }
+
+            Spacer(minLength: 0)
         }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.dash.primaryBackground)
     }
 
     private func collapsedEndpointCard(

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -207,9 +207,8 @@ struct InternalTransferScreen: View {
             pinnedCard(source, caption: NSLocalizedString("From", comment: ""))
             selectionGroup(
                 caption: NSLocalizedString("To", comment: ""),
-                networks: ChainNetwork.allCases,
+                networks: availableTargets(for: source),
                 selected: viewModel.resolvedSendTarget,
-                conflictingWith: source,
                 onSelect: viewModel.selectSendTarget)
         }
     }
@@ -266,9 +265,8 @@ struct InternalTransferScreen: View {
         VStack(spacing: 12) {
             selectionGroup(
                 caption: NSLocalizedString("From", comment: ""),
-                networks: ChainNetwork.allCases,
+                networks: availableSources(for: target),
                 selected: viewModel.resolvedReceiveSource,
-                conflictingWith: target,
                 onSelect: viewModel.selectReceiveSource)
 
             pinnedCard(target, caption: NSLocalizedString("To", comment: ""))
@@ -325,6 +323,17 @@ struct InternalTransferScreen: View {
             selected: selected,
             showsRadio: showsRadio,
             action: action)
+    }
+
+    /// Pinned-sheet picker lists (the balance-row arrow sheets): the fixed
+    /// endpoint's balance is left out entirely — only the standalone screen
+    /// shows all three with same-balance taps rejected.
+    private func availableTargets(for source: ChainNetwork) -> [ChainNetwork] {
+        ChainNetwork.allCases.filter { $0 != source }
+    }
+
+    private func availableSources(for target: ChainNetwork) -> [ChainNetwork] {
+        ChainNetwork.allCases.filter { $0 != target }
     }
 
     // MARK: - Transfer preview

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -71,6 +71,11 @@ struct InternalTransferScreen: View {
                     directionCards
                         .padding(.horizontal, 20)
 
+                    if let conflictNotice = viewModel.endpointConflictNotice {
+                        TransferAmountValidationNote(message: conflictNotice)
+                            .padding(.horizontal, 20)
+                    }
+
                     if viewModel.isBlockedBySync {
                         SyncGateNote()
                             .padding(.horizontal, 20)
@@ -202,8 +207,9 @@ struct InternalTransferScreen: View {
             pinnedCard(source, caption: NSLocalizedString("From", comment: ""))
             selectionGroup(
                 caption: NSLocalizedString("To", comment: ""),
-                networks: availableTargets(for: source),
+                networks: ChainNetwork.allCases,
                 selected: sanitizedTarget(for: source, proposed: viewModel.sendTarget),
+                conflictingWith: source,
                 onSelect: viewModel.selectSendTarget)
         }
     }
@@ -240,12 +246,14 @@ struct InternalTransferScreen: View {
                 caption: NSLocalizedString("From", comment: ""),
                 networks: ChainNetwork.allCases,
                 selected: viewModel.source,
+                conflictingWith: sanitizedTarget(for: viewModel.source, proposed: viewModel.sendTarget),
                 onSelect: viewModel.selectStandaloneSource)
 
             selectionGroup(
                 caption: NSLocalizedString("To", comment: ""),
-                networks: availableTargets(for: viewModel.source),
+                networks: ChainNetwork.allCases,
                 selected: sanitizedTarget(for: viewModel.source, proposed: viewModel.sendTarget),
+                conflictingWith: viewModel.source,
                 onSelect: viewModel.selectStandaloneTarget)
         }
     }
@@ -258,8 +266,9 @@ struct InternalTransferScreen: View {
         VStack(spacing: 12) {
             selectionGroup(
                 caption: NSLocalizedString("From", comment: ""),
-                networks: availableSources(for: target),
+                networks: ChainNetwork.allCases,
                 selected: sanitizedSource(into: target, proposed: viewModel.receiveSource),
+                conflictingWith: target,
                 onSelect: viewModel.selectReceiveSource)
 
             pinnedCard(target, caption: NSLocalizedString("To", comment: ""))
@@ -271,10 +280,15 @@ struct InternalTransferScreen: View {
         TransferSourceRow.dashBalanceTrailing(formatted)
     }
 
+    /// `conflictingWith` is the balance already occupying the opposite
+    /// endpoint: its row stays visible (the group always lists all three
+    /// balances) but dimmed, and tapping it is rejected by the view model
+    /// with an inline explanation.
     private func selectionGroup(
         caption: String,
         networks: [ChainNetwork],
         selected: ChainNetwork,
+        conflictingWith: ChainNetwork? = nil,
         onSelect: @escaping (ChainNetwork) -> Void
     ) -> some View {
         VStack(spacing: 8) {
@@ -287,6 +301,7 @@ struct InternalTransferScreen: View {
                     balanceTrailing: dashBalanceTrailing(display.balance),
                     selected: selected == network,
                     action: { onSelect(network) })
+                    .opacity(network == conflictingWith ? 0.45 : 1)
             }
         }
     }
@@ -310,14 +325,6 @@ struct InternalTransferScreen: View {
             selected: selected,
             showsRadio: showsRadio,
             action: action)
-    }
-
-    private func availableTargets(for source: ChainNetwork) -> [ChainNetwork] {
-        ChainNetwork.allCases.filter { $0 != source }
-    }
-
-    private func availableSources(for target: ChainNetwork) -> [ChainNetwork] {
-        ChainNetwork.allCases.filter { $0 != target }
     }
 
     private func sanitizedTarget(for source: ChainNetwork, proposed target: ChainNetwork) -> ChainNetwork {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -48,6 +48,17 @@ struct InternalTransferScreen: View {
 
     @State private var confirmation: InternalTransferConfirmation?
 
+    /// Standalone screen: which endpoint group is currently expanded into
+    /// its three-row picker. `nil` = both collapsed to their selected card,
+    /// so the screen never shows all six rows at once. Presentation state
+    /// only — the selection itself lives in the view model.
+    @State private var expandedEndpointGroup: EndpointGroup?
+
+    private enum EndpointGroup {
+        case from
+        case to
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if showsHeader {
@@ -241,20 +252,68 @@ struct InternalTransferScreen: View {
 
     private var swappableCards: some View {
         VStack(spacing: 12) {
-            selectionGroup(
+            endpointSelector(
+                group: .from,
                 caption: NSLocalizedString("From", comment: ""),
-                networks: ChainNetwork.allCases,
                 selected: viewModel.source,
                 conflictingWith: viewModel.resolvedSendTarget,
                 onSelect: viewModel.selectStandaloneSource)
 
-            selectionGroup(
+            endpointSelector(
+                group: .to,
                 caption: NSLocalizedString("To", comment: ""),
-                networks: ChainNetwork.allCases,
                 selected: viewModel.resolvedSendTarget,
                 conflictingWith: viewModel.source,
                 onSelect: viewModel.selectStandaloneTarget)
         }
+    }
+
+    /// Collapsed: one card showing the group's current selection, chevron
+    /// trailing; tapping expands it. Expanded: the three-row picker — a
+    /// valid pick collapses it again, a conflicting tap keeps it open with
+    /// the inline warning explaining the rejection.
+    @ViewBuilder
+    private func endpointSelector(
+        group: EndpointGroup,
+        caption: String,
+        selected: ChainNetwork,
+        conflictingWith conflict: ChainNetwork,
+        onSelect: @escaping (ChainNetwork) -> Void
+    ) -> some View {
+        if expandedEndpointGroup == group {
+            selectionGroup(
+                caption: caption,
+                networks: ChainNetwork.allCases,
+                selected: selected,
+                conflictingWith: conflict,
+                onSelect: { network in
+                    onSelect(network)
+                    if network != conflict {
+                        withAnimation { expandedEndpointGroup = nil }
+                    }
+                })
+        } else {
+            collapsedEndpointCard(selected, caption: caption) {
+                withAnimation { expandedEndpointGroup = group }
+            }
+        }
+    }
+
+    private func collapsedEndpointCard(
+        _ network: ChainNetwork,
+        caption: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        let display = networkDisplay(network)
+        return TransferSourceRow(
+            iconSystemName: display.icon,
+            caption: caption,
+            title: display.title,
+            balanceTrailing: dashBalanceTrailing(display.balance),
+            selected: false,
+            showsRadio: false,
+            showsChevron: true,
+            action: action)
     }
 
     /// Receive-sheet layout: the destination stays pinned as the bottom
@@ -456,6 +515,9 @@ struct TransferSourceRow: View {
     /// False renders a fixed (non-picker) endpoint card: no radio circle
     /// and no selection border.
     var showsRadio: Bool = true
+    /// With `showsRadio` false: true renders a tappable collapsed selector
+    /// (chevron trailing, expands a picker on tap) instead of a fixed card.
+    var showsChevron: Bool = false
     var action: () -> Void
 
     /// Trailing balance amount + Dash currency glyph, the standard trailing
@@ -498,6 +560,10 @@ struct TransferSourceRow: View {
 
                 if showsRadio {
                     radioIndicator
+                } else if showsChevron {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(Color.dash.secondaryText)
                 }
             }
             .padding(.horizontal, 14)
@@ -510,7 +576,7 @@ struct TransferSourceRow: View {
             .cornerRadius(12)
         }
         .buttonStyle(.plain)
-        .disabled(!showsRadio)
+        .disabled(!showsRadio && !showsChevron)
     }
 
     private var radioIndicator: some View {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -208,7 +208,7 @@ struct InternalTransferScreen: View {
             selectionGroup(
                 caption: NSLocalizedString("To", comment: ""),
                 networks: ChainNetwork.allCases,
-                selected: sanitizedTarget(for: source, proposed: viewModel.sendTarget),
+                selected: viewModel.resolvedSendTarget,
                 conflictingWith: source,
                 onSelect: viewModel.selectSendTarget)
         }
@@ -246,13 +246,13 @@ struct InternalTransferScreen: View {
                 caption: NSLocalizedString("From", comment: ""),
                 networks: ChainNetwork.allCases,
                 selected: viewModel.source,
-                conflictingWith: sanitizedTarget(for: viewModel.source, proposed: viewModel.sendTarget),
+                conflictingWith: viewModel.resolvedSendTarget,
                 onSelect: viewModel.selectStandaloneSource)
 
             selectionGroup(
                 caption: NSLocalizedString("To", comment: ""),
                 networks: ChainNetwork.allCases,
-                selected: sanitizedTarget(for: viewModel.source, proposed: viewModel.sendTarget),
+                selected: viewModel.resolvedSendTarget,
                 conflictingWith: viewModel.source,
                 onSelect: viewModel.selectStandaloneTarget)
         }
@@ -267,7 +267,7 @@ struct InternalTransferScreen: View {
             selectionGroup(
                 caption: NSLocalizedString("From", comment: ""),
                 networks: ChainNetwork.allCases,
-                selected: sanitizedSource(into: target, proposed: viewModel.receiveSource),
+                selected: viewModel.resolvedReceiveSource,
                 conflictingWith: target,
                 onSelect: viewModel.selectReceiveSource)
 
@@ -325,32 +325,6 @@ struct InternalTransferScreen: View {
             selected: selected,
             showsRadio: showsRadio,
             action: action)
-    }
-
-    private func sanitizedTarget(for source: ChainNetwork, proposed target: ChainNetwork) -> ChainNetwork {
-        source == target ? defaultTarget(for: source) : target
-    }
-
-    private func sanitizedSource(into target: ChainNetwork, proposed source: ChainNetwork) -> ChainNetwork {
-        source == target ? defaultSource(for: target) : source
-    }
-
-    private func defaultTarget(for source: ChainNetwork) -> ChainNetwork {
-        switch source {
-        case .core, .platform:
-            return .shielded
-        case .shielded:
-            return .core
-        }
-    }
-
-    private func defaultSource(for target: ChainNetwork) -> ChainNetwork {
-        switch target {
-        case .shielded:
-            return .core
-        case .core, .platform:
-            return .shielded
-        }
     }
 
     // MARK: - Transfer preview

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -84,11 +84,6 @@ struct InternalTransferScreen: View {
                     directionCards
                         .padding(.horizontal, 20)
 
-                    if let conflictNotice = viewModel.endpointConflictNotice {
-                        TransferAmountValidationNote(message: conflictNotice)
-                            .padding(.horizontal, 20)
-                    }
-
                     if viewModel.isBlockedBySync {
                         SyncGateNote()
                             .padding(.horizontal, 20)
@@ -269,19 +264,15 @@ struct InternalTransferScreen: View {
     }
 
     private func presentEndpointPicker(_ group: EndpointGroup) {
-        // A conflict notice from an earlier interaction must not open a
-        // fresh picker pre-scolded.
-        viewModel.clearEndpointConflictNotice()
         endpointPicker = group
     }
 
     /// Bottom-sheet balance picker for one endpoint, sized to slide over
-    /// the keypad area. A valid pick applies and dismisses; a conflicting
-    /// pick keeps the sheet open with the inline warning explaining the
-    /// rejection.
+    /// the keypad area. Every pick applies and dismisses — picking the
+    /// balance already on the opposite side moves that side to its default
+    /// (the view model keeps the endpoints distinct).
     private func endpointPickerSheet(for group: EndpointGroup) -> some View {
         let isFrom = group == .from
-        let conflict = isFrom ? viewModel.resolvedSendTarget : viewModel.source
         return VStack(alignment: .leading, spacing: 16) {
             Text(isFrom
                 ? NSLocalizedString("Transfer from", comment: "Internal transfer source picker title")
@@ -295,21 +286,14 @@ struct InternalTransferScreen: View {
                     : NSLocalizedString("To", comment: ""),
                 networks: ChainNetwork.allCases,
                 selected: isFrom ? viewModel.source : viewModel.resolvedSendTarget,
-                conflictingWith: conflict,
                 onSelect: { network in
                     if isFrom {
                         viewModel.selectStandaloneSource(network)
                     } else {
                         viewModel.selectStandaloneTarget(network)
                     }
-                    if network != conflict {
-                        endpointPicker = nil
-                    }
+                    endpointPicker = nil
                 })
-
-            if let notice = viewModel.endpointConflictNotice {
-                TransferAmountValidationNote(message: notice)
-            }
 
             Spacer(minLength: 0)
         }
@@ -357,15 +341,10 @@ struct InternalTransferScreen: View {
         TransferSourceRow.dashBalanceTrailing(formatted)
     }
 
-    /// `conflictingWith` is the balance already occupying the opposite
-    /// endpoint: its row stays visible (the group always lists all three
-    /// balances) but dimmed, and tapping it is rejected by the view model
-    /// with an inline explanation.
     private func selectionGroup(
         caption: String,
         networks: [ChainNetwork],
         selected: ChainNetwork,
-        conflictingWith: ChainNetwork? = nil,
         onSelect: @escaping (ChainNetwork) -> Void
     ) -> some View {
         VStack(spacing: 8) {
@@ -378,7 +357,6 @@ struct InternalTransferScreen: View {
                     balanceTrailing: dashBalanceTrailing(display.balance),
                     selected: selected == network,
                     action: { onSelect(network) })
-                    .opacity(network == conflictingWith ? 0.45 : 1)
             }
         }
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -418,6 +418,12 @@ final class InternalTransferViewModel: ObservableObject {
         receiveSource = network
     }
 
+    /// Presentation hook: opening a fresh endpoint picker discards a notice
+    /// left over from an earlier rejected tap.
+    func clearEndpointConflictNotice() {
+        endpointConflictNotice = nil
+    }
+
     private static func endpointConflictMessage(_ network: ChainNetwork) -> String {
         String.localizedStringWithFormat(
             NSLocalizedString(

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -426,6 +426,20 @@ final class InternalTransferViewModel: ObservableObject {
             network.balanceName)
     }
 
+    /// The To selection the pickers display: `sendTarget` guarded against
+    /// ever equaling the active From — always the same endpoint `route`
+    /// executes, so a radio can't highlight a balance the transfer won't use.
+    var resolvedSendTarget: ChainNetwork {
+        Self.sanitizedDestination(from: sendSource ?? source, proposed: sendTarget)
+    }
+
+    /// The From selection the receive sheet's pickers display, guarded
+    /// against equaling the pinned destination.
+    var resolvedReceiveSource: ChainNetwork {
+        guard let receiveTarget else { return receiveSource }
+        return Self.sanitizedSource(into: receiveTarget, proposed: receiveSource)
+    }
+
     /// The canonical route for validation/fees/execution.
     var route: InternalTransferRoute {
         if let source = sendSource {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -355,15 +355,9 @@ final class InternalTransferViewModel: ObservableObject {
         route == .platformToShielded && isPlatformShieldMaxDerived
     }
 
-    /// Set when a From/To tap was rejected because it would make both
-    /// endpoints the same balance. The selection is left unchanged; this
-    /// line tells the user why.
-    @Published private(set) var endpointConflictNotice: String?
-
     /// Pins the route for the receive sheet: a transfer INTO `target`.
     /// The From rows then pick the source among the other two balances.
     func applyReceiveRoute(into target: ChainNetwork) {
-        endpointConflictNotice = nil
         sendSource = nil
         receiveTarget = target
         receiveSource = Self.sanitizedSource(into: target, proposed: receiveSource)
@@ -375,61 +369,32 @@ final class InternalTransferViewModel: ObservableObject {
     /// Platform default to Shielded (privacy-forward); Shielded defaults
     /// to Core.
     func applySendRoute(from source: ChainNetwork) {
-        endpointConflictNotice = nil
         receiveTarget = nil
         sendSource = source
         sendTarget = Self.sanitizedDestination(from: source, proposed: sendTarget)
     }
 
+    /// Endpoint picks always apply. A pick that collides with the opposite
+    /// endpoint moves THAT endpoint to its default instead — the two sides
+    /// can never be the same balance.
     func selectStandaloneSource(_ network: ChainNetwork) {
-        guard network != sendTarget else {
-            endpointConflictNotice = Self.endpointConflictMessage(network)
-            return
-        }
-        endpointConflictNotice = nil
         source = network
+        sendTarget = Self.sanitizedDestination(from: network, proposed: sendTarget)
     }
 
     func selectStandaloneTarget(_ network: ChainNetwork) {
-        guard network != source else {
-            endpointConflictNotice = Self.endpointConflictMessage(network)
-            return
-        }
-        endpointConflictNotice = nil
         sendTarget = network
+        source = Self.sanitizedSource(into: network, proposed: source)
     }
 
     func selectSendTarget(_ network: ChainNetwork) {
-        guard network != (sendSource ?? source) else {
-            endpointConflictNotice = Self.endpointConflictMessage(network)
-            return
-        }
-        endpointConflictNotice = nil
-        sendTarget = network
+        let from = sendSource ?? source
+        sendTarget = Self.sanitizedDestination(from: from, proposed: network)
     }
 
     func selectReceiveSource(_ network: ChainNetwork) {
         guard let receiveTarget else { return }
-        guard network != receiveTarget else {
-            endpointConflictNotice = Self.endpointConflictMessage(network)
-            return
-        }
-        endpointConflictNotice = nil
-        receiveSource = network
-    }
-
-    /// Presentation hook: opening a fresh endpoint picker discards a notice
-    /// left over from an earlier rejected tap.
-    func clearEndpointConflictNotice() {
-        endpointConflictNotice = nil
-    }
-
-    private static func endpointConflictMessage(_ network: ChainNetwork) -> String {
-        String.localizedStringWithFormat(
-            NSLocalizedString(
-                "You can't transfer from %1$@ to %1$@. Pick a different balance for one side.",
-                comment: "Internal transfer From and To must differ"),
-            network.balanceName)
+        receiveSource = Self.sanitizedSource(into: receiveTarget, proposed: network)
     }
 
     /// The To selection the pickers display: `sendTarget` guarded against

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -355,9 +355,15 @@ final class InternalTransferViewModel: ObservableObject {
         route == .platformToShielded && isPlatformShieldMaxDerived
     }
 
+    /// Set when a From/To tap was rejected because it would make both
+    /// endpoints the same balance. The selection is left unchanged; this
+    /// line tells the user why.
+    @Published private(set) var endpointConflictNotice: String?
+
     /// Pins the route for the receive sheet: a transfer INTO `target`.
     /// The From rows then pick the source among the other two balances.
     func applyReceiveRoute(into target: ChainNetwork) {
+        endpointConflictNotice = nil
         sendSource = nil
         receiveTarget = target
         receiveSource = Self.sanitizedSource(into: target, proposed: receiveSource)
@@ -369,28 +375,55 @@ final class InternalTransferViewModel: ObservableObject {
     /// Platform default to Shielded (privacy-forward); Shielded defaults
     /// to Core.
     func applySendRoute(from source: ChainNetwork) {
+        endpointConflictNotice = nil
         receiveTarget = nil
         sendSource = source
         sendTarget = Self.sanitizedDestination(from: source, proposed: sendTarget)
     }
 
     func selectStandaloneSource(_ network: ChainNetwork) {
+        guard network != sendTarget else {
+            endpointConflictNotice = Self.endpointConflictMessage(network)
+            return
+        }
+        endpointConflictNotice = nil
         source = network
-        sendTarget = Self.sanitizedDestination(from: network, proposed: sendTarget)
     }
 
     func selectStandaloneTarget(_ network: ChainNetwork) {
-        sendTarget = Self.sanitizedDestination(from: source, proposed: network)
+        guard network != source else {
+            endpointConflictNotice = Self.endpointConflictMessage(network)
+            return
+        }
+        endpointConflictNotice = nil
+        sendTarget = network
     }
 
     func selectSendTarget(_ network: ChainNetwork) {
-        let from = sendSource ?? source
-        sendTarget = Self.sanitizedDestination(from: from, proposed: network)
+        guard network != (sendSource ?? source) else {
+            endpointConflictNotice = Self.endpointConflictMessage(network)
+            return
+        }
+        endpointConflictNotice = nil
+        sendTarget = network
     }
 
     func selectReceiveSource(_ network: ChainNetwork) {
         guard let receiveTarget else { return }
-        receiveSource = Self.sanitizedSource(into: receiveTarget, proposed: network)
+        guard network != receiveTarget else {
+            endpointConflictNotice = Self.endpointConflictMessage(network)
+            return
+        }
+        endpointConflictNotice = nil
+        receiveSource = network
+    }
+
+    private static func endpointConflictMessage(_ network: ChainNetwork) -> String {
+        String.localizedStringWithFormat(
+            NSLocalizedString(
+                "You can't transfer from %1$@ to %1$@. Pick a different balance for one side.",
+                comment: "Internal transfer From and To must differ"),
+            network.balanceName)
     }
 
     /// The canonical route for validation/fees/execution.

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -57,7 +57,8 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
     /// `viewDidAppear` instead of against a view that isn't on screen yet.
     private var timingSheetPendingAppearance = false
 
-    @objc init(activeTab: Int) {
+    @objc
+    init(activeTab: Int) {
         let resolved = PaymentsLandingTab.allCases.first { $0.rawValue == Self.tabRawValue(for: activeTab) }
             ?? .send
         self.viewModel = PaymentsLandingViewModel(activeTab: resolved)
@@ -154,6 +155,19 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         hostingController.didMove(toParent: self)
+
+        // Receive sheet: keep the pinned transfer route in lockstep with
+        // the receive toggle, so the fixed To card and the executed
+        // transfer can never disagree. (`$network` republishes the current
+        // value on subscription, covering the initial state too.)
+        if transferReceivePinned {
+            viewModel.$network
+                .receive(on: RunLoop.main)
+                .sink { [weak self] network in
+                    self?.embeddedTransferViewModel.applyReceiveRoute(into: network)
+                }
+                .store(in: &cancellables)
+        }
 
         // First-time transfer-timing education, free-form landing only —
         // the balance-row sheets never showed it and keep that behavior.

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -3,6 +3,7 @@
 //  DashWallet
 //
 
+import Combine
 import SwiftUI
 import UIKit
 
@@ -10,12 +11,12 @@ import UIKit
 final class PaymentsLandingHostingController: DWBasePayViewController {
 
     private let viewModel: PaymentsLandingViewModel
-    /// Non-nil only for the balance-row receive sheet: the Internal tab
-    /// then embeds the transfer form directly, preconfigured as a transfer
-    /// INTO the balance whose arrow opened the sheet (Core/Platform receive
-    /// from Shielded; Shielded receives from Core). The swap badge on the
-    /// form can still reverse it.
-    private let embeddedTransferViewModel: InternalTransferViewModel?
+    /// The Internal tab's embedded transfer form. Un-pinned (free From/To
+    /// pickers) on the full landing; the balance-row receive sheet pins the
+    /// destination (`transferReceivePinned`), the send sheet pins the source
+    /// (`transferSendFrom`).
+    private let embeddedTransferViewModel: InternalTransferViewModel
+    private let transferReceivePinned: Bool
     /// The Send tab's form. Pinned to the tapped balance as source for the
     /// balance-row send sheet (`transferSendFrom` then also pins the
     /// Internal tab's From card); un-pinned on the full landing.
@@ -29,10 +30,10 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
             onShareAddress: { [weak self] in self?.shareCurrentAddress() },
             onSpecifyAmount: { [weak self] in self?.pushSpecifyAmount() },
             onScanQR: { [weak self] in self?.performScanQRCodeAction() },
-            onShieldedBalance: { [weak self] in self?.handleShieldedBalanceTap() },
             embeddedTransferViewModel: embeddedTransferViewModel,
             onTransferCompleted: { [weak self] in self?.dismiss(animated: true) },
             transferSendFrom: transferSendFrom,
+            transferReceivePinned: transferReceivePinned,
             embeddedSendViewModel: embeddedSendViewModel,
             onSendContinue: { [weak self] in
                 guard let self else { return }
@@ -50,11 +51,20 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     private static let shieldedBalanceTimingShownKey = "DWShieldedBalanceTimingShown"
 
+    private var cancellables = Set<AnyCancellable>()
+    /// The Internal tab was activated before the landing finished appearing
+    /// (e.g. it is the initial tab) — present the timing sheet from
+    /// `viewDidAppear` instead of against a view that isn't on screen yet.
+    private var timingSheetPendingAppearance = false
+
     @objc init(activeTab: Int) {
         let resolved = PaymentsLandingTab.allCases.first { $0.rawValue == Self.tabRawValue(for: activeTab) }
             ?? .send
         self.viewModel = PaymentsLandingViewModel(activeTab: resolved)
-        self.embeddedTransferViewModel = nil
+        // The full landing's Internal tab is the transfer form itself,
+        // un-pinned: free From and To pickers.
+        self.embeddedTransferViewModel = InternalTransferViewModel()
+        self.transferReceivePinned = false
         // The full landing's Send tab is the send form itself (un-pinned:
         // full From picker) — same form the balance-row sheet embeds.
         self.embeddedSendViewModel = SendViewModel()
@@ -86,17 +96,18 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         self.showsHeader = showsHeader
         self.embeddedSendViewModel = SendViewModel(pinnedSource: sendNetwork)
         self.transferSendFrom = sendNetwork
+        let transferViewModel = InternalTransferViewModel()
         if let sendNetwork {
-            let transferViewModel = InternalTransferViewModel()
             transferViewModel.applySendRoute(from: sendNetwork)
-            self.embeddedTransferViewModel = transferViewModel
+            self.transferReceivePinned = false
         } else if embedInternalTransfer {
-            let transferViewModel = InternalTransferViewModel()
             transferViewModel.applyReceiveRoute(into: receiveNetwork)
-            self.embeddedTransferViewModel = transferViewModel
+            self.transferReceivePinned = true
         } else {
-            self.embeddedTransferViewModel = nil
+            // Free-form landing: no pinned endpoint.
+            self.transferReceivePinned = false
         }
+        self.embeddedTransferViewModel = transferViewModel
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -143,6 +154,30 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         hostingController.didMove(toParent: self)
+
+        // First-time transfer-timing education, free-form landing only —
+        // the balance-row sheets never showed it and keep that behavior.
+        if transferSendFrom == nil && !transferReceivePinned {
+            viewModel.$activeTab
+                .receive(on: RunLoop.main)
+                .sink { [weak self] tab in
+                    guard let self, tab == .internalTransfer else { return }
+                    if self.view.window == nil {
+                        self.timingSheetPendingAppearance = true
+                    } else {
+                        self.presentTransferTimingSheetIfNeeded()
+                    }
+                }
+                .store(in: &cancellables)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if timingSheetPendingAppearance {
+            timingSheetPendingAppearance = false
+            presentTransferTimingSheetIfNeeded()
+        }
     }
 
     // MARK: - Actions
@@ -180,37 +215,23 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         }
     }
 
-    private func handleShieldedBalanceTap() {
-        let alreadyShown = UserDefaults.standard.bool(forKey: Self.shieldedBalanceTimingShownKey)
-        if alreadyShown {
-            pushInternalTransfer()
-        } else {
-            presentTransferTimingSheet()
-        }
-    }
-
-    private func presentTransferTimingSheet() {
+    /// First-ever visit to the free-form Internal tab: explain transfer
+    /// timing before the user composes a transfer. The form is already
+    /// embedded underneath; "I got it" (not the X) acknowledges for good.
+    private func presentTransferTimingSheetIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: Self.shieldedBalanceTimingShownKey),
+              presentedViewController == nil
+        else { return }
         let host = UIHostingController(
             rootView: TransferTimingSheet(onConfirm: { [weak self] in
                 UserDefaults.standard.set(true, forKey: Self.shieldedBalanceTimingShownKey)
-                self?.dismiss(animated: true) {
-                    self?.pushInternalTransfer()
-                }
+                self?.dismiss(animated: true)
             }))
         if let sheet = host.sheetPresentationController {
             sheet.detents = [.medium()]
             sheet.prefersGrabberVisible = true
         }
         present(host, animated: true)
-    }
-
-    /// Pushes the internal-transfer screen onto the landing modal's own
-    /// navigation stack, keeping the user inside the same presentation.
-    /// (Full-landing path only — the receive sheet embeds the form in its
-    /// Internal tab instead; see `embeddedTransferViewModel`.)
-    private func pushInternalTransfer() {
-        let target = InternalTransferHostingController()
-        navigationController?.pushViewController(target, animated: true)
     }
 
     private static func tabRawValue(for objcCase: Int) -> String {

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -24,7 +24,7 @@ struct PaymentsLandingScreen: View {
     /// Set by the balance-row send sheet: the embedded transfer form pins
     /// this balance as its From card (destination picked on the To rows),
     /// instead of the receive sheet's pinned-destination layout.
-    var transferSendFrom: ChainNetwork? = nil
+    var transferSendFrom: ChainNetwork?
     /// True for the balance-row receive sheet: the transfer form pins the
     /// receive toggle's balance as its To card (source picked on the From
     /// rows). False (with `transferSendFrom` nil) = the free-form landing.
@@ -67,18 +67,15 @@ struct PaymentsLandingScreen: View {
                         showsHeader: false,
                         sendFrom: sendFrom)
                 } else if transferReceivePinned {
+                    // The hosting controller keeps the pinned route in
+                    // lockstep with the receive toggle (its `$network`
+                    // subscription), so the fixed To card and the executed
+                    // transfer can never disagree.
                     InternalTransferScreen(
                         viewModel: embeddedTransferViewModel,
                         onCompleted: onTransferCompleted,
                         showsHeader: false,
                         receiveInto: viewModel.network)
-                        // Keep the pinned route in lockstep with the receive
-                        // toggle, so the fixed To card and the executed
-                        // transfer can never disagree.
-                        .onAppear { embeddedTransferViewModel.applyReceiveRoute(into: viewModel.network) }
-                        .onChange(of: viewModel.network) { network in
-                            embeddedTransferViewModel.applyReceiveRoute(into: network)
-                        }
                 } else {
                     // Full landing: the transfer form itself, free From and
                     // To pickers — no intermediate action-row step.

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -16,16 +16,19 @@ struct PaymentsLandingScreen: View {
     var onShareAddress: () -> Void
     var onSpecifyAmount: () -> Void
     var onScanQR: () -> Void
-    var onShieldedBalance: () -> Void
-    /// When set, the Internal tab embeds the transfer form directly (the
-    /// same screen the balance-row arrows used to present standalone)
-    /// instead of the action-row list. Set by the receive and send sheets.
-    var embeddedTransferViewModel: InternalTransferViewModel? = nil
+    /// The Internal tab's embedded transfer form. The full landing shows it
+    /// un-pinned (free From + To pickers); the balance-row receive/send
+    /// sheets pin one endpoint via `transferReceivePinned`/`transferSendFrom`.
+    var embeddedTransferViewModel: InternalTransferViewModel
     var onTransferCompleted: () -> Void = {}
     /// Set by the balance-row send sheet: the embedded transfer form pins
     /// this balance as its From card (destination picked on the To rows),
     /// instead of the receive sheet's pinned-destination layout.
     var transferSendFrom: ChainNetwork? = nil
+    /// True for the balance-row receive sheet: the transfer form pins the
+    /// receive toggle's balance as its To card (source picked on the From
+    /// rows). False (with `transferSendFrom` nil) = the free-form landing.
+    var transferReceivePinned: Bool = false
     /// The Send tab IS the external-send form — pinned to the tapped
     /// balance as source on the balance-row send sheet, un-pinned (full
     /// From picker) on the full landing.
@@ -40,8 +43,7 @@ struct PaymentsLandingScreen: View {
     var body: some View {
         // Tighter chrome when a tab embeds a full form (transfer or send) —
         // its amount + cards + keypad need most of the sheet.
-        let isEmbeddedForm = (viewModel.activeTab == .internalTransfer && embeddedTransferViewModel != nil)
-            || viewModel.activeTab == .send
+        let isEmbeddedForm = viewModel.activeTab != .receive
         VStack(alignment: .center, spacing: isEmbeddedForm ? 12 : 20) {
             if showsHeader {
                 header
@@ -56,32 +58,34 @@ struct PaymentsLandingScreen: View {
                 receiveContent
                 Spacer()
             case .internalTransfer:
-                if let transferViewModel = embeddedTransferViewModel {
-                    if let sendFrom = transferSendFrom {
-                        // Send sheet: the From card is pinned by the tapped
-                        // balance; the To rows pick the destination.
-                        InternalTransferScreen(
-                            viewModel: transferViewModel,
-                            onCompleted: onTransferCompleted,
-                            showsHeader: false,
-                            sendFrom: sendFrom)
-                    } else {
-                        InternalTransferScreen(
-                            viewModel: transferViewModel,
-                            onCompleted: onTransferCompleted,
-                            showsHeader: false,
-                            receiveInto: viewModel.network)
-                            // Keep the pinned route in lockstep with the receive
-                            // toggle, so the fixed To card and the executed
-                            // transfer can never disagree.
-                            .onAppear { transferViewModel.applyReceiveRoute(into: viewModel.network) }
-                            .onChange(of: viewModel.network) { network in
-                                transferViewModel.applyReceiveRoute(into: network)
-                            }
-                    }
+                if let sendFrom = transferSendFrom {
+                    // Send sheet: the From card is pinned by the tapped
+                    // balance; the To rows pick the destination.
+                    InternalTransferScreen(
+                        viewModel: embeddedTransferViewModel,
+                        onCompleted: onTransferCompleted,
+                        showsHeader: false,
+                        sendFrom: sendFrom)
+                } else if transferReceivePinned {
+                    InternalTransferScreen(
+                        viewModel: embeddedTransferViewModel,
+                        onCompleted: onTransferCompleted,
+                        showsHeader: false,
+                        receiveInto: viewModel.network)
+                        // Keep the pinned route in lockstep with the receive
+                        // toggle, so the fixed To card and the executed
+                        // transfer can never disagree.
+                        .onAppear { embeddedTransferViewModel.applyReceiveRoute(into: viewModel.network) }
+                        .onChange(of: viewModel.network) { network in
+                            embeddedTransferViewModel.applyReceiveRoute(into: network)
+                        }
                 } else {
-                    internalContent
-                    Spacer()
+                    // Full landing: the transfer form itself, free From and
+                    // To pickers — no intermediate action-row step.
+                    InternalTransferScreen(
+                        viewModel: embeddedTransferViewModel,
+                        onCompleted: onTransferCompleted,
+                        showsHeader: false)
                 }
             case .send:
                 SendScreen(
@@ -241,47 +245,4 @@ struct PaymentsLandingScreen: View {
             .cornerRadius(12)
     }
 
-    // MARK: - Internal
-
-    private var internalContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text(NSLocalizedString("Internal transfer to/from", comment: ""))
-                .font(.caption)
-                .foregroundColor(Color.dash.secondaryText)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            actionRow(
-                iconSystemName: "shield.fill",
-                title: NSLocalizedString("Shielded balance", comment: ""),
-                action: onShieldedBalance)
-                .padding(.horizontal, 20)
-        }
-    }
-
-    // MARK: - Shared action row
-
-    private func actionRow(
-        iconSystemName: String,
-        title: String,
-        action: (() -> Void)?
-    ) -> some View {
-        Button(action: { action?() }) {
-            HStack(spacing: 12) {
-                Image(systemName: iconSystemName)
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(.blue)
-                    .frame(width: 24, height: 24)
-                Text(title)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.dash.primaryText)
-                Spacer()
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 14)
-            .background(Color.dash.secondaryBackground)
-            .cornerRadius(12)
-        }
-        .disabled(action == nil)
-    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pressing Send → **Internal** showed an intermediate action-row list ("Internal transfer to/from" with a single "Shielded balance" row) that pushed the transfer screen — an extra step for no benefit — and the transfer screen's endpoint pickers needed a redesign.

## What was done?

- **The full landing's Internal tab embeds the transfer form directly** (amount, From/To cards, keypad) — the intermediate list and the push-based flow were deleted. The first-time "Transfers take different times" sheet now presents on the Internal tab's first activation (same `DWShieldedBalanceTimingShown` key).
- **Compact endpoint selection on the standalone form**: the form shows just two cards — the selected From and the selected To, each with a chevron. Tapping one presents a fitted bottom-sheet modal (sliding over the keypad area) listing all three balances for that side.
- **Endpoints can never be the same balance**: picking the balance already on the opposite side applies the pick and auto-moves the other side to its default (Core/Platform pair with Shielded; Shielded pairs with Core). No rows are disabled or dimmed.
- **The balance-row arrow sheets are unchanged**: pinned endpoint card plus the two other balances as picker rows, exactly as before.
- Architecture cleanups from review: receive-sheet route sync moved from view modifiers into the hosting controller's `$network` subscription; endpoint sanitization lives only in `InternalTransferViewModel` (`resolvedSendTarget` / `resolvedReceiveSource`).

## How Has This Been Tested?

- Clean `dashpay` scheme simulator build (`ARCHS=arm64`).
- Simulator smoke on QA-iPhone16: embedded Internal tab renders directly under Send; endpoint invariants verified.
- Unit-test target is currently broken repo-wide (pre-existing).

## Breaking Changes

None. `InternalTransferHostingController` remains for the home-shortcut and menu prefill entry points.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)