### PR TITLE
fix(lock): show cancel action in forgot PIN recovery

### DIFF
--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -204,7 +204,10 @@ static CGFloat ActionButtonsHeight(void) {
         [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                       target:self
                                                       action:@selector(forgotPinRecoveryCancelAction:)];
-    controller.navigationItem.leftBarButtonItem = cancelButton;
+    // This controller is the root of a modal navigation stack. Our shared
+    // navigation controller clears left-side items for root controllers (to
+    // suppress a back button), so keep the modal escape action on the right.
+    controller.navigationItem.rightBarButtonItem = cancelButton;
 
     DWNavigationController *navigationController =
         [[DWNavigationController alloc] initWithRootViewController:controller];


### PR DESCRIPTION
## Summary
- keep the modal Cancel action visible on the recovery phrase screen opened from Forgot PIN
- return safely to the lock screen without changing the existing PIN

## Testing
- manually verified by requester
- full build skipped per requester

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the PIN recovery modal’s Cancel button from the left side of the navigation bar to the right side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->