### PR TITLE
fix(ui): tell shielded dust apart from a remainder another sweep can send

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -1019,7 +1019,9 @@ final class InternalTransferViewModel: ObservableObject {
                 isFullShieldedSweep = true
                 shieldedSweepAmountCredits = plan.amountCredits
                 if plan.remainingCredits > 0 {
-                    maxNotice = Self.shieldedRemainderMessage(plan.remainingCredits)
+                    maxNotice = Self.shieldedRemainderMessage(
+                        plan.remainingCredits,
+                        followUpCredits: plan.followUpCredits)
                 }
                 sourceDuffs = plan.amountCredits / 1000
             case .waitingForConfirmation(let credits):
@@ -1419,8 +1421,20 @@ final class InternalTransferViewModel: ObservableObject {
             formatted)
     }
 
-    private static func shieldedRemainderMessage(_ credits: UInt64) -> String {
+    private static func shieldedRemainderMessage(
+        _ credits: UInt64,
+        followUpCredits: UInt64
+    ) -> String {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
+        guard followUpCredits > 0 else {
+            // Spending these notes costs more than they hold, so no later
+            // sweep can move them — do not send the user round that loop.
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "%@ DASH stays in your Shielded balance: those notes are worth less than the fee to send them.",
+                    comment: "Shielded Max dust remainder"),
+                formatted)
+        }
         return String.localizedStringWithFormat(
             NSLocalizedString(
                 "%@ DASH is held in notes that don't fit in one transaction. Use Max again after this one settles to send the rest.",

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -70,8 +70,14 @@ struct ShieldedSweepPlan: Equatable {
     let feeCredits: UInt64
     let inputCredits: UInt64
     /// Funds that necessarily stay in the pool after this bundle. Normally
-    /// zero; non-zero when more than 16 notes require another sweep.
+    /// zero; non-zero when the notes do not all fit, or when some are worth
+    /// less than the fee of the action that would spend them.
     let remainingCredits: UInt64
+    /// What a FOLLOW-UP sweep of the leftover notes could actually pay out,
+    /// once its own fee is deducted. Zero when the leftovers are dust: they
+    /// cost more to spend than they carry, so no later sweep can move them
+    /// and telling the user to retry would loop forever.
+    let followUpCredits: UInt64
 }
 
 struct ShieldedSweepCandidate: Equatable {
@@ -393,12 +399,22 @@ final class ShieldedTransferCoordinator: ObservableObject {
             return .waitingForConfirmation(publishedBalance)
         }
 
+        // What a follow-up sweep of the untouched notes could pay out. The
+        // planner drops a note whose value is below the fee of the action that
+        // would carry it, so a leftover is not automatically sendable later —
+        // price it instead of assuming.
+        let leftovers = Array(noteValues.dropFirst(exact.noteCount))
+        let followUpCredits = ShieldedSweepPlanner.bestCandidate(
+            noteValues: leftovers,
+            feeForActions: feeForActions)?.amountCredits ?? 0
+
         return .ready(
             ShieldedSweepPlan(
                 amountCredits: exact.amountCredits,
                 feeCredits: exact.feeCredits,
                 inputCredits: exact.inputCredits,
-                remainingCredits: allCredits - exact.inputCredits))
+                remainingCredits: allCredits - exact.inputCredits,
+                followUpCredits: followUpCredits))
     }
 
     /// Largest amount the pool can fund inside ONE transition — the sweep

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -708,7 +708,9 @@ final class SendViewModel: ObservableObject {
                 isFullShieldedSweep = true
                 shieldedSweepAmountCredits = plan.amountCredits
                 if plan.remainingCredits > 0 {
-                    shieldedMaxNotice = Self.shieldedRemainderMessage(plan.remainingCredits)
+                    shieldedMaxNotice = Self.shieldedRemainderMessage(
+                        plan.remainingCredits,
+                        followUpCredits: plan.followUpCredits)
                 }
                 sourceDuffs = plan.amountCredits / 1000
             case .waitingForConfirmation(let credits):
@@ -776,8 +778,20 @@ final class SendViewModel: ObservableObject {
             formatted)
     }
 
-    private static func shieldedRemainderMessage(_ credits: UInt64) -> String {
+    private static func shieldedRemainderMessage(
+        _ credits: UInt64,
+        followUpCredits: UInt64
+    ) -> String {
         let formatted = (credits / 1000).formattedDashAmountWithoutCurrencySymbol
+        guard followUpCredits > 0 else {
+            // Spending these notes costs more than they hold, so no later
+            // sweep can move them — do not send the user round that loop.
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "%@ DASH stays in your Shielded balance: those notes are worth less than the fee to send them.",
+                    comment: "Shielded Max dust remainder"),
+                formatted)
+        }
         return String.localizedStringWithFormat(
             NSLocalizedString(
                 "%@ DASH is held in notes that don't fit in one transaction. Use Max again after this one settles to send the rest.",

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -380,6 +380,28 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(candidate?.amountCredits, UInt64(budget) * 1_000 - 100)
     }
 
+    func testShieldedSweepSkipsNotesWorthLessThanTheirAction() {
+        // A note below the marginal fee of the action that would spend it
+        // lowers the payout, so the planner must leave it. The 1-credit note
+        // here is exactly that case: taking it would cost 50 and gain 1.
+        let fees: [Int: UInt64] = [2: 100, 3: 150]
+
+        let candidate = ShieldedSweepPlanner.bestCandidate(
+            noteValues: [1_000, 500, 1],
+            feeForActions: { fees[$0] })
+
+        XCTAssertEqual(candidate?.noteCount, 2)
+        XCTAssertEqual(candidate?.inputCredits, 1_500)
+        XCTAssertEqual(candidate?.amountCredits, 1_400)
+
+        // And a follow-up sweep of that leftover pays out nothing, which is
+        // what tells the UI to stop inviting the user to retry.
+        XCTAssertNil(
+            ShieldedSweepPlanner.bestCandidate(
+                noteValues: [1],
+                feeForActions: { fees[$0] }))
+    }
+
     func testShieldedSpendableBalanceSubtractsFeeReserve() {
         XCTAssertEqual(
             TransferSpendAmountPolicy.spendableCredits(


### PR DESCRIPTION
Follow-up to #1020 — this commit was pushed shortly after that PR merged, so it missed it. Rebased onto current `develop`.

## Issue being fixed or feature implemented

`Max` on a shielded balance maximises the payout, so it deliberately leaves behind notes worth less than the Orchard action that would carry them: including such a note raises the fee by more than the note holds.

That leftover was reported with the same notice as a remainder left behind by the action budget — "use Max again once this one settles". For dust that advice never terminates, because no later sweep can move those notes profitably.

## What was done?

`ShieldedSweepPlan.followUpCredits` prices what a follow-up sweep of the leftovers could actually pay out, using the same planner. Zero means dust, and the notice then says the notes are worth less than the fee to send them, instead of inviting a retry that cannot help.

## What was tried and removed

This branch briefly carried a second commit offering to spend the dust anyway ("send the remaining X too — the extra fee costs Y"), by submitting the lower payout of a full-note-set plan. **Testnet showed it makes things strictly worse, so it has been dropped.**

The SDK selects notes from the *amount*: it accumulates largest-first until `amount + fee` is covered. Submitting a **lower** amount therefore needs **fewer** inputs, not more — the selector reused the same large notes, never touched the dust, and returned the difference as change:

| | Plain Max | With the "send everything" offer |
|---|---|---|
| Recipient received | 1.94670019 | 1.94621466 |
| Left in the pool | 0.00014297 | 0.00062851 |

The forgone 0.00048553 came back as a new note rather than being spent as fee, so the dust roughly quadrupled. `ShieldedSweepPlanner.revalidate` already encodes the reason — it demands `accumulated == amount + fee` exactly — but the alternative plan was never put through it.

Emptying the pool is not implementable app-side at all today. It needs one of these on the Rust side:

- an FFI that accepts an explicit note set to spend, or
- a `sweep all` entry point in `platform-wallet` that selects every note of an account itself.

Filing that separately; this PR keeps only the honest messaging.

## How Has This Been Tested?

- Clean `dashpay` build on top of current `develop` (`ARCHS=arm64`) — **BUILD SUCCEEDED**.
- Planner test added: `bestCandidate` skips a note below its marginal action fee, and a follow-up sweep of that leftover pays out nothing — the signal the notice keys off. The unit-test target is broken repo-wide (pre-existing), so it is compile-verified, not executed.
- Testnet: the removed offer was exercised on a real wallet, which is how its flaw surfaced (numbers above). The retained messaging change was observed in the same session — the dust notice reads correctly and no longer invites a retry.

## Breaking Changes

None. One reworded localized string — needs a Transifex pass.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone