### PR TITLE
fix(sync): clarify network-known transactions

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -4,7 +4,7 @@
 //
 //  Removes never-accepted transactions from local wallet state. Two
 //  entry points share the surgery:
-//  - `remove(txidWire:)` — the tx-detail "Remove if not on Blockchain"
+//  - `remove(txidWire:)` — the tx-detail "Remove if Not on Network"
 //    action for one stuck transaction (a parked asset lock, or any
 //    network-dropped send such as a stalled CoinJoin sweep chunk);
 //    explorer-checked per the rails below.
@@ -72,7 +72,7 @@ struct UnconfirmedTransactionRemover {
             case .confirmedLocally:
                 return NSLocalizedString("This transaction is confirmed and can't be removed.", comment: "Remove never-accepted transaction: local state says it's on-chain")
             case .transactionOnChain:
-                return NSLocalizedString("Transaction is on the blockchain", comment: "Remove never-accepted transaction: refused because the explorer found it")
+                return NSLocalizedString("Transaction is known to the network", comment: "Remove never-accepted transaction: refused because the explorer found it")
             case .verificationUnavailable:
                 return NSLocalizedString("Couldn't reach a block explorer to verify the transaction isn't on the blockchain. Check your connection and try again.", comment: "Remove never-accepted transaction: explorer unreachable")
             }

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -536,7 +536,7 @@ extension TxDetailModel {
         var supportsRemoval: Bool { statusRaw <= 1 }
     }
 
-    /// True when the "Remove if not on Blockchain" action applies outside
+    /// True when the "Remove if Not on Network" action applies outside
     /// the asset-lock retry route: the local store still has this
     /// transaction in mempool context (`.processing` — never IS-locked,
     /// never mined), which is exactly the state a network-dropped send

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -308,7 +308,7 @@ extension TXDetailViewController {
     private func confirmRemoveUnconfirmed() {
         let alert = UIAlertController(
             title: NSLocalizedString("Remove this transaction?", comment: "Remove never-accepted transaction: confirmation title"),
-            message: NSLocalizedString("The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network.", comment: "Remove never-accepted transaction: confirmation body"),
+            message: NSLocalizedString("The wallet first checks a block explorer. A transaction known to the network — whether it is waiting in the mempool or already included in a block — is never removed. If the transaction isn't found, it is deleted from this wallet on this device, and the coins it was trying to spend become available again. The wallet then rescans recent blocks as a safety check. Nothing is sent to the network.", comment: "Remove never-accepted transaction: confirmation body"),
             preferredStyle: .alert)
         alert.addAction(UIAlertAction(
             title: NSLocalizedString("Remove Transaction", comment: "Remove never-accepted transaction: destructive confirm button"),
@@ -351,12 +351,12 @@ extension TXDetailViewController {
         }
     }
 
-    /// The explorer says the transaction IS on the blockchain — removal
-    /// is refused and the wallet just needs to catch up.
+    /// The explorer knows the transaction, either from the mempool or a
+    /// block. Removal is refused until the local wallet catches up.
     private func presentRemovalRefused() {
         let alert = UIAlertController(
-            title: NSLocalizedString("Transaction is on the blockchain", comment: "Remove never-accepted transaction: refused because the explorer found it"),
-            message: NSLocalizedString("A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own.", comment: "Remove never-accepted transaction: refusal body"),
+            title: NSLocalizedString("Transaction is known to the network", comment: "Remove never-accepted transaction: refused because the explorer found it"),
+            message: NSLocalizedString("A block explorer reports that this transaction is known to the Dash network. It may still be waiting in the mempool or may already be included in a block, so it wasn't removed. The wallet will update its confirmation automatically once it is included in a synchronized block.", comment: "Remove never-accepted transaction: refusal body"),
             preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel))
         present(alert, animated: true)
@@ -416,7 +416,7 @@ extension TXDetailViewController {
                         cell.titleLabel.text = title
                         cell.titleLabel.textColor = .dw_label()
                     } else if item == .removeUnconfirmed {
-                        cell.titleLabel.text = NSLocalizedString("Remove if not on Blockchain", comment: "Delete a never-accepted transaction from local wallet state")
+                        cell.titleLabel.text = NSLocalizedString("Remove if Not on Network", comment: "Delete a never-accepted transaction from local wallet state")
                         cell.titleLabel.textColor = .systemRed
                     }
                     return cell

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -2594,7 +2594,7 @@
 "Rebroadcast" = "Rebroadcast";
 
 /* Delete a never-accepted transaction from local wallet state */
-"Remove if not on Blockchain" = "Remove if not on Blockchain";
+"Remove if Not on Network" = "Remove if Not on Network";
 
 /* Remove never-accepted transaction: confirmation title */
 "Remove this transaction?" = "Remove this transaction?";
@@ -2630,10 +2630,10 @@
 "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name." = "Removing the listing is a network transaction with a small fee, paid from your identity balance. You keep the name.";
 
 /* Remove never-accepted transaction: refused because the explorer found it */
-"Transaction is on the blockchain" = "Transaction is on the blockchain";
+"Transaction is known to the network" = "Transaction is known to the network";
 
 /* Remove never-accepted transaction: refusal body */
-"A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own." = "A block explorer reports this transaction on the Dash network, so it wasn't removed. The wallet will catch up with its confirmation on its own.";
+"A block explorer reports that this transaction is known to the Dash network. It may still be waiting in the mempool or may already be included in a block, so it wasn't removed. The wallet will update its confirmation automatically once it is included in a synchronized block." = "A block explorer reports that this transaction is known to the Dash network. It may still be waiting in the mempool or may already be included in a block, so it wasn't removed. The wallet will update its confirmation automatically once it is included in a synchronized block.";
 
 /* Remove never-accepted transaction: success */
 "Transaction removed" = "Transaction removed";
@@ -2642,7 +2642,7 @@
 "Transaction removed — rescan couldn't start, run Rescan Filters in Core Sync Status" = "Transaction removed — rescan couldn't start, run Rescan Filters in Core Sync Status";
 
 /* Remove never-accepted transaction: confirmation body */
-"The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network." = "The wallet first checks a block explorer — a transaction that is on the blockchain is never removed. If it isn't found, the transaction is deleted from this wallet on this device and the coins it was trying to spend become available again. The wallet then rescans recent blocks, so if the transaction does turn out to be on the blockchain, it comes back on its own. Nothing is sent to the network.";
+"The wallet first checks a block explorer. A transaction known to the network — whether it is waiting in the mempool or already included in a block — is never removed. If the transaction isn't found, it is deleted from this wallet on this device, and the coins it was trying to spend become available again. The wallet then rescans recent blocks as a safety check. Nothing is sent to the network." = "The wallet first checks a block explorer. A transaction known to the network — whether it is waiting in the mempool or already included in a block — is never removed. If the transaction isn't found, it is deleted from this wallet on this device, and the coins it was trying to spend become available again. The wallet then rescans recent blocks as a safety check. Nothing is sent to the network.";
 
 /* Remove never-accepted transaction: failure title */
 "Couldn't remove the transaction" = "Couldn't remove the transaction";


### PR DESCRIPTION
## Summary
- describe explorer-known transactions without claiming they are already mined
- explain that an unconfirmed transaction may still be in the mempool
- rename the recovery action to match its actual network-level check

## Verification
- confirmed the reported transaction was known by Insight before its block timestamp
- `plutil -lint DashWallet/en.lproj/Localizable.strings`
- dashpay Debug build for generic iOS Simulator (`BUILD SUCCEEDED`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated transaction removal guidance to use “Remove if Not on Network.”
  * Transactions already known to the Dash network, including those in the mempool, are now correctly treated as non-removable.
  * Improved refusal messaging to explain network status and automatic confirmation updates.
  * Clarified asset-lock retry instructions and related transaction status wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->