### PR TITLE
fix(wallet): charge the Core→Shielded pool fee on top of the amount

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift
@@ -46,11 +46,11 @@ struct JoinDashPayReadinessScreen: View {
     let onClaimInvitation: () -> Void
 
     /// Suggested deposit headroom (0.003 DASH in credits) added to the
-    /// shortfall prefill: the Core→Shielded route carves the Platform
-    /// pool fee from the locked value. The current Type-18 fee is about
-    /// 0.003 DASH, so depositing less headroom can leave the resulting
-    /// note below the required denomination. Only a suggestion — the
-    /// gates re-evaluate on the notes that actually land.
+    /// shortfall prefill. The Core→Shielded route now charges its pool fee
+    /// on top of the typed amount (the recipient receives the full amount),
+    /// so this is a pure safety margin against balance drift between the
+    /// prefill and the deposit. Only a suggestion — the gates re-evaluate
+    /// on the notes that actually land.
     private static let fundingFeeHeadroomCredits: UInt64 = 300_000_000
 
     private var snapshot: ShieldedIdentityFundingReadiness.Snapshot? {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -217,7 +217,9 @@ struct InternalTransferConfirmSheet: View {
     private var networkFeeCredits: UInt64? {
         switch route {
         case .coreToShielded:
-            return CoreToShieldedAmountPolicy.poolFeeCredits
+            // The lock charges the fee rounded UP to a whole duff — display
+            // that, so Amount + Network fee equals Total exactly.
+            return CoreToShieldedAmountPolicy.currentPoolFeeDuffs.map { $0 * 1000 }
         case .platformToShielded:
             // Shield (Type 15): base shielded fee. Real metered storage is
             // extra and only knowable on-chain, so this is a lower bound.

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -17,7 +17,7 @@ import SwiftDashSDK
 ///   - `.failed(msg)`    → summary card with red error + Try again / Close.
 ///
 /// Confirm executes `route` via the coordinator:
-///   - `.coreToShielded`     → `performAssetLock(amountDuffs:)`
+///   - `.coreToShielded`     → `performAssetLock(recipientAmountDuffs:)`
 ///   - `.platformToShielded` → `performShield(amountCredits:)`
 ///   - `.shieldedToCore`     → `performWithdraw(amountCredits:)`
 ///   - `.shieldedToPlatform` → `performUnshield(amountCredits:)`
@@ -211,8 +211,9 @@ struct InternalTransferConfirmSheet: View {
     private static let creditsPerDash: Decimal = 100_000_000_000
 
     /// Flat fee estimate (credits) for the active route, computed offline by
-    /// the SDK against the latest protocol version (so it matches the carved
-    /// fee). `nil` if the estimate is unavailable → the row shows "—".
+    /// the SDK against the latest protocol version (so it matches the fee the
+    /// SDK will charge). `nil` if the estimate is unavailable → the row
+    /// shows "—".
     private var networkFeeCredits: UInt64? {
         switch route {
         case .coreToShielded:
@@ -245,6 +246,24 @@ struct InternalTransferConfirmSheet: View {
         return "~ " + CurrencyExchanger.shared.fiatAmountString(for: dash)
     }
 
+    /// What actually leaves the source balance. Core→Shielded charges the
+    /// pool fee on top of the amount (the executed lock value); every other
+    /// route's total is the amount itself. "—" when the fee estimate is
+    /// unavailable — `canContinue` fails closed before that can be confirmed,
+    /// but the row must never show the un-inflated number.
+    private var totalString: String {
+        guard route == .coreToShielded else {
+            return dashDuffs.formattedDashAmount
+        }
+        guard let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+              let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                  forAmountDuffs: amountDuffsUnsigned,
+                  poolFeeCredits: poolFeeCredits),
+              let signedLockDuffs = Int64(exactly: lockDuffs)
+        else { return "—" }
+        return signedLockDuffs.formattedDashAmount
+    }
+
 
     // MARK: - Summary card
 
@@ -264,7 +283,7 @@ struct InternalTransferConfirmSheet: View {
             divider
             summaryRow(
                 label: NSLocalizedString("Total", comment: ""),
-                value: dashDuffs.formattedDashAmount)
+                value: totalString)
         }
         .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
@@ -445,7 +464,7 @@ struct InternalTransferConfirmSheet: View {
         Task {
             switch route {
             case .coreToShielded:
-                await coordinator.performAssetLock(amountDuffs: amountDuffsUnsigned)
+                await coordinator.performAssetLock(recipientAmountDuffs: amountDuffsUnsigned)
             case .platformToShielded:
                 await coordinator.performShield(amountCredits: creditsAmount)
             case .shieldedToCore:

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -45,10 +45,12 @@ enum InternalTransferRoute: Equatable {
 
 /// Shared Type-18 amount boundary for Core → Shielded transfers.
 ///
-/// `ShieldFromAssetLock` carves its pool fee from the single-use asset-lock
-/// value, so the lock must contain strictly more credits than that fee. Keep
-/// the estimator here as the one source of truth for amount validation and
-/// both transfer confirmation screens.
+/// The pool fee rides ON TOP of the typed amount: the app locks
+/// `amount + pool fee`, the SDK derives `shield_amount = lock − pool_fee`,
+/// so the recipient receives the full typed amount (plus a sub-duff rounding
+/// remainder in their favor) and the consensus surplus stays zero. Keep the
+/// estimator here as the one source of truth for amount validation and both
+/// transfer confirmation screens.
 @MainActor
 enum CoreToShieldedAmountPolicy {
     /// Asset-lock processing base cost folded into a ShieldFromAssetLock
@@ -67,11 +69,25 @@ enum CoreToShieldedAmountPolicy {
         return overflow ? nil : total
     }
 
-    /// User-entered Core amounts have duff precision (1000 Platform credits).
-    /// The SDK rejects `amountCredits <= poolFeeCredits`, so the smallest valid
-    /// value is the first whole duff strictly above the fee.
-    static func minimumAmountDuffs(poolFeeCredits: UInt64) -> UInt64 {
-        poolFeeCredits / 1000 + 1
+    /// Pool fee in whole duffs, rounded UP so a duff-denominated lock always
+    /// covers the full credit-denominated fee.
+    static func poolFeeDuffs(poolFeeCredits: UInt64) -> UInt64 {
+        poolFeeCredits / 1000 + (poolFeeCredits.isMultiple(of: 1000) ? 0 : 1)
+    }
+
+    /// Current pool fee in duffs; `nil` while the estimate is unavailable —
+    /// callers fail closed.
+    static var currentPoolFeeDuffs: UInt64? {
+        poolFeeCredits.map(poolFeeDuffs(poolFeeCredits:))
+    }
+
+    /// Fee-on-top L1 lock value that delivers exactly `amountDuffs` to the
+    /// shielded recipient (plus <1000 credits of round-up remainder, in the
+    /// user's favor). `nil` on UInt64 overflow — callers fail closed.
+    static func lockValueDuffs(forAmountDuffs amountDuffs: UInt64, poolFeeCredits: UInt64) -> UInt64? {
+        let (total, overflow) = amountDuffs.addingReportingOverflow(
+            poolFeeDuffs(poolFeeCredits: poolFeeCredits))
+        return overflow ? nil : total
     }
 }
 
@@ -662,14 +678,6 @@ final class InternalTransferViewModel: ObservableObject {
         }
     }
 
-    var coreToShieldedMinimumAmountDuffs: UInt64? {
-        guard route == .coreToShielded,
-              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits
-        else { return nil }
-        return CoreToShieldedAmountPolicy.minimumAmountDuffs(
-            poolFeeCredits: poolFeeCredits)
-    }
-
     /// Inline, user-facing explanation for an amount rejected before Confirm.
     /// Zero stays quiet while the user has not entered an amount; a
     /// fee-estimation failure fails closed with a generic retry.
@@ -677,21 +685,12 @@ final class InternalTransferViewModel: ObservableObject {
         if let maxNotice { return maxNotice }
         guard dashDuffsUnsigned > 0 else { return nil }
 
-        // Route minimum first: below the Type-18 pool fee the SDK refuses the
-        // asset lock however much Core balance backs it.
-        if route == .coreToShielded {
-            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-                return Self.feeEstimateUnavailableMessage
-            }
-            if dashDuffsUnsigned < minimumDuffs {
-                let formattedMinimum =
-                    "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-                return String.localizedStringWithFormat(
-                    NSLocalizedString(
-                        "The minimum amount you can send is %@",
-                        comment: "Internal transfer minimum amount"),
-                    formattedMinimum)
-            }
+        // The Core → Shielded pool fee rides on top of the amount, so there
+        // is no route minimum — but without the estimate the lock value
+        // cannot be derived, so fail closed before Confirm.
+        if route == .coreToShielded,
+           CoreToShieldedAmountPolicy.currentPoolFeeDuffs == nil {
+            return Self.feeEstimateUnavailableMessage
         }
 
         return insufficientBalanceMessage
@@ -704,10 +703,23 @@ final class InternalTransferViewModel: ObservableObject {
         let balanceName = route.source.balanceName
 
         switch route {
-        case .coreToShielded, .coreToPlatform:
-            // Asset-lock routes carve their pool fee from the locked value, but
-            // the funding transaction is still an L1 spend — only confirmed
-            // UTXOs, and the miner fee comes off the top.
+        case .coreToShielded:
+            // The pool fee rides on top of the amount, so the spendable
+            // envelope shrinks by the fee. Mirrors `canContinue`:
+            // requested > spendable − fee ⟺ requested + fee > spendable.
+            guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
+                return Self.feeEstimateUnavailableMessage
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: coreSpendableDuffs > feeDuffs
+                    ? coreSpendableDuffs - feeDuffs : 0)
+
+        case .coreToPlatform:
+            // This asset-lock route carves its processing fee from the locked
+            // value, but the funding transaction is still an L1 spend — only
+            // confirmed UTXOs, and the miner fee comes off the top.
             return TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedDuffs: dashDuffsUnsigned,
@@ -807,17 +819,19 @@ final class InternalTransferViewModel: ObservableObject {
         guard dashDuffsUnsigned > 0, !isBlockedBySync else { return false }
         switch route {
         case .coreToShielded:
-            // The Type-18 pool fee is carved from the asset-lock value. The
-            // SDK refuses to broadcast a single-use lock at or below that fee;
-            // enforce the same strict boundary before opening Confirm.
-            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs,
-                  dashDuffsUnsigned >= minimumDuffs
+            // Fee-on-top: the lock value is amount + pool fee, so the balance
+            // must cover both. Fails closed when the estimate is unavailable
+            // or the sum overflows.
+            guard let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+                  let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                      forAmountDuffs: dashDuffsUnsigned,
+                      poolFeeCredits: poolFeeCredits)
             else { return false }
-            return dashDuffsUnsigned <= coreSpendableDuffs
+            return lockDuffs <= coreSpendableDuffs
         case .coreToPlatform:
-            // Asset-lock routes: the pool/processing fee is carved from the
-            // locked value rather than charged on top. What still bounds them
-            // is the funding spend itself — confirmed UTXOs minus the L1 fee
+            // This asset-lock route carves its processing fee from the locked
+            // value rather than charging it on top. What still bounds it is
+            // the funding spend itself — confirmed UTXOs minus the L1 fee
             // reserve, which is exactly `coreSpendableDuffs`.
             return dashDuffsUnsigned <= coreSpendableDuffs
         case .platformToShielded:
@@ -857,7 +871,10 @@ final class InternalTransferViewModel: ObservableObject {
     private var feeReserveCredits: UInt64? {
         switch route {
         case .coreToShielded, .coreToPlatform:
-            // Asset-lock routes reserve nothing from the source balance.
+            // Core→Shielded's pool fee is duff-denominated and enforced in
+            // the route branches (`canContinue`, Max) directly; Core→Platform
+            // carves its fee from the locked value. Neither reserves credits
+            // from the source balance here.
             return 0
         case .platformToShielded:
             // Governed by the SDK's account/address-aware shield preflight.
@@ -993,7 +1010,29 @@ final class InternalTransferViewModel: ObservableObject {
         clearMaxSelection()
         let sourceDuffs: UInt64
         switch route {
-        case .coreToShielded, .coreToPlatform:
+        case .coreToShielded:
+            // Fee-on-top Max: the lock is amount + pool fee, so the largest
+            // recipient amount is L1-fee-aware spendable minus the pool fee.
+            // Fails closed (fills 0) when the fee estimate is unavailable.
+            guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
+                maxNotice = Self.feeEstimateUnavailableMessage
+                sourceDuffs = 0
+                break
+            }
+            sourceDuffs = coreSpendableDuffs > feeDuffs
+                ? coreSpendableDuffs - feeDuffs : 0
+            if coreSpendableDuffs == 0 {
+                maxNotice = Self.coreZeroMaxMessage(
+                    totalDuffs: coreBalanceDuffs,
+                    confirmedSpendableDuffs: SwiftDashSDKWalletState.shared.balance?.spendable ?? 0)
+            } else if sourceDuffs == 0 {
+                maxNotice = Self.feeReserveExceedsBalanceMessage(route.source)
+            } else {
+                // The balance card shows the total, so a Max that lands below
+                // it reads as a bug unless the held-back part is accounted for.
+                maxNotice = Self.coreHeldBackMessage(coreBalanceDuffs - sourceDuffs)
+            }
+        case .coreToPlatform:
             // Fee-aware max: spendable minus the send fee reserve (mirrors
             // DSAccount.maxOutputAmount), never the raw total — the asset-lock
             // spends core UTXOs and still needs room for the L1 fee.
@@ -1385,7 +1424,9 @@ final class InternalTransferViewModel: ObservableObject {
             formatted)
     }
 
-    private static func feeReserveExceedsBalanceMessage(_ source: ChainNetwork) -> String {
+    /// Shared with `SendViewModel`'s Core → Shielded Max (same fee-on-top
+    /// envelope) — keep `internal`.
+    static func feeReserveExceedsBalanceMessage(_ source: ChainNetwork) -> String {
         String.localizedStringWithFormat(
             NSLocalizedString(
                 "Your %@ balance is too low to cover the transfer fee.",

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -256,7 +256,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         case noPlatformAddress
         case authCancelled
         case authFailed
-        case amountBelowCoreToShieldedMinimum(UInt64)
+        case shieldedPoolFeeUnavailable
         case platformShieldCapacityChanged(maxShieldableCredits: UInt64?)
         case shieldedSweepWaiting(UInt64)
         case shieldedSweepChanged
@@ -283,13 +283,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 return NSLocalizedString("Authentication cancelled", comment: "InternalTransfer")
             case .authFailed:
                 return NSLocalizedString("Authentication failed", comment: "InternalTransfer")
-            case .amountBelowCoreToShieldedMinimum(let minimumDuffs):
-                let formattedMinimum = "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-                return String.localizedStringWithFormat(
-                    NSLocalizedString(
-                        "The minimum amount you can send is %@",
-                        comment: "Core to Shielded minimum amount"),
-                    formattedMinimum)
+            case .shieldedPoolFeeUnavailable:
+                return NSLocalizedString(
+                    "There was an error, please try again later",
+                    comment: "Core to Shielded pool fee estimate unavailable")
             case .platformShieldCapacityChanged(let maxShieldableCredits):
                 guard let maxShieldableCredits else {
                     return NSLocalizedString(
@@ -440,9 +437,11 @@ final class ShieldedTransferCoordinator: ObservableObject {
     ///
     /// Which balance funds the asset lock.
     enum AssetLockFundingSource: Equatable {
-        /// Exact amount, coin-selected from the BIP44 spendable balance —
-        /// the historical route behind the internal transfer and Send.
-        case bip44(amountDuffs: UInt64)
+        /// Amount the shielded recipient receives, coin-selected from the
+        /// BIP44 spendable balance — the historical route behind the internal
+        /// transfer and Send. The coordinator locks this plus the Type-18
+        /// pool fee on top.
+        case bip44(recipientAmountDuffs: UInt64)
         /// Whole-balance drain of the CoinJoin account: every mixed-coin
         /// UTXO funds the lock directly (lock value = Σ inputs − L1 fee,
         /// computed SDK-side) — the post-migration "move mixed coins to
@@ -452,35 +451,45 @@ final class ShieldedTransferCoordinator: ObservableObject {
 
     /// `recipientRaw43` nil = the wallet's own default Orchard address (the
     /// internal transfer); an external Send passes the recipient's raw
-    /// 43-byte payload. Type 18's remainder semantics apply either way: the
-    /// recipient receives `lock_value − pool_fee`.
-    func performAssetLock(amountDuffs: UInt64, recipientRaw43 recipientOverride: Data? = nil) async {
-        await performAssetLock(funding: .bip44(amountDuffs: amountDuffs), recipientRaw43: recipientOverride)
+    /// 43-byte payload. The recipient receives exactly `recipientAmountDuffs`:
+    /// the coordinator inflates the lock by the Type-18 pool fee, which the
+    /// SDK then subtracts back out (`shield_amount = lock − pool_fee`).
+    func performAssetLock(recipientAmountDuffs: UInt64, recipientRaw43 recipientOverride: Data? = nil) async {
+        await performAssetLock(
+            funding: .bip44(recipientAmountDuffs: recipientAmountDuffs),
+            recipientRaw43: recipientOverride)
     }
 
-    /// Funding-parameterized form of `performAssetLock(amountDuffs:)` — same
-    /// stages, polling, and resume semantics for both funding sources (a
-    /// stuck lock resumes by outpoint regardless of what funded it).
+    /// Funding-parameterized form of `performAssetLock(recipientAmountDuffs:)`
+    /// — same stages, polling, and resume semantics for both funding sources
+    /// (a stuck lock resumes by outpoint regardless of what funded it).
     func performAssetLock(funding: AssetLockFundingSource, recipientRaw43 recipientOverride: Data? = nil) async {
         guard beginTransfer() else { return }
         lastAssetLockOutPoint = nil
         Self.logger.info("🛡️ SHIELD-TX :: asset-lock route funding=\(String(describing: funding), privacy: .public) external=\(recipientOverride != nil)")
 
-        // Backstop both amount screens at the execution boundary. Besides
-        // protecting programmatic callers, this keeps a stale Confirm sheet
-        // from surfacing the Rust SDK's raw ShieldFromAssetLock build error.
-        // Only the BIP44 exact-amount form carries a caller amount; the
+        // The single fee-on-top point: the BIP44 form carries the amount the
+        // recipient must receive, and the lock is inflated by the pool fee
+        // here so the SDK's `shield_amount = lock − pool_fee` lands back on
+        // exactly that amount. Fails closed — a missing fee estimate, a zero
+        // amount, or overflow must never submit an un-inflated lock. The
         // CoinJoin drain's lock value is computed SDK-side, which preflights
         // it against the pool fee before broadcasting.
-        if case .bip44(let amountDuffs) = funding,
-           let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits {
-            let minimumDuffs = CoreToShieldedAmountPolicy.minimumAmountDuffs(
-                poolFeeCredits: poolFeeCredits)
-            guard amountDuffs >= minimumDuffs else {
-                handleFailure(
-                    CoordinatorError.amountBelowCoreToShieldedMinimum(minimumDuffs))
+        let bip44LockValueDuffs: UInt64?
+        if case .bip44(let recipientAmountDuffs) = funding {
+            guard recipientAmountDuffs > 0,
+                  let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+                  let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                      forAmountDuffs: recipientAmountDuffs,
+                      poolFeeCredits: poolFeeCredits)
+            else {
+                handleFailure(CoordinatorError.shieldedPoolFeeUnavailable)
                 return
             }
+            bip44LockValueDuffs = lockDuffs
+            Self.logger.info("🛡️ SHIELD-TX :: fee-on-top lock recipient=\(recipientAmountDuffs) lock=\(lockDuffs)")
+        } else {
+            bip44LockValueDuffs = nil
         }
 
         let env: Environment
@@ -507,11 +516,15 @@ final class ShieldedTransferCoordinator: ObservableObject {
                 recipientRaw43: recipientOverride ?? env.shieldedRecipient,
                 credits: nil)
             switch funding {
-            case .bip44(let amountDuffs):
+            case .bip44:
+                guard let lockValueDuffs = bip44LockValueDuffs else {
+                    // Unreachable: the entry guard derives it for every .bip44.
+                    throw CoordinatorError.shieldedPoolFeeUnavailable
+                }
                 try await env.manager.shieldedFundFromAssetLock(
                     walletId: env.walletId,
                     fundingAccountIndex: 0,
-                    amountDuffs: amountDuffs,
+                    amountDuffs: lockValueDuffs,
                     recipients: [recipient])
             case .coinJoinDrain:
                 try await env.manager.shieldedFundFromCoinJoinDrain(

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -946,7 +946,9 @@ struct SendConfirmSheet: View {
     private var networkFeeCredits: UInt64? {
         switch route {
         case .coreToShielded:
-            return CoreToShieldedAmountPolicy.poolFeeCredits
+            // The lock charges the fee rounded UP to a whole duff — display
+            // that, so Amount + Network fee equals Total exactly.
+            return CoreToShieldedAmountPolicy.currentPoolFeeDuffs.map { $0 * 1000 }
         case .platformToPlatform:
             // Credit transfer: the metered transition fee. The executor
             // states ~0.001 DASH as the conservative max.

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -898,7 +898,7 @@ struct SendConfirmSheet: View {
             divider
             summaryRow(
                 label: NSLocalizedString("Total", comment: ""),
-                value: dashDuffs.formattedDashAmount)
+                value: totalString)
         }
         .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
@@ -969,6 +969,25 @@ struct SendConfirmSheet: View {
         guard let credits = networkFeeCredits else { return "—" }
         let dash = Decimal(credits) / Self.creditsPerDash
         return "~ " + CurrencyExchanger.shared.fiatAmountString(for: dash)
+    }
+
+    /// What actually leaves the source balance. Core→Shielded charges the
+    /// pool fee on top of the amount (the executed lock value); every other
+    /// route's total is the amount itself. "—" when the fee estimate is
+    /// unavailable — `canContinue` fails closed before that can be confirmed,
+    /// but the row must never show the un-inflated number.
+    private var totalString: String {
+        guard route == .coreToShielded else {
+            return dashDuffs.formattedDashAmount
+        }
+        guard let amountDuffs = UInt64(exactly: dashDuffs),
+              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+              let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                  forAmountDuffs: amountDuffs,
+                  poolFeeCredits: poolFeeCredits),
+              let signedLockDuffs = Int64(exactly: lockDuffs)
+        else { return "—" }
+        return signedLockDuffs.formattedDashAmount
     }
 
     // MARK: - Info card
@@ -1070,7 +1089,7 @@ struct SendConfirmSheet: View {
                     return
                 }
                 await coordinator.performAssetLock(
-                    amountDuffs: UInt64(dashDuffs),
+                    recipientAmountDuffs: UInt64(dashDuffs),
                     recipientRaw43: destinationRaw43)
             case .platformToPlatform:
                 await coordinator.performPlatformSend(

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -34,8 +34,9 @@ final class SendViewModel: ObservableObject {
     enum Route: Equatable {
         case coreToCore
         /// BIP44 UTXOs → asset lock → Type 18 shield note for the
-        /// recipient's Orchard address (remainder semantics: they receive
-        /// `lock_value − pool_fee`).
+        /// recipient's Orchard address. The pool fee rides on top: the
+        /// coordinator locks `amount + pool_fee`, so the recipient receives
+        /// the full typed amount.
         case coreToShielded
         case platformToPlatform
         case platformToCore
@@ -443,9 +444,9 @@ final class SendViewModel: ObservableObject {
         switch route {
         case .coreToCore, .coreToShielded, .platformToCore, nil:
             // L1 send fees are handled by the payment processor; the
-            // asset-lock shield carves its pool fee from the locked value
-            // (nothing reserved from the Core balance, mirroring the
-            // internal transfer); the full-balance platform withdrawal
+            // asset-lock shield's pool fee is duff-denominated and enforced
+            // in the route branches (`canContinue`, Max) directly, mirroring
+            // the internal transfer; the full-balance platform withdrawal
             // nets its fee out of the preflighted payout.
             return 0
         case .platformToPlatform:
@@ -511,38 +512,18 @@ final class SendViewModel: ObservableObject {
         }
     }
 
-    /// Type-18's pool fee is carved out of the one-time asset-lock value.
-    /// Reuse the internal-transfer policy so external sends to a shielded
-    /// address cannot reach Confirm with an amount the SDK must reject.
-    var coreToShieldedMinimumAmountDuffs: UInt64? {
-        guard route == .coreToShielded,
-              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits
-        else { return nil }
-        return CoreToShieldedAmountPolicy.minimumAmountDuffs(
-            poolFeeCredits: poolFeeCredits)
-    }
-
     /// Inline explanation for an amount rejected before Confirm. Keep zero
     /// quiet until the user types.
     var amountValidationMessage: String? {
         if let shieldedMaxNotice { return shieldedMaxNotice }
         guard dashDuffsUnsigned > 0, let route else { return nil }
 
-        // Route minimum first: below the Type-18 pool fee the SDK refuses the
-        // asset lock however much Core balance backs it.
-        if route == .coreToShielded {
-            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs else {
-                return Self.feeEstimateUnavailableMessage
-            }
-            if dashDuffsUnsigned < minimumDuffs {
-                let formattedMinimum =
-                    "\(minimumDuffs.formattedDashAmountWithoutCurrencySymbol) DASH"
-                return String.localizedStringWithFormat(
-                    NSLocalizedString(
-                        "The minimum amount you can send is %@",
-                        comment: "External shielded send minimum amount"),
-                    formattedMinimum)
-            }
+        // The Core → Shielded pool fee rides on top of the amount, so there
+        // is no route minimum — but without the estimate the lock value
+        // cannot be derived, so fail closed before Confirm.
+        if route == .coreToShielded,
+           CoreToShieldedAmountPolicy.currentPoolFeeDuffs == nil {
+            return Self.feeEstimateUnavailableMessage
         }
 
         return insufficientBalanceMessage
@@ -556,11 +537,24 @@ final class SendViewModel: ObservableObject {
         let balanceName = source.balanceName
 
         switch route {
-        case .coreToCore, .coreToShielded:
+        case .coreToCore:
             return TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedDuffs: dashDuffsUnsigned,
                 spendableDuffs: coreBalanceDuffs)
+
+        case .coreToShielded:
+            // The pool fee rides on top of the amount, so the spendable
+            // envelope shrinks by the fee. Mirrors `canContinue`:
+            // requested > spendable − fee ⟺ requested + fee > spendable.
+            guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
+                return Self.feeEstimateUnavailableMessage
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: coreBalanceDuffs > feeDuffs
+                    ? coreBalanceDuffs - feeDuffs : 0)
 
         case .platformToPlatform:
             guard let reserve = feeReserveCredits else {
@@ -653,14 +647,15 @@ final class SendViewModel: ObservableObject {
             // unfundable send with its own error, so gate on the balance only.
             return dashDuffsUnsigned <= coreBalanceDuffs
         case .coreToShielded:
-            // Asset-lock route: the pool fee is carved from the locked value
-            // and the Rust side rejects an undersized lock. Enforce the same
-            // strict minimum as the internal Core → Shielded transfer before
-            // opening Confirm.
-            guard let minimumDuffs = coreToShieldedMinimumAmountDuffs,
-                  dashDuffsUnsigned >= minimumDuffs
+            // Fee-on-top: the lock value is amount + pool fee, so the balance
+            // must cover both. Fails closed when the estimate is unavailable
+            // or the sum overflows — same policy as the internal transfer.
+            guard let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+                  let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                      forAmountDuffs: dashDuffsUnsigned,
+                      poolFeeCredits: poolFeeCredits)
             else { return false }
-            return dashDuffsUnsigned <= coreBalanceDuffs
+            return lockDuffs <= coreBalanceDuffs
         case .platformToPlatform:
             guard let reserve = feeReserveCredits else { return false }
             return platformCredits >= reserve
@@ -689,11 +684,25 @@ final class SendViewModel: ObservableObject {
         clearShieldedMaxSelection()
         let sourceDuffs: UInt64
         switch route {
-        case .coreToCore, .coreToShielded, nil:
+        case .coreToCore, nil:
             // Fee-aware max: spendable minus the send fee reserve (mirrors
             // DSAccount.maxOutputAmount), never the raw total — which would
             // include unconfirmed/immature funds and leave no room for the fee.
             sourceDuffs = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
+        case .coreToShielded:
+            // Fee-on-top Max: the lock is amount + pool fee, so the largest
+            // recipient amount is the L1-fee-aware spendable minus the pool
+            // fee. Fails closed (fills 0) when the estimate is unavailable.
+            let spendable = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
+            guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
+                shieldedMaxNotice = Self.feeEstimateUnavailableMessage
+                sourceDuffs = 0
+                break
+            }
+            sourceDuffs = spendable > feeDuffs ? spendable - feeDuffs : 0
+            if spendable > 0, sourceDuffs == 0 {
+                shieldedMaxNotice = InternalTransferViewModel.feeReserveExceedsBalanceMessage(source)
+            }
         case .platformToPlatform:
             sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
         case .platformToCore:

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -84,6 +84,13 @@ final class SendViewModel: ObservableObject {
     // Balances — same feeds as `InternalTransferViewModel` (BIP44 duffs,
     // DIP-17 credits, Orchard credits).
     @Published private(set) var coreBalanceDuffs: UInt64 = 0
+
+    /// L1-fee-aware spendable Core balance — the same envelope Max fills.
+    /// Core → Shielded validation checks the fee-inclusive lock against this,
+    /// mirroring the internal transfer's `coreSpendableDuffs`.
+    var coreSpendableDuffs: UInt64 {
+        SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
+    }
     @Published private(set) var platformCredits: UInt64 = 0
     @Published private(set) var shieldedBalance: UInt64 = 0
 
@@ -550,11 +557,12 @@ final class SendViewModel: ObservableObject {
             guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
                 return Self.feeEstimateUnavailableMessage
             }
+            let spendableDuffs = coreSpendableDuffs
             return TransferSpendAmountPolicy.insufficientBalanceMessage(
                 balanceName: balanceName,
                 requestedDuffs: dashDuffsUnsigned,
-                spendableDuffs: coreBalanceDuffs > feeDuffs
-                    ? coreBalanceDuffs - feeDuffs : 0)
+                spendableDuffs: spendableDuffs > feeDuffs
+                    ? spendableDuffs - feeDuffs : 0)
 
         case .platformToPlatform:
             guard let reserve = feeReserveCredits else {
@@ -647,15 +655,17 @@ final class SendViewModel: ObservableObject {
             // unfundable send with its own error, so gate on the balance only.
             return dashDuffsUnsigned <= coreBalanceDuffs
         case .coreToShielded:
-            // Fee-on-top: the lock value is amount + pool fee, so the balance
-            // must cover both. Fails closed when the estimate is unavailable
-            // or the sum overflows — same policy as the internal transfer.
+            // Fee-on-top: the lock value is amount + pool fee, and the
+            // asset-lock funding is an L1 spend — validate against the
+            // fee-aware spendable envelope (same basis as Max), not the raw
+            // balance. Fails closed when the estimate is unavailable or the
+            // sum overflows — same policy as the internal transfer.
             guard let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
                   let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
                       forAmountDuffs: dashDuffsUnsigned,
                       poolFeeCredits: poolFeeCredits)
             else { return false }
-            return lockDuffs <= coreBalanceDuffs
+            return lockDuffs <= coreSpendableDuffs
         case .platformToPlatform:
             guard let reserve = feeReserveCredits else { return false }
             return platformCredits >= reserve
@@ -693,7 +703,7 @@ final class SendViewModel: ObservableObject {
             // Fee-on-top Max: the lock is amount + pool fee, so the largest
             // recipient amount is the L1-fee-aware spendable minus the pool
             // fee. Fails closed (fills 0) when the estimate is unavailable.
-            let spendable = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
+            let spendable = coreSpendableDuffs
             guard let feeDuffs = CoreToShieldedAmountPolicy.currentPoolFeeDuffs else {
                 shieldedMaxNotice = Self.feeEstimateUnavailableMessage
                 sourceDuffs = 0

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -314,15 +314,31 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(NormalizePlatformAddressActivityUnits().version, 20260727140000)
     }
 
-    func testCoreToShieldedMinimumIsFirstWholeDuffStrictlyAbovePoolFee() {
+    func testCoreToShieldedPoolFeeDuffsRoundsUpToCoverTheCreditFee() {
+        // A 200-credit remainder rounds up to the next whole duff…
         XCTAssertEqual(
-            CoreToShieldedAmountPolicy.minimumAmountDuffs(
+            CoreToShieldedAmountPolicy.poolFeeDuffs(poolFeeCredits: 212_851_200),
+            212_852)
+        // …while an exact duff multiple must NOT gain a spurious +1.
+        XCTAssertEqual(
+            CoreToShieldedAmountPolicy.poolFeeDuffs(poolFeeCredits: 212_851_000),
+            212_851)
+    }
+
+    func testCoreToShieldedLockValueIsAmountPlusRoundedUpFee() {
+        // Fee-on-top: the lock delivers the full typed amount to the pool.
+        XCTAssertEqual(
+            CoreToShieldedAmountPolicy.lockValueDuffs(
+                forAmountDuffs: 1_000_000,
                 poolFeeCredits: 212_851_200),
-            212_852)
-        XCTAssertEqual(
-            CoreToShieldedAmountPolicy.minimumAmountDuffs(
-                poolFeeCredits: 212_851_000),
-            212_852)
+            1_212_852)
+    }
+
+    func testCoreToShieldedLockValueFailsClosedOnOverflow() {
+        XCTAssertNil(
+            CoreToShieldedAmountPolicy.lockValueDuffs(
+                forAmountDuffs: UInt64.max,
+                poolFeeCredits: 212_851_200))
     }
 
     func testShieldedSweepChoosesPrefixWithLargestNetPayout() {


### PR DESCRIPTION
## Problem

Shielding 5 DASH delivered only **4.99787 DASH**. The app passed the typed amount as the asset-lock value, and the SDK derives `shield_amount = lock_value − pool_fee`, so the Type-18 pool fee (`compute_minimum_shielded_fee(2) + asset_lock_base_cost` = 212 851 200 credits ≈ 0.00213 DASH) was carved out of the amount. Meanwhile the confirm sheet already rendered "Network fee" + "Total" as if the fee were charged on top — the UI claimed semantics the code didn't have.

Platform→Shielded was already fee-on-top and is untouched.

## Fix

App-side only — no SDK/Rust changes. Since the SDK always subtracts exactly `pool_fee` from the lock, inflating the lock by the fee makes the recipient receive the full typed amount:

- **One inflation point** (`ShieldedTransferCoordinator.performAssetLock`): locks `amount + ceil(pool_fee)` via new `CoreToShieldedAmountPolicy` helpers (`poolFeeDuffs`, `lockValueDuffs`). The sub-duff round-up remainder (≤999 credits) goes to the recipient; the consensus surplus stays zero, so no `surplus_output` is needed. The parameter was renamed to `recipientAmountDuffs` so the semantic flip is compiler-enforced at both call sites.
- **Fail closed**: a missing fee estimate, zero amount, or overflow now aborts with a typed error (`.shieldedPoolFeeUnavailable`) — previously the execution-boundary guard was silently skipped when the estimate was unavailable and an un-inflated lock went out.
- **Validation & Max** (both `InternalTransferViewModel` and `SendViewModel`): `canContinue` checks `amount + fee ≤ spendable`, insufficient-balance messages report the fee-reduced envelope, Max fills `spendable − fee`.
- **Route minimum removed**: with fee-on-top, any amount ≥ 1 duff yields `lock > pool_fee` by construction (Rust has no other dust floor), so the old `poolFee/1000 + 1` minimum and its error copy are gone.
- **Confirm sheets**: the "Total" row now shows the executed lock value (amount + fee) on Core→Shielded, making the long-displayed fee-on-top claim true.
- **Resume path unchanged**: the SDK re-derives the shield amount from the on-chain lock value, so a resumed lock delivers the same amount.

Kept as-is on purpose: Core→Platform (carve is real there) and the CoinJoin drain (whole-balance semantics).

## Verification

- Clean `dashpay` scheme build (`iphonesimulator`, `ARCHS=arm64`) — the unit-test target is broken repo-wide, so the new `CoreToShieldedAmountPolicy` tests are compile-ready only.
- Testnet smoke pending: shield 0.01 → confirm Total = 0.01212852, shielded balance += exactly 0.01; Max = spendable − 212 852 duffs; tiny amounts (< old minimum) now allowed; external Send to a shielded address mirrors all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Core-to-Shielded transfers now add the pool fee to the entered amount, ensuring recipients receive the requested value.
  * Transfer totals, balance checks, and maximum amounts now reflect applicable fees.
  * Clear unavailable states are shown when fee or conversion estimates cannot be calculated.
  * Improved handling for fee rounding, amount overflow, and insufficient-balance scenarios.
* **Tests**
  * Added coverage for fee rounding, fee-inclusive transfer amounts, unavailable fee estimates, and overflow handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->