### PR TITLE
fix: make user-triggered UI transitions single-flight

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 		BD509A68B1A0B6E4599F9C7A /* DWProfileUpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82926C69F3BB675BEF1A1FFD /* DWProfileUpdateCoordinator.swift */; };
 		C05FA6CE3DDE2D0327D334E5 /* CoinJoinRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478AD92C1F1C11D09645DF4 /* CoinJoinRecovery.swift */; };
 		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
+		C0DE5A1126C7000000000011 /* UIViewControllerUserActionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A1026C7000000000012 /* UIViewControllerUserActionGateTests.swift */; };
 		C124DF94278D4238FAE0975D /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		C1A0B2C3D4E5F60718293A02 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
 		C1A0B2C3D4E5F60718293A03 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
@@ -3142,6 +3143,7 @@
 		BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailViewModel.swift; sourceTree = "<group>"; };
 		C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderPreviewFeeRow.swift; sourceTree = "<group>"; };
 		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
+		C0DE5A1026C7000000000012 /* UIViewControllerUserActionGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerUserActionGateTests.swift; sourceTree = "<group>"; };
 		C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsBarView.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D8E9F01234 /* TransferAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountView.swift; sourceTree = "<group>"; };
 		C3DAD266246AA6F10001624F /* DWScreenshotWarningViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWScreenshotWarningViewController.h; sourceTree = "<group>"; };
@@ -7070,6 +7072,7 @@
 				A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */,
 				B7C072AA26C7000000000002 /* DWContestedNameStatusServiceTests.swift */,
 				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
+				C0DE5A1026C7000000000012 /* UIViewControllerUserActionGateTests.swift */,
 				CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */,
 				CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */,
 				7A30000130A1000000000001 /* TransactionDirectionTests.swift */,
@@ -10248,6 +10251,7 @@
 				A17EED0126C7000000000001 /* WalletWipeSerialExecutorTests.swift in Sources */,
 				B7C072AA26C7000000000001 /* DWContestedNameStatusServiceTests.swift in Sources */,
 				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
+				C0DE5A1126C7000000000011 /* UIViewControllerUserActionGateTests.swift in Sources */,
 				CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */,
 				CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */,
 				7A30000230A1000000000002 /* TransactionDirectionTests.swift in Sources */,

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -17,10 +17,58 @@
 
 import UIKit
 import MessageUI
+import ObjectiveC
 import SwiftDashSDK
 
-@objc
+private final class UserActionGate {
+    private var isInProgress = false
+
+    func begin() -> Bool {
+        guard !isInProgress else { return false }
+
+        isInProgress = true
+        return true
+    }
+
+    func end() {
+        isInProgress = false
+    }
+}
+
+private var userActionGateKey: UInt8 = 0
+
 extension UIViewController {
+    /// Starts a UI action only when this controller does not already have one
+    /// in flight. Call this synchronously, before navigation, presentation, or
+    /// an asynchronous operation can yield back to the main run loop.
+    ///
+    /// End the action when a recoverable failure/cancel occurs or when the
+    /// source controller becomes visible again. Successful one-way transitions
+    /// intentionally leave it acquired so queued taps cannot replay afterward.
+    @objc(dw_beginExclusiveUserAction)
+    func dw_beginExclusiveUserAction() -> Bool {
+        userActionGate.begin()
+    }
+
+    @objc(dw_endExclusiveUserAction)
+    func dw_endExclusiveUserAction() {
+        userActionGate.end()
+    }
+
+    private var userActionGate: UserActionGate {
+        if let gate = objc_getAssociatedObject(self, &userActionGateKey) as? UserActionGate {
+            return gate
+        }
+
+        let gate = UserActionGate()
+        objc_setAssociatedObject(
+            self,
+            &userActionGateKey,
+            gate,
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return gate
+    }
+
     @objc
     func topController() -> UIViewController {
         if let vc = self as? UITabBarController {

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -20,6 +20,7 @@
 #import "DWLockActionButton.h"
 #import "DWLockPinInputView.h"
 #import "DWLockScreenModel.h"
+#import "DWQRScanModel.h"
 #import "DWRecoverViewController.h"
 #import "DWSetPinViewController.h"
 #import "DWUIKit.h"
@@ -70,7 +71,8 @@ static CGFloat ActionButtonsHeight(void) {
 @interface DWLockScreenViewController () <DWLockPinInputViewDelegate,
                                           DWLockScreenModelDelegate,
                                           DWRecoverViewControllerDelegate,
-                                          DWSetPinViewControllerDelegate>
+                                          DWSetPinViewControllerDelegate,
+                                          UIAdaptivePresentationControllerDelegate>
 
 @property (strong, nonatomic) DWLockScreenModel *model;
 
@@ -86,6 +88,9 @@ static CGFloat ActionButtonsHeight(void) {
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint *actionButtonsHeightConstraint;
 
 @property (nonatomic, assign) BOOL biometricsAuthorizationAttemptWasMade;
+
+- (BOOL)beginExclusiveUserAction;
+- (void)endExclusiveUserAction;
 
 @end
 
@@ -138,6 +143,8 @@ static CGFloat ActionButtonsHeight(void) {
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
+    [self endExclusiveUserAction];
+
     if (self.unlockMode == DWLockScreenViewControllerUnlockMode_Instantly) {
         [self tryOnceToUnlockUsingBiometrics];
     }
@@ -152,6 +159,10 @@ static CGFloat ActionButtonsHeight(void) {
 #pragma mark - Actions
 
 - (IBAction)forgotPinButtonAction:(UIButton *)sender {
+    if (![self beginExclusiveUserAction]) {
+        return;
+    }
+
     [self.model stopCheckingAuthState];
 
     // No PIN record at all (partial keychain restore, interrupted setup):
@@ -188,6 +199,7 @@ static CGFloat ActionButtonsHeight(void) {
                                                   style:UIAlertActionStyleCancel
                                                 handler:^(UIAlertAction *action) {
                                                     [self.model startCheckingAuthState];
+                                                    [self endExclusiveUserAction];
                                                 }]];
         [self presentViewController:sheet animated:YES completion:nil];
     }
@@ -219,6 +231,7 @@ static CGFloat ActionButtonsHeight(void) {
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  [self.model startCheckingAuthState];
+                                 [self endExclusiveUserAction];
                              }];
 }
 
@@ -231,6 +244,7 @@ static CGFloat ActionButtonsHeight(void) {
                                               style:UIAlertActionStyleCancel
                                             handler:^(UIAlertAction *action) {
                                                 [self.model startCheckingAuthState];
+                                                [self endExclusiveUserAction];
                                             }]];
     [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Wipe wallet", nil)
                                               style:UIAlertActionStyleDestructive
@@ -308,10 +322,15 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (IBAction)receiveButtonAction:(DWLockActionButton *)sender {
+    if (![self beginExclusiveUserAction]) {
+        return;
+    }
+
     // SwiftUI receive surface (Transparent / Platform / Shielded toggle),
     // narrowed to the Receive tab for the locked context.
     UIViewController *controller = [DWPaymentsLandingHostingController quickReceiveController];
     [self presentViewController:controller animated:YES completion:nil];
+    controller.presentationController.delegate = self;
 }
 
 - (IBAction)loginButtonAction:(DWLockActionButton *)sender {
@@ -319,7 +338,26 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (IBAction)scanToPayButtonAction:(DWLockActionButton *)sender {
+    if (![self beginExclusiveUserAction]) {
+        return;
+    }
+
     [self performScanQRCodeAction];
+}
+
+#pragma mark - UIAdaptivePresentationControllerDelegate
+
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+    [self endExclusiveUserAction];
+}
+
+#pragma mark - DWQRScanModelDelegate
+
+- (void)qrScanModelDidCancel:(DWQRScanModel *)viewModel {
+    [self dismissViewControllerAnimated:YES
+                             completion:^{
+                                 [self endExclusiveUserAction];
+                             }];
 }
 
 #pragma mark - DWNavigationFullscreenable
@@ -388,7 +426,9 @@ static CGFloat ActionButtonsHeight(void) {
 - (void)lockPinInputView:(DWLockPinInputView *)view didFinishInputWithText:(NSString *)text {
     BOOL isPinValid = [self.model checkPin:text];
     if (isPinValid) {
-        [self.delegate lockScreenViewControllerDidUnlock:self];
+        if ([self beginExclusiveUserAction]) {
+            [self.delegate lockScreenViewControllerDidUnlock:self];
+        }
     }
     else {
         [view clearAndShakePinField];
@@ -481,15 +521,34 @@ static CGFloat ActionButtonsHeight(void) {
     }
 
     if (self.model.isBiometricAuthenticationAllowed) {
+        if (![self beginExclusiveUserAction]) {
+            return;
+        }
+
         [self.model authenticateUsingBiometricsOnlyCompletion:^(BOOL authenticated) {
             if (authenticated) {
                 [self.delegate lockScreenViewControllerDidUnlock:self];
             }
             else {
+                [self endExclusiveUserAction];
                 [self hideLoginButtonIfNeeded];
             }
         }];
     }
+}
+
+- (BOOL)beginExclusiveUserAction {
+    if (![self dw_beginExclusiveUserAction]) {
+        return NO;
+    }
+
+    self.view.userInteractionEnabled = NO;
+    return YES;
+}
+
+- (void)endExclusiveUserAction {
+    [self dw_endExclusiveUserAction];
+    self.view.userInteractionEnabled = YES;
 }
 
 - (void)hideLoginButtonIfNeeded {

--- a/DashWallet/Sources/UI/Onboarding/DWOnboardingViewController.m
+++ b/DashWallet/Sources/UI/Onboarding/DWOnboardingViewController.m
@@ -150,6 +150,11 @@ static CGFloat const SCALE_FACTOR = 0.5;
 #pragma mark - Actions
 
 - (IBAction)skipButtonAction:(id)sender {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
+    self.view.userInteractionEnabled = NO;
+
     [self.delegate onboardingViewControllerDidFinish:self];
 }
 

--- a/DashWallet/Sources/UI/Payments/PaymentsViewController.swift
+++ b/DashWallet/Sources/UI/Payments/PaymentsViewController.swift
@@ -99,6 +99,8 @@ class PaymentsViewController: BaseViewController {
 
     @IBAction
     func closeButtonAction() {
+        guard dw_beginExclusiveUserAction() else { return }
+        view.isUserInteractionEnabled = false
         delegate?.paymentsViewControllerDidCancel(self)
     }
 
@@ -106,6 +108,13 @@ class PaymentsViewController: BaseViewController {
         super.viewDidLoad()
 
         configureHierarchy()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        dw_endExclusiveUserAction()
+        view.isUserInteractionEnabled = true
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -117,10 +126,6 @@ class PaymentsViewController: BaseViewController {
                 self.forceShowingEnterAddress = false
             }
         }
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
     }
 
     class func controller() -> PaymentsViewController {

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -51,6 +51,7 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
 @property (nullable, nonatomic, strong) NSURL *deferredURLToProcess;
 @property (nullable, nonatomic, strong) NSURL *deferredDeeplinkToProcess;
 @property (nonatomic, assign) BOOL walletWipeInProgress;
+@property (nonatomic, assign) BOOL setupCompletionInProgress;
 #if DASHPAY
 @property (null_resettable, nonatomic, strong) DWInvitationSetupState *invitationSetup;
 #endif
@@ -325,6 +326,11 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
 #pragma mark - DWSetupViewControllerDelegate
 
 - (void)setupViewControllerDidFinish:(DWSetupViewController *)controller {
+    if (self.setupCompletionInProgress) {
+        return;
+    }
+    self.setupCompletionInProgress = YES;
+
     [self.model setupDidFinish];
 
     UIViewController *mainController = self.mainController;
@@ -345,6 +351,8 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
 #pragma mark - DWWipeDelegate
 
 - (void)didWipeWallet {
+    self.setupCompletionInProgress = NO;
+
     UIViewController *setupController = [self setupController];
     [self transitionToController:setupController
                   transitionType:DWContainerTransitionType_ScaleAndCrossDissolve];
@@ -365,6 +373,7 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
         return;
     }
     self.walletWipeInProgress = YES;
+    self.setupCompletionInProgress = NO;
 
     UIViewController *setupController = [self setupController];
     [self transitionToController:setupController

--- a/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DWInitialViewController () <DWOnboardingViewControllerDelegate>
 
 @property (nonatomic, assign) BOOL launchingWasDeferred;
+@property (nonatomic, assign) BOOL onboardingCompletionInProgress;
 @property (nullable, nonatomic, strong) DWAppRootViewController *rootController;
 
 #if DASHPAY
@@ -92,6 +93,11 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - DWOnboardingViewControllerDelegate
 
 - (void)onboardingViewControllerDidFinish:(DWOnboardingViewController *)controller {
+    if (self.onboardingCompletionInProgress) {
+        return;
+    }
+    self.onboardingCompletionInProgress = YES;
+
     [self onboardingDidFinish];
 
     // Reinstall detection: if SDK wallet keychain material survived while

--- a/DashWallet/Sources/UI/Setup/BiometricAuth/DWBiometricAuthViewController.m
+++ b/DashWallet/Sources/UI/Setup/BiometricAuth/DWBiometricAuthViewController.m
@@ -19,6 +19,7 @@
 
 #import "DWBiometricAuthModel.h"
 #import "DWUIKit.h"
+#import "dashwallet-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -63,6 +64,9 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Actions
 
 - (IBAction)enableBiometricButtonAction:(id)sender {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
     self.view.userInteractionEnabled = NO;
 
     __weak typeof(self) weakSelf = self;
@@ -82,6 +86,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (IBAction)skipBiometricButtonAction:(id)sender {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
+    self.view.userInteractionEnabled = NO;
+
     [self.model disableBiometricAuth];
     [self.delegate biometricAuthViewControllerDidFinish:self];
 }

--- a/DashWallet/Sources/UI/Setup/DWSetupViewController.m
+++ b/DashWallet/Sources/UI/Setup/DWSetupViewController.m
@@ -75,6 +75,10 @@ static NSTimeInterval const ANIMATION_DURATION = 0.25;
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
 
+    [self dw_endExclusiveUserAction];
+    self.createWalletButton.enabled = YES;
+    self.recoverWalletButton.enabled = YES;
+
     if (!self.initialAnimationCompleted) {
         self.initialAnimationCompleted = YES;
 
@@ -94,6 +98,12 @@ static NSTimeInterval const ANIMATION_DURATION = 0.25;
 #pragma mark - Actions
 
 - (IBAction)createWalletButtonAction:(id)sender {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
+    self.createWalletButton.enabled = NO;
+    self.recoverWalletButton.enabled = NO;
+
     self.recoverWalletCommand = nil;
 
     [DWGlobalOptions sharedInstance].walletNeedsBackup = YES;
@@ -104,6 +114,12 @@ static NSTimeInterval const ANIMATION_DURATION = 0.25;
 }
 
 - (IBAction)recoverWalletButtonAction:(id)sender {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
+    self.createWalletButton.enabled = NO;
+    self.recoverWalletButton.enabled = NO;
+
     self.recoverWalletCommand = nil;
 
     DWRecoverViewController *controller = [[DWRecoverViewController alloc] init];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
@@ -95,11 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
                                                            style:UIAlertActionStyleCancel
                                                          handler:^(UIAlertAction *_Nonnull action) {
+                                                             [self.contentView endRecoveryAttempt];
                                                              [self.contentView activateTextView];
                                                          }];
     UIAlertAction *recoverAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Recover", nil)
                                                             style:UIAlertActionStyleDefault
                                                           handler:^(UIAlertAction *_Nonnull action) {
+                                                              [self.contentView endRecoveryAttempt];
                                                               DWPhraseRepairViewController *controller =
                                                                   [[DWPhraseRepairViewController alloc] initWithPhrase:phrase
                                                                                                          incorrectWord:incorrectWord];
@@ -109,7 +111,6 @@ NS_ASSUME_NONNULL_BEGIN
     [alert addAction:cancelAction];
     [alert addAction:recoverAction];
     [self presentViewController:alert animated:YES completion:nil];
-    [self showAlertWithTitle:nil message:message];
 }
 
 - (void)recoverContentView:(DWRecoverContentView *)view usedWordsHaveInvalidCount:(NSArray *)words {
@@ -127,11 +128,13 @@ NS_ASSUME_NONNULL_BEGIN
         UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
                                                                style:UIAlertActionStyleCancel
                                                              handler:^(UIAlertAction *_Nonnull action) {
+                                                                 [self.contentView endRecoveryAttempt];
                                                                  [self.contentView activateTextView];
                                                              }];
         UIAlertAction *recoverAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Recover", nil)
                                                                 style:UIAlertActionStyleDefault
                                                               handler:^(UIAlertAction *_Nonnull action) {
+                                                                  [self.contentView endRecoveryAttempt];
                                                                   DWPhraseRepairViewController *controller =
                                                                       [[DWPhraseRepairViewController alloc] initWithPhrase:[words componentsJoinedByString:@" "]
                                                                                                              incorrectWord:nil];
@@ -141,7 +144,6 @@ NS_ASSUME_NONNULL_BEGIN
         [alert addAction:cancelAction];
         [alert addAction:recoverAction];
         [self presentViewController:alert animated:YES completion:nil];
-        [self showAlertWithTitle:nil message:message];
     }
     else {
         NSString *message = NSLocalizedString(@"Recovery phrase must have 12, 15, 18, 21 or 24 words", nil);
@@ -173,6 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
                                                            style:UIAlertActionStyleCancel
                                                          handler:^(UIAlertAction *action) {
+                                                             [self.contentView endRecoveryAttempt];
                                                              [self.contentView activateTextView];
                                                          }];
     [alert addAction:cancelAction];
@@ -308,6 +311,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
                                                        style:UIAlertActionStyleCancel
                                                      handler:^(UIAlertAction *_Nonnull action) {
+                                                         [self.contentView endRecoveryAttempt];
                                                          [self.contentView activateTextView];
                                                      }];
     [alert addAction:okAction];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.h
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)activateTextView;
 - (void)continueAction;
+- (void)endRecoveryAttempt;
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, strong) NSLayoutConstraint *topConstraint;
 @property (readonly, nonatomic, strong) NSLayoutConstraint *textViewMinHeightConstraint;
 
+@property (nonatomic, assign) BOOL recoveryAttemptInProgress;
+
 @end
 
 @implementation DWRecoverContentView
@@ -133,6 +135,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self recoverWalletWithCurrentSeedPhrase];
 }
 
+- (void)endRecoveryAttempt {
+    self.recoveryAttemptInProgress = NO;
+}
+
 - (void)appendText:(NSString *)text {
     self.textView.text = [self.textView.text stringByAppendingFormat:@" %@", text];
 }
@@ -166,9 +172,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)recoverWalletWithCurrentSeedPhrase {
     NSUInteger count = [self.textView.text wordsCount];
-    if (count < 10) {
+    if (count < 10 || self.recoveryAttemptInProgress) {
         return;
     }
+    self.recoveryAttemptInProgress = YES;
 
     @autoreleasepool { // @autoreleasepool ensures sensitive data will be deallocated immediately
         UITextView *textView = self.textView;

--- a/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
@@ -113,16 +113,23 @@ final class BackupInfoViewController: BaseViewController {
 
     @objc
     private func closeAction() {
+        guard dw_beginExclusiveUserAction() else { return }
+        setActionsEnabled(false)
         delegate?.secureWalletRoutineDidCancel(self)
     }
 
     @IBAction
     func skipButtonAction() {
+        guard dw_beginExclusiveUserAction() else { return }
+        setActionsEnabled(false)
         delegate?.secureWalletRoutineDidCancel(self)
     }
 
     @IBAction
     func backupButtonAction() {
+        guard dw_beginExclusiveUserAction() else { return }
+        setActionsEnabled(false)
+
         let authManager = AuthenticationService.shared
         
         if type == .setup && authManager.didAuthenticate {
@@ -132,6 +139,7 @@ final class BackupInfoViewController: BaseViewController {
                    usingBiometricAuthentication: false,
                    alertIfLockout: true) { [weak self] authenticated, _, _ in
                 guard authenticated else {
+                    self?.endUserAction()
                     return
                 }
 
@@ -160,6 +168,12 @@ final class BackupInfoViewController: BaseViewController {
 
 
         configureHierarchy()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        endUserAction()
     }
 
     @objc
@@ -202,6 +216,16 @@ extension BackupInfoViewController {
         controller.shouldCreateNewWalletOnScreenshot = shouldCreateNewWalletOnScreenshot
         controller.delegate = delegate
         navigationController?.pushViewController(controller, animated: true)
+    }
+
+    private func endUserAction() {
+        dw_endExclusiveUserAction()
+        setActionsEnabled(true)
+    }
+
+    private func setActionsEnabled(_ enabled: Bool) {
+        bottomButtonStack.isUserInteractionEnabled = enabled
+        navigationItem.rightBarButtonItem?.isEnabled = enabled
     }
 
     private func reloadCloseButton() {

--- a/DashWallet/Sources/UI/Setup/SecureWallet/Seed/BackupSeedPhraseViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/Seed/BackupSeedPhraseViewController.swift
@@ -22,6 +22,7 @@ import UIKit
 class BackupSeedPhraseViewController: DWPreviewSeedPhraseViewController {
 
     var shouldCreateNewWalletOnScreenshot: Bool = false
+    private var hasAppeared = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,7 +41,20 @@ class BackupSeedPhraseViewController: DWPreviewSeedPhraseViewController {
         return NSLocalizedString("Continue", comment: "")
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        dw_endExclusiveUserAction()
+        if hasAppeared {
+            actionButton?.isEnabled = true
+        }
+        hasAppeared = true
+    }
+
     @objc override func actionButtonAction(_ sender: Any) {
+        guard dw_beginExclusiveUserAction() else { return }
+        actionButton?.isEnabled = false
+
         let seedPhrase = self.contentView.model
 
         let controller = DWVerifySeedPhraseViewController(seedPhrase: seedPhrase!)

--- a/DashWallet/Sources/UI/Setup/SecureWallet/VerifiedSuccessfully/VerifiedSuccessfullyViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/VerifiedSuccessfully/VerifiedSuccessfullyViewController.swift
@@ -49,6 +49,8 @@ final class VerifiedSuccessfullyViewController : UIViewController, NavigationFul
 
     @IBAction
     func continueButtonAction() {
+        guard dw_beginExclusiveUserAction() else { return }
+        continueButton.isEnabled = false
         delegate?.secureWalletRoutineDidFinish(self)
     }
 }

--- a/DashWallet/Sources/UI/Setup/SecureWallet/Verify/Views/DWVerifySeedPhraseContentView.m
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/Verify/Views/DWVerifySeedPhraseContentView.m
@@ -56,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSLayoutConstraint *verificationSeedPhraseTopConstraint;
 
 @property (nonatomic, assign) BOOL initialAnimationCompleted;
+@property (nonatomic, assign) BOOL verificationCompletionScheduled;
 
 @end
 
@@ -181,6 +182,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self.model selectWord:wordModel];
 
     if (self.model.seedPhraseHasBeenVerified) {
+        if (self.verificationCompletionScheduled) {
+            return;
+        }
+        self.verificationCompletionScheduled = YES;
+
         // show result when animation ends
         dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(DW_VERIFY_APPEAR_ANIMATION_DURATION * NSEC_PER_SEC));
         dispatch_after(when, dispatch_get_main_queue(), ^{

--- a/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.m
+++ b/DashWallet/Sources/UI/Setup/SetPin/DWSetPinViewController.m
@@ -79,10 +79,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - DWPinViewDelegate
 
 - (void)pinViewCancelButtonTap:(DWPinView *)pinView {
-    [self.delegate setPinViewControllerDidCancel:self];
+    if ([self dw_beginExclusiveUserAction]) {
+        [self.delegate setPinViewControllerDidCancel:self];
+    }
 }
 
 - (void)pinView:(DWPinView *)pinView didFinishWithPin:(NSString *)pin {
+    if (![self dw_beginExclusiveUserAction]) {
+        return;
+    }
+
     BOOL success = [self.model setPin:pin];
     if (success) {
         [self.delegate setPinViewControllerDidSetPin:self];

--- a/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
+++ b/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
@@ -91,7 +91,10 @@ class BaseNavigationController: UINavigationController {
 
     @IBAction
     func cancelButtonAction() {
-        dismiss(animated: true)
+        guard dw_beginExclusiveUserAction() else { return }
+        dismiss(animated: true) { [weak self] in
+            self?.dw_endExclusiveUserAction()
+        }
     }
 
     @objc
@@ -113,9 +116,18 @@ class BaseNavigationController: UINavigationController {
     }
 
     override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        guard !isPushAnimationInProgress else { return }
+
         isPushAnimationInProgress = true
 
         super.pushViewController(viewController, animated: animated)
+
+        // UIKit does not call the navigation delegate when a stack is being
+        // assembled before it is on screen. There is no visible transition to
+        // protect in that case, so do not leave the gate acquired indefinitely.
+        if !animated || view.window == nil {
+            isPushAnimationInProgress = false
+        }
     }
 
     override func viewDidLoad() {

--- a/DashWalletTests/UIViewControllerUserActionGateTests.swift
+++ b/DashWalletTests/UIViewControllerUserActionGateTests.swift
@@ -1,0 +1,34 @@
+//
+//  UIViewControllerUserActionGateTests.swift
+//  DashWalletTests
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+
+@testable import dashwallet
+import UIKit
+import XCTest
+
+@MainActor
+final class UIViewControllerUserActionGateTests: XCTestCase {
+    func testActionRemainsExclusiveUntilExplicitlyEnded() {
+        let controller = UIViewController()
+
+        XCTAssertTrue(controller.dw_beginExclusiveUserAction())
+        XCTAssertFalse(controller.dw_beginExclusiveUserAction())
+
+        controller.dw_endExclusiveUserAction()
+
+        XCTAssertTrue(controller.dw_beginExclusiveUserAction())
+    }
+
+    func testEachControllerHasAnIndependentGate() {
+        let first = UIViewController()
+        let second = UIViewController()
+
+        XCTAssertTrue(first.dw_beginExclusiveUserAction())
+        XCTAssertTrue(second.dw_beginExclusiveUserAction())
+        XCTAssertFalse(first.dw_beginExclusiveUserAction())
+        XCTAssertFalse(second.dw_beginExclusiveUserAction())
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

When the main thread is stalled, UIKit can queue several taps for the same control. The legacy onboarding flows generally treated each delivered event as a fresh action. In the observed case, repeated taps on **Recover Wallet** pushed the recovery controller once per queued tap after the main thread resumed.

The audit found the same class of risk at other one-way onboarding, authentication, modal, and delegate-completion boundaries. It also found two recovery-validation branches that explicitly presented a custom repair alert and then immediately presented a second generic alert.

## What was done?

- Added a reusable per-view-controller exclusive-action gate, exported to both Swift and Objective-C. It is acquired synchronously before navigation, presentation, authentication, or delegate completion can yield back to the run loop.
- Made `BaseNavigationController` reject pushes while a push transition is already in progress, using its existing transition state as a stack-wide safety net.
- Hardened onboarding/setup entry points, PIN creation, biometric setup, recovery submission (button and keyboard Return), backup/seed verification, the success screen, Payments close, and lock-screen actions.
- Added explicit release behavior for cancellation, recoverable failure, returning to a source screen, sheet dismissal, and QR-scan cancellation.
- Added defense-in-depth completion latches at the initial onboarding and setup-to-root boundaries, so a repeated child callback cannot repeat wallet recovery prompts or root transitions.
- Added a completion latch around the delayed seed-verification callback.
- Removed the two duplicate recovery alert presentations discovered by the audit.

Existing domain-level single-flight protections in wallet add/switch/remove, swaps, shielded transfers, contact actions, payment confirmation, and sync retry were reviewed and retained.

## How Has This Been Tested?

- Passed a full optimized simulator build:
  - scheme: `dashpay`
  - configuration: `Release`
  - destination: iPhone 17 Pro, iOS 26.5
- Verified the shared selectors are emitted in `dashwallet-Swift.h` for Objective-C callers.
- Added unit coverage for exclusivity, explicit release, and per-controller isolation.
- Ran `git diff --check` successfully.

Focused unit-test execution is currently blocked by an unrelated `develop` test-host target-membership failure: the `dashwallet` target compiles DashPay-only references such as `ContactAvatarView`, `CurrentUserProfileModel`, and `JoinDashPayViewModel` without their defining source files. The Release `dashpay` application target builds successfully.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
