### PR TITLE
fix: close nine crash and concurrency paths found after the TestFlight reports

### DIFF
--- a/DashWallet/Sources/Application/Tools.swift
+++ b/DashWallet/Sources/Application/Tools.swift
@@ -20,6 +20,13 @@ import Foundation
 private let formatterLock = NSLock()
 private var _cachedFormatters: [String: NumberFormatter] = [:]
 
+/// Guards the two lazily built singletons below. Deliberately not
+/// `formatterLock`: the `fiatFormatter` getter calls
+/// `fiatFormatter(currencyCode:)`, which takes that lock, and `NSLock` is not
+/// recursive. Nothing under `formatterLock` reaches back for this one, so the
+/// two never interleave.
+private let sharedFormatterLock = NSLock()
+
 private var _decimalFormatter: NumberFormatter!
 private var _fiatFormatter: NumberFormatter!
 private var _dashFormatter: NumberFormatter = {
@@ -80,6 +87,9 @@ private var _csvDashFormatter: NumberFormatter = {
 extension NumberFormatter {
 
     static var decimalFormatter: NumberFormatter {
+        sharedFormatterLock.lock()
+        defer { sharedFormatterLock.unlock() }
+
         guard let formatter = _decimalFormatter else {
             let formatter = NumberFormatter()
             formatter.isLenient = true
@@ -106,6 +116,9 @@ extension NumberFormatter {
     /// - Returns:`NumberFormatter`
     ///
     static var fiatFormatter: NumberFormatter {
+        sharedFormatterLock.lock()
+        defer { sharedFormatterLock.unlock() }
+
         if let fiatFormatter = _fiatFormatter, fiatFormatter.currencyCode == App.fiatCurrency {
             return fiatFormatter
         }

--- a/DashWallet/Sources/Categories/String+DashWallet.swift
+++ b/DashWallet/Sources/Categories/String+DashWallet.swift
@@ -71,7 +71,7 @@ extension String {
         let attributedString = NSMutableAttributedString(string: self)
 
         let locale = Locale.current
-        let decimalSeparator = locale.decimalSeparator!
+        let decimalSeparator = locale.decimalSeparator ?? "."
         let insufficientFractionDigits = decimalSeparator + "00"
         let defaultAttributes = [NSAttributedString.Key.foregroundColor: textColor]
 

--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -141,11 +141,45 @@ extension UIViewController {
             if let sdkLogsZip {
                 activityItems.append(sdkLogsZip)
             }
-            let activityViewController = UIActivityViewController(
-                activityItems: activityItems,
-                applicationActivities: nil
-            )
-            present(activityViewController, animated: true)
+            dw_presentActivityViewController(activityItems: activityItems)
         }
+    }
+}
+
+extension UIViewController {
+    /// Presents a share sheet, supplying the anchor that iPad requires:
+    /// there `UIActivityViewController` is always presented as a popover, and
+    /// a popover with neither `sourceView` nor `barButtonItem` throws
+    /// `NSInvalidArgumentException` from `presentationTransitionWillBegin` —
+    /// a hard crash. iPhone never hits it because the sheet is modal there.
+    ///
+    /// Callers with a tapped control pass it as `sourceView` (plus its
+    /// `bounds` as `sourceRect`). Callers driven from SwiftUI have no UIKit
+    /// sender, so the default anchors an arrow-less popover at the centre of
+    /// this controller's view.
+    func dw_presentActivityViewController(
+        activityItems: [Any],
+        sourceView: UIView? = nil,
+        sourceRect: CGRect? = nil,
+        completion: (() -> Void)? = nil
+    ) {
+        let activityViewController = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+
+        if let popover = activityViewController.popoverPresentationController {
+            let anchor = sourceView ?? view!
+            popover.sourceView = anchor
+
+            if let sourceRect {
+                popover.sourceRect = sourceRect
+            } else {
+                popover.sourceRect = CGRect(x: anchor.bounds.midX, y: anchor.bounds.midY, width: 0, height: 0)
+                popover.permittedArrowDirections = []
+            }
+        }
+
+        present(activityViewController, animated: true, completion: completion)
     }
 }

--- a/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
+++ b/DashWallet/Sources/Infrastructure/Database/DatabaseConnection.swift
@@ -55,9 +55,17 @@ class DatabaseConnection: NSObject {
         // one's bookkeeping insert throws mid-chain and every later migration is skipped.
         // (Shipped once: a no-op `SeedDB` duplicating 20250418145536 left fresh installs
         // without any table added after that version, e.g. `swap_orders`.)
+        // Thrown, not asserted: assertions are compiled out under
+        // `ENABLE_NS_ASSERTIONS = NO` in Release and TestFlight, which is
+        // where the duplicate would actually ship. The insert fails there on
+        // its own, but as an opaque SQLite constraint error — this names the
+        // cause in the log `AppDelegate` writes.
         let versions = migrationManager.migrations.map(\.version)
-        assert(Set(versions).count == versions.count,
-               "Duplicate migration versions: \(versions.sorted())")
+        guard Set(versions).count == versions.count else {
+            throw NSError(domain: "DatabaseConnection", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Duplicate migration versions: \(versions.sorted())"
+            ])
+        }
 
         if !migrationManager.hasMigrationsTable() {
             try migrationManager.createMigrationsTable()

--- a/DashWallet/Sources/Models/Coinbase/Accounts/AccountRepository.swift
+++ b/DashWallet/Sources/Models/Coinbase/Accounts/AccountRepository.swift
@@ -73,7 +73,10 @@ class AccountRepository {
         while endpoint != nil {
             let response: BasePaginationResponse<CoinbaseUserAccountData> = try await CoinbaseAPI.shared.request(endpoint!)
             items += response.data
-                .filter { $0.currency.type == .crypto && $0.balance.amount.decimal()! > 0 }
+                // `balance.amount` is a string straight out of the Coinbase
+                // response; anything Decimal can't parse is treated as no
+                // balance rather than force-unwrapped into a crash.
+                .filter { $0.currency.type == .crypto && ($0.balance.amount.decimal() ?? 0) > 0 }
                 .map { .init(info: $0, authInterop: authInterop) }
 
             if let nextUri = response.pagination.nextURI, !nextUri.isEmpty {

--- a/DashWallet/Sources/Models/Coinbase/Auth/Services/CBSecureTokenService.swift
+++ b/DashWallet/Sources/Models/Coinbase/Auth/Services/CBSecureTokenService.swift
@@ -25,7 +25,10 @@ class CBSecureTokenService: Codable {
     private(set) var accessTokenExpirationDate: Date
 
     private var httpClient: CoinbaseAPI { CoinbaseAPI.shared }
-    private var tokenRefreshTask: Task<Void, any Error>?
+    /// Every Coinbase request routes through `refreshTokenIfNeeded`, so
+    /// parallel requests reach this service at once; the actor keeps them to
+    /// one refresh and owns the task this class cannot hold safely.
+    private let tokenRefreshActor = TokenRefreshActor()
 
     init(accessToken: String, refreshToken: String, accessTokenExpirationDate: Date) {
         self.accessToken = accessToken
@@ -38,28 +41,19 @@ class CBSecureTokenService: Codable {
     }
 
     func refreshAccessToken() async throws {
-        if let task = tokenRefreshTask {
-            try await task.value
-            return
-        }
-
         if hasValidAccessToken &&
             accessTokenExpirationDate.timeIntervalSince1970 - Date().timeIntervalSince1970 > 300 {
             return
         }
 
-        tokenRefreshTask = Task {
-            defer {
-                tokenRefreshTask = nil
-            }
+        try await tokenRefreshActor.refreshToken(label: "Coinbase") { [weak self] in
+            guard let self else { return }
 
-            let result: CoinbaseTokenResponse = try await httpClient.request(.refreshToken(refreshToken: refreshToken))
-            accessToken = result.accessToken
-            refreshToken = result.refreshToken
-            accessTokenExpirationDate = result.expirationDate
+            let result: CoinbaseTokenResponse = try await self.httpClient.request(.refreshToken(refreshToken: self.refreshToken))
+            self.accessToken = result.accessToken
+            self.refreshToken = result.refreshToken
+            self.accessTokenExpirationDate = result.expirationDate
         }
-
-        try await tokenRefreshTask!.value
     }
 
     func revokeAccessToken() async throws {

--- a/DashWallet/Sources/Models/Explore Dash/Model/Entites/ExplorePointOfUse.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Model/Entites/ExplorePointOfUse.swift
@@ -80,7 +80,10 @@ extension ExplorePointOfUse {
 
         let merchantId: String
         let paymentMethod: PaymentMethod
-        let type: `Type`
+        /// `nil` when the synced database carries a `type` this build doesn't
+        /// know — a category added server-side, or a NULL. Unknown stays
+        /// unknown rather than being mapped onto one of the three cases.
+        let type: `Type`?
         let deeplink: String?
         let savingsBasisPoints: Int // in basis points 1 = 0.001%
         let denominationsType: String?
@@ -88,7 +91,7 @@ extension ExplorePointOfUse {
         let redeemType: String?
         let giftCardProviders: [GiftCardProviderInfo]
         
-        init(merchantId: String, paymentMethod: PaymentMethod, type: `Type`, deeplink: String?, savingsBasisPoints: Int, denominationsType: String?, denominations: [Int] = [], redeemType: String?, giftCardProviders: [GiftCardProviderInfo] = []) {
+        init(merchantId: String, paymentMethod: PaymentMethod, type: `Type`?, deeplink: String?, savingsBasisPoints: Int, denominationsType: String?, denominations: [Int] = [], redeemType: String?, giftCardProviders: [GiftCardProviderInfo] = []) {
             self.merchantId = merchantId
             self.paymentMethod = paymentMethod
             self.type = type
@@ -162,7 +165,9 @@ extension ExplorePointOfUse {
         }
 
         let manufacturer: String
-        let type: `Type`
+        /// `nil` when the row carries no `type` at all; a non-empty but
+        /// unrecognized value still resolves through `Type.init(rawValue:)`.
+        let type: `Type`?
     }
 }
 
@@ -247,13 +252,21 @@ extension ExplorePointOfUse: RowDecodable {
     static let redeemType = Expression<String?>("redeemType")
 
     init(row: Row) {
-        let name = row[ExplorePointOfUse.name]
+        // The explore database is generated server-side and none of its text
+        // columns are declared NOT NULL, so every column here can arrive as
+        // NULL. SQLite.swift's subscript for a non-optional `Expression` is
+        // `try! get(column)`, which aborts the process on NULL (and on a
+        // column the synced schema no longer carries) — `try? row.get` is the
+        // same read without that trap, and is what this initializer already
+        // used for `phone`, `logoLocation` and `coverImage`.
+        let name = (try? row.get(ExplorePointOfUse.name)) ?? ""
 
         let id = row[ExplorePointOfUse.id]
-        let active = row[ExplorePointOfUse.active]
+        // `active` is `INTEGER DEFAULT 1` in the schema; absent means active.
+        let active = (try? row.get(ExplorePointOfUse.active)) ?? true
 
         let city = row[ExplorePointOfUse.city]
-        let territory = row[ExplorePointOfUse.territory]
+        let territory = try? row.get(ExplorePointOfUse.territory)
         let address1 = row[ExplorePointOfUse.address1]
         let address2 = row[ExplorePointOfUse.address2]
         let address3 = row[ExplorePointOfUse.address3]
@@ -273,20 +286,23 @@ extension ExplorePointOfUse: RowDecodable {
         let phone: String? = try? row.get(ExplorePointOfUse.phone)?.digits
         let logoLocation: String? = try? row.get(ExplorePointOfUse.logoLocation)
         let coverImage: String? = try? row.get(ExplorePointOfUse.coverImage)
-        let source: String? = row[ExplorePointOfUse.source]
+        let source: String? = try? row.get(ExplorePointOfUse.source)
 
         let category: Category
         if let paymentMethodRaw = try? row.get(ExplorePointOfUse.paymentMethod) {
-            let merchantId = row[ExplorePointOfUse.merchantId]
-            let type: Merchant.`Type`! = .init(rawValue: row[ExplorePointOfUse.type])
+            let merchantId = (try? row.get(ExplorePointOfUse.merchantId)) ?? ""
+            // Written through an annotated binding: spelled out in full,
+            // `Merchant.`Type`` parses as the metatype and `.init(rawValue:)`
+            // doesn't resolve against it.
+            let type: Merchant.`Type`? = (try? row.get(ExplorePointOfUse.type)).flatMap { .init(rawValue: $0) }
             let deeplink = row[ExplorePointOfUse.deeplink]
-            let savingsPercentage = row[ExplorePointOfUse.savingPercentage]
+            let savingsPercentage = (try? row.get(ExplorePointOfUse.savingPercentage)) ?? 0
             let denominationsType = row[ExplorePointOfUse.denominationsType]
             let redeemType = row[ExplorePointOfUse.redeemType]
             category = .merchant(Merchant(merchantId: merchantId, paymentMethod: Merchant.PaymentMethod(rawValue: paymentMethodRaw)!,
                                           type: type, deeplink: deeplink, savingsBasisPoints: savingsPercentage, denominationsType: denominationsType, denominations: [], redeemType: redeemType, giftCardProviders: []))
         } else if let manufacturer = try? row.get(ExplorePointOfUse.manufacturer) {
-            let type: Atm.`Type`! = .init(rawValue: row[ExplorePointOfUse.type])
+            let type: Atm.`Type`? = (try? row.get(ExplorePointOfUse.type)).flatMap { .init(rawValue: $0) }
             category = .atm(Atm(manufacturer: manufacturer, type: type))
         } else {
             category = .unknown

--- a/DashWallet/Sources/Models/Explore Dash/Services/DashSpend/CTX/CTXSpendTokenService.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/DashSpend/CTX/CTXSpendTokenService.swift
@@ -29,7 +29,7 @@ protocol CTXSpendTokenProvider: AnyObject {
 class CTXSpendTokenService {
     static let shared = CTXSpendTokenService()
     
-    private var tokenRefreshTask: Task<Void, Error>?
+    private let tokenRefreshActor = TokenRefreshActor()
     private weak var tokenProvider: CTXSpendTokenProvider?
     
     private init() {}
@@ -39,12 +39,6 @@ class CTXSpendTokenService {
     }
     
     func refreshAccessToken() async throws {
-        // If there's already a refresh task running, wait for it
-        if let task = tokenRefreshTask {
-            try await task.value
-            return
-        }
-
         guard let tokenProvider = tokenProvider else {
             return
         }
@@ -53,11 +47,11 @@ class CTXSpendTokenService {
             return
         }
 
-        tokenRefreshTask = Task {
-            defer {
-                tokenRefreshTask = nil
-            }
-
+        // The actor both serializes concurrent callers — `CTXSpendAPI.request`
+        // funnels every 401 here, and gift-card screens issue several requests
+        // at once — and owns the in-flight task, which a plain property on this
+        // non-isolated class could not do safely.
+        try await tokenRefreshActor.refreshToken(label: "CTXSpend") {
             DWLogger.log("CTXSpend: Attempting to refresh access token")
 
             do {
@@ -77,7 +71,5 @@ class CTXSpendTokenService {
                 throw DashSpendError.tokenRefreshFailed
             }
         }
-
-        try await tokenRefreshTask!.value
     }
 } 

--- a/DashWallet/Sources/Models/Explore Dash/Services/DashSpend/PiggyCards/PiggyCardsTokenService.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/DashSpend/PiggyCards/PiggyCardsTokenService.swift
@@ -39,9 +39,15 @@ final class PiggyCardsTokenService {
     /// Thread-safe token refresh with automatic retry prevention
     func refreshAccessToken() async throws {
         // Use actor to ensure thread-safe, single refresh operation
-        try await tokenRefreshActor.refreshToken { [weak self] in
+        try await tokenRefreshActor.refreshToken(label: "PiggyCards") { [weak self] in
             guard let self = self else { throw DashSpendError.tokenRefreshFailed }
-            return try await self.performAutoLogin()
+
+            guard try await self.performAutoLogin() else {
+                DWLogger.log("PiggyCards: Token refresh failed")
+                throw DashSpendError.tokenRefreshFailed
+            }
+
+            DWLogger.log("PiggyCards: Token refresh completed successfully")
         }
     }
     
@@ -85,40 +91,37 @@ final class PiggyCardsTokenService {
 
 // MARK: - Thread-Safe Token Refresh Actor
 
-/// Actor ensures thread-safe token refresh operations
-/// Prevents concurrent refresh attempts that could cause API rate limiting
-private actor TokenRefreshActor {
-    private var isRefreshing = false
-    private var refreshTask: Task<Bool, Error>?
+/// Serializes token refreshes for one service: concurrent callers join the
+/// single in-flight attempt instead of each starting its own. Shared by every
+/// token service that refreshes from more than one API call at a time —
+/// PiggyCards, CTXSpend and Coinbase — because a plain stored `Task` property
+/// on a non-isolated class is a data race there, and force-unwrapping it after
+/// a competing caller's `defer` cleared it is a crash.
+actor TokenRefreshActor {
+    private var refreshTask: Task<Void, Error>?
 
-    func refreshToken(_ performRefresh: @escaping () async throws -> Bool) async throws {
+    /// - Parameters:
+    ///   - label: service name, used for the log line when a caller joins a
+    ///     refresh that is already running.
+    ///   - performRefresh: the refresh itself; throws to report failure.
+    func refreshToken(label: String, _ performRefresh: @escaping () async throws -> Void) async throws {
         // If already refreshing, wait for the existing task
         if let existingTask = refreshTask {
-            DWLogger.log("PiggyCards: Token refresh already in progress, waiting...")
-            _ = try await existingTask.value
+            DWLogger.log("\(label): Token refresh already in progress, waiting...")
+            try await existingTask.value
             return
         }
 
         // Start new refresh task
-        refreshTask = Task {
-            defer {
-                refreshTask = nil
-                isRefreshing = false
-            }
+        let task = Task { try await performRefresh() }
+        refreshTask = task
 
-            isRefreshing = true
-            let success = try await performRefresh()
-
-            if success {
-                DWLogger.log("PiggyCards: Token refresh completed successfully")
-            } else {
-                DWLogger.log("PiggyCards: Token refresh failed")
-                throw DashSpendError.tokenRefreshFailed
-            }
-
-            return success
+        do {
+            try await task.value
+            refreshTask = nil
+        } catch {
+            refreshTask = nil
+            throw error
         }
-
-        _ = try await refreshTask!.value
     }
 }

--- a/DashWallet/Sources/UI/CrowdNode/Online/CrowdNodeWebViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Online/CrowdNodeWebViewController.swift
@@ -76,7 +76,12 @@ class CrowdNodeWebViewController: BaseViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
                 if state == .linkedOnline {
-                    self?.navigationController?.replaceLast(3, with: CrowdNodePortalController.controller())
+                    // Both routes here end at the portal with nothing behind
+                    // it: entry from the shortcut starts on the portal itself
+                    // (two screens deep by now), entry from Getting Started is
+                    // three. Set the stack instead of counting screens off it.
+                    self?.navigationController?
+                        .setViewControllers([CrowdNodePortalController.controller()], animated: true)
                 }
             }
             .store(in: &cancellableBag)

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -205,8 +205,10 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     private func shareCurrentAddress() {
         guard let address = viewModel.currentAddress else { return }
-        let share = UIActivityViewController(activityItems: [address], applicationActivities: nil)
-        present(share, animated: true)
+        // The share control lives in the SwiftUI hierarchy, so there is no
+        // sender view to anchor to — the helper's centred default carries the
+        // popover anchor iPad requires.
+        dw_presentActivityViewController(activityItems: [address])
     }
 
     private func pushSpecifyAmount() {

--- a/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
+++ b/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
@@ -232,9 +232,15 @@ extension UINavigationController {
         viewControllers.first(where: { $0 is T })
     }
     
+    /// Replaces the last `n` controllers with `controller`, dropping the whole
+    /// stack when `n` exceeds it. Callers count the screens their own flow
+    /// pushed, but the same screen can be reached with a shallower stack —
+    /// CrowdNode opens on whichever controller matches the account state, so
+    /// its flows can start one or two levels below what the caller assumed —
+    /// and `removeLast` traps rather than throwing when `n` is too large.
     func replaceLast(_ n: Int = 1, with controller: UIViewController, animated: Bool = true) {
         var viewControllers = viewControllers
-        viewControllers.removeLast(n)
+        viewControllers.removeLast(min(n, viewControllers.count))
         viewControllers.append(controller)
         setViewControllers(viewControllers, animated: animated)
     }

--- a/DashWallet/Sources/Utils/TimeUtils.swift
+++ b/DashWallet/Sources/Utils/TimeUtils.swift
@@ -71,11 +71,26 @@ class TimeUtils {
                         return
                     }
                     
+                    // A datagram connection hands back whatever arrived, so
+                    // `minimumIncompleteLength` is not a floor here: a runt or
+                    // rewritten packet (captive portal, spoofed reply to this
+                    // ephemeral port) is delivered with no error, and indexing
+                    // past its end traps instead of throwing.
+                    // Copied into an array so the offsets below are positions
+                    // in the packet: `Data` subscripting is absolute, and a
+                    // sliced `Data` does not start at 0.
+                    let packet = [UInt8](message)
+
+                    guard packet.count >= 44 else {
+                        safeResume(with: nil)
+                        return
+                    }
+
                     // Parse the NTP response.
-                    let seconds = Int64(message[40]) << 24 |
-                        Int64(message[41]) << 16 |
-                        Int64(message[42]) << 8 |
-                        Int64(message[43])
+                    let seconds = Int64(packet[40]) << 24 |
+                        Int64(packet[41]) << 16 |
+                        Int64(packet[42]) << 8 |
+                        Int64(packet[43])
                     
                     let result = (seconds - 2_208_988_800) * 1000
                     safeResume(with: result)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two crash reports came in from TestFlight 9.0.0 (builds 25 and 28):

- an iPad user crashed on "share address" with `NSInvalidArgumentException` from `-[UIPopoverPresentationController presentationTransitionWillBegin]`;
- an iPhone user hit `SIGABRT` inside the Rust SDK — that one is fixed upstream in dashpay/rust-dashcore#955 and is **not** part of this PR.

Auditing the codebase for the same defect classes turned up five more crash paths reachable from ordinary use, plus four dangerous patterns whose reachability took longer to establish. None of them can be caught by a `do`/`catch`: every one is a trap or an abort, not a thrown error.

## What was done?

Three commits, readable independently.

**`fix(payments)` — the reported iPad crash.** On iPad `UIActivityViewController` is always presented as a popover, and a popover with neither `sourceView` nor `barButtonItem` throws when the presentation begins. The anchor lives in a new `dw_presentActivityViewController` helper rather than at the call site, because the support-log share had the same gap; both callers come from SwiftUI and have no sender view, so the helper anchors an arrow-less popover at the centre by default and accepts an explicit view or rect when one exists.

**`fix` — five crash paths.**

| Where | What aborts |
|---|---|
| `ExplorePointOfUse.init(row:)` | `Merchant.Type(rawValue:)` is the one enum in the file without a catch-all; its `nil` was passed as a non-optional argument. A merchant category added server-side aborts the app for everyone on the next database sync. `type` is now optional on `Merchant` and `Atm` — unknown stays unknown instead of being mapped onto an existing case. |
| `ExplorePointOfUse.init(row:)` | No text column in that schema is `NOT NULL`, and SQLite.swift's subscript for a non-optional `Expression` is `try! get(column)` — it aborts on `NULL` and on a column a synced schema no longer carries. The affected columns now read through `try? row.get`, as this initializer already did for `phone`, `logoLocation` and `coverImage`. |
| `TimeUtils` | The NTP reply was indexed at offsets 40-43 with no length check. `minimumIncompleteLength` is not a floor for UDP, so a runt or rewritten datagram (a captive portal intercepting 123/udp) arrives with no error and traps. Reachable from `HomeView.onAppear` on every visit. |
| `AccountRepository.all` | `balance.amount` from the Coinbase JSON was force-unwrapped through `Decimal(string:)`; unparseable now counts as no balance instead of taking down the accounts screen. |
| `CrowdNodeWebViewController` | `replaceLast(3)` assumed the Getting Started route's stack depth; entering from the home shortcut leaves two controllers and `removeLast(3)` traps. The call site sets the stack directly, and `replaceLast` clamps `n`, which also closes the same mismatch in `NewAccountViewController`. |

**`fix` — token refresh and three latent traps.** `CTXSpendTokenService` and `CBSecureTokenService` stored the in-flight refresh `Task` in a plain property on a non-isolated class and force-unwrapped it, with real concurrent callers on both sides (`CTXSpendAPI` funnels every 401 into the first; every Coinbase request reaches the second through `refreshTokenIfNeeded`). `PiggyCardsTokenService` already solved this with a private actor, so that actor is promoted to internal and reused by all three rather than copied. Also: `locale.decimalSeparator!` on the amount-entry path now falls back to `"."` as the sibling helper in the same file does; the two formatter singletons in `Tools` take a lock, as the cache beside them already does; and the duplicate-migration-version check throws instead of asserting, so it survives `ENABLE_NS_ASSERTIONS = NO` in Release and TestFlight and names the cause in the log.

## How Has This Been Tested?

- `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` — succeeds.
- The `URL(string:)` behaviour behind a sixth reported candidate was checked against the current Foundation parser and did not reproduce, so that one is deliberately not changed.
- No device or simulator run of the touched flows yet: the CrowdNode path needs an existing linked account, and the Explore paths need a synced database carrying the offending row. The unit-test target is broken on this branch (pre-existing), so nothing here is covered by automated tests.

Worth a reviewer's eye: the `Merchant.type` / `Atm.type` optionality ripples into eight comparison sites (`m.type == .online` and friends). They all keep compiling because comparing an optional against a case is still valid, and a row with an unknown type now reads as "not online" — the behaviour on merchants we can't classify is a product call, not a mechanical one.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
