### PR TITLE
fix(wallet): confirm global multi-wallet wipes

### DIFF
--- a/DASHSYNC_KEY_MIGRATION.md
+++ b/DASHSYNC_KEY_MIGRATION.md
@@ -140,13 +140,16 @@ testnet. The explicit strong acceptance phrase overrides both checks on this
 path. Forgot-PIN recovery stays non-destructive and may prove ownership with
 any one stored wallet phrase.
 
-These checks live at the wipe entry points, not inside
-`DWSwiftDashSDKWalletWiper` itself. Routes that reach the wiper without any
-recovery phrase remain: the lock-screen wipe offered after repeated failed PIN
-attempts, and the dev-only Reset Wallet menu item (compile-gated out of
-Release). Any new wipe entry point must bring its own authorization.
-TODO(wipe-auth): move set-wide authorization into a single boundary in front
-of the wiper so entry points collect evidence instead of enforcing policy.
+Every call to `DWSwiftDashSDKWalletWiper` supplies an explicit authorization
+reason. Recovery-screen wipes use `.recoveryFlow`; screenshot-triggered wallet
+replacement uses `.screenshotReplacement`; and phrase-less global deletion
+uses `.confirmedDeleteAll`. The post-reinstall and lock-screen routes obtain a
+strict count of distinct stored recovery phrases and, when more than one is
+present, name that count and require an explicit Delete All confirmation. A
+Keychain inventory error never produces the destructive action. The dev-only
+Reset All Wallets item uses the same all-wallet confirmation wording. Any new
+wipe entry point must collect one of these authorizations before invoking the
+wiper.
 
 ## Acceptance criteria
 

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -268,6 +268,26 @@ final class SwiftDashSDKHost {
         try WalletStorage().listWalletIdsWithMnemonic().count
     }
 
+    /// Number of logical wallets represented by the strict Keychain inventory.
+    /// The same recovery phrase may be stored under separate network-scoped
+    /// wallet ids; those entries count as one wallet in destructive UI copy.
+    /// Throws when enumeration or any mnemonic read fails so callers can fall
+    /// back to non-destructive retry/keep actions.
+    nonisolated static func distinctStoredWalletCount() throws -> Int {
+        distinctWalletCount(in: try strictlyPersistedMnemonics())
+    }
+
+    /// Pure logical-wallet count used after a strict inventory read. Separate
+    /// network-scoped ids carrying the same normalized phrase are one wallet.
+    nonisolated static func distinctWalletCount(
+        in entries: [(walletId: Data, mnemonic: String)]
+    ) -> Int {
+        let phrases = entries.map {
+            Mnemonic.normalizePhrase($0.mnemonic)
+        }
+        return Set(phrases).count
+    }
+
     /// Set-wide destructive-authorization predicate: true only when `phrase`,
     /// normalized, matches EVERY strictly readable stored mnemonic (multiple
     /// network-scoped ids for one seed all carry the same phrase and match).

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -17,6 +17,29 @@ import Foundation
 import OSLog
 import SwiftDashSDK
 
+/// Why a caller is allowed to request a global wallet wipe. Requiring an
+/// explicit value keeps phrase-authorized recovery, an honest user-confirmed
+/// delete-all action, and setup-time wallet replacement distinguishable at the
+/// destructive boundary and in logs.
+@objc(DWSwiftDashSDKWalletWipeAuthorization)
+enum SwiftDashSDKWalletWipeAuthorization: Int {
+    case recoveryFlow
+    case confirmedDeleteAll
+    case screenshotReplacement
+
+    fileprivate var removesPin: Bool {
+        self != .screenshotReplacement
+    }
+
+    fileprivate var logLabel: String {
+        switch self {
+        case .recoveryFlow: return "recovery-flow"
+        case .confirmedDeleteAll: return "confirmed-delete-all"
+        case .screenshotReplacement: return "screenshot-replacement"
+        }
+    }
+}
+
 /// Serializes full-wallet wipes and provides a FIFO barrier for callers that
 /// must not continue while a wipe is still mutating Keychain/runtime state.
 ///
@@ -95,14 +118,18 @@ final class SwiftDashSDKWalletWiper: NSObject {
 
     // MARK: - Public entry point
 
-    /// Starts a full app/SDK-owned wipe. PIN removal is part of the successful
-    /// wipe commit: a failed SDK deletion leaves both wallet material and its
-    /// authentication state available for retry. Callers observe completion
-    /// through `waitForPendingWipe`.
-    @objc(wipeWalletRemovingPin:)
-    static func wipeWallet(removingPin: Bool) {
+    /// Starts a full app/SDK-owned wipe for an explicitly identified
+    /// authorization path. Whether the PIN is removed is part of that path,
+    /// rather than an independently selectable flag: a failed SDK deletion
+    /// leaves both wallet material and its authentication state available for
+    /// retry. Callers observe completion through `waitForPendingWipe`.
+    @objc(wipeWalletWithAuthorization:)
+    static func wipeWallet(authorization: SwiftDashSDKWalletWipeAuthorization) {
+        logger.notice("global wipe requested; authorization=\(authorization.logLabel, privacy: .public)")
         wipeExecutor.enqueue {
-            performWipe(removingPin: removingPin)
+            performWipe(
+                removingPin: authorization.removesPin,
+                authorization: authorization)
         }
     }
 
@@ -123,7 +150,10 @@ final class SwiftDashSDKWalletWiper: NSObject {
     ///
     /// Idempotent. Reports failure when enumeration or any per-wallet SDK
     /// deletion fails, leaving runtime/registry state available for retry.
-    private static func performWipe(removingPin: Bool) -> Bool {
+    private static func performWipe(
+        removingPin: Bool,
+        authorization: SwiftDashSDKWalletWipeAuthorization
+    ) -> Bool {
         let startedAt = ContinuousClock.now
 
         // Classify the global Keychain inventory by its network-derived wallet
@@ -183,7 +213,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
 
         let elapsed = startedAt.duration(to: .now)
         logger.info(
-            "wiped SwiftDashSDK wallets across mainnet/testnet in \(String(describing: elapsed), privacy: .public)")
+            "wiped SwiftDashSDK wallets across mainnet/testnet in \(String(describing: elapsed), privacy: .public); authorization=\(authorization.logLabel, privacy: .public)")
 
         // Tear down the app-owned runtime now that all wallet material is
         // gone. This stops BLAST/SPV, drops the host-owned manager/wallet, and

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.h
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, DWLockScreenViewControllerUnlockMode) {
 @protocol DWLockScreenViewControllerDelegate <NSObject>
 
 - (void)lockScreenViewControllerDidUnlock:(DWLockScreenViewController *)controller;
+/// The support-assisted global wipe has already completed successfully.
 - (void)lockScreenViewControllerDidWipe:(DWLockScreenViewController *)controller;
 
 @end

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -235,8 +235,24 @@ static CGFloat ActionButtonsHeight(void) {
             if (strongSelf == nil) {
                 return;
             }
-            [strongSelf.delegate lockScreenViewControllerDidWipe:strongSelf];
+            [strongSelf presentSupportWipeRecovery];
         }];
+}
+
+- (void)presentSupportWipeRecovery {
+    DWRecoverViewController *controller = [[DWRecoverViewController alloc] init];
+    controller.action = DWRecoverAction_SupportWipe;
+    controller.delegate = self;
+    UIBarButtonItem *cancelButton =
+        [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                      target:self
+                                                      action:@selector(forgotPinRecoveryCancelAction:)];
+    controller.navigationItem.rightBarButtonItem = cancelButton;
+
+    DWNavigationController *navigationController =
+        [[DWNavigationController alloc] initWithRootViewController:controller];
+    navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
+    [self presentViewController:navigationController animated:YES completion:nil];
 }
 
 #pragma mark - DWRecoverViewControllerDelegate
@@ -251,10 +267,16 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (void)recoverViewControllerDidWipe:(DWRecoverViewController *)controller {
-    // Unreachable in ResetPin mode (wipe is offered by the lock screen's own
-    // action sheet, not this screen). Implemented for protocol conformance; if
-    // it ever fires, fail loud in debug and recover safely in release.
-    NSAssert(NO, @"ResetPin recovery never wipes; wipe is the lock screen's own path");
+    if (controller.action == DWRecoverAction_SupportWipe) {
+        [self dismissViewControllerAnimated:YES
+                                 completion:^{
+                                     [self.delegate lockScreenViewControllerDidWipe:self];
+                                 }];
+        return;
+    }
+
+    // ResetPin verifies ownership but never deletes wallet data.
+    NSAssert(NO, @"ResetPin recovery never wipes");
     [self dismissViewControllerAnimated:YES
                              completion:^{
                                  [self.model startCheckingAuthState];

--- a/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
+++ b/DashWallet/Sources/UI/LockScreen/DWLockScreenViewController.m
@@ -179,7 +179,7 @@ static CGFloat ActionButtonsHeight(void) {
                                                 handler:^(UIAlertAction *action) {
                                                     [self presentPinResetRecovery];
                                                 }]];
-        [sheet addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Wipe wallet", nil)
+        [sheet addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Wipe All Wallets", nil)
                                                   style:UIAlertActionStyleDestructive
                                                 handler:^(UIAlertAction *action) {
                                                     [self confirmWipeWallet];
@@ -223,21 +223,20 @@ static CGFloat ActionButtonsHeight(void) {
 }
 
 - (void)confirmWipeWallet {
-    UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:NSLocalizedString(@"Wipe wallet", nil)
-                         message:NSLocalizedString(@"This will erase this wallet from this device. You can only restore it with your recovery phrase.", nil)
-                  preferredStyle:UIAlertControllerStyleAlert];
-    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
-                                              style:UIAlertActionStyleCancel
-                                            handler:^(UIAlertAction *action) {
-                                                [self.model startCheckingAuthState];
-                                            }]];
-    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Wipe wallet", nil)
-                                              style:UIAlertActionStyleDestructive
-                                            handler:^(UIAlertAction *action) {
-                                                [self.delegate lockScreenViewControllerDidWipe:self];
-                                            }]];
-    [self presentViewController:alert animated:YES completion:nil];
+    __weak typeof(self) weakSelf = self;
+    [DWWalletDeleteAllConfirmationCoordinator
+        presentFrom:self
+        cancelHandler:^{
+            typeof(self) strongSelf = weakSelf;
+            [strongSelf.model startCheckingAuthState];
+        }
+        deleteAllHandler:^{
+            typeof(self) strongSelf = weakSelf;
+            if (strongSelf == nil) {
+                return;
+            }
+            [strongSelf.delegate lockScreenViewControllerDidWipe:strongSelf];
+        }];
 }
 
 #pragma mark - DWRecoverViewControllerDelegate

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -87,13 +87,13 @@ struct SecurityMenuScreen: View {
         } message: {
             Text(biometricsAlertMessage)
         }
-        .alert("Reset Wallet (Debug)", isPresented: $showResetWalletDebugAlert) {
+        .alert("Reset All Wallets (Debug)", isPresented: $showResetWalletDebugAlert) {
             Button("Cancel", role: .cancel) { }
-            Button("Wipe", role: .destructive) {
+            Button("Delete All", role: .destructive) {
                 delegateInternal.beginWipeWallet()
             }
         } message: {
-            Text("Wipes the wallet immediately without asking for the recovery phrase.")
+            Text("Permanently deletes all wallets on this device without asking for their recovery phrases.")
         }
     }
     
@@ -198,8 +198,8 @@ extension SecurityMenuScreen {
                 wipeDelegate.beginWipeWallet?()
             } else {
                 // This screen can be embedded without the app-root delegate in
-                // previews. Preserve the legacy local behavior in that case.
-                DWRecoverModel(action: .wipe).wipeWallet()
+                // previews. Preserve the local delete-all behavior in that case.
+                SwiftDashSDKWalletWiper.wipeWallet(authorization: .confirmedDeleteAll)
                 onHide()
             }
         }

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
@@ -123,7 +123,7 @@ class SecurityMenuViewModel: ObservableObject {
         // dev builds of both schemes (the dashpay scheme has no DASH_TESTNET).
         #if DEBUG || DASH_TESTNET
         menuItems.append(MenuItemModel(
-            title: "Reset Wallet (Debug)",
+            title: "Reset All Wallets (Debug)",
             icon: .custom("image-menu-reset_wallet", maxHeight: 22),
             action: { [weak self] in
                 self?.navigationDestination = .resetWalletDebug

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -462,10 +462,9 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
     self.lockWindow.hidden = YES;
     self.lockWindow.alpha = 1.0;
 
-    // Use the same HUD + FIFO completion gate as Debug Reset. Navigating to
-    // onboarding before the SDK wipe result would let a failed deletion expose
-    // create/recover controls while the old wallet is still present.
-    [self beginWipeWallet];
+    // The support recovery controller reports success only after the serial
+    // wiper has completed. Transition to setup without issuing a second wipe.
+    [self didWipeWallet];
 }
 
 #pragma mark - Notifications

--- a/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWAppRootViewController.m
@@ -355,11 +355,11 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
     _mainController = nil;
 }
 
-/// Debug Reset's coordinated wipe path. Unlike the legacy `didWipeWallet`
-/// notification, this transitions to the setup screen BEFORE deleting state,
-/// then blocks that screen with a HUD until the SDK wiper's FIFO barrier has
-/// completed. This avoids displaying a tappable-looking onboarding screen
-/// while synchronous SDK deletion still occupies MainActor.
+/// Coordinated path for an already-confirmed Delete All. Unlike the legacy
+/// `didWipeWallet` notification, this transitions to the setup screen BEFORE
+/// deleting state, then blocks that screen with a HUD until the SDK wiper's
+/// FIFO barrier has completed. This avoids displaying a tappable-looking
+/// onboarding screen while synchronous SDK deletion still occupies MainActor.
 - (void)beginWipeWallet {
     if (self.walletWipeInProgress) {
         return;
@@ -373,7 +373,7 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
     [self.model.homeModel walletDidWipe];
     _mainController = nil;
 
-    [setupController.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting Wallet…", nil)];
+    [setupController.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting All Wallets…", nil)];
 
     __weak typeof(self) weakSelf = self;
     // The SDK delete is synchronous on MainActor. Let UIKit commit the setup
@@ -403,8 +403,8 @@ static NSTimeInterval const UNLOCK_ANIMATION_DURATION = 0.25;
 
 - (void)presentWalletWipeFailure {
     UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Couldn’t Delete Wallet", nil)
-                                            message:NSLocalizedString(@"The wallet is still stored on this device. Please try again.", nil)
+        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Couldn’t Delete All Wallets", nil)
+                                            message:NSLocalizedString(@"Not all wallets could be deleted. Please try again.", nil)
                                      preferredStyle:UIAlertControllerStyleAlert];
 
     __weak typeof(self) weakSelf = self;

--- a/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
@@ -94,18 +94,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onboardingViewControllerDidFinish:(DWOnboardingViewController *)controller {
     [self onboardingDidFinish];
 
-    // Reinstall detection: if SDK wallet keychain material survived while
-    // UserDefaults did not, ask whether to keep or delete it.
-    // while UserDefaults didn't, the default transition to
-    // `DWAppRootViewController` would jump straight to the wallet home
-    // without ever asking the user. Gate the transition behind a Keep/Delete
-    // prompt, mirroring the SwiftExampleApp orphan-mnemonic UX. (Delete
-    // Keep lets the SDK host recover the persisted wallet.)
-    if (!DWWalletEnvironment.hasWallet) {
-        [self transitionToAppRoot];
-        return;
-    }
-
+    // Reinstall detection must use the coordinator's strict, set-wide
+    // inventory. The old Boolean presence check treated a Keychain read error
+    // as "no wallet" and could skip the Keep/Delete All prompt entirely.
     __weak typeof(self) weakSelf = self;
     [DWKeychainWalletRecoveryCoordinator
         presentReinstallKeepOrDeleteChoiceFrom:controller
@@ -123,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)deleteRecoveredWalletThenTransitionFromController:(UIViewController *)controller {
-    [controller.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting Wallet…", nil)];
+    [controller.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting All Wallets…", nil)];
 
     __weak typeof(self) weakSelf = self;
     // `PlatformWalletManager.deleteWallet` is synchronous and blocks the main
@@ -139,7 +130,8 @@ NS_ASSUME_NONNULL_BEGIN
 
         // SDK Keychain/runtime deletion and the successful PIN commit run as
         // one operation on the app-owned serial wipe executor.
-        [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:YES];
+        [DWSwiftDashSDKWalletWiper
+            wipeWalletWithAuthorization:DWSwiftDashSDKWalletWipeAuthorizationConfirmedDeleteAll];
 
         [DWSwiftDashSDKWalletWiper waitForPendingWipeWithCompletion:^(BOOL wipeSucceeded) {
             typeof(self) completedSelf = weakSelf;
@@ -158,8 +150,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)presentRecoveredWalletDeleteFailureFromController:(UIViewController *)controller {
     UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Couldn’t Delete Wallet", nil)
-                                            message:NSLocalizedString(@"The wallet is still stored on this device. Please try again.", nil)
+        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Couldn’t Delete All Wallets", nil)
+                                            message:NSLocalizedString(@"Not all wallets could be deleted. Please try again.", nil)
                                      preferredStyle:UIAlertControllerStyleAlert];
 
     __weak typeof(self) weakSelf = self;

--- a/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWInitialViewController.m
@@ -20,8 +20,8 @@
 #import "DWAppRootViewController.h"
 #import "DWGlobalOptions.h"
 #import "DWOnboardingViewController.h"
+#import "DWRecoverViewController.h"
 #import "DWUIKit.h"
-#import "UIView+DWHUD.h"
 #import "dashwallet-Swift.h"
 
 #if SNAPSHOT
@@ -30,10 +30,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface DWInitialViewController () <DWOnboardingViewControllerDelegate>
+@interface DWInitialViewController () <DWOnboardingViewControllerDelegate, DWRecoverViewControllerDelegate>
 
 @property (nonatomic, assign) BOOL launchingWasDeferred;
 @property (nullable, nonatomic, strong) DWAppRootViewController *rootController;
+@property (nullable, nonatomic, weak) UIViewController *reinstallWalletChoiceController;
 
 #if DASHPAY
 @property (nullable, nonatomic, strong) NSURL *deferredDeeplink;
@@ -94,6 +95,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)onboardingViewControllerDidFinish:(DWOnboardingViewController *)controller {
     [self onboardingDidFinish];
 
+    [self presentReinstallWalletChoiceFromController:controller];
+}
+
+- (void)presentReinstallWalletChoiceFromController:(UIViewController *)controller {
+    self.reinstallWalletChoiceController = controller;
+
     // Reinstall detection must use the coordinator's strict, set-wide
     // inventory. The old Boolean presence check treated a Keychain read error
     // as "no wallet" and could skip the Keep/Delete All prompt entirely.
@@ -106,64 +113,65 @@ NS_ASSUME_NONNULL_BEGIN
                                             return;
                                         }
                                         if (!keep) {
-                                            [strongSelf deleteRecoveredWalletThenTransitionFromController:controller];
+                                            [strongSelf presentReinstallSupportWipeFromController:controller];
                                             return;
                                         }
+                                        strongSelf.reinstallWalletChoiceController = nil;
                                         [strongSelf transitionToAppRoot];
                                     }];
 }
 
-- (void)deleteRecoveredWalletThenTransitionFromController:(UIViewController *)controller {
-    [controller.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting All Wallets…", nil)];
+- (void)presentReinstallSupportWipeFromController:(UIViewController *)host {
+    DWRecoverViewController *controller = [[DWRecoverViewController alloc] init];
+    controller.action = DWRecoverAction_SupportWipe;
+    controller.delegate = self;
+    UIBarButtonItem *cancelButton =
+        [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                      target:self
+                                                      action:@selector(reinstallSupportWipeCancelAction:)];
+    controller.navigationItem.rightBarButtonItem = cancelButton;
 
-    __weak typeof(self) weakSelf = self;
-    // `PlatformWalletManager.deleteWallet` is synchronous and blocks the main
-    // thread. Give UIKit enough time to commit the HUD's first frame before
-    // starting the wipe; a zero-delay main-queue dispatch can still run before
-    // the current render pass and leave the user staring at a frozen screen.
-    dispatch_time_t startTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC));
-    dispatch_after(startTime, dispatch_get_main_queue(), ^{
-        typeof(self) strongSelf = weakSelf;
-        if (strongSelf == nil) {
-            return;
-        }
-
-        // SDK Keychain/runtime deletion and the successful PIN commit run as
-        // one operation on the app-owned serial wipe executor.
-        [DWSwiftDashSDKWalletWiper
-            wipeWalletWithAuthorization:DWSwiftDashSDKWalletWipeAuthorizationConfirmedDeleteAll];
-
-        [DWSwiftDashSDKWalletWiper waitForPendingWipeWithCompletion:^(BOOL wipeSucceeded) {
-            typeof(self) completedSelf = weakSelf;
-            if (completedSelf == nil) {
-                return;
-            }
-            [controller.view dw_hideProgressHUD];
-            if (!wipeSucceeded) {
-                [completedSelf presentRecoveredWalletDeleteFailureFromController:controller];
-                return;
-            }
-            [completedSelf transitionToAppRoot];
-        }];
-    });
+    DWNavigationController *navigationController =
+        [[DWNavigationController alloc] initWithRootViewController:controller];
+    navigationController.modalPresentationStyle = UIModalPresentationFullScreen;
+    [host presentViewController:navigationController animated:YES completion:nil];
 }
 
-- (void)presentRecoveredWalletDeleteFailureFromController:(UIViewController *)controller {
-    UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Couldn’t Delete All Wallets", nil)
-                                            message:NSLocalizedString(@"Not all wallets could be deleted. Please try again.", nil)
-                                     preferredStyle:UIAlertControllerStyleAlert];
-
+- (void)reinstallSupportWipeCancelAction:(id)sender {
+    UIViewController *host = self.reinstallWalletChoiceController;
+    if (host == nil) {
+        return;
+    }
     __weak typeof(self) weakSelf = self;
-    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Retry", nil)
-                                              style:UIAlertActionStyleDefault
-                                            handler:^(UIAlertAction *_Nonnull action) {
-                                                typeof(self) strongSelf = weakSelf;
-                                                if (strongSelf != nil) {
-                                                    [strongSelf deleteRecoveredWalletThenTransitionFromController:controller];
-                                                }
-                                            }]];
-    [controller presentViewController:alert animated:YES completion:nil];
+    [host dismissViewControllerAnimated:YES
+                             completion:^{
+                                 typeof(self) strongSelf = weakSelf;
+                                 if (strongSelf != nil) {
+                                     [strongSelf presentReinstallWalletChoiceFromController:host];
+                                 }
+                             }];
+}
+
+#pragma mark - DWRecoverViewControllerDelegate
+
+- (void)recoverViewControllerDidWipe:(DWRecoverViewController *)controller {
+    NSAssert(controller.action == DWRecoverAction_SupportWipe, @"Only support wipe is presented during reinstall");
+    UIViewController *host = self.reinstallWalletChoiceController;
+    self.reinstallWalletChoiceController = nil;
+    if (host == nil) {
+        [self transitionToAppRoot];
+        return;
+    }
+    [host dismissViewControllerAnimated:YES
+                             completion:^{
+                                 [self transitionToAppRoot];
+                             }];
+}
+
+- (void)recoverViewControllerDidRecoverWallet:(DWRecoverViewController *)controller
+                               recoverCommand:(DWRecoverWalletCommand *)recoverCommand {
+    NSAssert(NO, @"Support wipe never recovers a wallet");
+    [self reinstallSupportWipeCancelAction:nil];
 }
 
 - (void)transitionToAppRoot {

--- a/DashWallet/Sources/UI/RootNavigation/DWRootModel.m
+++ b/DashWallet/Sources/UI/RootNavigation/DWRootModel.m
@@ -98,7 +98,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)wipeWallet {
-    [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:YES];
+    [DWSwiftDashSDKWalletWiper
+        wipeWalletWithAuthorization:DWSwiftDashSDKWalletWipeAuthorizationConfirmedDeleteAll];
 }
 
 #pragma mark - Notifications

--- a/DashWallet/Sources/UI/RootNavigation/DWWipeDelegate.h
+++ b/DashWallet/Sources/UI/RootNavigation/DWWipeDelegate.h
@@ -23,9 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)didWipeWallet;
 
-/// Begin a full wipe from a live app screen. Implementers that support this
-/// optional path must first present the onboarding wipe gate, then trigger the
-/// destructive wipe after the gate's progress HUD has rendered.
+/// Begin a full wipe after the user has explicitly confirmed Delete All.
+/// Implementers that support this optional path first present the onboarding
+/// wipe gate, then trigger the destructive wipe after its progress HUD renders.
 @optional
 - (void)beginWipeWallet;
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverAction.h
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverAction.h
@@ -25,6 +25,10 @@ typedef NS_ENUM(NSUInteger, DWRecoverAction) {
     // keep the wallet untouched (no re-import, no re-sync, no data loss). The
     // caller drives the Set-PIN step; this screen only gates on the phrase.
     DWRecoverAction_ResetPin,
+    // Rare support-assisted fallback for users who no longer have either the
+    // PIN or their recovery phrase. Unlike the regular Wipe flow, this mode
+    // accepts the localized acknowledgement phrase supplied by support.
+    DWRecoverAction_SupportWipe,
 };
 
 #endif /* DWRecoverAction_h */

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
@@ -41,8 +41,8 @@ private let dwRecoverLogger = Logger(
 extension DWRecoverModel {
     /// The plain-"wipe" gate: empty means "zero SDK balance AND the chain is
     /// fully synced" — an unsynced wallet can't prove it's empty, so it reads
-    /// as non-empty (fail-closed; the strong accept-phrase remains the
-    /// override). Replaces the DashSync read (`wallet.balance` + frozen
+    /// as non-empty (fail-closed; an exact recovery phrase remains available).
+    /// Replaces the DashSync read (`wallet.balance` + frozen
     /// `lastSyncBlockTimestamp`/`lastSyncBlockHeight`), which post-M6 never
     /// advanced and made this permanently false — the plain-"wipe" phrase was
     /// always refused. The literal shortcut is additionally permitted only
@@ -97,10 +97,9 @@ extension DWRecoverModel {
     /// authorization. Enumeration or any individual read failure also blocks
     /// it (logged), so a partially readable Keychain can never be mistaken
     /// for the complete wallet set. Phrase→seed is deterministic, but no key
-    /// material is derived here. The strong accept-phrase remains the
-    /// explicit override; the caller (`DWRecoverContentView.wipeWithPhrase:`)
-    /// routes the literal `DW_WIPE` shortcut to `isWalletEmpty` before this
-    /// check.
+    /// material is derived here. The support acknowledgement is deliberately
+    /// isolated in `DWRecoverAction_SupportWipe`; the regular caller routes the
+    /// literal `DW_WIPE` shortcut to `isWalletEmpty` before this check.
     @objc(canWipeWithPhrase:)
     func canWipeWithPhrase(_ phrase: String) -> Bool {
         do {
@@ -109,6 +108,26 @@ extension DWRecoverModel {
             dwRecoverLogger.error("wipe-with-phrase: keychain read failed; refusing: \(String(describing: error), privacy: .public)")
             return false
         }
+    }
+
+    /// Matches the localized support-only destructive acknowledgement after
+    /// applying the same Unicode canonicalization to both strings. The raw
+    /// text must reach this method before mnemonic cleanup, which deliberately
+    /// strips punctuation. `normalizePhrase` performs NFKD, lowercasing, and
+    /// whitespace collapsing without discarding diacritics or punctuation.
+    @objc(isWipeAcceptancePhrase:)
+    func isWipeAcceptancePhrase(_ phrase: String) -> Bool {
+        guard action == .supportWipe else { return false }
+        return Self.wipeAcceptancePhraseMatches(
+            phrase,
+            expectedPhrase: wipeAcceptPhrase())
+    }
+
+    static func wipeAcceptancePhraseMatches(
+        _ phrase: String,
+        expectedPhrase: String
+    ) -> Bool {
+        Mnemonic.normalizePhrase(phrase) == Mnemonic.normalizePhrase(expectedPhrase)
     }
 
     /// True when `phrase` matches at least one readable stored mnemonic — a

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel.m
@@ -53,7 +53,8 @@ NSInteger const DW_PHRASE_MULTIPLE = 3;
 // live in DWRecoverModel+Mnemonic.swift.
 
 - (void)wipeWallet {
-    [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:YES];
+    [DWSwiftDashSDKWalletWiper
+        wipeWalletWithAuthorization:DWSwiftDashSDKWalletWipeAuthorizationRecoveryFlow];
 }
 
 - (NSString *)wipeAcceptPhrase {

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverViewController.m
@@ -166,6 +166,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)recoverContentViewPerformWipe:(DWRecoverContentView *)view {
+    BOOL isSupportWipe = self.action == DWRecoverAction_SupportWipe;
     UIAlertControllerStyle style = IS_IPAD ? UIAlertControllerStyleAlert : UIAlertControllerStyleActionSheet;
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil
                                                                    message:nil
@@ -176,10 +177,16 @@ NS_ASSUME_NONNULL_BEGIN
                                                              [self.contentView activateTextView];
                                                          }];
     [alert addAction:cancelAction];
-    UIAlertAction *wipeAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Wipe", nil)
+    NSString *destructiveTitle = isSupportWipe
+                                     ? NSLocalizedString(@"Delete All", nil)
+                                     : NSLocalizedString(@"Wipe", nil);
+    UIAlertAction *wipeAction = [UIAlertAction actionWithTitle:destructiveTitle
                                                          style:UIAlertActionStyleDestructive
                                                        handler:^(UIAlertAction *action) {
-                                                           [self.view dw_showProgressHUDWithMessage:NSLocalizedString(@"Deleting Wallet…", nil)];
+                                                           NSString *progressMessage = isSupportWipe
+                                                                                           ? NSLocalizedString(@"Deleting All Wallets…", nil)
+                                                                                           : NSLocalizedString(@"Deleting Wallet…", nil);
+                                                           [self.view dw_showProgressHUDWithMessage:progressMessage];
                                                            [self.model wipeWallet];
                                                            __weak typeof(self) weakSelf = self;
                                                            [DWSwiftDashSDKWalletWiper
@@ -194,11 +201,33 @@ NS_ASSUME_NONNULL_BEGIN
                                                                        return;
                                                                    }
 
-                                                                   [strongSelf
-                                                                       showAlertWithTitle:NSLocalizedString(@"Couldn’t Delete Wallet", nil)
-                                                                                  message:NSLocalizedString(
-                                                                                              @"The wallet is still stored on this device. Please try again.",
-                                                                                              nil)];
+                                                                   NSString *failureTitle = isSupportWipe
+                                                                                                ? NSLocalizedString(@"Couldn’t Delete All Wallets", nil)
+                                                                                                : NSLocalizedString(@"Couldn’t Delete Wallet", nil);
+                                                                   NSString *failureMessage = isSupportWipe
+                                                                                                  ? NSLocalizedString(@"Not all wallets could be deleted. Please try again.", nil)
+                                                                                                  : NSLocalizedString(@"The wallet is still stored on this device. Please try again.", nil);
+                                                                   if (isSupportWipe) {
+                                                                       UIAlertController *failureAlert =
+                                                                           [UIAlertController alertControllerWithTitle:failureTitle
+                                                                                                               message:failureMessage
+                                                                                                        preferredStyle:UIAlertControllerStyleAlert];
+                                                                       [failureAlert addAction:
+                                                                                         [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", nil)
+                                                                                                                   style:UIAlertActionStyleCancel
+                                                                                                                 handler:^(UIAlertAction *action) {
+                                                                                                                     [strongSelf.contentView activateTextView];
+                                                                                                                 }]];
+                                                                       [failureAlert addAction:
+                                                                                         [UIAlertAction actionWithTitle:NSLocalizedString(@"Retry", nil)
+                                                                                                                   style:UIAlertActionStyleDefault
+                                                                                                                 handler:^(UIAlertAction *action) {
+                                                                                                                     [strongSelf recoverContentViewPerformWipe:view];
+                                                                                                                 }]];
+                                                                       [strongSelf presentViewController:failureAlert animated:YES completion:nil];
+                                                                       return;
+                                                                   }
+                                                                   [strongSelf showAlertWithTitle:failureTitle message:failureMessage];
                                                                }];
                                                        }];
     [alert addAction:wipeAction];
@@ -207,9 +236,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)recoverContentViewWipeNotAllowed:(DWRecoverContentView *)view {
     NSString *title = NSLocalizedString(@"This wallet is not empty or sync has not finished, you may not wipe it without the recovery phrase", nil);
-    NSString *message = [NSString stringWithFormat:
-                                      NSLocalizedString(@"If you still would like to wipe it please input: \"%@\"", nil),
-                                      self.model.wipeAcceptPhrase];
+    NSString *message = NSLocalizedString(@"Enter the recovery phrase to continue.", nil);
     [self showAlertWithTitle:title message:message];
 }
 
@@ -220,22 +247,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)recoverContentViewWipeBlockedByMultipleWallets:(DWRecoverContentView *)view {
     NSString *title = NSLocalizedString(@"Multiple wallets are stored on this device", nil);
-    NSString *message = [NSString stringWithFormat:
-                                      NSLocalizedString(@"Wiping would erase all of them, so a single wallet's recovery phrase is not enough. To erase every wallet on this device please input: \"%@\"", nil),
-                                      self.model.wipeAcceptPhrase];
+    NSString *message = NSLocalizedString(@"A single wallet's recovery phrase cannot authorize deleting multiple different wallets.", nil);
     [self showAlertWithTitle:title message:message];
 }
 
 - (void)recoverContentViewWipeShortcutUnavailableOnTestnet:(DWRecoverContentView *)view {
     NSString *title = NSLocalizedString(@"The \"wipe\" shortcut is not available on testnet", nil);
-    NSString *message = [NSString stringWithFormat:
-                                      NSLocalizedString(@"A zero testnet balance cannot prove this wallet is empty on mainnet. Enter the recovery phrase, or input: \"%@\"", nil),
-                                      self.model.wipeAcceptPhrase];
+    NSString *message = NSLocalizedString(@"A zero testnet balance cannot prove this wallet is empty on mainnet. Enter the recovery phrase to continue.", nil);
     [self showAlertWithTitle:title message:message];
 }
 
 - (void)recoverContentView:(DWRecoverContentView *)view phraseDidChange:(NSString *)phrase {
-    BOOL isPhraseValid = [phrase wordsCount] >= 10;
+    BOOL isPhraseValid = [phrase wordsCount] >= 10 || [self.model isWipeAcceptancePhrase:phrase];
     [self.actionButton setEnabled:isPhraseValid];
 }
 
@@ -273,6 +296,9 @@ NS_ASSUME_NONNULL_BEGIN
             self.title = hasPinSet
                              ? NSLocalizedString(@"Reset PIN", nil)
                              : NSLocalizedString(@"Set PIN", nil);
+            break;
+        case DWRecoverAction_SupportWipe:
+            self.title = NSLocalizedString(@"Wipe All Wallets", nil);
             break;
     }
 

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
@@ -166,13 +166,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)recoverWalletWithCurrentSeedPhrase {
     NSUInteger count = [self.textView.text wordsCount];
-    if (count < 10) {
+    NSString *rawPhrase = self.textView.text;
+    BOOL isSupportAcceptancePhrase = [self.model isWipeAcceptancePhrase:rawPhrase];
+    if (count < 10 && !isSupportAcceptancePhrase) {
         return;
     }
 
     @autoreleasepool { // @autoreleasepool ensures sensitive data will be deallocated immediately
         UITextView *textView = self.textView;
-        NSString *phrase = textView.text;
+        NSString *phrase = rawPhrase;
+
+        // The support acknowledgement is not a mnemonic. Recognize the raw
+        // localized sentence before cleanup strips punctuation (for example
+        // the comma in Polish) or the word validator rejects it.
+        if (isSupportAcceptancePhrase) {
+            [self wipeWithPhrase:phrase];
+            return;
+        }
 
         NSString *incorrectWord = nil;
         uint32_t incorrectWordCount = 0;
@@ -201,8 +211,10 @@ NS_ASSUME_NONNULL_BEGIN
             }
         }
 
-        if ([phrase isEqualToString:DW_WIPE] || [phrase isEqualToString:DW_WIPE_STRONG] ||
-            [[phrase lowercaseString] isEqualToString:[self.model.wipeAcceptPhrase lowercaseString]]) {
+        BOOL isRegularWipeShortcut =
+            self.model.action == DWRecoverAction_Wipe &&
+            ([phrase isEqualToString:DW_WIPE] || [phrase isEqualToString:DW_WIPE_STRONG]);
+        if (isRegularWipeShortcut) {
             [self wipeWithPhrase:phrase];
         }
         else if (incorrectWord && incorrectWordCount > 1) {
@@ -248,7 +260,7 @@ NS_ASSUME_NONNULL_BEGIN
             return;
         }
 
-        if ([phrase isEqualToString:DW_WIPE]) {
+        if (self.model.action == DWRecoverAction_Wipe && [phrase isEqualToString:DW_WIPE]) {
             if ([self.model isWalletEmpty]) {
                 [self.delegate recoverContentViewPerformWipe:self];
             }
@@ -266,7 +278,8 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.delegate recoverContentViewWipeNotAllowed:self];
             }
         }
-        else if ([phrase isEqualToString:DW_WIPE_STRONG] || [phrase.lowercaseString isEqualToString:self.model.wipeAcceptPhrase.lowercaseString]) {
+        else if ((self.model.action == DWRecoverAction_Wipe && [phrase isEqualToString:DW_WIPE_STRONG]) ||
+                 [self.model isWipeAcceptancePhrase:phrase]) {
             [self.delegate recoverContentViewPerformWipe:self];
         }
         else {

--- a/DashWallet/Sources/UI/Setup/SecureWallet/Seed/DWPreviewSeedPhraseModel.m
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/Seed/DWPreviewSeedPhraseModel.m
@@ -100,7 +100,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)clearAllWallets {
-    [DWSwiftDashSDKWalletWiper wipeWalletRemovingPin:NO];
+    [DWSwiftDashSDKWalletWiper
+        wipeWalletWithAuthorization:DWSwiftDashSDKWalletWipeAuthorizationScreenshotReplacement];
 }
 
 @end

--- a/DashWallet/Sources/UI/Setup/WalletRecovery/KeychainWalletRecoveryCoordinator.swift
+++ b/DashWallet/Sources/UI/Setup/WalletRecovery/KeychainWalletRecoveryCoordinator.swift
@@ -18,9 +18,10 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
         subsystem: "org.dashfoundation.dash",
         category: "wallet-delete-all-confirmation")
 
-    /// Presents the lock-screen delete-all confirmation after first obtaining
-    /// a complete, strict inventory. An unreadable or empty inventory never
-    /// produces a destructive action.
+    /// Presents the lock-screen warning before the support-assisted wipe flow.
+    /// A readable inventory produces exact count-aware copy. If inventory is
+    /// empty or unreadable, the user may still continue with a generic warning,
+    /// but deletion remains gated by the support acknowledgement phrase.
     @objc(presentFrom:cancelHandler:deleteAllHandler:)
     static func present(
         from host: UIViewController,
@@ -30,7 +31,10 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
         do {
             let walletCount = try SwiftDashSDKHost.distinctStoredWalletCount()
             guard walletCount > 0 else {
-                presentEmptyInventory(from: host, completion: cancelHandler)
+                presentWithoutVerifiedCount(
+                    from: host,
+                    cancelHandler: cancelHandler,
+                    continueHandler: deleteAllHandler)
                 return
             }
             present(
@@ -41,15 +45,10 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
         } catch {
             logger.error(
                 "failed to inventory wallets for delete-all confirmation: \(String(describing: error), privacy: .public)")
-            presentReadFailure(
+            presentWithoutVerifiedCount(
                 from: host,
                 cancelHandler: cancelHandler,
-                retryHandler: {
-                    present(
-                        from: host,
-                        cancelHandler: cancelHandler,
-                        deleteAllHandler: deleteAllHandler)
-                })
+                continueHandler: deleteAllHandler)
         }
     }
 
@@ -97,15 +96,15 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
         host.present(alert, animated: true)
     }
 
-    private static func presentReadFailure(
+    private static func presentWithoutVerifiedCount(
         from host: UIViewController,
         cancelHandler: @escaping () -> Void,
-        retryHandler: @escaping () -> Void
+        continueHandler: @escaping () -> Void
     ) {
         let alert = UIAlertController(
-            title: NSLocalizedString("Couldn’t Read Wallets", comment: ""),
+            title: NSLocalizedString("Delete All Wallets?", comment: ""),
             message: NSLocalizedString(
-                "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.",
+                "The number of wallets stored on this device could not be verified. Continuing requires a confirmation phrase provided by Dash Support before any wallet is deleted.",
                 comment: ""),
             preferredStyle: .alert)
         alert.addAction(
@@ -115,25 +114,9 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
                 handler: { _ in cancelHandler() }))
         alert.addAction(
             UIAlertAction(
-                title: NSLocalizedString("Retry", comment: ""),
-                style: .default,
-                handler: { _ in retryHandler() }))
-        host.present(alert, animated: true)
-    }
-
-    private static func presentEmptyInventory(
-        from host: UIViewController,
-        completion: @escaping () -> Void
-    ) {
-        let alert = UIAlertController(
-            title: NSLocalizedString("No Wallets Found", comment: ""),
-            message: NSLocalizedString("No stored wallets were found. Nothing was deleted.", comment: ""),
-            preferredStyle: .alert)
-        alert.addAction(
-            UIAlertAction(
-                title: NSLocalizedString("OK", comment: ""),
-                style: .default,
-                handler: { _ in completion() }))
+                title: NSLocalizedString("Continue", comment: ""),
+                style: .destructive,
+                handler: { _ in continueHandler() }))
         host.present(alert, animated: true)
     }
 }
@@ -141,8 +124,8 @@ final class WalletDeleteAllConfirmationCoordinator: NSObject {
 @objc(DWKeychainWalletRecoveryCoordinator)
 final class KeychainWalletRecoveryCoordinator: NSObject {
 
-    /// `true` = keep the stored wallets (or none exist), `false` = the user
-    /// explicitly confirmed Delete All.
+    /// `true` = keep the stored wallets (or none exist), `false` = continue to
+    /// the support-phrase gate. This coordinator never deletes wallets itself.
     @objc(presentReinstallKeepOrDeleteChoiceFrom:completion:)
     static func presentReinstallKeepOrDeleteChoice(
         from host: UIViewController,

--- a/DashWallet/Sources/UI/Setup/WalletRecovery/KeychainWalletRecoveryCoordinator.swift
+++ b/DashWallet/Sources/UI/Setup/WalletRecovery/KeychainWalletRecoveryCoordinator.swift
@@ -2,50 +2,221 @@
 //  KeychainWalletRecoveryCoordinator.swift
 //  DashWallet
 //
-//  Post-reinstall "Wallet found on this device" prompt. DashSync's keychain
-//  entries survive app reinstall, so the moment onboarding ends
-//  `chain.hasAWallet == YES` and the wallet would auto-recover silently —
-//  this coordinator gates that transition behind a Keep/Delete choice, with
-//  a destructive-action confirm on Delete.
+//  Post-reinstall "Wallets found on this device" prompt. SDK Keychain entries
+//  survive app reinstall, so this coordinator inventories every stored seed
+//  before allowing onboarding to keep them or explicitly delete all of them.
 //
 
 import Foundation
+import OSLog
 import UIKit
+
+@objc(DWWalletDeleteAllConfirmationCoordinator)
+final class WalletDeleteAllConfirmationCoordinator: NSObject {
+
+    private static let logger = Logger(
+        subsystem: "org.dashfoundation.dash",
+        category: "wallet-delete-all-confirmation")
+
+    /// Presents the lock-screen delete-all confirmation after first obtaining
+    /// a complete, strict inventory. An unreadable or empty inventory never
+    /// produces a destructive action.
+    @objc(presentFrom:cancelHandler:deleteAllHandler:)
+    static func present(
+        from host: UIViewController,
+        cancelHandler: @escaping () -> Void,
+        deleteAllHandler: @escaping () -> Void
+    ) {
+        do {
+            let walletCount = try SwiftDashSDKHost.distinctStoredWalletCount()
+            guard walletCount > 0 else {
+                presentEmptyInventory(from: host, completion: cancelHandler)
+                return
+            }
+            present(
+                from: host,
+                walletCount: walletCount,
+                cancelHandler: cancelHandler,
+                deleteAllHandler: deleteAllHandler)
+        } catch {
+            logger.error(
+                "failed to inventory wallets for delete-all confirmation: \(String(describing: error), privacy: .public)")
+            presentReadFailure(
+                from: host,
+                cancelHandler: cancelHandler,
+                retryHandler: {
+                    present(
+                        from: host,
+                        cancelHandler: cancelHandler,
+                        deleteAllHandler: deleteAllHandler)
+                })
+        }
+    }
+
+    static func present(
+        from host: UIViewController,
+        walletCount: Int,
+        cancelHandler: @escaping () -> Void,
+        deleteAllHandler: @escaping () -> Void
+    ) {
+        precondition(walletCount > 0)
+
+        let title: String
+        let message: String
+        let destructiveTitle: String
+        if walletCount == 1 {
+            title = NSLocalizedString("Delete Wallet?", comment: "")
+            message = NSLocalizedString(
+                "This permanently removes the wallet, private keys, and recovery phrase from this device. This cannot be undone.",
+                comment: "")
+            destructiveTitle = NSLocalizedString("Delete", comment: "")
+        } else {
+            title = NSLocalizedString("Delete All Wallets?", comment: "")
+            message = String(
+                format: NSLocalizedString(
+                    "This will erase all %ld wallets stored on this device. They can only be restored with their recovery phrases. Deleting them from this device cannot be undone.",
+                    comment: ""),
+                walletCount)
+            destructiveTitle = NSLocalizedString("Delete All", comment: "")
+        }
+
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert)
+        alert.addAction(
+            UIAlertAction(
+                title: NSLocalizedString("Cancel", comment: ""),
+                style: .cancel,
+                handler: { _ in cancelHandler() }))
+        alert.addAction(
+            UIAlertAction(
+                title: destructiveTitle,
+                style: .destructive,
+                handler: { _ in deleteAllHandler() }))
+        host.present(alert, animated: true)
+    }
+
+    private static func presentReadFailure(
+        from host: UIViewController,
+        cancelHandler: @escaping () -> Void,
+        retryHandler: @escaping () -> Void
+    ) {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Couldn’t Read Wallets", comment: ""),
+            message: NSLocalizedString(
+                "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.",
+                comment: ""),
+            preferredStyle: .alert)
+        alert.addAction(
+            UIAlertAction(
+                title: NSLocalizedString("Cancel", comment: ""),
+                style: .cancel,
+                handler: { _ in cancelHandler() }))
+        alert.addAction(
+            UIAlertAction(
+                title: NSLocalizedString("Retry", comment: ""),
+                style: .default,
+                handler: { _ in retryHandler() }))
+        host.present(alert, animated: true)
+    }
+
+    private static func presentEmptyInventory(
+        from host: UIViewController,
+        completion: @escaping () -> Void
+    ) {
+        let alert = UIAlertController(
+            title: NSLocalizedString("No Wallets Found", comment: ""),
+            message: NSLocalizedString("No stored wallets were found. Nothing was deleted.", comment: ""),
+            preferredStyle: .alert)
+        alert.addAction(
+            UIAlertAction(
+                title: NSLocalizedString("OK", comment: ""),
+                style: .default,
+                handler: { _ in completion() }))
+        host.present(alert, animated: true)
+    }
+}
 
 @objc(DWKeychainWalletRecoveryCoordinator)
 final class KeychainWalletRecoveryCoordinator: NSObject {
 
-    /// `true` = keep the existing wallet, `false` = user confirmed delete.
+    /// `true` = keep the stored wallets (or none exist), `false` = the user
+    /// explicitly confirmed Delete All.
     @objc(presentReinstallKeepOrDeleteChoiceFrom:completion:)
     static func presentReinstallKeepOrDeleteChoice(
         from host: UIViewController,
         completion: @escaping (Bool) -> Void
     ) {
-        presentPrimaryAlert(from: host, completion: completion)
+        do {
+            let walletCount = try SwiftDashSDKHost.distinctStoredWalletCount()
+            guard walletCount > 0 else {
+                completion(true)
+                return
+            }
+            presentPrimaryAlert(
+                from: host,
+                walletCount: walletCount,
+                completion: completion)
+        } catch {
+            presentInventoryReadFailure(from: host, completion: completion)
+        }
     }
 
     private static func presentPrimaryAlert(
         from host: UIViewController,
+        walletCount: Int,
         completion: @escaping (Bool) -> Void
     ) {
-        let alert = UIAlertController(
-            title: NSLocalizedString("Wallet found on this device", comment: ""),
-            message: NSLocalizedString(
+        let title: String
+        let message: String
+        let deleteTitle: String
+        let keepTitle: String
+        if walletCount == 1 {
+            title = NSLocalizedString("Wallet found on this device", comment: "")
+            message = NSLocalizedString(
                 "A wallet from a previous installation is still stored on this device. Keep using it, or delete it and start fresh? Make sure your recovery phrase is backed up before deleting.",
-                comment: ""),
+                comment: "")
+            deleteTitle = NSLocalizedString("Delete", comment: "")
+            keepTitle = NSLocalizedString("Keep Wallet", comment: "")
+        } else {
+            title = String(
+                format: NSLocalizedString("%ld wallets found on this device", comment: ""),
+                walletCount)
+            message = String(
+                format: NSLocalizedString(
+                    "%ld wallets from a previous installation are stored on this device. Delete All removes every wallet. Back up every recovery phrase before deleting.",
+                    comment: ""),
+                walletCount)
+            deleteTitle = NSLocalizedString("Delete All", comment: "")
+            keepTitle = NSLocalizedString("Keep Wallets", comment: "")
+        }
+
+        let alert = UIAlertController(
+            title: title,
+            message: message,
             preferredStyle: .alert)
 
         alert.addAction(
             UIAlertAction(
-                title: NSLocalizedString("Delete", comment: ""),
+                title: deleteTitle,
                 style: .destructive,
                 handler: { _ in
-                    presentDeleteConfirm(from: host, completion: completion)
+                    WalletDeleteAllConfirmationCoordinator.present(
+                        from: host,
+                        walletCount: walletCount,
+                        cancelHandler: {
+                            presentPrimaryAlert(
+                                from: host,
+                                walletCount: walletCount,
+                                completion: completion)
+                        },
+                        deleteAllHandler: { completion(false) })
                 }))
 
         alert.addAction(
             UIAlertAction(
-                title: NSLocalizedString("Keep Wallet", comment: ""),
+                title: keepTitle,
                 style: .default,
                 handler: { _ in
                     completion(true)
@@ -54,31 +225,31 @@ final class KeychainWalletRecoveryCoordinator: NSObject {
         host.present(alert, animated: true)
     }
 
-    private static func presentDeleteConfirm(
+    private static func presentInventoryReadFailure(
         from host: UIViewController,
         completion: @escaping (Bool) -> Void
     ) {
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Wallet?", comment: ""),
+            title: NSLocalizedString("Couldn’t Read Wallets", comment: ""),
             message: NSLocalizedString(
-                "This permanently removes the wallet, private keys, and recovery phrase from this device. This cannot be undone.",
+                "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.",
                 comment: ""),
             preferredStyle: .alert)
 
         alert.addAction(
             UIAlertAction(
-                title: NSLocalizedString("Cancel", comment: ""),
+                title: NSLocalizedString("Keep Wallets", comment: ""),
                 style: .cancel,
-                handler: { _ in
-                    presentPrimaryAlert(from: host, completion: completion)
-                }))
+                handler: { _ in completion(true) }))
 
         alert.addAction(
             UIAlertAction(
-                title: NSLocalizedString("Delete", comment: ""),
-                style: .destructive,
+                title: NSLocalizedString("Retry", comment: ""),
+                style: .default,
                 handler: { _ in
-                    completion(false)
+                    presentReinstallKeepOrDeleteChoice(
+                        from: host,
+                        completion: completion)
                 }))
 
         host.present(alert, animated: true)

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5565,6 +5565,7 @@
 "Delete All" = "Delete All";
 "Delete All Wallets?" = "Delete All Wallets?";
 "Deleting All Wallets…" = "Deleting All Wallets…";
+"The number of wallets stored on this device could not be verified. Continuing requires a confirmation phrase provided by Dash Support before any wallet is deleted." = "The number of wallets stored on this device could not be verified. Continuing requires a confirmation phrase provided by Dash Support before any wallet is deleted.";
 "Keep Wallets" = "Keep Wallets";
 "No stored wallets were found. Nothing was deleted." = "No stored wallets were found. Nothing was deleted.";
 "No Wallets Found" = "No Wallets Found";
@@ -5572,3 +5573,6 @@
 "The wallets stored on this device could not be verified. Nothing was deleted. Please try again." = "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.";
 "This will erase all %ld wallets stored on this device. They can only be restored with their recovery phrases. Deleting them from this device cannot be undone." = "This will erase all %ld wallets stored on this device. They can only be restored with their recovery phrases. Deleting them from this device cannot be undone.";
 "Wipe All Wallets" = "Wipe All Wallets";
+"A single wallet's recovery phrase cannot authorize deleting multiple different wallets." = "A single wallet's recovery phrase cannot authorize deleting multiple different wallets.";
+"A zero testnet balance cannot prove this wallet is empty on mainnet. Enter the recovery phrase to continue." = "A zero testnet balance cannot prove this wallet is empty on mainnet. Enter the recovery phrase to continue.";
+"Enter the recovery phrase to continue." = "Enter the recovery phrase to continue.";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -5556,3 +5556,19 @@
 "Every node votes together. Faster, but it publicly links your masternodes to each other." = "Every node votes together. Faster, but it publicly links your masternodes to each other.";
 "Each tap votes with one more node, so you choose how many to link together." = "Each tap votes with one more node, so you choose how many to link together.";
 "Selecting fewer nodes reveals less about which masternodes you run." = "Selecting fewer nodes reveals less about which masternodes you run.";
+
+/* Global wallet deletion */
+"%ld wallets found on this device" = "%ld wallets found on this device";
+"%ld wallets from a previous installation are stored on this device. Delete All removes every wallet. Back up every recovery phrase before deleting." = "%ld wallets from a previous installation are stored on this device. Delete All removes every wallet. Back up every recovery phrase before deleting.";
+"Couldn’t Delete All Wallets" = "Couldn’t Delete All Wallets";
+"Couldn’t Read Wallets" = "Couldn’t Read Wallets";
+"Delete All" = "Delete All";
+"Delete All Wallets?" = "Delete All Wallets?";
+"Deleting All Wallets…" = "Deleting All Wallets…";
+"Keep Wallets" = "Keep Wallets";
+"No stored wallets were found. Nothing was deleted." = "No stored wallets were found. Nothing was deleted.";
+"No Wallets Found" = "No Wallets Found";
+"Not all wallets could be deleted. Please try again." = "Not all wallets could be deleted. Please try again.";
+"The wallets stored on this device could not be verified. Nothing was deleted. Please try again." = "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.";
+"This will erase all %ld wallets stored on this device. They can only be restored with their recovery phrases. Deleting them from this device cannot be undone." = "This will erase all %ld wallets stored on this device. They can only be restored with their recovery phrases. Deleting them from this device cannot be undone.";
+"Wipe All Wallets" = "Wipe All Wallets";

--- a/DashWalletTests/WalletWipeSerialExecutorTests.swift
+++ b/DashWalletTests/WalletWipeSerialExecutorTests.swift
@@ -120,6 +120,72 @@ final class StoredWalletInventoryTests: XCTestCase {
     }
 }
 
+final class WipeAcceptancePhraseTests: XCTestCase {
+    private let polishPhrase =
+        "Akceptuję to, że stracę wszystkie moje monety jeśli nie będę miał frazy do odzyskiwania portfela"
+
+    func testRawPrecomposedPhraseMatchesDecomposedUnicodeWithoutRemovingPunctuation() {
+        let decomposed = polishPhrase.decomposedStringWithCompatibilityMapping
+
+        XCTAssertTrue(DWRecoverModel.wipeAcceptancePhraseMatches(
+            polishPhrase,
+            expectedPhrase: decomposed))
+    }
+
+    func testCaseAndWhitespaceAreNormalized() {
+        let typed =
+            "  AKCEPTUJĘ   TO, ŻE  STRACĘ WSZYSTKIE MOJE MONETY JEŚLI NIE BĘDĘ MIAŁ FRAZY DO ODZYSKIWANIA PORTFELA  "
+
+        XCTAssertTrue(DWRecoverModel.wipeAcceptancePhraseMatches(
+            typed,
+            expectedPhrase: polishPhrase))
+    }
+
+    func testSemanticChangesAreRejected() {
+        let missingDiacritic = polishPhrase.replacingOccurrences(
+            of: "Akceptuję",
+            with: "Akceptuje")
+        let missingComma = polishPhrase.replacingOccurrences(
+            of: "to, że",
+            with: "to że")
+        let changedWord = polishPhrase.replacingOccurrences(
+            of: "monety",
+            with: "środki")
+
+        XCTAssertFalse(DWRecoverModel.wipeAcceptancePhraseMatches(
+            missingDiacritic,
+            expectedPhrase: polishPhrase))
+        XCTAssertFalse(DWRecoverModel.wipeAcceptancePhraseMatches(
+            missingComma,
+            expectedPhrase: polishPhrase))
+        XCTAssertFalse(DWRecoverModel.wipeAcceptancePhraseMatches(
+            changedWord,
+            expectedPhrase: polishPhrase))
+    }
+
+    func testAcceptanceTextCanMatchBelowMnemonicWordThreshold() {
+        let phrase = "確認"
+
+        XCTAssertLessThan((phrase as NSString).wordsCount, 10)
+        XCTAssertTrue(DWRecoverModel.wipeAcceptancePhraseMatches(
+            phrase,
+            expectedPhrase: phrase))
+    }
+
+    func testObjectiveCBridgeAcceptsPhraseOnlyInSupportWipeMode() {
+        let supportModel = DWRecoverModel(action: .supportWipe)
+        let regularWipeModel = DWRecoverModel(action: .wipe)
+        let resetPinModel = DWRecoverModel(action: .resetPin)
+        let localizedPhrase = supportModel.wipeAcceptPhrase()
+
+        XCTAssertTrue(supportModel.isWipeAcceptancePhrase(localizedPhrase))
+        XCTAssertFalse(regularWipeModel.isWipeAcceptancePhrase(localizedPhrase))
+        XCTAssertFalse(resetPinModel.isWipeAcceptancePhrase(localizedPhrase))
+        XCTAssertFalse(supportModel.isWipeAcceptancePhrase("wipe"))
+        XCTAssertFalse(supportModel.isWipeAcceptancePhrase("exterminate!"))
+    }
+}
+
 final class MnemonicFirstWalletCreationTests: XCTestCase {
     func testPersistenceFailureDoesNotCreateWallet() {
         var storedMnemonic: String?

--- a/DashWalletTests/WalletWipeSerialExecutorTests.swift
+++ b/DashWalletTests/WalletWipeSerialExecutorTests.swift
@@ -95,6 +95,31 @@ final class WalletWipeSerialExecutorTests: XCTestCase {
     }
 }
 
+final class StoredWalletInventoryTests: XCTestCase {
+    func testDistinctWalletCountDeduplicatesNetworkScopedCopiesOfOneSeed() {
+        let seed = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+        let entries = [
+            (walletId: Data([0x01]), mnemonic: seed),
+            (walletId: Data([0x02]), mnemonic: seed),
+        ]
+
+        XCTAssertEqual(SwiftDashSDKHost.distinctWalletCount(in: entries), 1)
+    }
+
+    func testDistinctWalletCountIncludesDifferentSeedsAcrossNetworks() {
+        let entries = [
+            (
+                walletId: Data([0x01]),
+                mnemonic: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"),
+            (
+                walletId: Data([0x02]),
+                mnemonic: "legal winner thank year wave sausage worth useful legal winner thank yellow"),
+        ]
+
+        XCTAssertEqual(SwiftDashSDKHost.distinctWalletCount(in: entries), 2)
+    }
+}
+
 final class MnemonicFirstWalletCreationTests: XCTestCase {
     func testPersistenceFailureDoesNotCreateWallet() {
         var storedMnemonic: String?


### PR DESCRIPTION
## Summary
- show the strict logical-wallet count before reinstall and lock-screen deletion when the inventory is readable
- require the existing localized support acknowledgement phrase before Delete All from the lock screen or reinstall flow
- keep the acknowledgement hidden from the UI; Dash Support provides it only for the rare lost-PIN and lost-seed recovery case
- normalize the raw acknowledgement with NFKD, case folding, and whitespace collapsing while preserving words, diacritics, and punctuation
- allow the lock-screen support flow to continue with a generic warning when SDK inventory is empty or unreadable; reaching the failed-PIN threshold never starts deletion automatically
- keep reinstall inventory strict: read failures still offer only Keep/Retry
- route the successful phrase-authorized wipe through the serialized SDK boundary and wait for completion before navigation
- keep the ordinary Settings wipe seed-authorized; it does not accept the support acknowledgement

## Dependency
Stacked on #1014. After #1014 merges, retarget this PR to `develop`.

The Unicode acknowledgement fix previously proposed in #1019 is folded into this PR so the support policy and matcher are reviewed together.

## Verification
- `git diff --check` passes
- compile-ready tests cover Unicode normalization, punctuation/diacritic rejection, short non-space-delimited acknowledgement text, and SupportWipe-only scoping
- static call-site audit confirms there is no direct or duplicate wipe from the lock-screen and reinstall entry points
- the earlier dashpay Release arm64 simulator build passed before the latest support-flow commit
- per the current testing agreement, no Xcode build was run for the latest commit
- manual reinstall and lock-screen Support Wipe smoke tests remain required