### PR TITLE
fix(wallet): cap shielded spends at the state-transition size limit

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -472,6 +472,7 @@ final class InternalTransferViewModel: ObservableObject {
     /// input-selection envelope.
     private func routeDidChange() {
         clearMaxSelection()
+        refreshShieldedSpendCeiling()
 
         if route == .platformToCore {
             startWithdrawalPreflightIfNeeded()
@@ -543,6 +544,14 @@ final class InternalTransferViewModel: ObservableObject {
     /// balance mirror. Updates whenever a shielded sync pass completes.
     @Published private(set) var shieldedBalance: UInt64 = 0
 
+    /// Largest amount the pool can fund inside ONE transition — see
+    /// `ShieldedTransferCoordinator.spendCeilingCredits`. A typed amount above
+    /// this needs more notes than the 20 KiB state-transition limit admits and
+    /// would be rejected at broadcast, after the proof was built. `nil` while
+    /// the note set is reconciling, in which case the balance envelope is the
+    /// only bound this screen can apply; the coordinator still fails closed.
+    @Published private(set) var shieldedSpendCeilingCredits: UInt64?
+
     /// Drives the one-time restore gate reactively. A normal catch-up may set
     /// this to false, but it only blocks while the recovery marker is active.
     @Published private(set) var isChainSynced = SyncingActivityMonitor.shared.state == .syncDone
@@ -591,8 +600,28 @@ final class InternalTransferViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] credits in
                 self?.shieldedBalance = credits
+                self?.refreshShieldedSpendCeiling()
             }
             .store(in: &cancellables)
+    }
+
+    /// Fee kind for the pool-spending routes; `nil` for every other route.
+    private func shieldedFeeKind(for route: InternalTransferRoute) -> PlatformWalletManager.ShieldedFeeKind? {
+        switch route {
+        case .shieldedToCore: return .withdrawal
+        case .shieldedToPlatform: return .unshield
+        default: return nil
+        }
+    }
+
+    /// Recomputes `shieldedSpendCeilingCredits` from the current note set.
+    /// Cached rather than computed per keystroke — it reads SwiftData.
+    private func refreshShieldedSpendCeiling() {
+        guard let feeKind = shieldedFeeKind(for: route) else {
+            shieldedSpendCeilingCredits = nil
+            return
+        }
+        shieldedSpendCeilingCredits = ShieldedTransferCoordinator.spendCeilingCredits(feeKind: feeKind)
     }
 
     /// The raw numeric value the user has typed, with locale comma normalised
@@ -710,11 +739,19 @@ final class InternalTransferViewModel: ObservableObject {
             guard let reserve = feeReserveCredits else {
                 return Self.feeEstimateUnavailableMessage
             }
-            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+            if let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
-                feeReserveCredits: reserve)
+                feeReserveCredits: reserve) {
+                return message
+            }
+            // Affordable against the balance, but still unspendable in one
+            // transition when the notes are too fragmented.
+            if let ceiling = shieldedSpendCeilingCredits, creditsPreview > ceiling {
+                return Self.shieldedCeilingMessage(ceiling)
+            }
+            return nil
 
         case .platformToCore:
             // Stay quiet while the preflight is still resolving: Continue is
@@ -787,8 +824,13 @@ final class InternalTransferViewModel: ObservableObject {
             // pool (recipient receives the full amount), so the balance must
             // cover amount + fee. Fail closed if the reserve is unavailable.
             guard let reserve = feeReserveCredits else { return false }
-            return shieldedBalance >= reserve
-                && creditsPreview <= shieldedBalance - reserve
+            guard shieldedBalance >= reserve,
+                  creditsPreview <= shieldedBalance - reserve
+            else { return false }
+            if let ceiling = shieldedSpendCeilingCredits {
+                return creditsPreview <= ceiling
+            }
+            return true
         case .platformToCore:
             // Either the exact full-balance net payout (Max → AUTO path over
             // every address), or a partial amount within the single-input
@@ -1358,6 +1400,15 @@ final class InternalTransferViewModel: ObservableObject {
             NSLocalizedString(
                 "%@ DASH is still confirming. Use Max again once it settles.",
                 comment: "Shielded Max pending change"),
+            formatted)
+    }
+
+    private static func shieldedCeilingMessage(_ credits: UInt64) -> String {
+        let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Your Shielded balance is split across notes, and at most %@ DASH of it can be sent in one transaction. Send the rest afterwards.",
+                comment: "Shielded amount above the single-transaction ceiling"),
             formatted)
     }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -1356,7 +1356,7 @@ final class InternalTransferViewModel: ObservableObject {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
         return String.localizedStringWithFormat(
             NSLocalizedString(
-                "%@ DASH is still confirming. Withdraw again once it settles.",
+                "%@ DASH is still confirming. Use Max again once it settles.",
                 comment: "Shielded Max pending change"),
             formatted)
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -815,13 +815,18 @@ final class InternalTransferViewModel: ObservableObject {
             return nil
         case .shieldedToCore:
             // The withdraw/unshield fee scales with the number of spent notes;
-            // the SDK recomputes it from real note selection (up to the
-            // 16-action `max_shielded_transition_actions` cap) at send time.
-            // Reserve that worst case so a fragmented wallet can't pass the
-            // affordability check and then fail SDK note selection.
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 16)
+            // the SDK recomputes it from real note selection at send time.
+            // Reserve the worst case the 20 KiB state-transition limit admits
+            // (`ShieldedActionBudget.maxActionsPerTransition`) so a fragmented
+            // wallet can't pass the affordability check and then fail SDK note
+            // selection.
+            return try? PlatformWalletManager.estimateShieldedFee(
+                kind: .withdrawal,
+                numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 16)
+            return try? PlatformWalletManager.estimateShieldedFee(
+                kind: .unshield,
+                numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .platformToCore:
             // Full-balance withdrawal: the fee is already netted out of the
             // preflight's `netWithdrawable`; no reserve on top.

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -736,22 +736,31 @@ final class InternalTransferViewModel: ObservableObject {
             // A Max sweep is planned against the real note set rather than the
             // amount+reserve envelope, so it is affordable by construction.
             if isFullShieldedSweep { return nil }
+            // The ceiling is priced from the notes that would actually be
+            // spent, so it supersedes the flat reserve — which always charges
+            // a full-size bundle and would reject amounts a one- or two-note
+            // spend can afford.
+            if let ceiling = shieldedSpendCeilingCredits {
+                if creditsPreview > shieldedBalance {
+                    // Simply more than the wallet holds: name that, rather than
+                    // blaming note fragmentation.
+                    return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                        balanceName: balanceName,
+                        requestedDuffs: creditsPreview / 1000,
+                        spendableDuffs: ceiling / 1000)
+                }
+                return creditsPreview > ceiling ? Self.shieldedCeilingMessage(ceiling) : nil
+            }
+            // Ceiling unavailable (notes reconciling): fall back to the flat
+            // worst-case reserve.
             guard let reserve = feeReserveCredits else {
                 return Self.feeEstimateUnavailableMessage
             }
-            if let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
-                feeReserveCredits: reserve) {
-                return message
-            }
-            // Affordable against the balance, but still unspendable in one
-            // transition when the notes are too fragmented.
-            if let ceiling = shieldedSpendCeilingCredits, creditsPreview > ceiling {
-                return Self.shieldedCeilingMessage(ceiling)
-            }
-            return nil
+                feeReserveCredits: reserve)
 
         case .platformToCore:
             // Stay quiet while the preflight is still resolving: Continue is
@@ -823,14 +832,12 @@ final class InternalTransferViewModel: ObservableObject {
             // Unshield/withdraw: the SDK debits amount + fee from the shielded
             // pool (recipient receives the full amount), so the balance must
             // cover amount + fee. Fail closed if the reserve is unavailable.
-            guard let reserve = feeReserveCredits else { return false }
-            guard shieldedBalance >= reserve,
-                  creditsPreview <= shieldedBalance - reserve
-            else { return false }
             if let ceiling = shieldedSpendCeilingCredits {
                 return creditsPreview <= ceiling
             }
-            return true
+            guard let reserve = feeReserveCredits else { return false }
+            return shieldedBalance >= reserve
+                && creditsPreview <= shieldedBalance - reserve
         case .platformToCore:
             // Either the exact full-balance net payout (Max → AUTO path over
             // every address), or a partial amount within the single-input

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -978,7 +978,7 @@ final class InternalTransferViewModel: ObservableObject {
                 sourceDuffs = 0
             case .unavailable:
                 maxNotice = NSLocalizedString(
-                    "Your Shielded balance is not ready to withdraw. Sync and try Max again.",
+                    "Your Shielded balance is not ready to spend. Sync and try Max again.",
                     comment: "Shielded Max unavailable")
                 sourceDuffs = 0
             }
@@ -1365,7 +1365,7 @@ final class InternalTransferViewModel: ObservableObject {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
         return String.localizedStringWithFormat(
             NSLocalizedString(
-                "%@ DASH requires another Shielded withdrawal. Use Max again after this transfer settles.",
+                "%@ DASH is held in notes that don't fit in one transaction. Use Max again after this one settles to send the rest.",
                 comment: "Shielded Max multi-bundle remainder"),
             formatted)
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -306,7 +306,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
                 return String.localizedStringWithFormat(
                     NSLocalizedString(
-                        "%@ DASH is still confirming. Withdraw again once it settles.",
+                        "%@ DASH is still confirming. Try again once it settles.",
                         comment: "Shielded sweep pending change"),
                     formatted)
             case .shieldedSweepChanged:

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -260,6 +260,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         case platformShieldCapacityChanged(maxShieldableCredits: UInt64?)
         case shieldedSweepWaiting(UInt64)
         case shieldedSweepChanged
+        case shieldedAmountExceedsBundle(UInt64)
         case transferFailed(Error)
 
         var errorDescription: String? {
@@ -313,6 +314,13 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 return NSLocalizedString(
                     "Your Shielded balance changed. Close this confirmation and tap Max again.",
                     comment: "Shielded sweep changed before submit")
+            case .shieldedAmountExceedsBundle(let ceiling):
+                let formatted = (ceiling / 1000).formattedDashAmountWithoutCurrencySymbol
+                return String.localizedStringWithFormat(
+                    NSLocalizedString(
+                        "Your Shielded balance is split across notes, and at most %@ DASH of it can be sent in one transaction.",
+                        comment: "Shielded amount above the single-transaction ceiling"),
+                    formatted)
             case .transferFailed(let underlying):
                 return underlying.localizedDescription
             }
@@ -391,6 +399,36 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 feeCredits: exact.feeCredits,
                 inputCredits: exact.inputCredits,
                 remainingCredits: allCredits - exact.inputCredits))
+    }
+
+    /// Largest amount the pool can fund inside ONE transition — the sweep
+    /// plan's payout, which is by construction the best `ShieldedActionBudget`
+    /// notes can do. A larger amount needs more notes than the 20 KiB
+    /// state-transition limit admits, so it would be rejected at broadcast
+    /// after the proof was built.
+    ///
+    /// `nil` while the note set is mid-reconcile — the caller then has no
+    /// note-aware bound and falls back to its balance envelope.
+    static func spendCeilingCredits(
+        feeKind: PlatformWalletManager.ShieldedFeeKind
+    ) -> UInt64? {
+        guard case .ready(let plan) = sweepAvailability(feeKind: feeKind) else { return nil }
+        return plan.amountCredits
+    }
+
+    /// Fails closed when a non-sweep amount needs more notes than one
+    /// transition can carry. The amount screens check this too, but the guard
+    /// belongs here as well: it is the last point before authorization and
+    /// proof generation, and it covers callers that never ran that check.
+    private func rejectIfAboveSpendCeiling(
+        _ amountCredits: UInt64,
+        feeKind: PlatformWalletManager.ShieldedFeeKind
+    ) -> Bool {
+        guard let ceiling = Self.spendCeilingCredits(feeKind: feeKind),
+              amountCredits > ceiling
+        else { return false }
+        handleFailure(CoordinatorError.shieldedAmountExceedsBundle(ceiling))
+        return true
     }
 
     // MARK: - Public API
@@ -758,6 +796,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 return
             }
         } else {
+            if rejectIfAboveSpendCeiling(amountCredits, feeKind: .withdrawal) { return }
             submittedAmount = amountCredits
         }
 
@@ -863,6 +902,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 return
             }
         } else {
+            if rejectIfAboveSpendCeiling(amountCredits, feeKind: .unshield) { return }
             submittedAmount = amountCredits
         }
 
@@ -1118,6 +1158,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 return
             }
         } else {
+            if rejectIfAboveSpendCeiling(amountCredits, feeKind: .transfer) { return }
             submittedAmount = amountCredits
         }
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -42,11 +42,29 @@ import OSLog
 import SwiftData
 import SwiftDashSDK
 
+/// How many Orchard actions the app may put in one shielded transition.
+///
+/// Consensus allows 16 (`system_limits.max_shielded_transition_actions`), but
+/// the 20 KiB `system_limits.max_state_transition_size` binds first: the Halo 2
+/// proof grows ~2,681 bytes per action. Platform's
+/// `seed_pool_batch_fits_max_state_transition_size` test measures 2 actions →
+/// 8,294 B, 6 → 19,018 B, 7 → 21,699 B — and the 7-action bundle is rejected,
+/// which reaches the app as "State Transition exceeds maximum size of 20480
+/// bytes" from DAPI's broadcast check. Rust's pool seeder pins the same bound
+/// as `MAX_ACTIONS_PER_BATCH` in `rs-platform-wallet/src/wallet/shielded/seed_pool.rs`.
+///
+/// Spending more notes than this needs a second transition, which the sweep
+/// planner reports as `ShieldedSweepPlan.remainingCredits`.
+enum ShieldedActionBudget {
+    static let maxActionsPerTransition = 6
+}
+
 /// A note-aware full-balance spend plan. Unlike the amount screens' normal
 /// affordability reserve, a sweep prices the fee from the notes that will
 /// actually enter the Orchard bundle. That keeps a one-note withdrawal from
-/// reserving the 16-action worst-case fee and returning the difference as a
-/// persistent change note.
+/// reserving the worst-case fee for a full
+/// `ShieldedActionBudget.maxActionsPerTransition` bundle and returning the
+/// difference as a persistent change note.
 struct ShieldedSweepPlan: Equatable {
     let amountCredits: UInt64
     let feeCredits: UInt64
@@ -69,7 +87,7 @@ struct ShieldedSweepCandidate: Equatable {
 enum ShieldedSweepPlanner {
     static func bestCandidate(
         noteValues: [UInt64],
-        maxActions: Int = 16,
+        maxActions: Int = ShieldedActionBudget.maxActionsPerTransition,
         feeForActions: (Int) -> UInt64?
     ) -> ShieldedSweepCandidate? {
         guard maxActions > 0 else { return nil }
@@ -114,7 +132,7 @@ enum ShieldedSweepPlanner {
     static func revalidate(
         noteValues: [UInt64],
         amountCredits: UInt64,
-        maxActions: Int = 16,
+        maxActions: Int = ShieldedActionBudget.maxActionsPerTransition,
         feeForActions: (Int) -> UInt64?
     ) -> ShieldedSweepCandidate? {
         let values = noteValues.sorted(by: >)
@@ -304,10 +322,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
     // MARK: - Full-balance shielded sweep
 
     /// Builds the Max plan from the active wallet's persisted unspent notes.
-    /// The Rust selector is largest-first and a transition is capped at 16
-    /// actions, so the first bundle consumes at most the 16 largest notes.
-    /// Any remainder is reported to the amount screen instead of being left
-    /// behind silently.
+    /// The Rust selector is largest-first and the app caps a transition at
+    /// `ShieldedActionBudget.maxActionsPerTransition` actions, so the first
+    /// bundle consumes at most that many of the largest notes. Any remainder is
+    /// reported to the amount screen instead of being left behind silently.
     static func sweepAvailability(
         feeKind: PlatformWalletManager.ShieldedFeeKind
     ) -> ShieldedSweepAvailability {
@@ -1067,7 +1085,11 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// Orchard address, decoded from their bech32m display form). Stages:
     /// `.signing → .proving → .broadcasting → .success` — same opaque-call
     /// shape as `performWithdraw`/`performUnshield`.
-    func performShieldedTransfer(amountCredits: UInt64, recipientRaw43: Data) async {
+    func performShieldedTransfer(
+        amountCredits: UInt64,
+        sweepAll: Bool = false,
+        recipientRaw43: Data
+    ) async {
         guard beginTransfer() else { return }
         Self.logger.info("🛡️ SHIELD-TX :: shielded→shielded send amount=\(amountCredits) credits")
 
@@ -1077,6 +1099,26 @@ final class ShieldedTransferCoordinator: ObservableObject {
         } catch {
             handleFailure(error)
             return
+        }
+
+        // Re-price the sweep against the note set as it stands now — same
+        // guard as `performWithdraw`, so a note that was spent or discovered
+        // between Max and confirm fails closed instead of building a bundle
+        // the pool can no longer fund exactly.
+        let submittedAmount: UInt64
+        if sweepAll {
+            switch Self.sweepAvailability(feeKind: .transfer) {
+            case .ready(let plan) where plan.amountCredits == amountCredits:
+                submittedAmount = plan.amountCredits
+            case .waitingForConfirmation(let credits):
+                handleFailure(CoordinatorError.shieldedSweepWaiting(credits))
+                return
+            case .ready, .unavailable:
+                handleFailure(CoordinatorError.shieldedSweepChanged)
+                return
+            }
+        } else {
+            submittedAmount = amountCredits
         }
 
         do {
@@ -1095,7 +1137,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 resolver: MnemonicResolver(),
                 account: 0,
                 recipientRaw43: recipientRaw43,
-                amount: amountCredits)
+                amount: submittedAmount)
         } catch {
             handleSpendError(error, manager: env.manager)
             return

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -1099,6 +1099,7 @@ struct SendConfirmSheet: View {
                 }
                 await coordinator.performShieldedTransfer(
                     amountCredits: creditsAmount,
+                    sweepAll: isFullShieldedSweep,
                     recipientRaw43: destinationRaw43)
             case .coreToCore:
                 // Unreachable: the screen routes Core → Core through the L1

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -420,13 +420,19 @@ final class SendViewModel: ObservableObject {
         case .platformToPlatform:
             return Self.platformTransferFeeReserveCredits
         case .shieldedToCore:
-            // Worst-case note selection (16 actions) — same reasoning as the
-            // internal transfer's reserve.
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 16)
+            // Worst-case note selection for a bundle the size limit actually
+            // admits — same reasoning as the internal transfer's reserve.
+            return try? PlatformWalletManager.estimateShieldedFee(
+                kind: .withdrawal,
+                numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 16)
+            return try? PlatformWalletManager.estimateShieldedFee(
+                kind: .unshield,
+                numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToShielded:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 16)
+            return try? PlatformWalletManager.estimateShieldedFee(
+                kind: .transfer,
+                numActions: ShieldedActionBudget.maxActionsPerTransition)
         }
     }
 
@@ -641,9 +647,16 @@ final class SendViewModel: ObservableObject {
             sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
         case .platformToCore:
             sourceDuffs = platformWithdrawableDuffs ?? 0
-        case .shieldedToCore, .shieldedToPlatform:
-            let feeKind: PlatformWalletManager.ShieldedFeeKind =
-                route == .shieldedToCore ? .withdrawal : .unshield
+        case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
+            // All three spend the pool, so all three plan Max against the real
+            // note set. A flat reserve here would price a full-size bundle and
+            // hand the unspent difference back as a change note.
+            let feeKind: PlatformWalletManager.ShieldedFeeKind
+            switch route {
+            case .shieldedToCore: feeKind = .withdrawal
+            case .shieldedToPlatform: feeKind = .unshield
+            default: feeKind = .transfer
+            }
             switch ShieldedTransferCoordinator.sweepAvailability(feeKind: feeKind) {
             case .ready(let plan):
                 isFullShieldedSweep = true
@@ -661,8 +674,6 @@ final class SendViewModel: ObservableObject {
                     comment: "Shielded Max unavailable")
                 sourceDuffs = 0
             }
-        case .shieldedToShielded:
-            sourceDuffs = creditsMinusFeeReserve(shieldedBalance) / 1000
         }
 
         isApplyingMax = true

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -177,13 +177,11 @@ final class SendViewModel: ObservableObject {
     /// Recomputes `shieldedSpendCeilingCredits` from the current note set.
     /// Cached rather than computed per keystroke — it reads SwiftData.
     private func refreshShieldedSpendCeiling() {
-        guard let feeKind = shieldedFeeKind(for: route),
-              case .ready(let plan) = ShieldedTransferCoordinator.sweepAvailability(feeKind: feeKind)
-        else {
+        guard let feeKind = shieldedFeeKind(for: route) else {
             shieldedSpendCeilingCredits = nil
             return
         }
-        shieldedSpendCeilingCredits = plan.amountCredits
+        shieldedSpendCeilingCredits = ShieldedTransferCoordinator.spendCeilingCredits(feeKind: feeKind)
     }
 
     // MARK: - Destination classification

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -757,7 +757,7 @@ final class SendViewModel: ObservableObject {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
         return String.localizedStringWithFormat(
             NSLocalizedString(
-                "%@ DASH is still confirming. Withdraw again once it settles.",
+                "%@ DASH is still confirming. Use Max again once it settles.",
                 comment: "Shielded Max pending change"),
             formatted)
     }

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -576,22 +576,31 @@ final class SendViewModel: ObservableObject {
             // A Max sweep is planned against the real note set rather than the
             // amount+reserve envelope, so it is affordable by construction.
             if isFullShieldedSweep { return nil }
+            // The ceiling is priced from the notes that would actually be
+            // spent, so it supersedes the flat reserve — which always charges
+            // a full-size bundle and would reject amounts a one- or two-note
+            // spend can afford.
+            if let ceiling = shieldedSpendCeilingCredits {
+                if creditsPreview > shieldedBalance {
+                    // Simply more than the wallet holds: name that, rather than
+                    // blaming note fragmentation.
+                    return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                        balanceName: balanceName,
+                        requestedDuffs: creditsPreview / 1000,
+                        spendableDuffs: ceiling / 1000)
+                }
+                return creditsPreview > ceiling ? Self.shieldedCeilingMessage(ceiling) : nil
+            }
+            // Ceiling unavailable (notes reconciling): fall back to the flat
+            // worst-case reserve.
             guard let reserve = feeReserveCredits else {
                 return Self.feeEstimateUnavailableMessage
             }
-            if let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
-                feeReserveCredits: reserve) {
-                return message
-            }
-            // Affordable against the balance, but still unspendable in one
-            // transition when the notes are too fragmented.
-            if let ceiling = shieldedSpendCeilingCredits, creditsPreview > ceiling {
-                return Self.shieldedCeilingMessage(ceiling)
-            }
-            return nil
+                feeReserveCredits: reserve)
 
         case .platformToCore:
             // Stay quiet while the preflight is still resolving: Continue is
@@ -664,14 +673,12 @@ final class SendViewModel: ObservableObject {
             if isFullShieldedSweep {
                 return shieldedSweepAmountCredits != nil
             }
-            guard let reserve = feeReserveCredits else { return false }
-            guard shieldedBalance >= reserve,
-                  creditsPreview <= shieldedBalance - reserve
-            else { return false }
             if let ceiling = shieldedSpendCeilingCredits {
                 return creditsPreview <= ceiling
             }
-            return true
+            guard let reserve = feeReserveCredits else { return false }
+            return shieldedBalance >= reserve
+                && creditsPreview <= shieldedBalance - reserve
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -670,7 +670,7 @@ final class SendViewModel: ObservableObject {
                 sourceDuffs = 0
             case .unavailable:
                 shieldedMaxNotice = NSLocalizedString(
-                    "Your Shielded balance is not ready to withdraw. Sync and try Max again.",
+                    "Your Shielded balance is not ready to spend. Sync and try Max again.",
                     comment: "Shielded Max unavailable")
                 sourceDuffs = 0
             }
@@ -725,7 +725,7 @@ final class SendViewModel: ObservableObject {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
         return String.localizedStringWithFormat(
             NSLocalizedString(
-                "%@ DASH requires another Shielded withdrawal. Use Max again after this transfer settles.",
+                "%@ DASH is held in notes that don't fit in one transaction. Use Max again after this one settles to send the rest.",
                 comment: "Shielded Max multi-bundle remainder"),
             formatted)
     }

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -86,6 +86,15 @@ final class SendViewModel: ObservableObject {
     @Published private(set) var platformCredits: UInt64 = 0
     @Published private(set) var shieldedBalance: UInt64 = 0
 
+    /// Largest amount the pool can fund inside ONE transition — the same
+    /// note-aware number Max produces. A typed amount above this needs more
+    /// notes than `ShieldedActionBudget` admits, so the bundle would exceed the
+    /// 20 KiB state-transition limit and be rejected at broadcast, after the
+    /// proof was already built. `nil` while the note set is mid-reconcile
+    /// (`sweepAvailability` is not `.ready`), in which case the amount screen
+    /// falls back to the balance envelope alone.
+    @Published private(set) var shieldedSpendCeilingCredits: UInt64?
+
     /// Live result of `preflightWithdrawal()` for the Platform → Core route —
     /// same semantics as the internal transfer's: `nil` while unknown,
     /// affordability fails closed.
@@ -150,8 +159,31 @@ final class SendViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] credits in
                 self?.shieldedBalance = credits
+                self?.refreshShieldedSpendCeiling()
             }
             .store(in: &cancellables)
+    }
+
+    /// Fee kind for the pool-spending routes; `nil` for every other route.
+    private func shieldedFeeKind(for route: Route?) -> PlatformWalletManager.ShieldedFeeKind? {
+        switch route {
+        case .shieldedToCore: return .withdrawal
+        case .shieldedToPlatform: return .unshield
+        case .shieldedToShielded: return .transfer
+        default: return nil
+        }
+    }
+
+    /// Recomputes `shieldedSpendCeilingCredits` from the current note set.
+    /// Cached rather than computed per keystroke — it reads SwiftData.
+    private func refreshShieldedSpendCeiling() {
+        guard let feeKind = shieldedFeeKind(for: route),
+              case .ready(let plan) = ShieldedTransferCoordinator.sweepAvailability(feeKind: feeKind)
+        else {
+            shieldedSpendCeilingCredits = nil
+            return
+        }
+        shieldedSpendCeilingCredits = plan.amountCredits
     }
 
     // MARK: - Destination classification
@@ -258,6 +290,7 @@ final class SendViewModel: ObservableObject {
     /// needs the withdrawal preflight (fee headroom + full-balance payout).
     private func routeDidChange() {
         clearShieldedMaxSelection()
+        refreshShieldedSpendCeiling()
         guard route == .platformToCore else {
             preflightTask?.cancel()
             preflightTask = nil
@@ -548,11 +581,19 @@ final class SendViewModel: ObservableObject {
             guard let reserve = feeReserveCredits else {
                 return Self.feeEstimateUnavailableMessage
             }
-            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+            if let message = TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedCredits: creditsPreview,
                 balanceCredits: shieldedBalance,
-                feeReserveCredits: reserve)
+                feeReserveCredits: reserve) {
+                return message
+            }
+            // Affordable against the balance, but still unspendable in one
+            // transition when the notes are too fragmented.
+            if let ceiling = shieldedSpendCeilingCredits, creditsPreview > ceiling {
+                return Self.shieldedCeilingMessage(ceiling)
+            }
+            return nil
 
         case .platformToCore:
             // Stay quiet while the preflight is still resolving: Continue is
@@ -626,8 +667,13 @@ final class SendViewModel: ObservableObject {
                 return shieldedSweepAmountCredits != nil
             }
             guard let reserve = feeReserveCredits else { return false }
-            return shieldedBalance >= reserve
-                && creditsPreview <= shieldedBalance - reserve
+            guard shieldedBalance >= reserve,
+                  creditsPreview <= shieldedBalance - reserve
+            else { return false }
+            if let ceiling = shieldedSpendCeilingCredits {
+                return creditsPreview <= ceiling
+            }
+            return true
         }
     }
 
@@ -651,12 +697,7 @@ final class SendViewModel: ObservableObject {
             // All three spend the pool, so all three plan Max against the real
             // note set. A flat reserve here would price a full-size bundle and
             // hand the unspent difference back as a change note.
-            let feeKind: PlatformWalletManager.ShieldedFeeKind
-            switch route {
-            case .shieldedToCore: feeKind = .withdrawal
-            case .shieldedToPlatform: feeKind = .unshield
-            default: feeKind = .transfer
-            }
+            guard let feeKind = shieldedFeeKind(for: route) else { return }
             switch ShieldedTransferCoordinator.sweepAvailability(feeKind: feeKind) {
             case .ready(let plan):
                 isFullShieldedSweep = true
@@ -718,6 +759,15 @@ final class SendViewModel: ObservableObject {
             NSLocalizedString(
                 "%@ DASH is still confirming. Withdraw again once it settles.",
                 comment: "Shielded Max pending change"),
+            formatted)
+    }
+
+    private static func shieldedCeilingMessage(_ credits: UInt64) -> String {
+        let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
+        return String.localizedStringWithFormat(
+            NSLocalizedString(
+                "Your Shielded balance is split across notes, and at most %@ DASH of it can be sent in one transaction. Send the rest afterwards.",
+                comment: "Shielded amount above the single-transaction ceiling"),
             formatted)
     }
 

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -363,6 +363,23 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
                 noteCount: 2))
     }
 
+    func testShieldedSweepStopsAtTheActionBudget() {
+        // The 20 KiB `max_state_transition_size` ceiling, not the 16-action
+        // consensus cap, is what bounds a bundle: a 7-action transition is
+        // ~21,699 B and DAPI rejects it. The planner must stop at the budget
+        // even when every further note would raise the payout.
+        let notes = Array(repeating: UInt64(1_000), count: 12)
+        let budget = ShieldedActionBudget.maxActionsPerTransition
+
+        let candidate = ShieldedSweepPlanner.bestCandidate(
+            noteValues: notes,
+            feeForActions: { _ in 100 })
+
+        XCTAssertEqual(candidate?.noteCount, budget)
+        XCTAssertEqual(candidate?.inputCredits, UInt64(budget) * 1_000)
+        XCTAssertEqual(candidate?.amountCredits, UInt64(budget) * 1_000 - 100)
+    }
+
     func testShieldedSpendableBalanceSubtractsFeeReserve() {
         XCTAssertEqual(
             TransferSpendAmountPolicy.spendableCredits(


### PR DESCRIPTION
## Issue being fixed or feature implemented

Sending from the Shielded balance failed or short-changed the user, in two related ways:

1. **Broadcast rejected.** A shielded spend was planned against the 16-action consensus cap (`max_shielded_transition_actions`), but the 20 KiB `max_state_transition_size` binds first — the Halo 2 proof grows ~2,681 bytes per action, so a 7-action bundle is ~21,699 B. A wallet fragmented across 7+ notes built its proof and only then failed with:

   > `shielded transfer failed: Shielded broadcast failed: Dapi client error: ... "State Transition exceeds maximum size of 20480 bytes"`

2. **Max left funds behind.** On the shielded → shielded route, Max reserved a full-size bundle's fee via a flat `numActions: 16` estimate instead of pricing the notes that actually enter the bundle. The unspent difference came back as a change note, so "Max" visibly did not send the balance.

The 6-action bound is the one Rust already pins as `MAX_ACTIONS_PER_BATCH` in `rs-platform-wallet/src/wallet/shielded/seed_pool.rs`, measured by platform's `seed_pool_batch_fits_max_state_transition_size` test (2 actions → 8,294 B, 6 → 19,018 B, 7 → 21,699 B, rejected).

## What was done?

- Added `ShieldedActionBudget.maxActionsPerTransition` (6) as the single source for the bound, replacing five hardcoded `16`s across the sweep planner and the fee estimates.
- Moved the shielded → shielded Max onto the note-aware `sweepAvailability` planner, alongside the withdraw and unshield routes, so the fee comes from the notes that will actually be spent and any genuine remainder is reported rather than stranded.
- Added `shieldedSpendCeilingCredits` so a **typed** amount is checked against what the notes can fund in one transition. Previously only Max was capped; a typed amount above it passed the amount screen, built its proof, and failed at broadcast.
- `performShieldedTransfer` now takes `sweepAll` and re-prices the plan before signing, matching `performWithdraw` / `performUnshield`. It was the only shielded route without that guard, so a note spent or discovered between Max and confirm would submit a stale amount.
- Reworded the two shielded Max notices, which named the withdraw route ("requires another Shielded withdrawal", "not ready to withdraw") while also being shown for transfers and unshields.

The ceiling is unknown while the note set is reconciling; the check then falls back to the balance envelope rather than blocking every send. That window is documented at the property.

## How Has This Been Tested?

- Clean `dashpay` build: `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator ARCHS=arm64 build` → **BUILD SUCCEEDED**.
- Added `testShieldedSweepStopsAtTheActionBudget`; the two existing `ShieldedSweepPlanner` tests were re-checked against the new default and are unaffected. The unit-test target is broken repo-wide (pre-existing), so these are compile-verified but not executed.
- **Not yet smoke-tested on testnet.** The three flows to exercise on a wallet with 7+ notes: Max sends the largest-6 total and shows the remainder notice; a typed amount above that ceiling blocks Continue with the explanation; a second Max after the first settles sends the rest.

## Breaking Changes

None. Two localized strings were reworded and one was added, so those keys need a Transifex pass.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Shielded Max transfers by accurately calculating spendable balances and single-transaction limits.
  * Added safeguards to recheck full-balance transfers before confirmation, preventing stale or changed amounts from being submitted.
  * Updated transfer messages to clarify unavailable balances, notes still confirming, fragmented funds, transaction-size limits, and amounts that cannot fit in one transaction.

* **Bug Fixes**
  * Improved fee estimates and validation for shielded transfers.
  * Prevented shielded sweep plans from exceeding supported action limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->