### PR TITLE
ci: update release actions to Node 24

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -63,7 +63,7 @@ jobs:
       # package, so both repositories must be siblings in the Actions
       # workspace.
       - name: Checkout dashwallet-ios
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.wallet_ref }}
           path: dashwallet-ios
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout platform
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: dashpay/platform
           ref: ${{ inputs.platform_ref }}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Restore release XCFramework cache
         id: xcframework-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/platform/packages/swift-sdk/DashSDKFFI.xcframework
           key: dash-sdk-xcframework-v1-${{ runner.os }}-${{ runner.arch }}-xcode-26.6-rust-1.92-ios-sim-release-${{ steps.release-info.outputs.platform_sha }}
@@ -328,7 +328,7 @@ jobs:
 
       - name: Cache Cargo dependencies
         if: steps.xcframework-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -357,7 +357,7 @@ jobs:
 
       - name: Save release XCFramework cache
         if: steps.xcframework-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/platform/packages/swift-sdk/DashSDKFFI.xcframework
           key: ${{ steps.xcframework-cache.outputs.cache-primary-key }}
@@ -371,7 +371,7 @@ jobs:
           version: "1.15.2"
 
       - name: Cache CocoaPods dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/Library/Caches/CocoaPods


### PR DESCRIPTION
## Summary

- update both release checkouts from `actions/checkout@v4` to `@v6`
- update Cargo and CocoaPods caching from `actions/cache@v4` to `@v5`
- update explicit XCFramework restore/save actions from `@v4` to `@v5`
- remove Node 20 deprecation warnings from the official GitHub actions used by this workflow

## Validation

- `git diff --check`
- workflow YAML parsing
- verified every checkout/cache reference in the release workflow uses the Node 24 action version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation components to newer versions.
  * Improved reliability of caching and repository checkout steps used during TestFlight releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->