### PR TITLE
feat(dashpay): prompt for a temporary username alongside a contested submission

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
@@ -133,6 +133,15 @@ public final class DWIdentityRegistrationBridge: NSObject {
     /// surface for what is effectively SwiftDashSDK-path-only state.
     @objc public var preferredFundingSource: DWIdentityFundingSource = .core
 
+    /// Non-contested companion ("temporary") username to register in the
+    /// same flow as a contested submission — see
+    /// `DWIdentityRegistrationCoordinator.startCreateUsername`'s
+    /// `temporaryUsername` parameter. Same lifecycle as
+    /// `preferredFundingSource`: written by the SwiftUI form right before
+    /// submit (nil for a plain submission), preserved across `.failed` so
+    /// a retry keeps the user's choice, reset on `.completed`.
+    @objc public var pendingTemporaryUsername: String?
+
     // MARK: - Subscriptions
 
     private var coordinatorSubscription: AnyCancellable?
@@ -155,12 +164,14 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
-        Self.logger.info("🪪 IDENT-BRIDGE :: startCreateUsername username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public)")
+        let temporaryUsername = pendingTemporaryUsername
+        Self.logger.info("🪪 IDENT-BRIDGE :: startCreateUsername username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public) temporary=\(temporaryUsername ?? "none", privacy: .public)")
         Task { @MainActor in
             do {
                 let identityId = try await DWIdentityRegistrationCoordinator.shared.startCreateUsername(
                     username,
-                    fundingSource: source)
+                    fundingSource: source,
+                    temporaryUsername: temporaryUsername)
                 let hex = identityId.map { String(format: "%02x", $0) }.joined()
                 completion(hex, nil)
             } catch {
@@ -176,12 +187,14 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
+        let temporaryUsername = pendingTemporaryUsername
         Self.logger.info("🪪 IDENT-BRIDGE :: retry username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public)")
         Task { @MainActor in
             do {
                 let identityId = try await DWIdentityRegistrationCoordinator.shared.retry(
                     username,
-                    fundingSource: source)
+                    fundingSource: source,
+                    temporaryUsername: temporaryUsername)
                 let hex = identityId.map { String(format: "%02x", $0) }.joined()
                 completion(hex, nil)
             } catch {
@@ -282,6 +295,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         // strand a PP-only wallet on a path that has no Core balance.
         if case .completed = phase {
             preferredFundingSource = .core
+            pendingTemporaryUsername = nil
         }
 
         // Internal notification — DWDashPayModel observes this,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationBridge.swift
@@ -164,7 +164,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
-        let temporaryUsername = pendingTemporaryUsername
+        let temporaryUsername = sanitizedTemporaryUsername(for: username)
         Self.logger.info("🪪 IDENT-BRIDGE :: startCreateUsername username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public) temporary=\(temporaryUsername ?? "none", privacy: .public)")
         Task { @MainActor in
             do {
@@ -187,7 +187,7 @@ public final class DWIdentityRegistrationBridge: NSObject {
         completion: @escaping (String?, NSError?) -> Void
     ) {
         let source = preferredFundingSource
-        let temporaryUsername = pendingTemporaryUsername
+        let temporaryUsername = sanitizedTemporaryUsername(for: username)
         Self.logger.info("🪪 IDENT-BRIDGE :: retry username=\(username, privacy: .public) funding=\(source.logLabel, privacy: .public)")
         Task { @MainActor in
             do {
@@ -231,6 +231,29 @@ public final class DWIdentityRegistrationBridge: NSObject {
     }
 
     // MARK: - Internal
+
+    /// Resolve `pendingTemporaryUsername` for a submission of `username`.
+    ///
+    /// The property channel can go stale: a PIN-cancelled attempt never
+    /// reaches a terminal phase (so the `.completed` cleanup doesn't
+    /// run), and the legacy Obj-C entry point
+    /// (`DWDashPayModel.createUsername:`) never writes the property at
+    /// all. Rather than let a stale companion fail an unrelated
+    /// submission at the coordinator's pre-flight pairing guard, drop —
+    /// and clear — any value that doesn't validly pair with the label
+    /// actually being submitted (contested main + non-contested
+    /// companion). An intentional retry of the same contested attempt
+    /// still pairs validly, so it keeps the user's choice.
+    private func sanitizedTemporaryUsername(for username: String) -> String? {
+        guard let temporary = pendingTemporaryUsername else { return nil }
+        guard DWContestedNameStatusService.isContestedLabel(username),
+              !DWContestedNameStatusService.isContestedLabel(temporary) else {
+            Self.logger.warning("🪪 IDENT-BRIDGE :: dropping stale temporary username \(temporary, privacy: .public) for submission of \(username, privacy: .public)")
+            pendingTemporaryUsername = nil
+            return nil
+        }
+        return temporary
+    }
 
     /// Subscribe to the coordinator's published surface and mirror
     /// each transition into the cached @objc state + post the internal

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWIdentityRegistrationCoordinator.swift
@@ -295,6 +295,19 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// an active attempt.
     private(set) var currentFundingSource: DWIdentityFundingSource = .core
 
+    /// Non-contested companion label registered alongside a contested
+    /// submission in the same flow ("temporary username"), non-nil only
+    /// after its `registerDpnsName` succeeded. Read by
+    /// `CreateUsernameViewModel.registrationOutcome(for:)` to tell the
+    /// form which of the two names actually landed.
+    private(set) var registeredTemporaryUsername: String?
+
+    /// Failure description when the companion registration was requested
+    /// but failed. Deliberately non-fatal: the contested submission has
+    /// already succeeded by the time the companion registers, so the flow
+    /// completes and the form reports the partial outcome.
+    private(set) var temporaryUsernameError: String?
+
     // MARK: - Internal state
 
     private var controller: DWIdentityRegistrationController?
@@ -337,6 +350,7 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         case shieldedCreateUnconfirmed
         case missingInvitation
         case alreadyInFlight
+        case invalidTemporaryUsername
 
         var errorDescription: String? {
             switch self {
@@ -395,6 +409,8 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
                 return NSLocalizedString("This invitation link is not valid.", comment: "DashPay Invitations")
             case .alreadyInFlight:
                 return NSLocalizedString("Identity registration already in progress", comment: "DashPay")
+            case .invalidTemporaryUsername:
+                return NSLocalizedString("The temporary username must not itself require voting.", comment: "Usernames")
             }
         }
     }
@@ -418,13 +434,38 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     /// `startClaimInvitation(username:invitationURI:)`, which supplies
     /// the voucher link; calling this method with `.invitation` and no
     /// `invitationURI` fails with `.missingInvitation`.
+    ///
+    /// `temporaryUsername` (contested submissions only) is a
+    /// NON-contested companion label registered to the same identity
+    /// right after the contested submission, inside the same authorized
+    /// flow — the user is reachable at it while masternode voting runs,
+    /// and keeps it permanently afterwards. Its registration failure is
+    /// non-fatal (`temporaryUsernameError`); its success is recorded in
+    /// `registeredTemporaryUsername` and mirrored to `DWGlobalOptions`
+    /// as the active username (the deferred contested label then never
+    /// displaces it — `finalizeWon` only backfills an empty mirror, so
+    /// a vote win adds the second name instead of replacing the first).
     @discardableResult
     func startCreateUsername(
         _ username: String,
         fundingSource: DWIdentityFundingSource = .core,
-        invitationURI: String? = nil
+        invitationURI: String? = nil,
+        temporaryUsername: String? = nil
     ) async throws -> Identifier {
-        Self.logger.info("🪪 IDENT-COORD :: startCreateUsername username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public)")
+        Self.logger.info("🪪 IDENT-COORD :: startCreateUsername username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public) temporary=\(temporaryUsername ?? "none", privacy: .public)")
+
+        // A companion label only makes sense next to a contested main
+        // label, and must itself be non-contested — registering a second
+        // contested name here would silently open a second vote the UI
+        // never explained. Reject before any money moves.
+        if let temporaryUsername {
+            guard DWContestedNameStatusService.isContestedLabel(username),
+                  !DWContestedNameStatusService.isContestedLabel(temporaryUsername)
+            else {
+                Self.logger.error("🪪 IDENT-COORD :: invalid temporary username pairing main=\(username, privacy: .public) temporary=\(temporaryUsername, privacy: .public)")
+                throw CoordinatorError.invalidTemporaryUsername
+            }
+        }
 
         // Preconditions — resolved once up-front so failures are
         // surfaced before the PIN prompt.
@@ -795,6 +836,34 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
             }
         }
 
+        // Step 3.6: companion (temporary) username. The contested label
+        // above is only preregistered — it belongs to nobody until the
+        // vote resolves — so the user asked for a second, non-contested
+        // name to be reachable at in the meantime. Same identity, same
+        // signer, no additional PIN prompt. Failure is deliberately
+        // non-fatal: the contested submission (the primary intent, and
+        // the user's locked funds) already succeeded, so the flow
+        // completes and the form reports the partial outcome from
+        // `temporaryUsernameError`.
+        if let temporaryUsername, isContestedSubmission {
+            do {
+                _ = try await wallet.registerDpnsName(
+                    identityId: identityId,
+                    name: temporaryUsername,
+                    signer: signer)
+                registeredTemporaryUsername = temporaryUsername
+                Self.logger.info("🪪 IDENT-COORD :: temporary DPNS name registered: \(temporaryUsername, privacy: .public)")
+                // Push the new label into the identity read model right
+                // away (same post-registration refresh the marketplace's
+                // `register(label:)` does) so profile/username surfaces
+                // don't wait for the next Home-appear sync.
+                DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+            } catch {
+                temporaryUsernameError = error.localizedDescription
+                Self.logger.error("🪪 IDENT-COORD :: temporary DPNS registration failed: \(String(describing: error), privacy: .public)")
+            }
+        }
+
         // Step 4: mark complete + mirror to DWGlobalOptions. The
         // controller transition triggers the phaseSubscription
         // sink which posts the notification + writes
@@ -820,12 +889,14 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     @discardableResult
     func startClaimInvitation(
         username: String,
-        invitationURI: String
+        invitationURI: String,
+        temporaryUsername: String? = nil
     ) async throws -> Identifier {
         try await startCreateUsername(
             username,
             fundingSource: .invitation,
-            invitationURI: invitationURI)
+            invitationURI: invitationURI,
+            temporaryUsername: temporaryUsername)
     }
 
     /// Direct purchase of a marketplace-listed name from the
@@ -1019,10 +1090,14 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
     @discardableResult
     func retry(
         _ username: String,
-        fundingSource: DWIdentityFundingSource = .core
+        fundingSource: DWIdentityFundingSource = .core,
+        temporaryUsername: String? = nil
     ) async throws -> Identifier {
         Self.logger.info("🪪 IDENT-COORD :: retry username=\(username, privacy: .public) funding=\(fundingSource.logLabel, privacy: .public)")
-        return try await startCreateUsername(username, fundingSource: fundingSource)
+        return try await startCreateUsername(
+            username,
+            fundingSource: fundingSource,
+            temporaryUsername: temporaryUsername)
     }
 
     /// Abort the current attempt and reset to `.idle`. Safe to call
@@ -1252,7 +1327,19 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         if case .completed = newPhase, let username = currentUsername {
             let isContestedSubmission = DWContestedNameStatusService.shared.isPendingLabel(username)
             if isContestedSubmission {
-                Self.logger.info("🪪 IDENT-COORD :: completed (contested) — deferring DWGlobalOptions mirror writes")
+                if let temporaryUsername = registeredTemporaryUsername {
+                    // The companion name registered in Step 3.6 is live
+                    // immediately — it becomes the active username while
+                    // the contested label stays deferred until the vote
+                    // resolves. `finalizeWon` only backfills an EMPTY
+                    // mirror, so a later vote win adds the contested name
+                    // to the identity without displacing this one.
+                    Self.logger.info("🪪 IDENT-COORD :: completed (contested) — mirroring temporary username \(temporaryUsername, privacy: .public)")
+                    DWGlobalOptions.sharedInstance().dashpayUsername = temporaryUsername
+                    DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = true
+                } else {
+                    Self.logger.info("🪪 IDENT-COORD :: completed (contested) — deferring DWGlobalOptions mirror writes")
+                }
             } else {
                 DWGlobalOptions.sharedInstance().dashpayUsername = username
                 DWGlobalOptions.sharedInstance().dashpayRegistrationCompleted = true
@@ -1323,6 +1410,8 @@ final class DWIdentityRegistrationCoordinator: ObservableObject {
         lastErrorMessage = nil
         currentUsername = nil
         currentFundingSource = .core
+        registeredTemporaryUsername = nil
+        temporaryUsernameError = nil
     }
 
     /// Look up the persisted identity at `pinnedIdentityIndex` for

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -334,6 +334,7 @@ struct CreateUsernameView: View {
         .sheet(isPresented: $showContestedConfirmation) {
             ContestedNameConfirmationSheet(
                 viewModel: viewModel,
+                temporaryField: viewModel.temporaryField,
                 onSubmit: { temporaryUsername in
                     confirmContestedSubmission(temporaryUsername: temporaryUsername)
                 },
@@ -924,11 +925,11 @@ struct CreateUsernameView: View {
 /// swiping the sheet down cancels the submission entirely.
 private struct ContestedNameConfirmationSheet: View {
     @ObservedObject var viewModel: CreateUsernameViewModel
+    @ObservedObject var temporaryField: TemporaryUsernameFieldModel
     /// Called with the validated temporary username, or nil for
     /// "continue without one". The caller dismisses the sheet.
     let onSubmit: (String?) -> Void
     let onCancel: () -> Void
-    @FocusState private var isTemporaryFieldFocused: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -958,27 +959,16 @@ private struct ContestedNameConfirmationSheet: View {
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 4)
 
-                    TextInput(
-                        label: NSLocalizedString("Temporary username", comment: "Usernames"),
-                        text: $viewModel.temporaryUsername,
-                        autocapitalization: .never)
+                    TemporaryUsernameField(model: temporaryField)
                         .padding(.top, 16)
-                        .focused($isTemporaryFieldFocused)
-
-                    if temporaryRuleResult != .hidden {
-                        ValidationCheck(
-                            validationResult: temporaryRuleResult,
-                            text: temporaryRuleText
-                        ).padding(.top, 16)
-                    }
                 }
             }
 
             DashButton(
                 text: NSLocalizedString("Submit both usernames", comment: "Usernames"),
-                isEnabled: viewModel.temporaryUsernameCheck == .available
+                isEnabled: temporaryField.check == .available
             ) {
-                onSubmit(viewModel.temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines))
+                onSubmit(temporaryField.trimmedText)
             }
             .padding(.top, 8)
 
@@ -1002,27 +992,57 @@ private struct ContestedNameConfirmationSheet: View {
         .padding(.bottom, 20)
         .presentationDetents([.large])
         .onAppear {
-            viewModel.prepareTemporaryUsernameSuggestion()
-            isTemporaryFieldFocused = true
+            temporaryField.seedSuggestion(from: viewModel.username)
         }
     }
 
     /// The join-the-vote wording only holds while the join window is
     /// still open; past it (or with no known contest) the generic
     /// contested message is the honest one — same rule as the alert
-    /// this sheet replaced.
+    /// this sheet replaced. Both variants state the real fee semantics:
+    /// the contest fee is SPENT at submission (it prefunds the vote
+    /// poll's specialized balance, whose leftover goes to the network's
+    /// processing pools at poll end — see rs-drive-abci's
+    /// `clean_up_after_contested_resources_vote_polls_end`), never
+    /// locked-and-returned.
     private var voteMessage: String {
         viewModel.activeContestContenders != nil && !viewModel.activeContestJoinClosed
             ? NSLocalizedString(
-                "A vote for this name is already in progress — your request will join it as a contender. Your Dash will be locked until voting completes.",
+                "A vote for this name is already in progress — your request will join it as a contender. The contest fee is spent when you submit and is not returned, even if you do not win the name.",
                 comment: "Usernames")
             : NSLocalizedString(
-                "This name requires voting. Your Dash will be locked until voting completes.",
+                "This name requires a masternode vote. The contest fee is spent when you submit and is not returned, even if you do not win the name.",
                 comment: "Usernames")
     }
+}
 
-    private var temporaryRuleResult: UsernameValidationRuleResult {
-        switch viewModel.temporaryUsernameCheck {
+// MARK: - TemporaryUsernameField
+
+/// TextInput + single validation rule row for a temporary-username
+/// field, bound to a `TemporaryUsernameFieldModel`. Shared by the
+/// contested confirmation sheet above and `UsernameRequestStatusScreen`'s
+/// register section so the two surfaces render the same rules.
+struct TemporaryUsernameField: View {
+    @ObservedObject var model: TemporaryUsernameFieldModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            TextInput(
+                label: NSLocalizedString("Temporary username", comment: "Usernames"),
+                text: $model.text,
+                autocapitalization: .never)
+
+            if ruleResult != .hidden {
+                ValidationCheck(
+                    validationResult: ruleResult,
+                    text: ruleText
+                ).padding(.top, 16)
+            }
+        }
+    }
+
+    private var ruleResult: UsernameValidationRuleResult {
+        switch model.check {
         case .empty:
             return .hidden
         case .invalidLength, .invalidCharacters, .stillContested:
@@ -1038,8 +1058,8 @@ private struct ContestedNameConfirmationSheet: View {
         }
     }
 
-    private var temporaryRuleText: String {
-        switch viewModel.temporaryUsernameCheck {
+    private var ruleText: String {
+        switch model.check {
         case .empty:
             return ""
         case .invalidLength:

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -107,10 +107,21 @@ struct CreateUsernameView: View {
     /// then only corrects a selection that became non-viable, instead
     /// of overriding the user's explicit choice.
     @State private var didUserPickFundingSource: Bool = false
-    /// Tracks the contested-name confirmation alert. Continue routes
-    /// through this alert (instead of submitting directly) when the
+    /// Tracks the contested-name confirmation sheet. Continue routes
+    /// through this sheet (instead of submitting directly) when the
     /// typed name is contested-eligible — `viewModel.isContestedCandidate`.
+    /// Besides acknowledging the vote wait, the sheet prompts for a
+    /// non-contested temporary username registered in the same flow.
     @State private var showContestedConfirmation: Bool = false
+    /// Companion ("temporary") username that the completed contested
+    /// submission actually registered — read by `votingSubmittedMessage`
+    /// (the live `viewModel.temporaryUsername` field must not be read
+    /// there: the sheet is gone and its state can be edited or reset).
+    @State private var registeredTemporaryUsername: String? = nil
+    /// Companion username that was requested but failed to register —
+    /// the contested submission itself succeeded, so the voting alert
+    /// carries the partial-outcome note instead of an error popup.
+    @State private var failedTemporaryUsername: String? = nil
     /// Tracks the buy-listed-name confirmation alert; the button routes
     /// here when `viewModel.canPurchaseListedNameDirectly`.
     @State private var showPurchaseConfirmation: Bool = false
@@ -320,35 +331,13 @@ struct CreateUsernameView: View {
         .onChange(of: viewModel.hasPendingRegistrationRecovery) { _ in
             syncFundingSourceToViableSource()
         }
-        .alert(
-            NSLocalizedString("Contested name", comment: "Usernames"),
-            isPresented: $showContestedConfirmation
-        ) {
-            Button(NSLocalizedString("Submit anyway", comment: "Usernames"), role: .destructive) {
-                // The alert can sit open across the join-window boundary.
-                // Re-check at the moment of confirmation: a submission the
-                // network would refuse is replaced by a fresh availability
-                // answer (which shows the join-closed state) instead of a
-                // broadcast failure.
-                if viewModel.activeContestContenders != nil, viewModel.activeContestJoinClosed {
-                    showContestedConfirmation = false
-                    viewModel.refreshRegistrationRecoveryState()
-                    return
-                }
-                performSubmit()
-            }
-            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) { }
-        } message: {
-            // The join-the-vote wording only holds while the join window is
-            // still open; past it (or with no known contest) the generic
-            // contested message is the honest one.
-            Text(viewModel.activeContestContenders != nil && !viewModel.activeContestJoinClosed
-                ? NSLocalizedString(
-                    "A vote for this name is already in progress — your request will join it as a contender. Your Dash will be locked until voting completes.",
-                    comment: "Usernames")
-                : NSLocalizedString(
-                    "This name requires voting. Your Dash will be locked until voting completes.",
-                    comment: "Usernames"))
+        .sheet(isPresented: $showContestedConfirmation) {
+            ContestedNameConfirmationSheet(
+                viewModel: viewModel,
+                onSubmit: { temporaryUsername in
+                    confirmContestedSubmission(temporaryUsername: temporaryUsername)
+                },
+                onCancel: { showContestedConfirmation = false })
         }
         .alert(
             NSLocalizedString("Buy username", comment: "Usernames"),
@@ -717,14 +706,29 @@ struct CreateUsernameView: View {
         }
     }
 
-    /// Encapsulates the submit-to-bridge dance so both the direct
-    /// Continue path and the contested-name alert's "Submit anyway"
-    /// button can share the code. Writes the funding-source pick
-    /// into the bridge right before submit. The bridge resets to
-    /// `.core` on every terminal phase, so a stale picker value
-    /// can't leak into a future attempt; this single write is the
-    /// only synchronization needed.
-    private func performSubmit() {
+    /// Confirmation handler for both of the contested-name sheet's
+    /// submit buttons (`temporaryUsername` nil = "without a temporary
+    /// username"). The sheet can sit open across the join-window
+    /// boundary, so re-check at the moment of confirmation: a submission
+    /// the network would refuse is replaced by a fresh availability
+    /// answer (which shows the join-closed state) instead of a
+    /// broadcast failure.
+    private func confirmContestedSubmission(temporaryUsername: String?) {
+        showContestedConfirmation = false
+        if viewModel.activeContestContenders != nil, viewModel.activeContestJoinClosed {
+            viewModel.refreshRegistrationRecoveryState()
+            return
+        }
+        performSubmit(temporaryUsername: temporaryUsername)
+    }
+
+    /// Encapsulates the submit-to-bridge dance so the direct Continue
+    /// path and the contested sheet's confirmation can share the code.
+    /// Writes the funding-source pick into the bridge right before
+    /// submit. The bridge resets to `.core` on every terminal phase, so
+    /// a stale picker value can't leak into a future attempt; this
+    /// single write is the only synchronization needed.
+    private func performSubmit(temporaryUsername: String? = nil) {
         if !viewModel.isInvitationMode {
             DWIdentityRegistrationBridge.shared.preferredFundingSource =
                 viewModel.hasPendingRegistrationRecovery ? .core : fundingSource
@@ -735,7 +739,7 @@ struct CreateUsernameView: View {
             // bridge completion resolves the outcome at the terminal phase.
             inProgress = true
             screenLockedAfterAuth = false
-            let outcome = await viewModel.submitUsernameRequest {
+            let outcome = await viewModel.submitUsernameRequest(temporaryUsername: temporaryUsername) {
                 isTextInputFocused = false
                 screenLockedAfterAuth = true
             }
@@ -744,7 +748,9 @@ struct CreateUsernameView: View {
             switch outcome {
             case .success:
                 showSuccess = true
-            case .submittedForVoting:
+            case let .submittedForVoting(registeredTemporary, temporaryError):
+                registeredTemporaryUsername = registeredTemporary
+                failedTemporaryUsername = temporaryError != nil ? temporaryUsername : nil
                 showVotingSubmitted = true
             case .cancelled:
                 screenLockedAfterAuth = false
@@ -761,19 +767,40 @@ struct CreateUsernameView: View {
     /// hence "around". Falls back to the date-less wording when no pending
     /// bookmark exists rather than inventing a deadline.
     private var votingSubmittedMessage: String {
-        guard let endTime = DWContestedNameStatusService.shared.pendingVotingEndTime else {
-            return String.localizedStringWithFormat(
+        var message: String
+        if let endTime = DWContestedNameStatusService.shared.pendingVotingEndTime {
+            message = String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "“%1$@” has been submitted for voting. It is not registered to you yet. Voting ends around %2$@ — we will notify you with the result.",
+                    comment: "Usernames"),
+                viewModel.username,
+                DWDateFormatter.sharedInstance.dateAndTime(from: endTime))
+        } else {
+            message = String.localizedStringWithFormat(
                 NSLocalizedString(
                     "“%@” has been submitted for voting. It is not registered to you yet. We will notify you when voting ends.",
                     comment: "Usernames"),
                 viewModel.username)
         }
-        return String.localizedStringWithFormat(
-            NSLocalizedString(
-                "“%1$@” has been submitted for voting. It is not registered to you yet. Voting ends around %2$@ — we will notify you with the result.",
-                comment: "Usernames"),
-            viewModel.username,
-            DWDateFormatter.sharedInstance.dateAndTime(from: endTime))
+        // Companion-name outcome from the same flow: registered (the
+        // user is reachable right away, and keeps the name past the
+        // vote) or requested-but-failed (partial outcome — the contested
+        // submission itself succeeded).
+        if let temporary = registeredTemporaryUsername {
+            message += " " + String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "In the meantime you are reachable at “%1$@”, which is yours to keep. If the vote awards you “%2$@”, you will be reachable at both usernames.",
+                    comment: "Usernames"),
+                temporary,
+                viewModel.username)
+        } else if let failed = failedTemporaryUsername {
+            message += " " + String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "Your temporary username “%@” could not be registered. You can register another username later.",
+                    comment: "Usernames"),
+                failed)
+        }
+        return message
     }
 
     /// Viable funding sources in privacy-descending priority order.
@@ -884,6 +911,153 @@ struct CreateUsernameView: View {
             return NSLocalizedString("Username is in voting. You will be notified when voting ends.", comment: "Usernames")
         case .empty, .invalid, .hidden:
             return "" // rule row is hidden for these states
+        }
+    }
+}
+
+/// Contested-name confirmation sheet. Replaces the old plain
+/// "Submit anyway" alert: besides acknowledging the vote wait and the
+/// locked Dash, it prompts the user to register a non-contested
+/// temporary username to the same identity in the same flow (one PIN
+/// prompt) — they are reachable at it while the vote runs, and keep it
+/// permanently afterwards. Skipping is an explicit secondary action;
+/// swiping the sheet down cancels the submission entirely.
+private struct ContestedNameConfirmationSheet: View {
+    @ObservedObject var viewModel: CreateUsernameViewModel
+    /// Called with the validated temporary username, or nil for
+    /// "continue without one". The caller dismisses the sheet.
+    let onSubmit: (String?) -> Void
+    let onCancel: () -> Void
+    @FocusState private var isTemporaryFieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(NSLocalizedString("Contested name", comment: "Usernames"))
+                        .foregroundColor(.dash.primaryText)
+                        .font(.title2.bold())
+                        .padding(.top, 24)
+                    Text(voteMessage)
+                        .foregroundColor(.dash.secondaryText)
+                        .font(.subheadline)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 8)
+
+                    Text(NSLocalizedString("Add a temporary username", comment: "Usernames"))
+                        .foregroundColor(.dash.primaryText)
+                        .font(.subheadline.bold())
+                        .padding(.top, 24)
+                    Text(String.localizedStringWithFormat(
+                        NSLocalizedString(
+                            "While the vote is in progress, “%@” does not belong to you yet and other users cannot find you by it. Add a non-contested username to use DashPay right away. It stays yours permanently — if the vote awards you the contested name, you will be reachable at both usernames.",
+                            comment: "Usernames"),
+                        viewModel.username))
+                        .foregroundColor(.dash.secondaryText)
+                        .font(.subheadline)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 4)
+
+                    TextInput(
+                        label: NSLocalizedString("Temporary username", comment: "Usernames"),
+                        text: $viewModel.temporaryUsername,
+                        autocapitalization: .never)
+                        .padding(.top, 16)
+                        .focused($isTemporaryFieldFocused)
+
+                    if temporaryRuleResult != .hidden {
+                        ValidationCheck(
+                            validationResult: temporaryRuleResult,
+                            text: temporaryRuleText
+                        ).padding(.top, 16)
+                    }
+                }
+            }
+
+            DashButton(
+                text: NSLocalizedString("Submit both usernames", comment: "Usernames"),
+                isEnabled: viewModel.temporaryUsernameCheck == .available
+            ) {
+                onSubmit(viewModel.temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+            .padding(.top, 8)
+
+            DashButton(
+                text: NSLocalizedString("Continue without a temporary username", comment: "Usernames"),
+                style: .plain
+            ) {
+                onSubmit(nil)
+            }
+            .padding(.top, 4)
+
+            DashButton(
+                text: NSLocalizedString("Cancel", comment: ""),
+                style: .plain
+            ) {
+                onCancel()
+            }
+            .padding(.top, 4)
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 20)
+        .presentationDetents([.large])
+        .onAppear {
+            viewModel.prepareTemporaryUsernameSuggestion()
+            isTemporaryFieldFocused = true
+        }
+    }
+
+    /// The join-the-vote wording only holds while the join window is
+    /// still open; past it (or with no known contest) the generic
+    /// contested message is the honest one — same rule as the alert
+    /// this sheet replaced.
+    private var voteMessage: String {
+        viewModel.activeContestContenders != nil && !viewModel.activeContestJoinClosed
+            ? NSLocalizedString(
+                "A vote for this name is already in progress — your request will join it as a contender. Your Dash will be locked until voting completes.",
+                comment: "Usernames")
+            : NSLocalizedString(
+                "This name requires voting. Your Dash will be locked until voting completes.",
+                comment: "Usernames")
+    }
+
+    private var temporaryRuleResult: UsernameValidationRuleResult {
+        switch viewModel.temporaryUsernameCheck {
+        case .empty:
+            return .hidden
+        case .invalidLength, .invalidCharacters, .stillContested:
+            return .invalid
+        case .checking:
+            return .loading
+        case .available:
+            return .valid
+        case .taken:
+            return .invalidCritical
+        case .error:
+            return .error
+        }
+    }
+
+    private var temporaryRuleText: String {
+        switch viewModel.temporaryUsernameCheck {
+        case .empty:
+            return ""
+        case .invalidLength:
+            return NSLocalizedString("Between 3 and 23 characters", comment: "Usernames")
+        case .invalidCharacters:
+            return NSLocalizedString("Letter, numbers and hyphens only", comment: "Usernames")
+        case .stillContested:
+            return NSLocalizedString(
+                "This username would also require voting — try adding a digit between 2 and 9",
+                comment: "Usernames")
+        case .checking:
+            return NSLocalizedString("Validating username…", comment: "Usernames")
+        case .available:
+            return NSLocalizedString("Username available", comment: "Usernames")
+        case .taken:
+            return NSLocalizedString("Username taken", comment: "Usernames")
+        case .error:
+            return NSLocalizedString("Validating username failed", comment: "Usernames")
         }
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -104,6 +104,37 @@ class CreateUsernameViewModel: ObservableObject {
     /// `dash_sdk_dpns_is_contested_username` — no network call.
     @Published private(set) var isContestedCandidate: Bool = false
 
+    /// Companion ("temporary") username typed into the contested-name
+    /// confirmation sheet. Validated by the pipeline below into
+    /// `temporaryUsernameCheck`; submitted through
+    /// `submitUsernameRequest(temporaryUsername:)` when the user
+    /// confirms with it.
+    @Published var temporaryUsername: String = ""
+
+    /// Validation verdict for `temporaryUsername`. The companion label
+    /// must pass the same local rules as the main field AND be
+    /// non-contested (a contested companion would silently open a second
+    /// vote) AND be available on DPNS.
+    @Published private(set) var temporaryUsernameCheck: TemporaryUsernameCheck = .empty
+
+    enum TemporaryUsernameCheck: Equatable {
+        case empty
+        case invalidLength
+        case invalidCharacters
+        /// The label would itself go to a masternode vote — the whole
+        /// point of the companion name is to avoid that.
+        case stillContested
+        case checking
+        case available
+        case taken
+        case error
+    }
+
+    /// In-flight DPNS availability check for the companion label —
+    /// cancelled and replaced on every input change, like
+    /// `availabilityCheckTask` for the main field.
+    private var temporaryAvailabilityTask: Task<Void, Never>?
+
     /// The typed label lost an earlier contest to a masternode LOCK, so nobody
     /// can register it. It still reports as available (no owner holds the
     /// domain document), which is why this needs its own flag: the rule row
@@ -174,7 +205,7 @@ class CreateUsernameViewModel: ObservableObject {
     /// mainnet) has closed: the name can no longer be requested until
     /// the vote resolves. Always true once the vote itself has ended.
     /// Consulted at render time AND as the last-moment gate behind the
-    /// contested confirmation's "Submit anyway".
+    /// contested confirmation sheet's submit actions.
     var activeContestJoinClosed: Bool {
         guard let endsAt = activeContestEndsAt else { return false }
         return UsernameMarketplaceService.contenderJoinDeadline(voteEnd: endsAt) <= Date()
@@ -297,22 +328,38 @@ class CreateUsernameViewModel: ObservableObject {
             }
             .store(in: &cancellableBag)
 
+        $temporaryUsername
+            .throttle(for: .milliseconds(500), scheduler: RunLoop.main, latest: true)
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] text in
+                self?.validateTemporaryUsername(text)
+            }
+            .store(in: &cancellableBag)
+
         DWIdentityRegistrationCoordinator.shared.$phase
             .receive(on: RunLoop.main)
             .sink { [weak self] phase in
                 self?.handleRegistrationPhase(phase)
             }
             .store(in: &cancellableBag)
-        
+
         observeBalance()
     }
     
     /// Terminal outcome of a username-registration attempt, surfaced to
     /// the SwiftUI form so it can keep the screen up through the PIN +
     /// registration and then show the right native alert.
+    ///
+    /// `.submittedForVoting` carries the companion ("temporary")
+    /// username's result: `temporaryUsername` is the non-contested label
+    /// registered alongside the contested submission (nil when the user
+    /// skipped it), `temporaryUsernameError` the failure description when
+    /// it was requested but could not be registered (the contested
+    /// submission itself still succeeded).
     enum UsernameRegistrationOutcome {
         case success
-        case submittedForVoting
+        case submittedForVoting(temporaryUsername: String?, temporaryUsernameError: String?)
         case cancelled
         case failure(String)
     }
@@ -330,7 +377,14 @@ class CreateUsernameViewModel: ObservableObject {
     /// The funding source is read from
     /// `DWIdentityRegistrationBridge.shared.preferredFundingSource`,
     /// written by `CreateUsernameView` immediately before this call.
-    func submitUsernameRequest(onRegistrationStarted: @escaping @MainActor () -> Void = {}) async -> UsernameRegistrationOutcome {
+    ///
+    /// `temporaryUsername` — non-contested companion label to register
+    /// in the same flow (contested submissions only; the confirmation
+    /// sheet collects it). nil submits the typed name alone.
+    func submitUsernameRequest(
+        temporaryUsername: String? = nil,
+        onRegistrationStarted: @escaping @MainActor () -> Void = {}
+    ) async -> UsernameRegistrationOutcome {
         // The cached ceiling tracks the balance publisher, which is enough for
         // per-keystroke validation. Submission spends real UTXOs, so re-derive
         // it once here from the live set: one FFI walk on an explicit user
@@ -360,7 +414,8 @@ class CreateUsernameViewModel: ObservableObject {
             do {
                 _ = try await DWIdentityRegistrationCoordinator.shared.startClaimInvitation(
                     username: submittedUsername,
-                    invitationURI: invitationURI)
+                    invitationURI: invitationURI,
+                    temporaryUsername: temporaryUsername)
                 return registrationOutcome(for: submittedUsername)
             } catch DWIdentityRegistrationCoordinator.CoordinatorError.authCancelled {
                 return .cancelled
@@ -369,6 +424,11 @@ class CreateUsernameViewModel: ObservableObject {
                     Self.registrationFailureMessage(error, username: submittedUsername))
             }
         }
+
+        // Same lifecycle as `preferredFundingSource` (written by the
+        // form right before this call): nil for a plain submission,
+        // preserved across `.failed` so a retry keeps the choice.
+        DWIdentityRegistrationBridge.shared.pendingTemporaryUsername = temporaryUsername
 
         return await withCheckedContinuation { (continuation: CheckedContinuation<UsernameRegistrationOutcome, Never>) in
             DWIdentityRegistrationBridge.shared.startCreateUsername(submittedUsername) { [weak self] _, error in
@@ -456,7 +516,74 @@ class CreateUsernameViewModel: ObservableObject {
               DWContestedNameStatusService.labelsMatch(pending, username) else {
             return .success
         }
-        return .submittedForVoting
+        // The coordinator's companion-name fields are still set here —
+        // `resetState()` only clears them when the NEXT attempt starts.
+        let coordinator = DWIdentityRegistrationCoordinator.shared
+        return .submittedForVoting(
+            temporaryUsername: coordinator.registeredTemporaryUsername,
+            temporaryUsernameError: coordinator.temporaryUsernameError)
+    }
+
+    /// Seed the confirmation sheet's companion field with a variant of
+    /// the typed contested name that is guaranteed non-contested: any
+    /// digit 2–9 in the label takes it out of the contested character
+    /// set (`[a-z01-]` after homograph folding), so `<name>2` always
+    /// qualifies. Availability is NOT guaranteed — the normal check
+    /// runs on it and the user edits if it's taken.
+    func prepareTemporaryUsernameSuggestion() {
+        guard temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return // keep what the user already typed on a reopened sheet
+        }
+        var suggestion = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !suggestion.isEmpty else { return }
+        if suggestion.count >= DW_MAX_USERNAME_LENGTH {
+            suggestion = String(suggestion.prefix(Int(DW_MAX_USERNAME_LENGTH) - 1))
+        }
+        temporaryUsername = suggestion + "2"
+    }
+
+    /// Local rules + non-contested gate + debounced DPNS availability
+    /// for the companion label. Mirrors `validateUsername`'s structure,
+    /// but as a single verdict enum — the sheet shows one rule row.
+    private func validateTemporaryUsername(_ raw: String) {
+        temporaryAvailabilityTask?.cancel()
+        let label = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !label.isEmpty else {
+            temporaryUsernameCheck = .empty
+            return
+        }
+        guard label.count >= DW_MIN_USERNAME_LENGTH && label.count <= DW_MAX_USERNAME_LENGTH else {
+            temporaryUsernameCheck = .invalidLength
+            return
+        }
+        guard label.rangeOfCharacter(from: illegalChars) == nil,
+              label.first != "-", label.last != "-" else {
+            temporaryUsernameCheck = .invalidCharacters
+            return
+        }
+        guard !DWContestedNameStatusService.isContestedLabel(label) else {
+            temporaryUsernameCheck = .stillContested
+            return
+        }
+        temporaryUsernameCheck = .checking
+        temporaryAvailabilityTask = Task { [weak self] in
+            do { try await Task.sleep(nanoseconds: Self.availabilityDebounceNanos) }
+            catch { return }
+            guard let self, !Task.isCancelled else { return }
+            let verdict: TemporaryUsernameCheck
+            do {
+                let available = try await DWIdentityRegistrationCoordinator.shared
+                    .dpnsCheckAvailability(label)
+                verdict = available ? .available : .taken
+            } catch {
+                verdict = .error
+            }
+            // Drop stale results — the field changed while the RPC ran.
+            guard !Task.isCancelled,
+                  self.temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines) == label
+            else { return }
+            self.temporaryUsernameCheck = verdict
+        }
     }
 
     private func handleRegistrationPhase(_ phase: DWIdentityRegistrationController.Phase) {

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -135,6 +135,19 @@ class CreateUsernameViewModel: ObservableObject {
     /// `availabilityCheckTask` for the main field.
     private var temporaryAvailabilityTask: Task<Void, Never>?
 
+    /// The trimmed companion label the current `temporaryUsernameCheck`
+    /// belongs to (in flight or settled) — same role as
+    /// `availabilityCheckLabel` for the main field. Lets the seeding
+    /// path validate synchronously without the later throttled pipeline
+    /// emission restarting the check for the unchanged label.
+    private var temporaryCheckLabel: String?
+
+    /// Main label the current `temporaryUsername` was suggested from
+    /// (or edited against). A different main label invalidates the
+    /// companion — a name derived from an abandoned contested name
+    /// must not survive into the next one's confirmation sheet.
+    private var temporaryUsernameSuggestionBase: String?
+
     /// The typed label lost an earlier contest to a masternode LOCK, so nobody
     /// can register it. It still reports as available (no owner holds the
     /// domain document), which is why this needs its own flag: the rule row
@@ -512,8 +525,12 @@ class CreateUsernameViewModel: ObservableObject {
     }
 
     private func registrationOutcome(for username: String) -> UsernameRegistrationOutcome {
-        guard let pending = DWContestedNameStatusService.shared.pendingLabel,
-              DWContestedNameStatusService.labelsMatch(pending, username) else {
+        // Membership across ALL pending entries, not the single-slot
+        // `pendingLabel` (the oldest): an older unresolved contested
+        // submission in the store must not make THIS submission read as
+        // a completed registration. Same check the coordinator's
+        // `handlePhaseChange` uses for the mirror-write decision.
+        guard DWContestedNameStatusService.shared.isPendingLabel(username) else {
             return .success
         }
         // The coordinator's companion-name fields are still set here —
@@ -531,23 +548,44 @@ class CreateUsernameViewModel: ObservableObject {
     /// qualifies. Availability is NOT guaranteed — the normal check
     /// runs on it and the user edits if it's taken.
     func prepareTemporaryUsernameSuggestion() {
-        guard temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return // keep what the user already typed on a reopened sheet
+        let base = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !base.isEmpty else { return }
+        // Keep what the user already typed on a reopened sheet — but
+        // only when it was typed against THIS main label. A companion
+        // suggested from (or edited for) an abandoned contested name is
+        // re-seeded instead of silently carried over.
+        if temporaryUsernameSuggestionBase == base,
+           !temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            validateTemporaryUsername(temporaryUsername)
+            return
         }
-        var suggestion = username.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !suggestion.isEmpty else { return }
+        temporaryUsernameSuggestionBase = base
+        var suggestion = base
         if suggestion.count >= DW_MAX_USERNAME_LENGTH {
             suggestion = String(suggestion.prefix(Int(DW_MAX_USERNAME_LENGTH) - 1))
         }
         temporaryUsername = suggestion + "2"
+        // Validate synchronously so the sheet's rule row + submit button
+        // don't sit blank/disabled through the pipeline's 500 ms
+        // throttle; the later emission for the same label no-ops via
+        // `temporaryCheckLabel`.
+        validateTemporaryUsername(temporaryUsername)
     }
 
     /// Local rules + non-contested gate + debounced DPNS availability
     /// for the companion label. Mirrors `validateUsername`'s structure,
     /// but as a single verdict enum — the sheet shows one rule row.
     private func validateTemporaryUsername(_ raw: String) {
-        temporaryAvailabilityTask?.cancel()
         let label = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Same label as the existing check state → keep it (a settled
+        // verdict stays settled, an in-flight `.checking` keeps its
+        // task) instead of resetting and re-querying. `.error` retries,
+        // as for the main field.
+        if label == temporaryCheckLabel, temporaryUsernameCheck != .error {
+            return
+        }
+        temporaryAvailabilityTask?.cancel()
+        temporaryCheckLabel = label
         guard !label.isEmpty else {
             temporaryUsernameCheck = .empty
             return

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -53,7 +53,7 @@ class CreateUsernameViewModel: ObservableObject {
     /// type doc). Used here for `contestPrecheck` — the one vote-state
     /// query that distinguishes a locked name from one mid-vote.
     private let marketplaceService = UsernameMarketplaceService()
-    private let illegalChars = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-").inverted
+    private let illegalChars = TemporaryUsernameFieldModel.illegalCharacters
     private var submittedRegistrationUsername: String?
     private var didNotifyRegistrationStarted = false
     private var onRegistrationStarted: (@MainActor () -> Void)?
@@ -104,49 +104,11 @@ class CreateUsernameViewModel: ObservableObject {
     /// `dash_sdk_dpns_is_contested_username` — no network call.
     @Published private(set) var isContestedCandidate: Bool = false
 
-    /// Companion ("temporary") username typed into the contested-name
-    /// confirmation sheet. Validated by the pipeline below into
-    /// `temporaryUsernameCheck`; submitted through
-    /// `submitUsernameRequest(temporaryUsername:)` when the user
-    /// confirms with it.
-    @Published var temporaryUsername: String = ""
-
-    /// Validation verdict for `temporaryUsername`. The companion label
-    /// must pass the same local rules as the main field AND be
-    /// non-contested (a contested companion would silently open a second
-    /// vote) AND be available on DPNS.
-    @Published private(set) var temporaryUsernameCheck: TemporaryUsernameCheck = .empty
-
-    enum TemporaryUsernameCheck: Equatable {
-        case empty
-        case invalidLength
-        case invalidCharacters
-        /// The label would itself go to a masternode vote — the whole
-        /// point of the companion name is to avoid that.
-        case stillContested
-        case checking
-        case available
-        case taken
-        case error
-    }
-
-    /// In-flight DPNS availability check for the companion label —
-    /// cancelled and replaced on every input change, like
-    /// `availabilityCheckTask` for the main field.
-    private var temporaryAvailabilityTask: Task<Void, Never>?
-
-    /// The trimmed companion label the current `temporaryUsernameCheck`
-    /// belongs to (in flight or settled) — same role as
-    /// `availabilityCheckLabel` for the main field. Lets the seeding
-    /// path validate synchronously without the later throttled pipeline
-    /// emission restarting the check for the unchanged label.
-    private var temporaryCheckLabel: String?
-
-    /// Main label the current `temporaryUsername` was suggested from
-    /// (or edited against). A different main label invalidates the
-    /// companion — a name derived from an abandoned contested name
-    /// must not survive into the next one's confirmation sheet.
-    private var temporaryUsernameSuggestionBase: String?
+    /// Input + validation state for the companion ("temporary")
+    /// username collected by the contested-name confirmation sheet.
+    /// Submitted through `submitUsernameRequest(temporaryUsername:)`
+    /// when the user confirms with it.
+    let temporaryField = TemporaryUsernameFieldModel()
 
     /// The typed label lost an earlier contest to a masternode LOCK, so nobody
     /// can register it. It still reports as available (no owner holds the
@@ -341,15 +303,6 @@ class CreateUsernameViewModel: ObservableObject {
             }
             .store(in: &cancellableBag)
 
-        $temporaryUsername
-            .throttle(for: .milliseconds(500), scheduler: RunLoop.main, latest: true)
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] text in
-                self?.validateTemporaryUsername(text)
-            }
-            .store(in: &cancellableBag)
-
         DWIdentityRegistrationCoordinator.shared.$phase
             .receive(on: RunLoop.main)
             .sink { [weak self] phase in
@@ -539,89 +492,6 @@ class CreateUsernameViewModel: ObservableObject {
         return .submittedForVoting(
             temporaryUsername: coordinator.registeredTemporaryUsername,
             temporaryUsernameError: coordinator.temporaryUsernameError)
-    }
-
-    /// Seed the confirmation sheet's companion field with a variant of
-    /// the typed contested name that is guaranteed non-contested: any
-    /// digit 2–9 in the label takes it out of the contested character
-    /// set (`[a-z01-]` after homograph folding), so `<name>2` always
-    /// qualifies. Availability is NOT guaranteed — the normal check
-    /// runs on it and the user edits if it's taken.
-    func prepareTemporaryUsernameSuggestion() {
-        let base = username.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !base.isEmpty else { return }
-        // Keep what the user already typed on a reopened sheet — but
-        // only when it was typed against THIS main label. A companion
-        // suggested from (or edited for) an abandoned contested name is
-        // re-seeded instead of silently carried over.
-        if temporaryUsernameSuggestionBase == base,
-           !temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            validateTemporaryUsername(temporaryUsername)
-            return
-        }
-        temporaryUsernameSuggestionBase = base
-        var suggestion = base
-        if suggestion.count >= DW_MAX_USERNAME_LENGTH {
-            suggestion = String(suggestion.prefix(Int(DW_MAX_USERNAME_LENGTH) - 1))
-        }
-        temporaryUsername = suggestion + "2"
-        // Validate synchronously so the sheet's rule row + submit button
-        // don't sit blank/disabled through the pipeline's 500 ms
-        // throttle; the later emission for the same label no-ops via
-        // `temporaryCheckLabel`.
-        validateTemporaryUsername(temporaryUsername)
-    }
-
-    /// Local rules + non-contested gate + debounced DPNS availability
-    /// for the companion label. Mirrors `validateUsername`'s structure,
-    /// but as a single verdict enum — the sheet shows one rule row.
-    private func validateTemporaryUsername(_ raw: String) {
-        let label = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Same label as the existing check state → keep it (a settled
-        // verdict stays settled, an in-flight `.checking` keeps its
-        // task) instead of resetting and re-querying. `.error` retries,
-        // as for the main field.
-        if label == temporaryCheckLabel, temporaryUsernameCheck != .error {
-            return
-        }
-        temporaryAvailabilityTask?.cancel()
-        temporaryCheckLabel = label
-        guard !label.isEmpty else {
-            temporaryUsernameCheck = .empty
-            return
-        }
-        guard label.count >= DW_MIN_USERNAME_LENGTH && label.count <= DW_MAX_USERNAME_LENGTH else {
-            temporaryUsernameCheck = .invalidLength
-            return
-        }
-        guard label.rangeOfCharacter(from: illegalChars) == nil,
-              label.first != "-", label.last != "-" else {
-            temporaryUsernameCheck = .invalidCharacters
-            return
-        }
-        guard !DWContestedNameStatusService.isContestedLabel(label) else {
-            temporaryUsernameCheck = .stillContested
-            return
-        }
-        temporaryUsernameCheck = .checking
-        temporaryAvailabilityTask = Task { [weak self] in
-            do { try await Task.sleep(nanoseconds: Self.availabilityDebounceNanos) }
-            catch { return }
-            guard let self, !Task.isCancelled else { return }
-            let verdict: TemporaryUsernameCheck
-            do {
-                let available = try await DWIdentityRegistrationCoordinator.shared
-                    .dpnsCheckAvailability(label)
-                verdict = available ? .available : .taken
-            } catch {
-                verdict = .error
-            }
-            // Drop stale results — the field changed while the RPC ran.
-            guard !Task.isCancelled,
-                  self.temporaryUsername.trimmingCharacters(in: .whitespacesAndNewlines) == label
-            else { return }
-            self.temporaryUsernameCheck = verdict
-        }
     }
 
     private func handleRegistrationPhase(_ phase: DWIdentityRegistrationController.Phase) {
@@ -1005,5 +875,157 @@ class CreateUsernameViewModel: ObservableObject {
         hasRecommendedBalance = balance >= DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME
             || PlatformPaymentIdentityFundingPolicy.canFundCurrentWallet(
                 fundingDuffs: UInt64(DWDP_MIN_BALANCE_FOR_CONTESTED_USERNAME))
+    }
+}
+
+// MARK: - TemporaryUsernameFieldModel
+
+/// Input + validation state for a "temporary username" field — the
+/// non-contested companion label offered next to a contested submission.
+/// One shared implementation for its two surfaces (the signup flow's
+/// contested confirmation sheet, and `UsernameRequestStatusScreen`'s
+/// register section for an identity already waiting on a vote) so the
+/// rules cannot drift: local length/character checks, a
+/// must-not-be-contested gate, then a debounced DPNS availability check.
+@MainActor
+final class TemporaryUsernameFieldModel: ObservableObject {
+    /// The companion label as typed. Bound to the field's `TextInput`;
+    /// validated through the throttled pipeline below into `check`.
+    @Published var text: String = ""
+
+    /// Validation verdict for `text`. Only `.available` labels are
+    /// submittable.
+    @Published private(set) var check: Check = .empty
+
+    enum Check: Equatable {
+        case empty
+        case invalidLength
+        case invalidCharacters
+        /// The label would itself go to a masternode vote — the whole
+        /// point of a temporary username is to avoid that.
+        case stillContested
+        case checking
+        case available
+        case taken
+        case error
+    }
+
+    var trimmedText: String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Complement of the characters a DPNS label may contain. Shared
+    /// with `CreateUsernameViewModel`'s main-field validation — one
+    /// definition for the same rule.
+    nonisolated static let illegalCharacters =
+        CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-").inverted
+
+    /// In-flight DPNS availability check — cancelled and replaced on
+    /// every input change, like `CreateUsernameViewModel`'s
+    /// `availabilityCheckTask` for the main field.
+    private var availabilityTask: Task<Void, Never>?
+
+    /// The trimmed label the current `check` belongs to (in flight or
+    /// settled) — same role as the main field's `availabilityCheckLabel`.
+    /// Lets `seedSuggestion` validate synchronously without the later
+    /// throttled pipeline emission restarting the check for the
+    /// unchanged label.
+    private var checkLabel: String?
+
+    /// Main label the current `text` was suggested from (or edited
+    /// against). A different main label invalidates the companion — a
+    /// name derived from an abandoned contested name must not survive
+    /// into the next one's prompt.
+    private var suggestionBase: String?
+
+    private var cancellableBag = Set<AnyCancellable>()
+
+    init() {
+        $text
+            .throttle(for: .milliseconds(500), scheduler: RunLoop.main, latest: true)
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] value in
+                self?.validate(value)
+            }
+            .store(in: &cancellableBag)
+    }
+
+    /// Seed the field with a variant of `mainLabel` that is guaranteed
+    /// non-contested: any digit 2–9 in the label takes it out of the
+    /// contested character set (`[a-z01-]` after homograph folding), so
+    /// `<name>2` always qualifies. Availability is NOT guaranteed — the
+    /// normal check runs on it and the user edits if it's taken.
+    func seedSuggestion(from mainLabel: String) {
+        let base = mainLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !base.isEmpty else { return }
+        // Keep what the user already typed on a reopened surface — but
+        // only when it was typed against THIS main label.
+        if suggestionBase == base, !trimmedText.isEmpty {
+            validate(text)
+            return
+        }
+        suggestionBase = base
+        var suggestion = base
+        if suggestion.count >= DW_MAX_USERNAME_LENGTH {
+            suggestion = String(suggestion.prefix(Int(DW_MAX_USERNAME_LENGTH) - 1))
+        }
+        text = suggestion + "2"
+        // Validate synchronously so the rule row + submit button don't
+        // sit blank/disabled through the pipeline's 500 ms throttle; the
+        // later emission for the same label no-ops via `checkLabel`.
+        validate(text)
+    }
+
+    /// Local rules + non-contested gate + debounced DPNS availability.
+    /// Mirrors `CreateUsernameViewModel.validateUsername`'s structure,
+    /// but as a single verdict enum — the surfaces show one rule row.
+    private func validate(_ raw: String) {
+        let label = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Same label as the existing check state → keep it (a settled
+        // verdict stays settled, an in-flight `.checking` keeps its
+        // task) instead of resetting and re-querying. `.error` retries,
+        // as for the main field.
+        if label == checkLabel, check != .error {
+            return
+        }
+        availabilityTask?.cancel()
+        checkLabel = label
+        guard !label.isEmpty else {
+            check = .empty
+            return
+        }
+        guard label.count >= DW_MIN_USERNAME_LENGTH && label.count <= DW_MAX_USERNAME_LENGTH else {
+            check = .invalidLength
+            return
+        }
+        guard label.rangeOfCharacter(from: Self.illegalCharacters) == nil,
+              label.first != "-", label.last != "-" else {
+            check = .invalidCharacters
+            return
+        }
+        guard !DWContestedNameStatusService.isContestedLabel(label) else {
+            check = .stillContested
+            return
+        }
+        check = .checking
+        availabilityTask = Task { [weak self] in
+            // Same debounce as the main field's availability check
+            // (the legacy VALIDATION_DEBOUNCE_DELAY).
+            do { try await Task.sleep(nanoseconds: 400_000_000) }
+            catch { return }
+            guard let self, !Task.isCancelled else { return }
+            let verdict: Check
+            do {
+                let available = try await DWIdentityRegistrationCoordinator.shared
+                    .dpnsCheckAvailability(label)
+                verdict = available ? .available : .taken
+            } catch {
+                verdict = .error
+            }
+            // Drop stale results — the field changed while the RPC ran.
+            guard !Task.isCancelled, self.trimmedText == label else { return }
+            self.check = verdict
+        }
     }
 }

--- a/DashWallet/Sources/UI/DashPay/Usernames/UsernameRequestStatusScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Usernames/UsernameRequestStatusScreen.swift
@@ -93,6 +93,59 @@ final class UsernameRequestStatusViewModel: ObservableObject {
             loadError = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
         }
     }
+
+    #if DASHPAY
+    // MARK: Temporary username (DASHPAY only — the field model and the
+    // marketplace registration live in dashpay-target-only files)
+
+    /// Input + validation for the non-contested temporary username the
+    /// screen offers while the vote is unresolved. Same shared model the
+    /// signup flow's contested confirmation sheet uses.
+    let temporaryField = TemporaryUsernameFieldModel()
+
+    @Published private(set) var isRegisteringTemporary = false
+    /// Non-nil drives the registration-failure alert.
+    @Published var temporaryRegistrationError: String?
+    /// Set on success — flips the offer section to its confirmation and
+    /// keeps it flipped for this screen visit (the identity-info
+    /// snapshot also stops reporting an empty username list).
+    @Published private(set) var justRegisteredTemporaryUsername: String?
+
+    /// Stateless facade, instantiated per view model by design (see its
+    /// type doc). `register(label:)` refuses contested labels, so the
+    /// field's non-contested gate has a second line of defense.
+    private let marketplaceService = UsernameMarketplaceService()
+
+    /// Offer the temporary-username section only while it can still
+    /// help: the vote is unresolved (or not yet indexed — the bookmark
+    /// this screen was opened from proves a submission exists) and the
+    /// identity owns no other username to be reached at.
+    var canOfferTemporaryUsername: Bool {
+        guard justRegisteredTemporaryUsername == nil else { return false }
+        guard DWCurrentUserIdentityInfo.shared.usernames.isEmpty else { return false }
+        guard let voteState else { return true }
+        if case .ongoing = voteState.outcome { return true }
+        return false
+    }
+
+    /// Register the validated temporary username to the existing
+    /// identity via the marketplace service (own PIN prompt; refreshes
+    /// the identity snapshot on success). PIN cancel is a silent no-op.
+    func registerTemporaryUsername() async {
+        let label = temporaryField.trimmedText
+        guard temporaryField.check == .available, !isRegisteringTemporary else { return }
+        isRegisteringTemporary = true
+        defer { isRegisteringTemporary = false }
+        do {
+            try await marketplaceService.register(label: label)
+            justRegisteredTemporaryUsername = label
+        } catch UsernameMarketplaceService.ServiceError.authCancelled {
+            // User backed out of the PIN — keep the section as-is.
+        } catch {
+            temporaryRegistrationError = UsernameMarketplaceService.userFacingMessage(for: error)
+        }
+    }
+    #endif
 }
 
 // MARK: - UsernameRequestStatusScreen
@@ -138,6 +191,30 @@ struct UsernameRequestStatusScreen: View {
                 }
             }
 
+            #if DASHPAY
+            // The gap this closes: a user whose FIRST username went to a
+            // vote has no username at all until it resolves. Offer the
+            // same non-contested temporary username the signup flow now
+            // prompts for — here, registered to the already-existing
+            // identity.
+            if viewModel.canOfferTemporaryUsername {
+                TemporaryUsernameRegistrationSection(
+                    viewModel: viewModel,
+                    temporaryField: viewModel.temporaryField)
+            } else if let registered = viewModel.justRegisteredTemporaryUsername {
+                Section {
+                    Text(String.localizedStringWithFormat(
+                        NSLocalizedString(
+                            "“%1$@” is now your username. If the vote awards you “%2$@”, you will be reachable at both usernames.",
+                            comment: "Usernames"),
+                        registered,
+                        viewModel.label))
+                        .font(.caption)
+                        .foregroundColor(Color.dash.secondaryText)
+                }
+            }
+            #endif
+
             if let voteState = viewModel.voteState {
                 Section(NSLocalizedString("Who is requesting this name", comment: "Usernames")) {
                     ForEach(voteState.contenders) { contender in
@@ -179,6 +256,21 @@ struct UsernameRequestStatusScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .task { await viewModel.refresh() }
         .refreshable { await viewModel.refresh() }
+        #if DASHPAY
+        .alert(
+            NSLocalizedString("Registration failed", comment: "Usernames"),
+            isPresented: Binding(
+                get: { viewModel.temporaryRegistrationError != nil },
+                set: { if !$0 { viewModel.temporaryRegistrationError = nil } }
+            )
+        ) {
+            Button(NSLocalizedString("OK", comment: "")) {
+                viewModel.temporaryRegistrationError = nil
+            }
+        } message: {
+            Text(viewModel.temporaryRegistrationError ?? "")
+        }
+        #endif
     }
 
     /// Describes only what Platform actually reported. A contest that is not
@@ -219,6 +311,49 @@ struct UsernameRequestStatusScreen: View {
         }
     }
 }
+
+#if DASHPAY
+// MARK: - TemporaryUsernameRegistrationSection
+
+/// "Add a temporary username" list section: explainer, the shared
+/// validated field, and the register action. A separate struct (rather
+/// than inline in the screen body) so it observes the field model
+/// directly — the register button's enabled state must re-render on
+/// every validation change, and nested `ObservableObject`s don't
+/// propagate through the parent's `@StateObject`.
+private struct TemporaryUsernameRegistrationSection: View {
+    @ObservedObject var viewModel: UsernameRequestStatusViewModel
+    @ObservedObject var temporaryField: TemporaryUsernameFieldModel
+
+    var body: some View {
+        Section(NSLocalizedString("Add a temporary username", comment: "Usernames")) {
+            Text(String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "You do not have a username while the vote is in progress. Register a non-contested username now — it is yours to keep, and if the vote awards you “%@”, you will be reachable at both usernames.",
+                    comment: "Usernames"),
+                viewModel.label))
+                .font(.caption)
+                .foregroundColor(Color.dash.secondaryText)
+
+            TemporaryUsernameField(model: temporaryField)
+                .padding(.vertical, 4)
+
+            DashButton(
+                text: NSLocalizedString("Register username", comment: "Usernames"),
+                size: .medium,
+                isEnabled: temporaryField.check == .available && !viewModel.isRegisteringTemporary,
+                isLoading: viewModel.isRegisteringTemporary
+            ) {
+                Task { await viewModel.registerTemporaryUsername() }
+            }
+            .padding(.vertical, 4)
+        }
+        .onAppear {
+            temporaryField.seedSuggestion(from: viewModel.label)
+        }
+    }
+}
+#endif
 
 // MARK: - ContestantStatusRow
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -194,6 +194,9 @@
 /* DashSpend/Maya */
 "A previous Dash conversion is still confirming. Please wait for it to confirm (about 2–5 minutes) before starting a new one." = "A previous Dash conversion is still confirming. Please wait for it to confirm (about 2–5 minutes) before starting a new one.";
 
+/* Usernames */
+"A vote for this name is already in progress — your request will join it as a contender. The contest fee is spent when you submit and is not returned, even if you do not win the name." = "A vote for this name is already in progress — your request will join it as a contender. The contest fee is spent when you submit and is not returned, even if you do not win the name.";
+
 /* No comment provided by engineer. */
 "A wallet from a previous installation is still stored on this device. Keep using it, or delete it and start fresh? Make sure your recovery phrase is backed up before deleting." = "A wallet from a previous installation is still stored on this device. Keep using it, or delete it and start fresh? Make sure your recovery phrase is backed up before deleting.";
 
@@ -797,6 +800,9 @@
 /* Username marketplace: activity overlay while the purchase transition runs */
 "Completing your purchase…" = "Completing your purchase…";
 
+/* Usernames */
+"Register username" = "Register username";
+
 /* Username marketplace: activity overlay while the delist transition runs */
 "Removing the listing…" = "Removing the listing…";
 
@@ -811,6 +817,9 @@
 
 /* Usernames */
 "The temporary username must not itself require voting." = "The temporary username must not itself require voting.";
+
+/* Usernames */
+"This name requires a masternode vote. The contest fee is spent when you submit and is not returned, even if you do not win the name." = "This name requires a masternode vote. The contest fee is spent when you submit and is not returned, even if you do not win the name.";
 
 /* Usernames */
 "This username would also require voting — try adding a digit between 2 and 9" = "This username would also require voting — try adding a digit between 2 and 9";
@@ -2821,6 +2830,9 @@
 /* Username marketplace: purchase confirmation body with seller clarity */
 "You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately." = "You are buying from an independent user, not from Dash or this app. The price plus a small network fee is paid from your identity balance, and the name moves to your identity immediately.";
 
+/* Usernames */
+"You do not have a username while the vote is in progress. Register a non-contested username now — it is yours to keep, and if the vote awards you “%@”, you will be reachable at both usernames." = "You do not have a username while the vote is in progress. Register a non-contested username now — it is yours to keep, and if the vote awards you “%@”, you will be reachable at both usernames.";
+
 /* DashPay: body of the enable success sheet */
 "You're all set. Other users can now send you contact requests — and you can send yours." = "You're all set. Other users can now send you contact requests — and you can send yours.";
 
@@ -4458,6 +4470,9 @@
 
 /* Usernames */
 "Your temporary username “%@” could not be registered. You can register another username later." = "Your temporary username “%@” could not be registered. You can register another username later.";
+
+/* Usernames */
+"“%1$@” is now your username. If the vote awards you “%2$@”, you will be reachable at both usernames." = "“%1$@” is now your username. If the vote awards you “%2$@”, you will be reachable at both usernames.";
 
 /* Usernames */
 "“%1$@” will be purchased for %2$@ Dash. The price is paid from your wallet balance." = "“%1$@” will be purchased for %2$@ Dash. The price is paid from your wallet balance.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -257,6 +257,9 @@
 /* No comment provided by engineer. */
 "Add a New Contact" = "Add a New Contact";
 
+/* Usernames */
+"Add a temporary username" = "Add a temporary username";
+
 /* Wallets */
 "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase." = "Add another wallet to this device. You can create a brand-new wallet or restore one from its recovery phrase.";
 
@@ -707,6 +710,9 @@
 /* DashPay Contacts: success card after sending a request */
 "Contact request sent to %@" = "Contact request sent to %@";
 
+/* Usernames */
+"Continue without a temporary username" = "Continue without a temporary username";
+
 /* Identity top-up sheet — body */
 "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates." = "Convert Dash into identity credits to pay for Platform actions like contact requests and profile updates.";
 
@@ -755,6 +761,9 @@
 /* Username marketplace: search row for a contested label with an active vote by others */
 "In a network vote — you can join as a contender" = "In a network vote — you can join as a contender";
 
+/* Usernames */
+"In the meantime you are reachable at “%1$@”, which is yours to keep. If the vote awards you “%2$@”, you will be reachable at both usernames." = "In the meantime you are reachable at “%1$@”, which is yours to keep. If the vote awards you “%2$@”, you will be reachable at both usernames.";
+
 /* Username marketplace: search row for a label a past vote locked */
 "Locked by a network vote — nobody can register it" = "Locked by a network vote — nobody can register it";
 
@@ -793,6 +802,18 @@
 
 /* Username marketplace: activity overlay while the set-price transition runs */
 "Listing for sale…" = "Listing for sale…";
+
+/* Usernames */
+"Submit both usernames" = "Submit both usernames";
+
+/* Usernames */
+"Temporary username" = "Temporary username";
+
+/* Usernames */
+"The temporary username must not itself require voting." = "The temporary username must not itself require voting.";
+
+/* Usernames */
+"This username would also require voting — try adding a digit between 2 and 9" = "This username would also require voting — try adding a digit between 2 and 9";
 
 /* Username marketplace: activity overlay while the transfer transition runs */
 "Transferring the username…" = "Transferring the username…";
@@ -2785,6 +2806,9 @@
 /* DashPay FAQ */
 "When will contact requests become private?" = "When will contact requests become private?";
 
+/* Usernames */
+"While the vote is in progress, “%@” does not belong to you yet and other users cannot find you by it. Add a non-contested username to use DashPay right away. It stays yours permanently — if the vote awards you the contested name, you will be reachable at both usernames." = "While the vote is in progress, “%@” does not belong to you yet and other users cannot find you by it. Add a non-contested username to use DashPay right away. It stays yours permanently — if the vote awards you the contested name, you will be reachable at both usernames.";
+
 /* DashPay FAQ */
 "Why do I need to enable it?" = "Why do I need to enable it?";
 
@@ -4431,6 +4455,9 @@
 
 /* Usernames */
 "Buy username" = "Buy username";
+
+/* Usernames */
+"Your temporary username “%@” could not be registered. You can register another username later." = "Your temporary username “%@” could not be registered. You can register another username later.";
 
 /* Usernames */
 "“%1$@” will be purchased for %2$@ Dash. The price is paid from your wallet balance." = "“%1$@” will be purchased for %2$@ Dash. The price is paid from your wallet balance.";


### PR DESCRIPTION
## Issue being fixed or feature implemented

A contested DPNS name is only preregistered — it belongs to nobody until masternode voting resolves (~90 min testnet, ~2 weeks mainnet), so a first-time DashPay signup that picks one leaves the user with no reachable username for the entire wait. This PR prompts the user, at the moment they confirm a contested submission, to also register a non-contested **temporary username** they keep permanently — making it clear that when the contest closes in their favor they will be reachable at **both** usernames.

## What was done?

- **Contested confirmation alert → sheet** (`CreateUsernameViewController.swift`): the "Submit anyway" alert is now `ContestedNameConfirmationSheet`. It keeps the existing vote-wait / locked-Dash warning (both wording variants, and the last-moment join-window re-check), and adds a temporary-username field seeded with a guaranteed non-contested suggestion (`<name>2` — any digit 2–9 takes a label out of the contested character set). Primary action "Submit both usernames"; skipping is an explicit secondary action; swipe-down cancels.
- **Live validation for the companion label** (`CreateUsernameViewModel.swift`): same length/character rules as the main field, a must-not-be-contested gate (a contested companion would silently open a second vote), and a debounced DPNS availability check, surfaced through the existing `ValidationCheck` row styling.
- **One authorized flow** (`DWIdentityRegistrationCoordinator.swift`): `startCreateUsername` gains an optional `temporaryUsername`. The companion registers right after the contested submission's bookkeeping — same identity, same signer, no second PIN prompt — with a pre-flight guard rejecting invalid pairings before any money moves. Companion failure is deliberately non-fatal (the contested submission already succeeded) and surfaces as a partial-outcome note in the "Username submitted" alert.
- **Mirror semantics**: on completion the temporary name becomes the `DWGlobalOptions` active username while the contested label stays deferred as before. `finalizeWon` only backfills an *empty* mirror, so a vote win adds the contested name to the identity without displacing the temporary one — both end up live. The voting banner keeps working since it keys off the pending-contest bookmark, not the mirror.
- **Bridge threading** (`DWIdentityRegistrationBridge.swift`): `pendingTemporaryUsername` follows the `preferredFundingSource` lifecycle (written by the form before submit, preserved across `.failed` so retry keeps it, cleared on `.completed`). The invitation-claim path passes the parameter directly.
- Nine new user-facing strings added to `en.lproj/Localizable.strings`.

- **Post-submission surface** (`UsernameRequestStatusScreen.swift`, `d41f38ac1`): the prompt originally existed only inside the signup flow, so an identity whose first username was already in a vote (submitted on an older build, or with the prompt skipped) was never offered a reachable name. The request-status screen now carries an "Add a temporary username" section — same shared validated field (`TemporaryUsernameFieldModel`, extracted so the two surfaces can't drift), registering to the existing identity via `UsernameMarketplaceService.register(label:)`. Shown only while the vote is unresolved and the identity owns no other username; `#if DASHPAY`-gated because the screen also compiles in the dashwallet target.
- **Copy correction**: the confirmation previously claimed "Your Dash will be locked until voting completes" — false: the contest fee prefunds the vote poll's specialized balance, whose leftover is swept into the network's processing pools at poll end (`rs-drive-abci` `clean_up_after_contested_resources_vote_polls_end`); nothing returns to the contender. Both variants now say the fee is spent at submission and not returned.

## How Has This Been Tested?

- Clean build of the `dashpay` scheme (arm64 iOS Simulator), no new warnings in touched files.
- Not smoke-tested end-to-end on testnet: exercising the sheet requires an identity-less wallet holding ≥0.25 tDASH, which the standing QA simulators (which hold identities) can't provide without destroying their state. QA should verify: (1) the sheet appears on Continue for a contested name with the suggestion pre-validated, (2) after submitting both, the profile shows the temporary username immediately while the home banner still shows the voting state, (3) a vote win adds the contested name without replacing the temporary one.
- The unit-test target is broken pre-existing (per CLAUDE.md), so no new tests were added.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for choosing an optional temporary username when a preferred username is contested.
  * Temporary usernames are validated for availability and eligibility before registration.
  * Users can accept suggestions, enter their own name, skip the option, or cancel.
  * Registration results now show whether the temporary username was registered successfully.
* **Bug Fixes**
  * Preserved temporary username details when retrying failed registrations.
  * Cleared invalid or outdated temporary usernames before submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
