### PR TITLE
fix: keep the lock window key when the reinstall flow presents it mid-transition

### DIFF
--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -234,6 +234,10 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
                            selector:@selector(applicationDidEnterBackgroundNotification)
                                name:UIApplicationDidEnterBackgroundNotification
                              object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(windowDidBecomeKeyNotification:)
+                               name:UIWindowDidBecomeKeyNotification
+                             object:nil];
 
     __weak typeof(self) weakSelf = self;
     self.model.currentNetworkDidChangeBlock = ^{
@@ -432,6 +436,37 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
 
 - (void)applicationWillResignActiveNotification {
     [self.model applicationWillResignActiveNotification];
+}
+
+- (void)windowDidBecomeKeyNotification:(NSNotification *)notification {
+    // Keeps the displayed lock window key. The post-onboarding reinstall flow
+    // (Keep Wallet → transitionToAppRoot → deferred
+    // applicationDidBecomeActiveNotification) calls makeKeyAndVisible while the
+    // onboarding container transition and the Keep/Delete alert teardown are
+    // still in flight; their completion can hand key status back to the main
+    // window. The lock screen then stays visible but keyboard/first-responder
+    // input routes to the main window underneath — the failure mode described
+    // by the INFO note in viewDidLoad. Whenever the main window becomes key
+    // while the lock window is displayed, take key (and front) back.
+    if (notification.object != self.view.window) {
+        return;
+    }
+    if (self.displayedLockNavigationController == nil || self.lockWindow.hidden) {
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (strongSelf == nil) {
+            return;
+        }
+        if (strongSelf.displayedLockNavigationController != nil &&
+            !strongSelf.lockWindow.hidden &&
+            !strongSelf.lockWindow.isKeyWindow) {
+            [strongSelf.lockWindow makeKeyAndVisible];
+        }
+    });
 }
 
 #pragma mark - Demo Mode

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -448,7 +448,8 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
     // input routes to the main window underneath — the failure mode described
     // by the INFO note in viewDidLoad. Whenever the main window becomes key
     // while the lock window is displayed, take key (and front) back.
-    if (notification.object != self.view.window) {
+    UIWindow *mainWindow = (UIWindow *)notification.object;
+    if (mainWindow != self.view.window) {
         return;
     }
     if (self.displayedLockNavigationController == nil || self.lockWindow.hidden) {
@@ -459,6 +460,13 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (strongSelf == nil) {
+            return;
+        }
+        // Re-validate before acting: only take key back if the main window
+        // still holds it. If key has already moved to another window
+        // (software keyboard, LocalAuthentication prompt), leave it alone —
+        // a later steal by the main window fires this observer again.
+        if (mainWindow != strongSelf.view.window || !mainWindow.isKeyWindow) {
             return;
         }
         if (strongSelf.displayedLockNavigationController != nil &&


### PR DESCRIPTION
## Issue being fixed or feature implemented

During the reinstall/upgrade first-launch flow (onboarding carousel → "Wallet found on this device" → Keep Wallet → PIN lock screen), the lock screen can render but receive no touch or keyboard input; terminating and relaunching the app is the only way out. Found during PR #985 verification (2026-08-12, simulator, DEBUG legacy-keychain fixture).

Root cause: a key-window race. The reinstall path (Keep Wallet → `transitionToAppRoot` → deferred `applicationDidBecomeActiveNotification` in `viewDidAppear`) calls `[self.lockWindow makeKeyAndVisible]` while the Keep/Delete alert teardown and the onboarding→root container cross-dissolve are still in flight. When their completion lands afterwards, UIKit hands key status back to the main window — the lock screen stays visible while input routes to the window underneath. This is exactly the failure mode the long-standing INFO note in `DWAppRootViewController.m viewDidLoad` warns about ("lockWindow will be visible, but main window remain key"). Because it is a race, some runs sail through, which is why the bug reproduces intermittently.

## What was done?

`DWAppRootViewController` now observes `UIWindowDidBecomeKeyNotification`. Whenever the **main window** becomes key while the lock window is displayed, the lock window re-asserts `makeKeyAndVisible` on the next runloop turn. The guard:

- is inert once `lockWindow.hidden` is set, so the unlock and wipe handoffs keep their existing behavior;
- never contests system windows (software keyboard, LocalAuthentication prompt) — it only reacts to the app's main window taking key;
- closes the race regardless of which side wins, and also covers the migration-hold lock presentation path that PR #985 adds.

## How Has This Been Tested?

On a fresh iPhone 16 (iOS 26.3) simulator with the canonical `dashpay` Debug build:

1. **Deterministic race simulation** — with the lock screen displayed, forced `[mainWindow makeKeyWindow]` via lldb (the exact stolen-key state the race produces). On resume, the guard re-keyed the lock window (verified via lldb: key window is the lock `UIWindow`, no longer `DWWindow`). Without the fix this state persists until relaunch.
2. **Full reinstall flow** — created a wallet (PIN set), then simulated reinstall (wiped the app's UserDefaults plists + killed the sim's cfprefsd, keychain kept): carousel → Skip → "Wallet found on this device" → Keep Wallet → lock screen. Both PIN-pad taps and hardware-keyboard digits register on first try, and the PIN unlocks to home.
3. **Regression** — normal relaunch → lock → keyboard-only unlock works; the guard does not re-key the lock window after unlocking (no re-lock flash, home reachable).

Note: the unit-test target is currently broken repo-wide (pre-existing), so verification is the clean `dashpay` build + the simulator smoke above per the current standard.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-screen behavior when the app returns to the foreground.
  * Ensured the lock screen remains visible and active when the app’s main window becomes active.
  * Improved reliability when the app regains focus, helping prevent the lock screen from being unintentionally dismissed or hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->