### PR TITLE
fix(dashpay): add back navigation to notifications

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift
@@ -21,6 +21,8 @@ struct NotificationsScreen: View {
     @StateObject private var viewModel = ContactsViewModel()
     @State private var selectedContact: ContactItem? = nil
 
+    let onBack: () -> Void
+
     /// Read-state captured once at screen entry so rows don't jump
     /// between sections while the user is looking at them; the marker
     /// itself advances on exit (`markNotificationsViewed`).
@@ -29,10 +31,20 @@ struct NotificationsScreen: View {
     var body: some View {
         ZStack {
             Color.dash.primaryBackground.ignoresSafeArea()
-            content
+
+            VStack(spacing: 0) {
+                NavigationBar(
+                    leading: { NavigationBarElement.back.button { onBack() } },
+                    central: {
+                        Text(NSLocalizedString("Notifications", comment: "DashPay Notifications"))
+                            .font(.subheadMedium)
+                            .foregroundColor(.dash.primaryText)
+                    }
+                )
+
+                content
+            }
         }
-        .navigationTitle(NSLocalizedString("Notifications", comment: "DashPay Notifications"))
-        .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $selectedContact) { contact in
             ContactProfileSheet(contact: contact)
         }

--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -202,8 +202,13 @@ class HomeViewController: DWBasePayViewController, NavigationBarDisplayable {
 
     @objc func notificationAction() {
         // Notifications are backed by the SwiftDashSDK contacts service.
-        let controller = UIHostingController(rootView: NotificationsScreen())
-        navigationController?.pushViewController(controller, animated: true)
+        guard let navigation = navigationController,
+              navigation.topViewController === self else { return }
+        let screen = NotificationsScreen(onBack: { [weak navigation] in
+            navigation?.popViewController(animated: true)
+        })
+        let controller = UIHostingController(rootView: screen)
+        navigation.pushViewController(controller, animated: true)
     }
 
     @objc func profileAction() {


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Notifications screen is pushed from Home inside a SwiftUI hosting controller whose UIKit navigation bar is hidden, leaving no visible way to return to Home.

## What was done?

- added the standard in-content back button and centered Notifications title
- wired Back to pop the existing Home navigation stack through a weak callback
- prevented rapid taps from stacking duplicate Notifications screens
- left Home profile navigation and shared navigation-bar behavior unchanged

## How Has This Been Tested?

- dashpay Debug build for an arm64 iOS Simulator succeeded
- git diff --check passed
- verified the final commit changes only NotificationsScreen and its Home entry point

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

The dashpay scheme has no configured test target; this UI-only change was verified with a full build and navigation-flow audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Added a custom Notifications screen header with a centered title and back button.
  - Improved back navigation from the Notifications screen.
  - Prevented notification navigation when the Home screen is not currently active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->