### PR TITLE
fix(ui): show shielded sends in history immediately, not at next resync

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -458,9 +458,17 @@ class HomeViewModel: ObservableObject {
     }
     
     /// Entities whose rows the home feed actually renders.
+    ///
+    /// `PersistentShieldedActivity` is included because a shielded operation's
+    /// only history representation is its activity row: the SDK live-records
+    /// it during the spend itself, and without a reload trigger here the row
+    /// stayed invisible until the next shielded resync repainted the list.
+    /// Storm-safe: the Rust scan flushes activity entries only for new
+    /// entries or real status upgrades, never on steady-state passes.
     private static let feedRowEntityNames: Set<String> = [
         "PersistentTransaction",
         "PersistentTxo",
+        "PersistentShieldedActivity",
     ]
 
     /// Whether a SwiftData save touched anything the feed renders.


### PR DESCRIPTION
## Issue being fixed or feature implemented

A shielded transaction sent from the app did not appear in the home transaction history until the next shielded resync (~60–90s later), even though the send completed immediately.

## What was done?

Root cause: the SDK live-records a `PersistentShieldedActivity` row during the spend itself (Pending, then Confirmed), so the row is in SwiftData within seconds of broadcast — but the home feed's SwiftData-save reload filter (`HomeViewModel.feedRowEntityNames`) only passed `PersistentTransaction`/`PersistentTxo` saves. The shielded-activity save was silently dropped, and the list only repainted when the next shielded resync happened to kick an unrelated reload trigger.

Fix: add `PersistentShieldedActivity` to `feedRowEntityNames`, so shielded-activity inserts/updates flow through the existing throttled reload funnel. This also removes the same latency for incoming shielded receives and pending→confirmed status flips, which went through the identical filtered-out save path.

Storm safety (the reason this filter exists): verified on the Rust side that `derive_activity_into_changeset` in rs-platform-wallet flushes activity entries only for new entries or genuine status upgrades — steady-state sync passes emit nothing, so this does not reintroduce periodic full reloads.

## How Has This Been Tested?

- Clean `dashpay` scheme build (`xcodebuild -sdk iphonesimulator ARCHS=arm64`).
- Unit-test target remains broken pre-existing; no runnable tests cover this path.
- Not yet smoke-tested with a live testnet shielded send (needs a funded shielded balance + proving round-trip); the trigger mechanism is the same NSManagedObjectContextDidSave path already proven for `PersistentTransaction` rows written by the same SDK persistence handler.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)