### PR TITLE
ci: fix TestFlight build distribution

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -547,7 +547,6 @@ jobs:
           set -euo pipefail
 
           fastlane_gem_home="$RUNNER_TEMP/fastlane-gems"
-          existing_gem_path=$(gem env path)
           gem install fastlane \
             --version "$FASTLANE_VERSION" \
             --install-dir "$fastlane_gem_home" \
@@ -555,12 +554,12 @@ jobs:
 
           echo "FASTLANE_BIN=$fastlane_gem_home/bin/fastlane" >> "$GITHUB_ENV"
           echo "GEM_HOME=$fastlane_gem_home" >> "$GITHUB_ENV"
-          echo "GEM_PATH=$fastlane_gem_home:$existing_gem_path" >> "$GITHUB_ENV"
+          echo "GEM_PATH=$fastlane_gem_home" >> "$GITHUB_ENV"
           echo "$fastlane_gem_home/bin" >> "$GITHUB_PATH"
 
           GEM_HOME="$fastlane_gem_home" \
-          GEM_PATH="$fastlane_gem_home:$existing_gem_path" \
-            "$fastlane_gem_home/bin/fastlane" --version
+          GEM_PATH="$fastlane_gem_home" \
+            "$fastlane_gem_home/bin/fastlane" "_${FASTLANE_VERSION}_" --version
 
       - name: Distribute build to external TestFlight group
         if: inputs.testflight_group != 'Upload only'
@@ -573,9 +572,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          "$FASTLANE_BIN" pilot distribute \
+          "$FASTLANE_BIN" "_${FASTLANE_VERSION}_" pilot distribute \
             --api_key_path "$FASTLANE_API_KEY_PATH" \
             --app_identifier "$BUNDLE_ID" \
+            --app_platform ios \
             --app_version "$VERSION" \
             --build_number "$BUILD" \
             --groups "$TESTFLIGHT_GROUP" \


### PR DESCRIPTION
## Summary

- pass `--app_platform ios` to `pilot distribute` so Fastlane does not prompt in non-interactive CI
- isolate the temporary Fastlane gem installation from system gems
- explicitly activate the pinned Fastlane version for both verification and distribution

## Root cause

The archive and App Store Connect upload succeeded, but `pilot distribute` prompted for the app platform and failed because GitHub Actions is non-interactive. The previous `GEM_PATH` also exposed system Fastlane `2.237.0`, despite installing pinned version `2.232.2`.

## Validation

- `git diff --check`
- workflow YAML parsing
- read-only review of Fastlane CLI arguments and RubyGems isolation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TestFlight release workflow reliability by using the configured Fastlane version consistently.
  * Ensured distribution runs explicitly target the iOS app platform.
  * Isolated workflow dependencies to the dedicated release environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->