### PR TITLE
ci: wait for TestFlight build processing

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -590,19 +590,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          "$FASTLANE_BIN" "_${FASTLANE_VERSION}_" pilot distribute \
-            --api_key_path "$FASTLANE_API_KEY_PATH" \
-            --app_identifier "$BUNDLE_ID" \
-            --app_platform ios \
-            --app_version "$VERSION" \
-            --build_number "$BUILD" \
-            --groups "$TESTFLIGHT_GROUP" \
-            --distribute_external true \
-            --notify_external_testers true \
-            --submit_beta_review true \
-            --changelog "$WHAT_TO_TEST" \
-            --wait_processing_interval 30 \
-            --wait_processing_timeout_duration 7200
+          "$FASTLANE_BIN" "_${FASTLANE_VERSION}_" run upload_to_testflight \
+            api_key_path:"$FASTLANE_API_KEY_PATH" \
+            app_identifier:"$BUNDLE_ID" \
+            app_platform:ios \
+            app_version:"$VERSION" \
+            build_number:"$BUILD" \
+            distribute_only:true \
+            groups:"$TESTFLIGHT_GROUP" \
+            distribute_external:true \
+            notify_external_testers:true \
+            submit_beta_review:true \
+            changelog:"$WHAT_TO_TEST" \
+            wait_processing_interval:30 \
+            wait_processing_timeout_duration:7200
 
       - name: Write release summary
         env:


### PR DESCRIPTION
## Summary

- replace direct `pilot distribute` with the official `upload_to_testflight` action in `distribute_only` mode
- wait for the exact app version/build number and TestFlight beta details to finish processing
- distribute to the selected external group and submit Beta App Review only after processing completes

## Root cause

`pilot distribute` queried App Store Connect once, about 25 seconds after a successful upload, and failed with `No build to distribute!`. Its CLI path does not use `BuildWatcher`, so the configured processing interval and timeout were ignored.

## Validation

- `git diff --check`
- workflow YAML parsing
- verified behavior against Fastlane 2.232.2 `UploadToTestflightAction` and `Pilot::BuildManager` source