### PR TITLE
ci: persist release dependency caches

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -370,8 +370,9 @@ jobs:
         with:
           version: "1.15.2"
 
-      - name: Cache CocoaPods dependencies
-        uses: actions/cache@v5
+      - name: Restore CocoaPods dependencies cache
+        id: cocoapods-cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/Library/Caches/CocoaPods
@@ -384,6 +385,15 @@ jobs:
         run: |
           set -euo pipefail
           pod _1.15.2_ install --deployment
+
+      - name: Save CocoaPods dependencies cache
+        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ${{ github.workspace }}/dashwallet-ios/Pods
+          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
 
       - name: Restore private app configuration
         env:

--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -326,9 +326,10 @@ jobs:
           set -euo pipefail
           rustup target add aarch64-apple-ios aarch64-apple-ios-sim
 
-      - name: Cache Cargo dependencies
+      - name: Restore Cargo dependencies cache
+        id: cargo-cache
         if: steps.xcframework-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/registry
@@ -355,6 +356,15 @@ jobs:
           ./build_ios.sh --target ios --target sim --profile release
           test -d DashSDKFFI.xcframework
 
+      - name: Save Cargo dependencies cache
+        if: steps.xcframework-cache.outputs.cache-hit != 'true' && steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
+
       - name: Save release XCFramework cache
         if: steps.xcframework-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
@@ -377,9 +387,7 @@ jobs:
           path: |
             ~/Library/Caches/CocoaPods
             ${{ github.workspace }}/dashwallet-ios/Pods
-          key: >-
-            cocoapods-${{ runner.os }}-${{ runner.arch }}-1.15.2-
-            ${{ hashFiles('dashwallet-ios/Podfile.lock') }}
+          key: cocoapods-${{ runner.os }}-${{ runner.arch }}-1.15.2-${{ hashFiles('dashwallet-ios/Podfile.lock') }}
 
       - name: Install CocoaPods dependencies
         run: |


### PR DESCRIPTION
## Summary

- restore Cargo and CocoaPods caches explicitly before their build/install steps
- save Cargo immediately after a successful XCFramework build
- save `Pods` and the CocoaPods download cache immediately after a successful install
- remove the accidental whitespace from the CocoaPods cache key
- preserve dependency caches even if archive, upload, or TestFlight distribution fails later

## Root cause

The prior release restored both dependency caches with misses and later failed during TestFlight distribution. The combined `actions/cache` post-steps were skipped on job failure, so neither cache was persisted for the next release.

## Validation

- `git diff --check`
- workflow YAML parsing
- `pod _1.15.2_ install --deployment`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved TestFlight build efficiency by caching Cargo and CocoaPods dependencies separately.
  * Restores dependencies before installation and saves newly generated caches only when needed.
  * Reuses existing cache keys to reduce setup time for subsequent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->