### PR TITLE
fix(dashpay): repair the invitation-claim aftermath and rebuild the banner as a menu row

### DIFF
--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,15 @@
 {
-  "originHash": "cecc72572cc422aa0d68b46e2be53c36997e822a15e2da6434836b8dda9e4934",
-  "pins": [
+  "originHash" : "2b9d5280ec4645105debdfd588a911137d45333db7102b1ec79310afb20db9cc",
+  "pins" : [
     {
-      "identity": "dashuikit",
-      "kind": "remoteSourceControl",
-      "location": "https://github.com/dashpay/DashUIKit",
-      "state": {
-        "branch": "master",
-        "revision": "88bf41f3c3e8c66bf7ac653841643d4a4bed2444"
+      "identity" : "dashuikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/dashpay/DashUIKit",
+      "state" : {
+        "branch" : "master",
+        "revision" : "5b373b141054438e94903af52b9ec324f1efbdb2"
       }
     }
   ],
-  "version": 3
+  "version" : 3
 }

--- a/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
+++ b/DashWallet/Sources/Models/Usernames/CurrentUserProfileModel.swift
@@ -33,7 +33,11 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
     @objc private(set) var state: CurrentUserProfileModelState = .none
     @objc let updateModel: DWDPUpdateProfileModel
     @Published private(set) var showJoinDashpay: Bool = false
-    
+    /// Chain still catching up. The Join DashPay row stays visible throughout
+    /// (it is a standing menu entry) but presents itself as unavailable:
+    /// registration cannot be started until the chain is synced.
+    @Published private(set) var isSyncing: Bool = false
+
     override init() {
         updateModel = DWDPUpdateProfileModel()
         super.init()
@@ -41,7 +45,8 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
         model.$state
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] state in
+                self?.isSyncing = state != .syncDone
                 self?.updateShowJoinDashpay()
             }
             .store(in: &cancellableBag)
@@ -106,8 +111,20 @@ class CurrentUserProfileModel: NSObject, ObservableObject {
         }
         showJoinDashpay = JoinDashPayBannerPolicy.shouldShow(
             contextReady: identityState.contextReady,
-            syncDone: model.state == .syncDone,
-            dismissed: UsernamePrefs.shared.joinDashPayDismissed,
+            // Not gated on sync. The More entry is a standing menu row, and
+            // gating it made it come and go depending on how far the chain
+            // had caught up — the row was simply absent for the whole of a
+            // long sync. Registration itself still needs a synced chain; the
+            // row reflects that in its own copy rather than by vanishing.
+            syncDone: true,
+            // Deliberately not `UsernamePrefs.shared.joinDashPayDismissed`.
+            // That flag is set by the close control, which exists only on
+            // Home — the More entry has no dismiss affordance at all. Reading
+            // it here meant one tap on Home's close permanently removed the
+            // menu entry too, with no way for the user to bring it back.
+            // On More the banner is a standing menu row: it disappears when
+            // the user actually has a username, not when they dismiss it.
+            dismissed: false,
             hasRegisteredUsername: hasUsername,
             hasRegistrationInProgress: hasPendingRecoveredName)
     }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -63,7 +63,14 @@ class CreateUsernameViewController: UIViewController {
             #if DASHPAY
             let mainTabController = self.tabBarController as? MainTabbarController
             #endif
-            navigationController?.popViewController(animated: true)
+            // Pop the whole registration stack, not one level. The invitation
+            // entry pushes this screen ON TOP of the redeem screen, so popping
+            // once lands the freshly-registered user back on "Claim your
+            // invitation" — a flow they just completed and cannot repeat.
+            // Every push site roots this flow at a tab's own screen, so
+            // unwinding to that root is the correct destination for all of
+            // them (Home for the home/deep-link entries, More for the menu).
+            navigationController?.popToRootViewController(animated: true)
             self.completionHandler?(true)
             #if DASHPAY
             if let transitionCoordinator = navigationController?.transitionCoordinator {

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewModel.swift
@@ -382,6 +382,22 @@ class CreateUsernameViewModel: ObservableObject {
                     username: submittedUsername,
                     invitationURI: invitationURI,
                     temporaryUsername: temporaryUsername)
+                // This path never touches `DWIdentityRegistrationBridge.shared`,
+                // so on an invitation-first launch that singleton is never
+                // constructed, never observes the coordinator's phases, and
+                // never posts the canonical registration notification —
+                // `.shared` and `.stateChangedNotification` are independently
+                // lazy statics, so referencing the notification name does not
+                // build the bridge. Every consumer of app-wide "registered now"
+                // state (the DashPay tab set, the More screen's Join DashPay
+                // banner, `DWCurrentUserIdentityInfo`'s cached snapshot) then
+                // kept its pre-registration value until the next launch rebuilt
+                // it from disk. Announce it explicitly here, the same way
+                // `DWCurrentUserIdentityInfo.reconcileRecoveredIdentity()` does
+                // for identities that arrive outside the bridge's flow.
+                DWCurrentUserIdentityInfo.shared.refreshFromSDK()
+                NotificationCenter.default.post(
+                    name: .DWDashPayRegistrationStatusUpdated, object: nil)
                 return registrationOutcome(for: submittedUsername)
             } catch DWIdentityRegistrationCoordinator.CoordinatorError.authCancelled {
                 return .cancelled

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
@@ -158,7 +158,7 @@ struct JoinDashPayMenuItem: View {
     @StateObject var viewModel: JoinDashPayViewModel
     @ObservedObject private var shieldedReadiness = ShieldedIdentityFundingReadiness.shared
     var onTap: (JoinDashPayState) -> Void
-    var onDismiss: ((JoinDashPayState) -> Void)? = nil
+    var onDismiss: ((JoinDashPayState) -> Void)?
     /// Chain still catching up. The row stays visible but presents itself as
     /// unavailable — greyed icon and text, a note saying why, and no action —
     /// because registration cannot start before the chain is synced. Showing

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift
@@ -35,82 +35,20 @@ extension JoinDashPayState {
     }
 }
 
-struct JoinDashPayView: View {
-    @StateObject var viewModel: JoinDashPayViewModel
-    /// Drives the `.callToAction` subtitle nudge: the banner is the
-    /// earliest surface where "fund your Shielded balance now, register
-    /// in a few hours" can reach the user, so the copy tracks the
-    /// shielded readiness state (add funds → maturing countdown → ready).
-    @ObservedObject private var shieldedReadiness = ShieldedIdentityFundingReadiness.shared
-    var onTap: (JoinDashPayState) -> Void
-    var onActionButton: ((JoinDashPayState) -> Void)? = nil
-    var onDismissButton: ((JoinDashPayState) -> Void)? = nil
-    var onSizeChange: ((CGSize) -> Void)? = nil
-    
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(alignment: .center, spacing: 12) {
-                Image(leadingIconName)
-                    .padding(.horizontal, 10)
-                
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(titleText)
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .foregroundColor(.dash.primaryText)
-                        .multilineTextAlignment(.leading)
-                    
-                    if viewModel.state != .registered {
-                        Text(subtitleText)
-                            .font(.footnote)
-                            .foregroundColor(.dash.tertiaryText)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .multilineTextAlignment(.leading)
-                            .padding(.top, 2)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            
-            if viewModel.state.hasAction() {
-                ButtonsGroup(
-                    orientation: .horizontal,
-                    size: .small,
-                    positiveButtonText: actionButtonText,
-                    positiveButtonIcon: actionButtonIcon,
-                    positiveButtonAction: {
-                        onActionButton?(viewModel.state)
-                    },
-                    negativeButtonText: NSLocalizedString("Hide", comment: ""),
-                    negativeButtonAction: {
-                        onDismissButton?(viewModel.state)
-                    }
-                ).padding(.top, 15)
-                 .padding(.trailing, 10)
-            }
-        }
-        .padding(.vertical, 15)
-        .padding(.leading, 15)
-        .padding(.trailing, 5)
-        .background(
-            GeometryReader { geometry in
-                onSizeChange?(geometry.size)
-                return Color.dash.secondaryBackground
-            }
-        )
-        .cornerRadius(8)
-        .shadow(color: .shadow, radius: 10, x: 0, y: 5)
-        .onTapGesture {
-            onTap(viewModel.state)
-        }
-        .onAppear {
-            viewModel.checkUsername()
-        }
-    }
-    
-    private var leadingIconName: String {
-        switch viewModel.state {
+/// State → banner copy for the Join DashPay surfaces. Holds the inputs the
+/// copy depends on and nothing else, so both call sites of
+/// `JoinDashPayMenuItem` (Home and More) render identical text from one place.
+///
+/// `@MainActor` because the voting subtitle reads
+/// `DWContestedNameStatusService.shared`, which is main-actor isolated.
+@MainActor
+struct JoinDashPayCopy {
+    let state: JoinDashPayState
+    let username: String
+    let shieldedSnapshot: ShieldedIdentityFundingReadiness.Snapshot?
+
+    var iconName: String {
+        switch state {
         case .none, .callToAction, .registered:
             return "dp_user_generic"
         case .voting:
@@ -121,15 +59,15 @@ struct JoinDashPayView: View {
             return "username_rejected"
         }
     }
-    
-    private var titleText: String {
-        switch viewModel.state {
+
+    var title: String {
+        switch state {
         case .none:
             return NSLocalizedString("Join DashPay", comment: "")
         case .callToAction:
             return NSLocalizedString("Upgrade to DashPay", comment: "")
         case .voting, .registered:
-            return viewModel.username
+            return username
         case .approved:
             return NSLocalizedString("Your username has been successfully created", comment: "Usernames")
         case .failed:
@@ -141,12 +79,12 @@ struct JoinDashPayView: View {
         }
     }
     
-    private var subtitleText: String {
-        switch viewModel.state {
+    var subtitle: String {
+        switch state {
         case .none:
             return NSLocalizedString("Request your username", comment: "")
         case .callToAction:
-            switch shieldedReadiness.standardSnapshot?.state {
+            switch shieldedSnapshot?.state {
             case .maturing(let readyAt):
                 let time = DateFormatter.localizedString(from: readyAt, dateStyle: .none, timeStyle: .short)
                 return String.localizedStringWithFormat(
@@ -164,29 +102,29 @@ struct JoinDashPayView: View {
                     NSLocalizedString(
                         "Username %@ has been submitted for voting. Voting ends around %@.",
                         comment: "Usernames"),
-                    viewModel.username,
+                    username,
                     endDate)
             }
             return String.localizedStringWithFormat(
                 NSLocalizedString(
                     "Username %@ has been submitted for voting. We will notify you when voting ends.",
                     comment: "Usernames"),
-                viewModel.username)
+                username)
         case .approved:
             return NSLocalizedString("Get started by setting up your profile picture and other information.", comment: "Usernames")
         case .failed:
-            return String.localizedStringWithFormat(NSLocalizedString("For some reason, the request for the username '%@' has failed.", comment: "Usernames"), viewModel.username)
+            return String.localizedStringWithFormat(NSLocalizedString("For some reason, the request for the username '%@' has failed.", comment: "Usernames"), username)
         case .blocked:
-            return String.localizedStringWithFormat(NSLocalizedString("The username '%@' was blocked by the Dash Network. Please try again by requesting another username.", comment: "Usernames"), viewModel.username)
+            return String.localizedStringWithFormat(NSLocalizedString("The username '%@' was blocked by the Dash Network. Please try again by requesting another username.", comment: "Usernames"), username)
         case .contested:
-            return String.localizedStringWithFormat(NSLocalizedString("Due to the voting process, the Dash Network has decided to assign the username '%@' to someone else. Please try again by requesting another username.", comment: "Usernames"), viewModel.username)
+            return String.localizedStringWithFormat(NSLocalizedString("Due to the voting process, the Dash Network has decided to assign the username '%@' to someone else. Please try again by requesting another username.", comment: "Usernames"), username)
         case .registered:
             return ""
         }
     }
     
-    private var actionButtonText: String {
-        switch viewModel.state {
+    var actionText: String {
+        switch state {
         case .callToAction:
             return NSLocalizedString("Upgrade", comment: "")
         case .approved:
@@ -195,13 +133,181 @@ struct JoinDashPayView: View {
             return NSLocalizedString("Retry", comment: "")
         }
     }
-    
-    private var actionButtonIcon: IconName? {
-        switch viewModel.state {
+
+    var actionIcon: IconName? {
+        switch state {
         case .failed, .blocked, .contested:
             return .system("arrow.counterclockwise")
         default:
             return nil
         }
+    }
+}
+
+/// The Join DashPay banner, rendered as a standard menu row. Used on both
+/// Home and More.
+///
+/// There are no Hide/Upgrade buttons: the whole row is the primary action —
+/// tapping it means "act on this state" (upgrade / edit profile / retry).
+///
+/// `onDismiss` is optional and decides whether the trailing close control
+/// exists. Home passes it (the banner is an interruption there, so it must
+/// be dismissible); More does not, because the banner is a permanent menu
+/// entry that the user scrolls past rather than something to get rid of.
+struct JoinDashPayMenuItem: View {
+    @StateObject var viewModel: JoinDashPayViewModel
+    @ObservedObject private var shieldedReadiness = ShieldedIdentityFundingReadiness.shared
+    var onTap: (JoinDashPayState) -> Void
+    var onDismiss: ((JoinDashPayState) -> Void)? = nil
+    /// Chain still catching up. The row stays visible but presents itself as
+    /// unavailable — greyed icon and text, a note saying why, and no action —
+    /// because registration cannot start before the chain is synced. Showing
+    /// it and refusing the tap is what tells the user the feature exists and
+    /// is coming; hiding the row entirely (the previous behaviour) just made
+    /// it look like the menu was missing an entry.
+    var isSyncing: Bool = false
+
+    private var copy: JoinDashPayCopy {
+        JoinDashPayCopy(
+            state: viewModel.state,
+            username: viewModel.username,
+            shieldedSnapshot: shieldedReadiness.standardSnapshot)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            DashUIKit.MenuItem(
+                leadingIcon: .custom(copy.iconName, bundle: .main),
+                isEnabled: !isSyncing,
+                disabledLeadingIcon: .custom("menu-send-account-disabled", bundle: .dashUIKit),
+                title: copy.title,
+                helpText: viewModel.state == .registered ? nil : copy.subtitle,
+                accessory: .none
+            )
+            // No action while the chain is catching up: every destination this
+            // row leads to (join, retry, edit profile) needs a synced chain, so
+            // a tap here could only fail. The note below says why.
+            .onTapGesture {
+                guard !isSyncing else { return }
+                onTap(viewModel.state)
+            }
+            .overlay(alignment: .topTrailing) {
+                if let onDismiss {
+                    Button {
+                        onDismiss(viewModel.state)
+                    } label: {
+                        XmarkIcon(size: 10, color: .dash.tertiaryText)
+                            // Keep the tap target comfortable without letting
+                            // the glyph itself push the row's layout around.
+                            .padding(14)
+                            .contentShape(Rectangle())
+                    }
+                    // An overlay rather than `MenuItem`'s `accessory:` — the
+                    // accessory sits vertically centred in the row, and this
+                    // close belongs in the top trailing corner.
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if isSyncing {
+                HStack(spacing: 0) {
+                    Spacer()
+
+                    Text(NSLocalizedString("Available after sync finishes", comment: "DashPay"))
+                        .dashFont(.footnote)
+                        .foregroundStyle(Color.dash.blue)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 6)
+                        .background(Color.dash.blueAlpha5)
+                        .clipShape(.rect(cornerRadius: 14))
+
+                    Spacer()
+                }
+                .padding(.bottom, 8)
+            }
+        }
+        .modifier(MenuViewModifier())
+        .onAppear {
+            viewModel.checkUsername()
+        }
+    }
+}
+
+// MARK: - Previews
+
+/// The syncing presentation: greyed icon and text via `MenuItem`'s own
+/// disabled styling, the "available after sync" note, and no action. Compare
+/// against the enabled previews below — the row must stay in place and only
+/// change its appearance, never disappear.
+#Preview("Menu row — syncing") {
+    VStack(spacing: 12) {
+        JoinDashPayMenuItem(
+            viewModel: JoinDashPayViewModel(initialState: .callToAction),
+            onTap: { _ in },
+            isSyncing: true)
+
+        JoinDashPayMenuItem(
+            viewModel: JoinDashPayViewModel(initialState: .callToAction),
+            onTap: { _ in },
+            isSyncing: false)
+    }
+    .padding(20)
+}
+
+/// The More presentation: no close control — the row is a permanent menu
+/// entry there. Rendered inside the same card the menu groups use.
+#Preview("Menu row — More (no close)") {
+    ScrollView {
+        VStack(spacing: 12) {
+            ForEach(
+                [
+                    JoinDashPayState.callToAction,
+                    .voting,
+                    .approved,
+                    .failed,
+                    .blocked,
+                    .contested,
+                    .registered
+                ],
+                id: \.self
+            ) { state in
+                JoinDashPayMenuItem(
+                    viewModel: JoinDashPayViewModel(initialState: state),
+                    onTap: { _ in })
+                    .padding(6)
+                    .background(Color.dash.secondaryBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            }
+        }
+        .padding(20)
+    }
+}
+
+/// The Home presentation: identical row plus the trailing close control.
+/// Worth comparing against the More preview — the close sits in the top
+/// trailing corner and must not shift the title or subtitle.
+#Preview("Menu row — Home (with close)") {
+    ScrollView {
+        VStack(spacing: 12) {
+            ForEach(
+                [
+                    JoinDashPayState.callToAction,
+                    .voting,
+                    .approved,
+                    .failed,
+                    .registered
+                ],
+                id: \.self
+            ) { state in
+                JoinDashPayMenuItem(
+                    viewModel: JoinDashPayViewModel(initialState: state),
+                    onTap: { _ in },
+                    onDismiss: { _ in })
+                    .padding(6)
+                    .background(Color.dash.secondaryBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            }
+        }
+        .padding(20)
     }
 }

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -319,12 +319,19 @@ struct HomeViewContent<Content: View>: View {
                             .frame(height: viewModel.headerHeight)
                     }
                     
+                    SyncingHeaderView(onFilterTap: {
+                        showFilterDialog = true
+                    }, onSyncTap: {
+                        delegate?.homeViewShowSyncingStatus()
+                    })
+
                     #if DASHPAY
                     if viewModel.showJoinDashpay {
-                        JoinDashPayView(
+                        JoinDashPayMenuItem(
                             viewModel: joinDPViewModel,
-                            onTap: { _ in },
-                            onActionButton: { state in
+                            // The row is the action now — this is what the
+                            // Upgrade/Edit/Retry button used to do.
+                            onTap: { state in
                                 if state == .approved {
                                     delegate?.homeViewEditProfile()
                                     joinDPViewModel.markAsDismissed()
@@ -340,21 +347,15 @@ struct HomeViewContent<Content: View>: View {
                                     // they first looked at DashPay.
                                     self.shouldShowJoinDashPayInfo = true
                                 }
-                            }, onDismissButton: { _ in
+                            }, onDismiss: { _ in
                                 joinDPViewModel.markAsDismissed()
                                 viewModel.checkJoinDashPay()
                             }
-                        ).padding(.horizontal, 14)
-                         .padding(.bottom, 4)
+                        )
+                        .padding(.horizontal, 20)
                     }
                     #endif
-                    
-                    SyncingHeaderView(onFilterTap: {
-                        showFilterDialog = true
-                    }, onSyncTap: {
-                        delegate?.homeViewShowSyncingStatus()
-                    })
-                    
+
                     if viewModel.txItems.isEmpty {
                         // An empty feed means "nothing yet" only once the first
                         // load has finished; before that it just means the

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -350,7 +350,8 @@ struct HomeViewContent<Content: View>: View {
                             }, onDismiss: { _ in
                                 joinDPViewModel.markAsDismissed()
                                 viewModel.checkJoinDashPay()
-                            }
+                            },
+                            isSyncing: viewModel.isSyncing
                         )
                         .padding(.horizontal, 20)
                     }

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -167,6 +167,10 @@ class HomeViewModel: ObservableObject {
     @Published var showCoinJoinMoveFundsSheet: Bool = false
     @Published private(set) var timeSkew: TimeInterval = 0
     @Published private(set) var showJoinDashpay: Bool = false
+    /// Chain still catching up. The Join DashPay banner stays visible
+    /// throughout but presents itself as unavailable: registration cannot be
+    /// started until the chain is synced.
+    @Published private(set) var isSyncing: Bool = false
     /// Selected filter categories (multi-select checkboxes). Defaults to every
     /// category — i.e. "All". Never empty: the dialog blocks unchecking the
     /// last box.
@@ -440,6 +444,9 @@ class HomeViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 guard let self = self else { return }
+                #if DASHPAY
+                self.isSyncing = state != .syncDone
+                #endif
                 if state == .syncing {
                     // Reload once per transition into .syncing — replaces the
                     // legacy sync-will-start notification observer. Goes
@@ -2930,7 +2937,12 @@ extension HomeViewModel {
 
         self.showJoinDashpay = JoinDashPayBannerPolicy.shouldShow(
             contextReady: identityState.contextReady,
-            syncDone: syncModel.state == .syncDone,
+            // Not gated on sync — same as the More entry. Gating made the
+            // banner appear only once the chain had caught up, so the surface
+            // that carries the "Have an invitation?" entry was missing for the
+            // whole of a long sync. It now stays put and renders as
+            // unavailable (`isSyncing`) instead of vanishing.
+            syncDone: true,
             dismissed: UsernamePrefs.shared.joinDashPayDismissed,
             hasRegisteredUsername: hasRegisteredUsername,
             hasRegistrationInProgress: identityScopedRegistrationState)

--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -333,12 +333,20 @@ extension MainTabbarController {
     }
 
     func applyPendingDashPayTabReconfiguration() {
-        guard pendingDashPayTabReconfiguration else { return }
-
         if containsCreateUsernameController(in: self) {
             return
         }
 
+        // Deliberately NOT gated on `pendingDashPayTabReconfiguration`. That
+        // flag is only raised once `reconfigureDashPayTabsIfNeeded` has already
+        // seen an identity, but the canonical registration notification can be
+        // posted before `DWCurrentUserIdentityInfo` observes the new
+        // `PersistentIdentity` row — the `hasDashPayIdentity` guard then
+        // returns first and the flag is never set. Gating here on a flag that
+        // was never raised is what left the DashPay tabs missing until the
+        // next launch. `reconfigureDashPayTabsIfNeeded` is idempotent (it
+        // early-returns once the five-tab layout is installed), so calling it
+        // unconditionally is safe.
         reconfigureDashPayTabsIfNeeded()
     }
     #endif

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewController.swift
@@ -215,28 +215,20 @@ struct MainMenuScreen: View {
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                TopIntro(title: NSLocalizedString("More", comment: ""))
-                    .padding(.leading, 20)
-                    .padding(.trailing, 60)
-                    .padding(.top, 10)
-                    .padding(.bottom, 20)
-
                 #if DASHPAY
                 if viewModel.showJoinDashpay {
-                    JoinDashPayView(
+                    JoinDashPayMenuItem(
                         viewModel: joinDPViewModel,
+                        // The row replaced a card with two buttons, so it
+                        // needs a handler covering both — see
+                        // `handleJoinDashPayRowTap`.
                         onTap: { state in
-                            handleJoinDashPayTap(state: state)
+                            handleJoinDashPayRowTap(state: state)
                         },
-                        onActionButton: { state in
-                            handleJoinDashPayAction(state: state)
-                        },
-                        onDismissButton: { state in
-                            joinDPViewModel.markAsDismissed()
-                            viewModel.refreshJoinDashPayBanner()
-                        }
+                        isSyncing: viewModel.isSyncing
                     )
-                    .padding(.horizontal, 18)
+                    .padding(.vertical, 20)
+                    .padding(.horizontal, 20)
                 }
                 #endif
                 
@@ -432,6 +424,26 @@ struct MainMenuScreen: View {
         vc.pushViewController(controller, animated: true)
     }
     
+    /// Where a tap on the DashPay menu row goes. The row replaced a card with
+    /// two buttons, so it has to cover what both of them did — it is not the
+    /// old action button under a new name.
+    ///
+    /// In particular `.callToAction` must NOT reach `editProfile()`: that
+    /// method guards on an existing identity and returns silently for exactly
+    /// the users this state describes, which read on screen as a dead row.
+    private func handleJoinDashPayRowTap(state: JoinDashPayState) {
+        switch state {
+        case .none, .callToAction, .blocked, .failed, .contested:
+            // Not registered (or the attempt failed): open the join flow,
+            // which also carries the "Have an invitation?" entry.
+            handleJoinButtonAction()
+        case .approved, .registered:
+            editProfile()
+        case .voting:
+            showUsernameRequestStatus()
+        }
+    }
+
     private func handleJoinDashPayAction(state: JoinDashPayState) {
         switch state {
         case .blocked, .failed, .contested:

--- a/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Main/MainMenuViewModel.swift
@@ -50,6 +50,7 @@ class MainMenuViewModel: ObservableObject {
     let dashPayModel: DWDashPayProtocol?
     let userProfileModel: CurrentUserProfileModel?
     @Published private(set) var showJoinDashpay: Bool = false
+    @Published private(set) var isSyncing: Bool = false
     #endif
 
     weak var delegate: MainMenuViewModelDelegate?
@@ -66,6 +67,10 @@ class MainMenuViewModel: ObservableObject {
         userProfileModel?.$showJoinDashpay
             .receive(on: DispatchQueue.main)
             .assign(to: &$showJoinDashpay)
+
+        userProfileModel?.$isSyncing
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$isSyncing)
     }
 
     func refreshJoinDashPayBanner() {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -452,6 +452,9 @@
 /* No comment provided by engineer. */
 "Autohide Balance" = "Autohide Balance";
 
+/* DashPay */
+"Available after sync finishes" = "Available after sync finishes";
+
 /* SPV diagnostics */
 "Available only while SPV is running with a wallet bound." = "Available only while SPV is running with a wallet bound.";
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Claiming a DashPay invitation and registering a non-contested username left the app in three wrong states, each of which a relaunch silently fixed:

1. The user landed back on **"Claim your invitation"** — the screen they had just completed and cannot repeat.
2. The DashPay tab set stayed at **three tabs instead of five**.
3. The **"Join DashPay" banner stayed on More** as if nothing had been registered.

(2) and (3) share one root cause. `CreateUsernameViewModel`'s invitation branch calls `DWIdentityRegistrationCoordinator` directly and never touches `DWIdentityRegistrationBridge.shared`. That singleton is the only poster of `DWDashPayRegistrationStatusUpdatedNotification`, and it subscribes to the coordinator inside its own lazy `init` — `.shared` and `.stateChangedNotification` are independently lazy statics, so referencing the notification name does not construct the bridge. On an invitation-first launch — the normal case, since invitations exist to onboard new users — the bridge is never built and the canonical notification is never posted at all. Nothing informs the tab bar, the banner, or `DWCurrentUserIdentityInfo`. A relaunch works because `CurrentUserProfileModel.init()` recomputes from disk, which the coordinator had already written correctly.

## What was done?

**Landing (1)** — `CreateUsernameViewController` popped a single level; the invitation entry pushes the form on top of the redeem screen. It now unwinds to the tab's root, which is the correct destination for all three push sites.

**Notification (2, 3)** — the invitation branch announces registration explicitly after a successful claim, mirroring what `DWCurrentUserIdentityInfo.reconcileRecoveredIdentity()` already does for identities that arrive outside the bridge's flow.

**Tabs (2)** — `applyPendingDashPayTabReconfiguration` gated on a flag that `reconfigureDashPayTabsIfNeeded` only raises *after* it has seen an identity. When the notification landed before `DWCurrentUserIdentityInfo` could observe the new row, the flag stayed false and the tabs were never rebuilt. The gate is gone; the rebuild is idempotent.

**Banner redesign** — Join DashPay is now a standard menu row (`JoinDashPayMenuItem`) on both Home and More, replacing the card with Hide/Upgrade buttons:

- the whole row is the action;
- the trailing close appears **only on Home**, where the banner is an interruption. More is a standing menu entry;
- More no longer reads the dismissal flag — one tap on Home's close used to remove the menu entry permanently, with no way to restore it;
- neither surface is gated on sync any more: the row stays in place while the chain catches up and presents itself as unavailable (greyed leading icon and text, plus an "Available after sync finishes" note) instead of disappearing, and its tap is inert in that state. On Home this also matters because that banner carries the only "Have an invitation?" entry in the app — precisely what a freshly invited user needs while their chain is still behind;
- state-to-copy mapping moved into `JoinDashPayCopy`, shared by both surfaces so they cannot drift.

The row also needed its own tap handler rather than reusing the old action button's: `.callToAction` reached `editProfile()`, which guards on an existing identity and returns silently for exactly the users that state describes — a row that looked dead.

## Screenshots

<img width="1170" height="2532" alt="IMG_8053" src="https://github.com/user-attachments/assets/3c9896ab-36fc-47de-9b35-cb182bbd34ca" />

**Home — row with the close control**

<img width="1170" height="2532" alt="IMG_8054" src="https://github.com/user-attachments/assets/4cf9a4dc-1d88-4d56-9abb-380254d489ee" />

**More — row without the close control**

<img width="1170" height="2532" alt="IMG_8052" src="https://github.com/user-attachments/assets/c512dbce-0dee-4424-86e0-40f00d240d6f" />

**Syncing — greyed icon, "Available after sync finishes", inert tap**

_(pending)_

## Dependencies

Requires DashUIKit#12 (merged) for the `menu-send-account-disabled` asset used as the row's `disabledLeadingIcon`. `Package.resolved` is bumped to that revision in this PR.

## How Has This Been Tested?

Clean `dashpay` build (`xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator ARCHS=arm64`) against DashUIKit master. SwiftUI previews added for each presentation: `Menu row — More (no close)`, `Menu row — Home (with close)`, `Menu row — syncing`.

**Not yet smoke-tested end to end on testnet**: the invitation-claim run that produced these findings predates the fixes. The three symptoms should be re-checked by hand — claim an invitation with a non-contested name, then confirm the landing screen, five tabs, and the banner retiring without a relaunch.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation