### PR TITLE
fix(ui): keep syncing alert above tab navigation

### DIFF
--- a/DashWallet/Sources/UI/Home/HomeViewController.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController.swift
@@ -607,7 +607,9 @@ extension HomeViewController: HomeViewDelegate {
 
     func homeViewShowSyncingStatus() {
         let controller = SyncingAlertViewController()
-        present(controller, animated: true, completion: nil)
+        // Own the popup at the tab-container level so its dimming view also
+        // blocks tab changes while Home's presentation hierarchy is active.
+        (tabBarController ?? self).present(controller, animated: true, completion: nil)
     }
 
     func homeViewDidChangeTopBarVisibility(shouldShow: Bool) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Opening the syncing details from Home and then changing tabs detached Home's presentation hierarchy while the custom sync popup was still active. Returning to Home left its content unloaded, and dismissing the popup exposed a black background.

## What was done?

- Present the syncing popup from the enclosing tab-bar controller so the custom presentation and dimming view own the complete tab interface.
- Keep Home as a fallback presenter for standalone or non-tab-container usage.

## How Has This Been Tested?

- `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build`
- `git diff --check`

The production DashPay arm64 simulator build succeeds with Xcode 26.6. An isolated `SNAPSHOT` smoke build was also attempted, but that configuration remains blocked by the pre-existing `BackupSeedPhraseViewController.swift` `accessibilityIdentifier` compile error documented by the repository's test guidance.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syncing status presentation to ensure it appears correctly when accessed from the tab-based interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->