### PR TITLE
ci: verify auto-managed TestFlight build

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -635,10 +635,16 @@ jobs:
               platform: "IOS",
               limit: 30
             )
-            uploaded_build = builds
+            new_builds = builds
               .reject { |build| existing_build_ids.include?(build.id) }
               .select { |build| Time.parse(build.uploaded_date.to_s) >= upload_started_at }
-              .max_by { |build| Time.parse(build.uploaded_date.to_s) }
+            if new_builds.size > 1
+              candidates = new_builds.map { |build| "#{build.version} (#{build.id})" }.join(", ")
+              warn "::error::Multiple builds appeared after this upload: #{candidates}. Refusing to distribute an ambiguous build."
+              exit 1
+            end
+
+            uploaded_build = new_builds.first
             break if uploaded_build
 
             if Time.now >= deadline


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #1011: fail closed if more than one new App Store Connect build appears after the workflow upload.

## What was done?

The resolver now distributes only a single unambiguous build and reports all candidate IDs before failing if concurrent external uploads are detected.

## How Has This Been Tested?

- YAML parse
- embedded Ruby syntax check
- `git diff --check`

## Breaking Changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App Store build handling by detecting ambiguous upload results.
  * Reports the affected build versions and IDs instead of selecting one automatically.
  * Continues normally when exactly one matching build is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->