### PR TITLE
fix(wallet): normalize wipe acceptance phrase

### DIFF
--- a/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/DWRecoverModel+Mnemonic.swift
@@ -111,6 +111,23 @@ extension DWRecoverModel {
         }
     }
 
+    /// Matches the localized destructive-action acknowledgement after applying
+    /// the same Unicode canonicalization to both strings. `normalizePhrase`
+    /// performs NFKD, lowercasing, and whitespace collapsing; it does not
+    /// discard diacritics, words, or punctuation, so the acknowledgement
+    /// remains semantically exact.
+    @objc(isWipeAcceptancePhrase:)
+    func isWipeAcceptancePhrase(_ phrase: String) -> Bool {
+        Self.wipeAcceptancePhraseMatches(phrase, expectedPhrase: wipeAcceptPhrase())
+    }
+
+    static func wipeAcceptancePhraseMatches(
+        _ phrase: String,
+        expectedPhrase: String
+    ) -> Bool {
+        Mnemonic.normalizePhrase(phrase) == Mnemonic.normalizePhrase(expectedPhrase)
+    }
+
     /// True when `phrase` matches at least one readable stored mnemonic — a
     /// non-destructive ownership signal. Backs the forgot-PIN check and the
     /// wipe screen's honest-denial copy (the typed phrase matches one wallet

--- a/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
+++ b/DashWallet/Sources/UI/Setup/RecoverWallet/Views/DWRecoverContentView.m
@@ -202,7 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         if ([phrase isEqualToString:DW_WIPE] || [phrase isEqualToString:DW_WIPE_STRONG] ||
-            [[phrase lowercaseString] isEqualToString:[self.model.wipeAcceptPhrase lowercaseString]]) {
+            [self.model isWipeAcceptancePhrase:phrase]) {
             [self wipeWithPhrase:phrase];
         }
         else if (incorrectWord && incorrectWordCount > 1) {
@@ -266,7 +266,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.delegate recoverContentViewWipeNotAllowed:self];
             }
         }
-        else if ([phrase isEqualToString:DW_WIPE_STRONG] || [phrase.lowercaseString isEqualToString:self.model.wipeAcceptPhrase.lowercaseString]) {
+        else if ([phrase isEqualToString:DW_WIPE_STRONG] || [self.model isWipeAcceptancePhrase:phrase]) {
             [self.delegate recoverContentViewPerformWipe:self];
         }
         else {

--- a/DashWalletTests/WalletWipeSerialExecutorTests.swift
+++ b/DashWalletTests/WalletWipeSerialExecutorTests.swift
@@ -120,6 +120,48 @@ final class StoredWalletInventoryTests: XCTestCase {
     }
 }
 
+final class WipeAcceptancePhraseTests: XCTestCase {
+    private let polishPhrase = "Akceptuję to, że stracę wszystkie moje monety jeśli nie będę miał frazy do odzyskiwania portfela"
+
+    func testPrecomposedPhraseMatchesDecomposedUnicode() {
+        let decomposed = polishPhrase.decomposedStringWithCompatibilityMapping
+
+        XCTAssertTrue(DWRecoverModel.wipeAcceptancePhraseMatches(
+            polishPhrase,
+            expectedPhrase: decomposed))
+    }
+
+    func testCaseAndWhitespaceAreNormalized() {
+        let typed = "  AKCEPTUJĘ   TO, ŻE  STRACĘ WSZYSTKIE MOJE MONETY JEŚLI NIE BĘDĘ MIAŁ FRAZY DO ODZYSKIWANIA PORTFELA  "
+
+        XCTAssertTrue(DWRecoverModel.wipeAcceptancePhraseMatches(
+            typed,
+            expectedPhrase: polishPhrase))
+    }
+
+    func testMissingDiacriticIsRejected() {
+        let typed = polishPhrase.replacingOccurrences(of: "Akceptuję", with: "Akceptuje")
+
+        XCTAssertFalse(DWRecoverModel.wipeAcceptancePhraseMatches(
+            typed,
+            expectedPhrase: polishPhrase))
+    }
+
+    func testChangedPunctuationIsRejected() {
+        let typed = polishPhrase.replacingOccurrences(of: "to, że", with: "to że")
+
+        XCTAssertFalse(DWRecoverModel.wipeAcceptancePhraseMatches(
+            typed,
+            expectedPhrase: polishPhrase))
+    }
+
+    func testLocalizedAcceptancePhrasePassesObjectiveCBridge() {
+        let model = DWRecoverModel(action: .wipe)
+
+        XCTAssertTrue(model.isWipeAcceptancePhrase(model.wipeAcceptPhrase()))
+    }
+}
+
 final class RecoveryPhraseRoutingTests: XCTestCase {
     private let seedA = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     private let seedB = "legal winner thank year wave sausage worth useful legal winner thank yellow"


### PR DESCRIPTION
## Summary

- normalize both the entered text and the localized long wipe acceptance phrase before comparison
- preserve case-insensitive matching and whitespace folding across Unicode composed/decomposed forms
- replace both raw acceptance-phrase comparisons with the shared Objective-C-accessible helper
- add focused regression tests for Polish diacritics, whitespace, case, and mismatches

## Scope

This does not change the short `wipe` / `exterminate!` shortcuts, the 10-word threshold, or global wipe authorization rules.

## Dependency

Stacked on #1018. After #1018 merges, this PR can be retargeted to `develop`.

## Verification

- `git diff --check`
- compile-ready normalization tests added
- full Xcode build intentionally not run, per request