### PR TITLE
fix(ui): derive the send source from the address until the user picks one

### DIFF
--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -53,6 +53,15 @@ final class SendViewModel: ObservableObject {
     @Published var source: ChainNetwork = .core {
         didSet { sourceDidChange() }
     }
+    /// True once the From step has been changed by the user. Until then the
+    /// source is derived from the destination on every address change: the
+    /// initial `.core` is a placeholder, not a decision, and treating it as
+    /// one is what left a pasted shielded address funded from the
+    /// transparent balance.
+    private var userPickedSource = false
+    /// Set while `destinationDidChange` derives the source, so its write to
+    /// `source` isn't mistaken for a user pick.
+    private var isDerivingSource = false
     private var isApplyingMax = false
     @Published var amountText: String = "0" {
         didSet {
@@ -218,13 +227,22 @@ final class SendViewModel: ObservableObject {
         guard newDestination != destination else { return }
         destination = newDestination
 
-        // Keep the source legal for the new destination; prefer keeping the
-        // user's pick, else the first valid source that has any balance,
-        // else the first valid source. A pinned source never moves — an
-        // incompatible destination reads back as `pinnedSourceMismatch`.
+        // Keep an explicit user pick when it is still legal for the new
+        // destination; otherwise derive the source from the destination —
+        // the first valid source that has any balance, else the first valid
+        // source. `validSources` is ordered by preference, so a shielded
+        // address funds itself from the pool rather than from the standing
+        // `.core` default (which is legal for it, and would therefore have
+        // survived a "keep whatever is selected" rule and silently turned a
+        // private transfer into an on-chain shield). A pinned source never
+        // moves — an incompatible destination reads back as
+        // `pinnedSourceMismatch`.
         let valid = validSources
-        if pinnedSource == nil, !valid.isEmpty, !valid.contains(source) {
-            source = valid.first { balanceDuffs(of: $0) > 0 } ?? valid[0]
+        if pinnedSource == nil, !valid.isEmpty, !userPickedSource || !valid.contains(source) {
+            let preferred = valid.first { balanceDuffs(of: $0) > 0 } ?? valid[0]
+            if preferred != source {
+                setSourceWithoutClaimingUserIntent(preferred)
+            }
         }
         routeDidChange()
     }
@@ -249,7 +267,18 @@ final class SendViewModel: ObservableObject {
     }
 
     private func sourceDidChange() {
+        if !isDerivingSource {
+            userPickedSource = true
+        }
         routeDidChange()
+    }
+
+    /// Move the source without recording it as the user's pick, so a later
+    /// destination change is still free to re-derive it.
+    private func setSourceWithoutClaimingUserIntent(_ network: ChainNetwork) {
+        isDerivingSource = true
+        defer { isDerivingSource = false }
+        source = network
     }
 
     // MARK: - Sources & route


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pasting (or scanning) a shielded address on the Send screen opened the **From** step on **Transparent**, even when the shielded pool held a balance.

`SendViewModel.source` starts at `.core`, and `.core` is a *legal* source for a shielded destination — it is the asset-lock shield route. The existing rule only re-picked the source when the current one became illegal for the new destination, so that standing initial value was treated as if the user had chosen it and survived every address change.

The result was not cosmetic: unless the user noticed the picker and switched it, a transfer they meant to keep inside the shielded pool went out as an on-chain shield from the transparent balance.

## What was done?

`SendViewModel` now tracks whether the From step has ever been changed by the user:

- until it has, every destination change re-derives the source from `validSources` — which is already ordered by preference (`[.shielded, .core]` for a shielded destination) — taking the first entry that has a balance;
- once the user picks a source explicitly, that pick is kept for as long as it stays legal for the entered destination;
- the derived write goes through a helper that does not record it as a user pick, so a later address change is still free to re-derive;
- a pinned source (the balance-row send sheet) is untouched — an incompatible address still reads back as `pinnedSourceMismatch`.

Every way an address reaches the screen assigns `addressText` — typing, the clipboard suggestion chip, the in-screen scan (`ingestScannedInput`), and the bech32m scan routing in `DWBasePayViewController` that prefills this screen — so all of them share the new behavior. Base58 Core scans keep the legacy payment-processor path and have no From step at all.

Resulting selection:

| Address | Balances | From |
|---|---|---|
| shielded | shielded pool funded | **Shielded** (was Transparent) |
| shielded | shielded pool empty | Transparent (shield route) |
| transparent | transparent funded | Transparent (unchanged) |
| any | user picked it and it is legal | the user's pick |

## How Has This Been Tested?

- `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` → **BUILD SUCCEEDED**, both before and after rebasing onto current `develop`.
- Manual two-device check on testnet: a shielded address copied on device A and pasted on device B now opens the From step on Shielded; scanning the same address by QR behaves identically. With an empty shielded pool the screen still falls back to Transparent and the shield route.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment source selection when destinations change.
  * Preserves a source explicitly selected by the user when it remains valid.
  * Automatically selects a funded, valid source when the current source is no longer suitable.
  * Prevents internally derived source changes from overriding the user’s selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->