### PR TITLE
ci: cache CocoaPods release dependencies

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -348,6 +348,16 @@ jobs:
         with:
           version: "1.15.2"
 
+      - name: Cache CocoaPods dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ${{ github.workspace }}/dashwallet-ios/Pods
+          key: >-
+            cocoapods-${{ runner.os }}-${{ runner.arch }}-1.15.2-
+            ${{ hashFiles('dashwallet-ios/Podfile.lock') }}
+
       - name: Install CocoaPods dependencies
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- cache the CocoaPods download cache and generated `Pods` directory in the dashpay TestFlight workflow
- key the cache by runner OS, architecture, CocoaPods 1.15.2, and `Podfile.lock`
- continue running `pod install --deployment` after cache restoration to validate the lockfile

## Validation
- actionlint 1.7.12
- YAML parsing
- diff whitespace check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build efficiency by caching CocoaPods dependencies during TestFlight releases.
  * Repeated builds can now reuse previously downloaded dependencies when the environment and dependency versions match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->