### PR TITLE
fix(wallet): provision added wallets across networks

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -542,11 +542,41 @@ final class SwiftDashSDKHost {
         case alreadyExists(walletId: Data)
     }
 
+    /// Networks that still need a persisted representation for a logical
+    /// wallet, ordered so the running network is created first. Keeping this
+    /// decision pure makes the cross-network add behavior regression-testable
+    /// without constructing SDK managers.
+    nonisolated static func missingWalletNetworks(
+        mnemonic: String,
+        persistedWalletIds: Set<Data>,
+        currentNetwork: Network
+    ) throws -> [Network] {
+        let otherNetwork: Network
+        switch currentNetwork {
+        case .mainnet:
+            otherNetwork = .testnet
+        case .testnet:
+            otherNetwork = .mainnet
+        default:
+            throw HostError.unsupportedNetwork(currentNetwork)
+        }
+
+        let walletIds = try SwiftDashSDKStoredWalletNetworkResolver.walletIds(for: mnemonic)
+        return [currentNetwork, otherNetwork].filter { network in
+            guard let walletId = walletIds[network] else { return false }
+            return !persistedWalletIds.contains(walletId)
+        }
+    }
+
     /// Add a wallet from `mnemonic` ADDITIVELY: create it in the already-running
-    /// manager and persist its mnemonic, WITHOUT tearing down the runtime,
-    /// touching the active-wallet registry, or rebinding the published active
-    /// wallet. The caller (Wallets screen "Add Wallet") switches to the new
-    /// wallet afterward via `SwiftDashSDKWalletRuntime.switchWallet`.
+    /// manager and persist its mnemonic, then materialize the same logical
+    /// wallet for the other supported network. This is explicit provisioning
+    /// at create/import time; reinstall recovery remains network-scoped and
+    /// must never manufacture a mirror from an arbitrary surviving entry.
+    /// Neither operation touches the active-wallet registries or rebinds the
+    /// published active wallet. The caller (Wallets screen "Add Wallet")
+    /// switches to the current-network wallet afterward via
+    /// `SwiftDashSDKWalletRuntime.switchWallet`.
     ///
     /// Requires a running host (a bound active wallet already exists — adding
     /// is only reachable from the Wallets screen). Returns `.alreadyExists`
@@ -559,6 +589,7 @@ final class SwiftDashSDKHost {
     /// uses the LIVE manager and does not publish or set-active.
     @discardableResult
     func addWallet(mnemonic: String, isImported: Bool) async throws -> AddWalletResult {
+        let mnemonic = Mnemonic.normalizePhrase(mnemonic)
         guard !mnemonic.isEmpty, Mnemonic.validate(mnemonic) else {
             throw HostError.invalidMnemonic
         }
@@ -568,29 +599,42 @@ final class SwiftDashSDKHost {
             throw HostError.walletNotFound(runningNetwork ?? .mainnet)
         }
 
-        // Idempotence guard: `createWallet` is keyed by the deterministic
-        // walletId, so adding an already-present wallet would no-op. Detect it
-        // from the persisted-mnemonic set (the switchable-wallet source of
-        // truth) and report `.alreadyExists` rather than a fabricated success.
-        let derivedId = try Wallet(mnemonic: mnemonic, network: network).id
-        if Self.persistedMnemonics().contains(where: { $0.walletId == derivedId }) {
-            Self.logger.info("🪺 HOST :: addWallet — walletId already persisted; not re-adding")
-            return .alreadyExists(walletId: derivedId)
+        let walletIds = try SwiftDashSDKStoredWalletNetworkResolver.walletIds(for: mnemonic)
+        guard let currentWalletId = walletIds[network] else {
+            throw HostError.unsupportedNetwork(network)
         }
 
-        let createdWallet = try createAndPersist(
+        let persistedWalletIds = Set(try WalletStorage().listWalletIdsWithMnemonic())
+        let networksToCreate = try Self.missingWalletNetworks(
             mnemonic: mnemonic,
-            manager: manager,
-            network: network,
-            // Same semantics as `createOrImportWallet`: imports scan
-            // from the network's import floor, freshly generated
-            // wallets from the tip.
-            birthHeight: isImported
-                ? Self.importedWalletBirthHeight(for: network)
-                : nil)
+            persistedWalletIds: persistedWalletIds,
+            currentNetwork: network)
+        let createsCurrentNetwork = networksToCreate.contains(network)
 
-        Self.logger.info("🪺 HOST :: added managed wallet for \(network.rawValue, privacy: .public) (additive)")
-        return .added(walletId: createdWallet.walletId)
+        for targetNetwork in networksToCreate {
+            let targetManager = targetNetwork == network
+                ? manager
+                : try managerForStoredWalletOperation(network: targetNetwork)
+            _ = try createAndPersist(
+                mnemonic: mnemonic,
+                manager: targetManager,
+                network: targetNetwork,
+                // Same semantics as `createOrImportWallet`: imports scan
+                // from each network's import floor, freshly generated
+                // wallets from that network's tip.
+                birthHeight: isImported
+                    ? Self.importedWalletBirthHeight(for: targetNetwork)
+                    : nil)
+            Self.logger.info(
+                "🪺 HOST :: added managed wallet for \(targetNetwork.rawValue, privacy: .public) (additive)")
+        }
+
+        if createsCurrentNetwork {
+            return .added(walletId: currentWalletId)
+        }
+
+        Self.logger.info("🪺 HOST :: current-network walletId already persisted; missing mirror repaired if needed")
+        return .alreadyExists(walletId: currentWalletId)
     }
 
     /// Derive the deterministic wallet id, persist and verify its mnemonic, then
@@ -764,6 +808,13 @@ final class SwiftDashSDKHost {
     /// second open of the same SQLite store and leaving the published runtime
     /// unchanged until the wipe commits.
     func managerForWipe(network: Network) throws -> PlatformWalletManager {
+        try managerForStoredWalletOperation(network: network)
+    }
+
+    /// Returns a manager over the network's persisted store without changing
+    /// the published runtime. Shared by full-device wipe and explicit
+    /// cross-network wallet provisioning.
+    private func managerForStoredWalletOperation(network: Network) throws -> PlatformWalletManager {
         if runningNetwork == network, let manager {
             return manager
         }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -481,7 +481,10 @@ final class SwiftDashSDKHost {
     /// This is the fresh-install / recover path: it rebuilds the runtime from
     /// scratch (`buildRuntime` tears down any running manager), stores and
     /// verifies its mnemonic, creates the wallet, pins it active in the registry, and
-    /// publishes it as bound. Onboarding's first wallet uses this.
+    /// publishes it as bound. Onboarding's first wallet uses this and requests
+    /// an explicit representation on every supported network. Legacy DashSync
+    /// migration keeps the default network-scoped behavior so it can never
+    /// manufacture cross-network copies while replaying old key material.
     ///
     /// For adding a wallet ALONGSIDE existing ones without rebinding the
     /// active wallet, use `addWallet(mnemonic:isImported:)` instead — this path replaces
@@ -490,7 +493,8 @@ final class SwiftDashSDKHost {
     func createOrImportWallet(
         mnemonic: String,
         network: Network,
-        isImported: Bool
+        isImported: Bool,
+        provisionAcrossSupportedNetworks: Bool = false
     ) async throws -> ManagedPlatformWallet {
         guard !mnemonic.isEmpty, Mnemonic.validate(mnemonic) else {
             throw HostError.invalidMnemonic
@@ -514,6 +518,28 @@ final class SwiftDashSDKHost {
                 birthHeight: isImported
                     ? Self.importedWalletBirthHeight(for: handles.network)
                     : nil)
+
+            if provisionAcrossSupportedNetworks {
+                let persistedWalletIds = Set(try WalletStorage().listWalletIdsWithMnemonic())
+                let missingNetworks = try Self.missingWalletNetworks(
+                    mnemonic: mnemonic,
+                    persistedWalletIds: persistedWalletIds,
+                    currentNetwork: network)
+
+                for targetNetwork in missingNetworks where targetNetwork != network {
+                    let targetManager = try managerForStoredWalletOperation(
+                        network: targetNetwork)
+                    _ = try createAndPersist(
+                        mnemonic: mnemonic,
+                        manager: targetManager,
+                        network: targetNetwork,
+                        birthHeight: isImported
+                            ? Self.importedWalletBirthHeight(for: targetNetwork)
+                            : nil)
+                    Self.logger.info(
+                        "🪺 HOST :: provisioned onboarding wallet for \(targetNetwork.rawValue, privacy: .public)")
+                }
+            }
         } catch {
             // `createOrImportWallet` owns a freshly-built (not yet published)
             // runtime, so tear it down on failure. `createAndPersist` has

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletCreator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletCreator.swift
@@ -167,7 +167,8 @@ final class SwiftDashSDKWalletCreator: NSObject {
                 result = .success(try await SwiftDashSDKHost.shared.createOrImportWallet(
                     mnemonic: mnemonic,
                     network: network,
-                    isImported: isImported
+                    isImported: isImported,
+                    provisionAcrossSupportedNetworks: true
                 ).walletId)
             } catch {
                 result = .failure(error)

--- a/DashWalletTests/WalletWipeSerialExecutorTests.swift
+++ b/DashWalletTests/WalletWipeSerialExecutorTests.swift
@@ -201,6 +201,40 @@ final class StoredWalletInventoryTests: XCTestCase {
         XCTAssertNotEqual(ids[.mainnet], ids[.testnet])
     }
 
+    func testAddWalletCreatesCurrentNetworkThenMissingMirror() throws {
+        XCTAssertEqual(
+            try SwiftDashSDKHost.missingWalletNetworks(
+                mnemonic: seedA,
+                persistedWalletIds: [],
+                currentNetwork: .mainnet),
+            [.mainnet, .testnet])
+        XCTAssertEqual(
+            try SwiftDashSDKHost.missingWalletNetworks(
+                mnemonic: seedA,
+                persistedWalletIds: [],
+                currentNetwork: .testnet),
+            [.testnet, .mainnet])
+    }
+
+    func testAddWalletCreatesOnlyMissingNetworkMirror() throws {
+        let ids = try SwiftDashSDKStoredWalletNetworkResolver.walletIds(for: seedA)
+        let mainnetId = try XCTUnwrap(ids[.mainnet])
+        let testnetId = try XCTUnwrap(ids[.testnet])
+
+        XCTAssertEqual(
+            try SwiftDashSDKHost.missingWalletNetworks(
+                mnemonic: seedA,
+                persistedWalletIds: [mainnetId],
+                currentNetwork: .mainnet),
+            [.testnet])
+        XCTAssertEqual(
+            try SwiftDashSDKHost.missingWalletNetworks(
+                mnemonic: seedA,
+                persistedWalletIds: [mainnetId, testnetId],
+                currentNetwork: .mainnet),
+            [])
+    }
+
     func testRecoveryWipeTreatsMirroredIdsAsOneNormalizedSeed() {
         XCTAssertEqual(
             SwiftDashSDKWalletWiper.soleNormalizedMnemonic(


### PR DESCRIPTION
## Summary

- explicitly persist and create a newly added wallet on both mainnet and testnet
- repair a missing network mirror when the current-network wallet already exists
- keep reinstall recovery network-scoped so deleted wallets are not resurrected

## Context

The network-safe recovery fix intentionally stopped replaying every Keychain mnemonic through both network managers. That closed the deleted-wallet resurrection bug, but Add Wallet still created only the current-network representation. A wallet added on mainnet therefore disappeared after switching to testnet.

This PR moves cross-network provisioning to the explicit create/import action instead of reintroducing implicit mirroring during reinstall recovery.

Provisioning is intentionally additive and idempotent. If a rare later-network creation fails, retry creates only the missing representation. We do not perform destructive rollback across independent network managers, SwiftData stores, and Keychain.

## Verification

- added regression coverage for current-first ordering, missing-mirror repair, and the already-mirrored no-op
- the author completed an Xcode build and the manual path: add on mainnet, switch to testnet, relaunch, verify the wallet remains present and previously deleted wallets remain deleted
- git diff --check passes

## Scope

Reset Wallet UI/routing was split into #1027.

Empty-network bootstrap is tracked separately in #1026.