### PR TITLE
ci: initialize Spaceship API client

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -548,7 +548,7 @@ jobs:
           cd "$RUNNER_TEMP"
 
           "$FASTLANE_RUBY" <<'RUBY'
-          require "spaceship/connect_api"
+          require "spaceship"
 
           Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from_json_file(
             ENV.fetch("FASTLANE_API_KEY_PATH")
@@ -609,7 +609,7 @@ jobs:
           cd "$RUNNER_TEMP"
 
           "$FASTLANE_RUBY" <<'RUBY'
-          require "spaceship/connect_api"
+          require "spaceship"
           require "set"
           require "time"
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Release run 31708614460 failed before upload because importing only `spaceship/connect_api` does not initialize the shared ConnectAPI token accessor.

## What was done?

Load the full `spaceship` entrypoint in both build discovery scripts.

## How Has This Been Tested?

- reproduced `ConnectAPI.token=` missing with the narrow import
- verified `Spaceship::ConnectAPI.respond_to?(:token=)` using the pinned Fastlane 2.232.2 Ruby environment
- YAML parse and embedded Ruby syntax checks

## Breaking Changes

None.