### PR TITLE
fix(wallet): prevent multi-wallet global wipe

### DIFF
--- a/DASHSYNC_KEY_MIGRATION.md
+++ b/DASHSYNC_KEY_MIGRATION.md
@@ -122,15 +122,31 @@ A Wallets-screen Remove may route into the global wipe only after Keychain
 ground truth proves every stored wallet ID belongs to the same recovery phrase
 as the target; the currently rendered row count is not an authoritative
 last-wallet check. Enumeration or any individual mnemonic-read failure denies
-that route.
+that route. A sole rendered wallet whose removal cannot route to the reset
+flow is refused up front with an explanation, rather than walked into a
+per-wallet removal that must fail (per-wallet removal always leaves a wallet
+to switch to, enforced independently of the active-wallet registry).
 
-Recovery-phrase authorization inside the global wipe is set-wide: the typed
-phrase must match every strictly readable stored mnemonic (multiple
-network-scoped IDs for that same phrase are allowed). The plain `wipe` shortcut
-is allowed only with exactly one stored wallet ID because the published balance
-is scoped to the active wallet/network. The explicit strong acceptance phrase
-remains the global emergency override. Forgot-PIN recovery stays
-non-destructive and may prove ownership with any one stored wallet phrase.
+Recovery-phrase authorization on the recover-screen wipe path is set-wide: the
+typed phrase must match every stored mnemonic, and any unreadable entry (or an
+enumeration failure) denies authorization outright — a partially readable
+Keychain never authorizes. Multiple network-scoped IDs for the same phrase are
+allowed. A phrase that matches some but not all stored wallets is refused with
+copy that says so (it is not reported as a phrase mismatch). The plain `wipe`
+shortcut is allowed only with exactly one stored wallet ID and only while the
+active network is mainnet, because the published balance is scoped to the
+active wallet/network and cannot prove a mainnet balance while running on
+testnet. The explicit strong acceptance phrase overrides both checks on this
+path. Forgot-PIN recovery stays non-destructive and may prove ownership with
+any one stored wallet phrase.
+
+These checks live at the wipe entry points, not inside
+`DWSwiftDashSDKWalletWiper` itself. Routes that reach the wiper without any
+recovery phrase remain: the lock-screen wipe offered after repeated failed PIN
+attempts, and the dev-only Reset Wallet menu item (compile-gated out of
+Release). Any new wipe entry point must bring its own authorization.
+TODO(wipe-auth): move set-wide authorization into a single boundary in front
+of the wiper so entry points collect evidence instead of enforcing policy.
 
 ## Acceptance criteria
 
@@ -145,7 +161,7 @@ non-destructive and may prove ownership with any one stored wallet phrase.
   into the global wipe;
 - one wallet's recovery phrase cannot authorize a global wipe while a distinct
   wallet is stored, and active-network zero balance cannot authorize one while
-  any additional wallet ID is stored;
+  any additional wallet ID is stored or while the active network is testnet;
 - a successful wipe deletes all SDK-owned mnemonic/managed-wallet/active-wallet
   state, while a failed wipe reports failure without an app-side seed deletion;
 - no migration code deletes `org.dashfoundation.dash` entries;

--- a/DASHSYNC_KEY_MIGRATION.md
+++ b/DASHSYNC_KEY_MIGRATION.md
@@ -118,6 +118,20 @@ Every wipe entry point waits for the same explicit result before navigating or
 creating a replacement wallet. The frozen DashSync mnemonic keychain service
 `org.dashfoundation.dash` remains read-only and is never deleted by app wipe.
 
+A Wallets-screen Remove may route into the global wipe only after Keychain
+ground truth proves every stored wallet ID belongs to the same recovery phrase
+as the target; the currently rendered row count is not an authoritative
+last-wallet check. Enumeration or any individual mnemonic-read failure denies
+that route.
+
+Recovery-phrase authorization inside the global wipe is set-wide: the typed
+phrase must match every strictly readable stored mnemonic (multiple
+network-scoped IDs for that same phrase are allowed). The plain `wipe` shortcut
+is allowed only with exactly one stored wallet ID because the published balance
+is scoped to the active wallet/network. The explicit strong acceptance phrase
+remains the global emergency override. Forgot-PIN recovery stays
+non-destructive and may prove ownership with any one stored wallet phrase.
+
 ## Acceptance criteria
 
 - one and multiple DashSync wallets import without selecting the wrong active
@@ -127,6 +141,11 @@ creating a replacement wallet. The frozen DashSync mnemonic keychain service
 - create/import/recovery use the same host boundary;
 - create/import persist and verify the mnemonic before the wallet becomes live;
 - network switch mirrors only the active wallet while the legacy shim exists;
+- a hidden or unrestorable second wallet cannot make a row-level Remove route
+  into the global wipe;
+- one wallet's recovery phrase cannot authorize a global wipe while a distinct
+  wallet is stored, and active-network zero balance cannot authorize one while
+  any additional wallet ID is stored;
 - a successful wipe deletes all SDK-owned mnemonic/managed-wallet/active-wallet
   state, while a failed wipe reports failure without an app-side seed deletion;
 - no migration code deletes `org.dashfoundation.dash` entries;

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -261,6 +261,45 @@ final class SwiftDashSDKHost {
         }
     }
 
+    /// Count of persisted SDK wallet ids. Attributes-only Keychain
+    /// enumeration — no mnemonic secrets are read. Throws on enumeration
+    /// failure so destructive callers stay fail-closed.
+    nonisolated static func persistedWalletIdCount() throws -> Int {
+        try WalletStorage().listWalletIdsWithMnemonic().count
+    }
+
+    /// Set-wide destructive-authorization predicate: true only when `phrase`,
+    /// normalized, matches EVERY strictly readable stored mnemonic (multiple
+    /// network-scoped ids for one seed all carry the same phrase and match).
+    /// False for an empty normalized phrase or an empty wallet set —
+    /// `allSatisfy` on `[]` is vacuously true, and a walletless install must
+    /// never authorize a wipe. Throws when enumeration or any individual
+    /// mnemonic read fails. Consumers: `canWipeWithPhrase` and the
+    /// Wallets-screen reset routing.
+    nonisolated static func allStoredMnemonicsMatch(phrase: String) throws -> Bool {
+        try allMnemonicsMatch(phrase: phrase, in: strictlyPersistedMnemonics())
+    }
+
+    /// Core of `allStoredMnemonicsMatch(phrase:)` over pre-fetched `entries`,
+    /// for callers that already hold the strict enumeration (avoids a second
+    /// Keychain pass).
+    nonisolated static func allMnemonicsMatch(
+        phrase: String, in entries: [(walletId: Data, mnemonic: String)]) -> Bool {
+        let typed = Mnemonic.normalizePhrase(phrase)
+        guard !typed.isEmpty, !entries.isEmpty else { return false }
+        return entries.allSatisfy { Mnemonic.normalizePhrase($0.mnemonic) == typed }
+    }
+
+    /// Lenient any-match sibling for NON-destructive ownership checks
+    /// (forgot-PIN, honest-denial copy selection): true when `phrase` matches
+    /// at least one readable stored mnemonic; unreadable entries are skipped
+    /// (`persistedMnemonics()` semantics, errors logged there).
+    nonisolated static func anyStoredMnemonicMatches(phrase: String) -> Bool {
+        let typed = Mnemonic.normalizePhrase(phrase)
+        guard !typed.isEmpty else { return false }
+        return persistedMnemonics().contains { Mnemonic.normalizePhrase($0.mnemonic) == typed }
+    }
+
     /// Throwaway key-wallet stack (manager + wallet) for path-based key
     /// derivation, built from the persisted mnemonic of the host's active
     /// wallet. Separate from the running `PlatformWalletManager` — key

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -230,9 +230,11 @@ final class SwiftDashSDKHost {
 
     /// Every persisted SDK wallet mnemonic, keyed by its stored walletId —
     /// the same `WalletStorage` keychain surface `hasPersistedSDKWallet` reads.
-    /// Consumers: reinstall recovery (`start`'s `walletNotFound` retry) and
-    /// the wipe-with-phrase comparison. A keychain error reads as empty
-    /// (logged); an entry whose mnemonic can't be retrieved is skipped.
+    /// Consumers: reinstall recovery (`start`'s `walletNotFound` retry),
+    /// switchable-wallet discovery, and non-destructive phrase checks. A
+    /// keychain error reads as empty (logged); an entry whose mnemonic can't
+    /// be retrieved is skipped. Destructive authorization uses the strict
+    /// variant below.
     nonisolated static func persistedMnemonics() -> [(walletId: Data, mnemonic: String)] {
         do {
             let storage = WalletStorage()
@@ -244,6 +246,18 @@ final class SwiftDashSDKHost {
         } catch {
             logger.error("🪺 HOST :: mnemonic keychain enumeration failed: \(String(describing: error), privacy: .public)")
             return []
+        }
+    }
+
+    /// Strict variant for destructive authorization. Unlike
+    /// `persistedMnemonics()`, this throws when enumeration OR any individual
+    /// mnemonic read fails, so callers cannot mistake a partially readable
+    /// Keychain for the complete wallet set.
+    nonisolated static func strictlyPersistedMnemonics() throws -> [(walletId: Data, mnemonic: String)] {
+        let storage = WalletStorage()
+        return try storage.listWalletIdsWithMnemonic().map { walletId in
+            let mnemonic = try storage.retrieveMnemonic(for: walletId)
+            return (walletId: walletId, mnemonic: mnemonic)
         }
     }
 

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
@@ -118,6 +118,10 @@ class SecurityMenuViewModel: ObservableObject {
             }
         ))
         
+        // Dev-only: wipes every wallet with no phrase, bypassing the wipe
+        // authorization the release flows enforce — never ship it. Gated for
+        // dev builds of both schemes (the dashpay scheme has no DASH_TESTNET).
+        #if DEBUG || DASH_TESTNET
         menuItems.append(MenuItemModel(
             title: "Reset Wallet (Debug)",
             icon: .custom("image-menu-reset_wallet", maxHeight: 22),
@@ -125,6 +129,7 @@ class SecurityMenuViewModel: ObservableObject {
                 self?.navigationDestination = .resetWalletDebug
             }
         ))
+        #endif
 
         items = menuItems
     }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
@@ -246,16 +246,26 @@ struct WalletsScreen: View {
 
     // MARK: - Remove routing
 
-    /// The last remaining wallet routes to the existing full reset flow
-    /// (`DWResetWalletInfoViewController`), preserving today's reset semantics;
-    /// any other wallet gets the per-wallet recovery-phrase remove sheet.
+    /// A wallet whose recovery phrase provably covers every stored wallet
+    /// (Keychain ground truth) routes to the full reset flow
+    /// (`DWResetWalletInfoViewController`); a wallet with siblings on this
+    /// network gets the per-wallet recovery-phrase remove sheet. A sole
+    /// rendered wallet that can't route to reset — a distinct wallet is
+    /// stored for the other network, or the Keychain couldn't be read — is
+    /// refused up front with an explanation: the per-wallet sheet would
+    /// verify the phrase and then refuse anyway, because removal must leave
+    /// a wallet to switch to.
     private func beginRemove(_ row: WalletRow) {
         if viewModel.removalRoutesToFullReset(walletId: row.walletId) {
             let controller = DWResetWalletInfoViewController.make()
             controller.delegate = resetDelegate
             vc.pushViewController(controller, animated: true)
-        } else {
+        } else if viewModel.rows.contains(where: { $0.walletId != row.walletId }) {
             removeTarget = row
+        } else {
+            viewModel.errorMessage = NSLocalizedString(
+                "This is the only wallet on this network, but other wallet data is stored on this device (or the wallet list could not be read), so it can't be removed here. Remove the other wallet first, or add another wallet on this network.",
+                comment: "Wallets")
         }
     }
 }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -125,8 +125,6 @@ final class WalletsViewModel: ObservableObject {
     /// Cheap visibility gate for the Switch Wallet shortcut (offered while > 1).
     static var switchableWalletCount: Int { switchableWallets().count }
 
-    var hasSingleWallet: Bool { rows.count <= 1 }
-
     // MARK: - Switch
 
     /// Switch the active wallet to `walletId`, showing a progress overlay while
@@ -274,10 +272,7 @@ final class WalletsViewModel: ObservableObject {
         do {
             let entries = try SwiftDashSDKHost.strictlyPersistedMnemonics()
             guard let target = entries.first(where: { $0.walletId == walletId }) else { return false }
-            let targetMnemonic = Mnemonic.normalizePhrase(target.mnemonic)
-            return !targetMnemonic.isEmpty && entries.allSatisfy {
-                Mnemonic.normalizePhrase($0.mnemonic) == targetMnemonic
-            }
+            return SwiftDashSDKHost.allMnemonicsMatch(phrase: target.mnemonic, in: entries)
         } catch {
             Self.logger.error("last-wallet proof failed; refusing global reset: \(String(describing: error), privacy: .public)")
             return false
@@ -307,7 +302,10 @@ final class WalletsViewModel: ObservableObject {
 
     /// Remove `walletId` from this device (this device's copy only — funds stay
     /// recoverable with the phrase). Precondition (enforced by the screen): the
-    /// recovery phrase was verified, and this is NOT the last wallet.
+    /// recovery phrase was verified, and another wallet exists on this network
+    /// to switch to — also re-checked here, independent of the registry's
+    /// active id, so a stale registry can never let the only rendered wallet
+    /// be hard-deleted outside the reset flow.
     ///
     /// If `walletId` is the active wallet, auto-switch to any other wallet
     /// first (await the rebind) so the runtime never ends up bound to a
@@ -319,14 +317,16 @@ final class WalletsViewModel: ObservableObject {
         removeInProgress = true
         defer { removeInProgress = false }
 
+        guard let other = rows.first(where: { $0.walletId != walletId })?.walletId else {
+            // No other wallet on this network — per-wallet removal must leave
+            // a wallet to switch to. The screen refuses this case up front
+            // (`beginRemove`); this bail is defense in depth.
+            Self.logger.error("removeWallet: refusing to remove the only wallet on this network")
+            errorMessage = NSLocalizedString("Cannot remove the last wallet here.", comment: "Wallets")
+            return
+        }
+
         if walletId == activeWalletId() {
-            guard let other = rows.first(where: { $0.walletId != walletId })?.walletId else {
-                // No other wallet — the screen routes the last wallet to the
-                // full reset flow instead of calling this. Bail defensively.
-                Self.logger.error("removeWallet: refusing to remove the only wallet")
-                errorMessage = NSLocalizedString("Cannot remove the last wallet here.", comment: "Wallets")
-                return
-            }
             switchInProgress = true
             do {
                 try await SwiftDashSDKWalletRuntime.shared.switchWallet(to: other)

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -264,12 +264,24 @@ final class WalletsViewModel: ObservableObject {
 
     // MARK: - Remove
 
-    /// Whether removing `walletId` requires routing to the full reset flow —
-    /// true only when it is the sole remaining wallet. The screen presents
-    /// `DWResetWalletInfoViewController` in that case (preserving today's
-    /// last-wallet reset semantics); otherwise it drives `removeWallet`.
+    /// Whether removing `walletId` may route to the GLOBAL reset flow. The
+    /// reset deletes every SDK mnemonic, including wallets that are not
+    /// loaded/rendered on the current network, so `rows.count` is not a safe
+    /// last-wallet test. Prove from Keychain ground truth that every stored
+    /// wallet id resolves to the same recovery phrase as the target. Any
+    /// enumeration/read failure returns false (fail closed).
     func removalRoutesToFullReset(walletId: Data) -> Bool {
-        rows.count <= 1
+        do {
+            let entries = try SwiftDashSDKHost.strictlyPersistedMnemonics()
+            guard let target = entries.first(where: { $0.walletId == walletId }) else { return false }
+            let targetMnemonic = Mnemonic.normalizePhrase(target.mnemonic)
+            return !targetMnemonic.isEmpty && entries.allSatisfy {
+                Mnemonic.normalizePhrase($0.mnemonic) == targetMnemonic
+            }
+        } catch {
+            Self.logger.error("last-wallet proof failed; refusing global reset: \(String(describing: error), privacy: .public)")
+            return false
+        }
     }
 
     /// Derive the walletId of `mnemonic` on the current network WITHOUT

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
@@ -12,6 +12,7 @@
 //
 
 import Foundation
+import OSLog
 import SwiftDashSDK
 
 // Cached BIP-39 wordlist membership sets, composed once from the SDK's
@@ -33,45 +34,90 @@ private let dwAllLanguagesWordSet: Set<String> = MnemonicLanguage.allCases
         union.formUnion(Mnemonic.wordList(language: language))
     }
 
+private let dwRecoverLogger = Logger(
+    subsystem: "org.dashfoundation.dash",
+    category: "recover-wipe")
+
 extension DWRecoverModel {
-    /// The plain-"wipe" gate (C6-D): empty means "zero SDK balance AND the
-    /// chain is fully synced" — an unsynced wallet can't prove it's empty, so
-    /// it reads as non-empty (fail-closed; the strong accept-phrase remains
-    /// the override). Replaces the DashSync read (`wallet.balance` + frozen
+    /// The plain-"wipe" gate: empty means "zero SDK balance AND the chain is
+    /// fully synced" — an unsynced wallet can't prove it's empty, so it reads
+    /// as non-empty (fail-closed; the strong accept-phrase remains the
+    /// override). Replaces the DashSync read (`wallet.balance` + frozen
     /// `lastSyncBlockTimestamp`/`lastSyncBlockHeight`), which post-M6 never
     /// advanced and made this permanently false — the plain-"wipe" phrase was
-    /// always refused. The literal shortcut is permitted only when Keychain
-    /// proves there is exactly one stored wallet id; the published balance is
-    /// active-wallet state and cannot prove that another wallet or network is
-    /// empty.
+    /// always refused. The literal shortcut is additionally permitted only
+    /// when Keychain proves there is exactly one stored wallet id AND the
+    /// active network is mainnet: the published balance is active-wallet,
+    /// active-network state, so it can prove neither another wallet's balance
+    /// nor the same seed's mainnet balance while running on testnet. The
+    /// cheap in-memory checks run first; the id count is an attributes-only
+    /// Keychain enumeration (no mnemonic secrets are read). Enumeration
+    /// failure denies (logged).
     @objc(isWalletEmpty)
     func isWalletEmpty() -> Bool {
-        guard let entries = try? SwiftDashSDKHost.strictlyPersistedMnemonics(),
-              entries.count == 1 else { return false }
-        guard let balance = SwiftDashSDKWalletState.shared.balance else { return false }
-        return balance.total == 0 && SyncingActivityMonitor.shared.state == .syncDone
+        guard let balance = SwiftDashSDKWalletState.shared.balance,
+              balance.total == 0,
+              SyncingActivityMonitor.shared.state == .syncDone,
+              WalletEnvironment.isMainnet else { return false }
+        do {
+            return try SwiftDashSDKHost.persistedWalletIdCount() == 1
+        } catch {
+            dwRecoverLogger.error("plain-wipe gate: wallet-id count failed; refusing: \(String(describing: error), privacy: .public)")
+            return false
+        }
     }
 
-    /// Authorizes the GLOBAL wipe with a recovery phrase (C6-D): the typed
-    /// phrase, normalized, must match EVERY stored SDK mnemonic. Multiple
-    /// network-scoped ids for the same seed are allowed; a distinct second
-    /// wallet blocks authorization. Enumeration or any individual read failure
-    /// also blocks it, so a partially readable Keychain can never be mistaken
+    /// The plain-"wipe" shortcut is mainnet-only (see `isWalletEmpty`). Lets
+    /// the wipe screen explain a testnet denial honestly instead of claiming
+    /// the wallet is not empty.
+    @objc(plainWipeAllowedOnCurrentNetwork)
+    func plainWipeAllowedOnCurrentNetwork() -> Bool {
+        WalletEnvironment.isMainnet
+    }
+
+    /// True when more than one wallet id is stored — the reason the plain
+    /// "wipe" shortcut (and a single wallet's phrase) can be refused. Lets
+    /// the wipe screen explain a denial honestly instead of blaming balance
+    /// or the phrase. Enumeration failure reads as false (the generic denial
+    /// copy applies; logged).
+    @objc(hasMultipleStoredWalletIds)
+    func hasMultipleStoredWalletIds() -> Bool {
+        do {
+            return try SwiftDashSDKHost.persistedWalletIdCount() > 1
+        } catch {
+            dwRecoverLogger.error("wallet-id count failed: \(String(describing: error), privacy: .public)")
+            return false
+        }
+    }
+
+    /// Authorizes the GLOBAL wipe with a recovery phrase: the typed phrase,
+    /// normalized, must match EVERY stored SDK mnemonic
+    /// (`SwiftDashSDKHost.allStoredMnemonicsMatch`). Multiple network-scoped
+    /// ids for the same seed are allowed; a distinct second wallet blocks
+    /// authorization. Enumeration or any individual read failure also blocks
+    /// it (logged), so a partially readable Keychain can never be mistaken
     /// for the complete wallet set. Phrase→seed is deterministic, but no key
-    /// material is derived here. The strong accept-phrase remains the explicit
-    /// override.
-    /// The literal-"wipe" arm of the old method was dead here — the caller
-    /// (`DWRecoverContentView.wipeWithPhrase:`) routes `DW_WIPE` to
-    /// `isWalletEmpty` before ever reaching this check.
+    /// material is derived here. The strong accept-phrase remains the
+    /// explicit override; the caller (`DWRecoverContentView.wipeWithPhrase:`)
+    /// routes the literal `DW_WIPE` shortcut to `isWalletEmpty` before this
+    /// check.
     @objc(canWipeWithPhrase:)
     func canWipeWithPhrase(_ phrase: String) -> Bool {
-        let typed = Mnemonic.normalizePhrase(phrase)
-        guard !typed.isEmpty else { return false }
-        guard let entries = try? SwiftDashSDKHost.strictlyPersistedMnemonics(),
-              !entries.isEmpty else { return false }
-        return entries.allSatisfy { entry in
-            Mnemonic.normalizePhrase(entry.mnemonic) == typed
+        do {
+            return try SwiftDashSDKHost.allStoredMnemonicsMatch(phrase: phrase)
+        } catch {
+            dwRecoverLogger.error("wipe-with-phrase: keychain read failed; refusing: \(String(describing: error), privacy: .public)")
+            return false
         }
+    }
+
+    /// True when `phrase` matches at least one readable stored mnemonic — a
+    /// non-destructive ownership signal. Backs the forgot-PIN check and the
+    /// wipe screen's honest-denial copy (the typed phrase matches one wallet
+    /// of several, so the set-wide wipe authorization refused it).
+    @objc(phraseMatchesAnyStoredWallet:)
+    func phraseMatchesAnyStoredWallet(_ phrase: String) -> Bool {
+        SwiftDashSDKHost.anyStoredMnemonicMatches(phrase: phrase)
     }
 
     /// Non-destructive forgot-PIN ownership check. Any one persisted wallet's
@@ -80,11 +126,7 @@ extension DWRecoverModel {
     /// whose global destructive action must account for the complete set.
     @objc(canResetPinWithPhrase:)
     func canResetPinWithPhrase(_ phrase: String) -> Bool {
-        let typed = Mnemonic.normalizePhrase(phrase)
-        guard !typed.isEmpty else { return false }
-        return SwiftDashSDKHost.persistedMnemonics().contains { entry in
-            Mnemonic.normalizePhrase(entry.mnemonic) == typed
-        }
+        phraseMatchesAnyStoredWallet(phrase)
     }
 
     @objc(phraseIsValid:)

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
@@ -40,24 +40,46 @@ extension DWRecoverModel {
     /// the override). Replaces the DashSync read (`wallet.balance` + frozen
     /// `lastSyncBlockTimestamp`/`lastSyncBlockHeight`), which post-M6 never
     /// advanced and made this permanently false — the plain-"wipe" phrase was
-    /// always refused.
+    /// always refused. The literal shortcut is permitted only when Keychain
+    /// proves there is exactly one stored wallet id; the published balance is
+    /// active-wallet state and cannot prove that another wallet or network is
+    /// empty.
     @objc(isWalletEmpty)
     func isWalletEmpty() -> Bool {
+        guard let entries = try? SwiftDashSDKHost.strictlyPersistedMnemonics(),
+              entries.count == 1 else { return false }
         guard let balance = SwiftDashSDKWalletState.shared.balance else { return false }
         return balance.total == 0 && SyncingActivityMonitor.shared.state == .syncDone
     }
 
-    /// Authorizes a wipe with the wallet's own recovery phrase (C6-D): the
-    /// typed phrase, normalized, must equal a persisted SDK mnemonic
-    /// (normalized). Equivalent to the old DashSync check — a transient
-    /// wallet's BIP32/BIP44 xpub comparison — because BIP39 phrase→seed is
-    /// deterministic, but derives no key material. No persisted SDK mnemonic
-    /// ⇒ false (fail-closed; the strong accept-phrase still allows a wipe).
+    /// Authorizes the GLOBAL wipe with a recovery phrase (C6-D): the typed
+    /// phrase, normalized, must match EVERY stored SDK mnemonic. Multiple
+    /// network-scoped ids for the same seed are allowed; a distinct second
+    /// wallet blocks authorization. Enumeration or any individual read failure
+    /// also blocks it, so a partially readable Keychain can never be mistaken
+    /// for the complete wallet set. Phrase→seed is deterministic, but no key
+    /// material is derived here. The strong accept-phrase remains the explicit
+    /// override.
     /// The literal-"wipe" arm of the old method was dead here — the caller
     /// (`DWRecoverContentView.wipeWithPhrase:`) routes `DW_WIPE` to
     /// `isWalletEmpty` before ever reaching this check.
     @objc(canWipeWithPhrase:)
     func canWipeWithPhrase(_ phrase: String) -> Bool {
+        let typed = Mnemonic.normalizePhrase(phrase)
+        guard !typed.isEmpty else { return false }
+        guard let entries = try? SwiftDashSDKHost.strictlyPersistedMnemonics(),
+              !entries.isEmpty else { return false }
+        return entries.allSatisfy { entry in
+            Mnemonic.normalizePhrase(entry.mnemonic) == typed
+        }
+    }
+
+    /// Non-destructive forgot-PIN ownership check. Any one persisted wallet's
+    /// phrase is sufficient because resetting the app-global PIN keeps every
+    /// wallet intact. This deliberately differs from `canWipeWithPhrase`,
+    /// whose global destructive action must account for the complete set.
+    @objc(canResetPinWithPhrase:)
+    func canResetPinWithPhrase(_ phrase: String) -> Bool {
         let typed = Mnemonic.normalizePhrase(phrase)
         guard !typed.isEmpty else { return false }
         return SwiftDashSDKHost.persistedMnemonics().contains { entry in

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.h
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.h
@@ -38,8 +38,8 @@ extern NSInteger const DW_PHRASE_MULTIPLE;
 /// keychain restore, interrupted setup) is "set".
 - (BOOL)hasPinSet;
 
-// `isWalletEmpty`, `canWipeWithPhrase:`, `cleanupPhrase:`, `normalizePhrase:`,
-// `wordIsLocal:`, `wordIsValid:` are provided by the Swift extension
+// `isWalletEmpty`, wipe/reset-PIN phrase authorization, and mnemonic helpers
+// are provided by the Swift extension
 // `DWRecoverModel+Mnemonic.swift` (SwiftDashSDK) and reach Obj-C callers
 // through the generated `dashwallet-Swift.h`.
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
@@ -50,7 +50,7 @@ NSInteger const DW_PHRASE_MULTIPLE = 3;
 }
 
 // `isWalletEmpty`, wipe/reset-PIN phrase authorization, and mnemonic helpers
-// live in DWRecoverModel+Mnemonic.swift — C6-D.
+// live in DWRecoverModel+Mnemonic.swift.
 
 - (void)wipeWallet {
     [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:YES];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
@@ -49,8 +49,8 @@ NSInteger const DW_PHRASE_MULTIPLE = 3;
     return [[DWAuthenticationService shared] hasPin];
 }
 
-// `isWalletEmpty` and `canWipeWithPhrase:` live in DWRecoverModel+Mnemonic.swift
-// (SDK balance + sync-done gate; normalized-phrase comparison) — C6-D.
+// `isWalletEmpty`, wipe/reset-PIN phrase authorization, and mnemonic helpers
+// live in DWRecoverModel+Mnemonic.swift — C6-D.
 
 - (void)wipeWallet {
     [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:YES];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
@@ -218,6 +218,22 @@ NS_ASSUME_NONNULL_BEGIN
     [self showAlertWithTitle:nil message:message];
 }
 
+- (void)recoverContentViewWipeBlockedByMultipleWallets:(DWRecoverContentView *)view {
+    NSString *title = NSLocalizedString(@"Multiple wallets are stored on this device", nil);
+    NSString *message = [NSString stringWithFormat:
+                                      NSLocalizedString(@"Wiping would erase all of them, so a single wallet's recovery phrase is not enough. To erase every wallet on this device please input: \"%@\"", nil),
+                                      self.model.wipeAcceptPhrase];
+    [self showAlertWithTitle:title message:message];
+}
+
+- (void)recoverContentViewWipeShortcutUnavailableOnTestnet:(DWRecoverContentView *)view {
+    NSString *title = NSLocalizedString(@"The \"wipe\" shortcut is not available on testnet", nil);
+    NSString *message = [NSString stringWithFormat:
+                                      NSLocalizedString(@"A zero testnet balance cannot prove this wallet is empty on mainnet. Enter the recovery phrase, or input: \"%@\"", nil),
+                                      self.model.wipeAcceptPhrase];
+    [self showAlertWithTitle:title message:message];
+}
+
 - (void)recoverContentView:(DWRecoverContentView *)view phraseDidChange:(NSString *)phrase {
     BOOL isPhraseValid = [phrase wordsCount] >= 10;
     [self.actionButton setEnabled:isPhraseValid];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.h
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)recoverContentViewPerformWipe:(DWRecoverContentView *)view;
 - (void)recoverContentViewWipeNotAllowed:(DWRecoverContentView *)view;
 - (void)recoverContentViewWipeNotAllowedPhraseMismatch:(DWRecoverContentView *)view;
+- (void)recoverContentViewWipeBlockedByMultipleWallets:(DWRecoverContentView *)view;
+- (void)recoverContentViewWipeShortcutUnavailableOnTestnet:(DWRecoverContentView *)view;
 
 @end
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
@@ -252,6 +252,16 @@ NS_ASSUME_NONNULL_BEGIN
             if ([self.model isWalletEmpty]) {
                 [self.delegate recoverContentViewPerformWipe:self];
             }
+            else if ([self.model hasMultipleStoredWalletIds]) {
+                // The shortcut is refused because of the stored-wallet count,
+                // not balance/sync — the "not empty" copy would be false.
+                [self.delegate recoverContentViewWipeBlockedByMultipleWallets:self];
+            }
+            else if (![self.model plainWipeAllowedOnCurrentNetwork]) {
+                // Mainnet-only shortcut: a zero testnet balance can't prove
+                // the seed's mainnet balance is empty.
+                [self.delegate recoverContentViewWipeShortcutUnavailableOnTestnet:self];
+            }
             else {
                 [self.delegate recoverContentViewWipeNotAllowed:self];
             }
@@ -262,6 +272,12 @@ NS_ASSUME_NONNULL_BEGIN
         else {
             if ([self.model canWipeWithPhrase:phrase]) {
                 [self.delegate recoverContentViewPerformWipe:self];
+            }
+            else if ([self.model phraseMatchesAnyStoredWallet:phrase]) {
+                // The phrase does match a stored wallet — just not all of
+                // them, so the set-wide wipe authorization refused it. Saying
+                // "doesn't match" here would be false and alarming.
+                [self.delegate recoverContentViewWipeBlockedByMultipleWallets:self];
             }
             else if (phrase) {
                 [self.delegate recoverContentViewWipeNotAllowedPhraseMismatch:self];

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
         // wallet; anything else (including the wipe magic words) is a mismatch.
         // Isolated from the wipe machinery so no wallet is ever erased here.
         if (self.model.action == DWRecoverAction_ResetPin) {
-            if ([self.model canWipeWithPhrase:phrase]) {
+            if ([self.model canResetPinWithPhrase:phrase]) {
                 [self.delegate recoverContentViewDidVerifyPhraseForPinReset:self];
             }
             else {


### PR DESCRIPTION
## Summary

- require strict Keychain enumeration before a Wallets-screen removal may enter the global reset flow
- require a recovery phrase to match every stored SDK wallet before authorizing a global wipe
- allow the plain `wipe` shortcut only when exactly one wallet ID is stored
- keep forgotten-PIN recovery non-destructive by using a separate any-wallet ownership check

## Root cause

The Wallets screen treated its rendered row count as the complete wallet inventory, but the global reset deletes SDK mnemonics across networks, including wallets not loaded in the current view. The recovery flow also accepted a phrase matching any persisted wallet, and its zero-balance shortcut checked only the active wallet. Together, those paths could authorize deleting a distinct second wallet.

## Safety behavior

Destructive authorization now fails closed if wallet enumeration or any mnemonic read fails. Multiple network-scoped IDs remain valid when they all resolve to the same recovery phrase.

## Verification

- canonical `dashpay` arm64 simulator build passed
- changed Swift sources passed `swiftc -parse`
- Xcode project passed `plutil -lint`
- staged patch passed `git diff --check`
- unit tests were not run because the repository's test target is documented as pre-existing broken


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Strengthened authorization for full wallet resets by validating all stored wallet recovery phrases.
  - Destructive reset actions now fail safely when wallet information is missing, unreadable, hidden, or inconsistent.
  - Updated recovery checks to account for multiple stored wallets and distinct recovery phrases.

- **Bug Fixes**
  - Reset PIN verification now uses the correct recovery-phrase validation rules.
  - Improved handling of wallet-empty checks and recovery flows when wallet data cannot be confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->