### PR TITLE
fix(wallet): restrict reset to one logical wallet

### DIFF
--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -140,6 +140,10 @@ struct SecurityMenuScreen: View {
                     self.vc.pushViewController(controller, animated: true)
                 }
             }
+        case .resetWallet:
+            let controller = DWResetWalletInfoViewController.make()
+            controller.delegate = delegateInternal
+            vc.pushViewController(controller, animated: true)
         case .resetWalletDebug:
             showResetWalletDebugAlert = true
         case .none:

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -27,6 +27,7 @@ struct SecurityMenuScreen: View {
     @StateObject private var recoveryPhraseFlow = RecoveryPhraseFlowViewModel()
     @State private var showBiometricsAlert = false
     @State private var showMultipleWalletsResetAlert = false
+    @State private var showNoWalletResetAlert = false
     @State private var showResetWalletInventoryError = false
     @State private var showResetWalletDebugAlert = false
     
@@ -82,6 +83,9 @@ struct SecurityMenuScreen: View {
         .onReceive(viewModel.$showBiometricsAlert) { show in
             showBiometricsAlert = show
         }
+        .onReceive(viewModel.$resetWalletDestination.compactMap { $0 }) { destination in
+            handleResetWalletDestination(destination)
+        }
         .onReceive(recoveryPhraseFlow.$navigationEvent.compactMap { $0 }) { event in
             handleRecoveryPhraseNavigation(event)
         }
@@ -107,12 +111,22 @@ struct SecurityMenuScreen: View {
                 comment: "Security — reset wallet"))
         }
         .alert(
+            NSLocalizedString("No Wallet Found", comment: "Security — reset wallet"),
+            isPresented: $showNoWalletResetAlert
+        ) {
+            Button(NSLocalizedString("OK", comment: ""), role: .cancel) { }
+        } message: {
+            Text(NSLocalizedString(
+                "There are no wallets stored on this device to reset.",
+                comment: "Security — reset wallet"))
+        }
+        .alert(
             NSLocalizedString("Could Not Read Wallets", comment: "Security — reset wallet"),
             isPresented: $showResetWalletInventoryError
         ) {
             Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) { }
             Button(NSLocalizedString("Retry", comment: "")) {
-                beginResetWallet()
+                viewModel.beginResetWallet()
             }
         } message: {
             Text(NSLocalizedString(
@@ -168,8 +182,6 @@ struct SecurityMenuScreen: View {
                     self.vc.pushViewController(controller, animated: true)
                 }
             }
-        case .resetWallet:
-            beginResetWallet()
         case .resetWalletDebug:
             showResetWalletDebugAlert = true
         case .none:
@@ -222,21 +234,21 @@ struct SecurityMenuScreen: View {
         }
     }
 
-    private func beginResetWallet() {
-        do {
-            switch try SwiftDashSDKHost.distinctStoredWalletCount() {
-            case 1:
-                let controller = DWResetWalletInfoViewController.make()
-                controller.delegate = delegateInternal
-                vc.pushViewController(controller, animated: true)
-            case 2...:
-                showMultipleWalletsResetAlert = true
-            default:
-                showResetWalletInventoryError = true
-            }
-        } catch {
+    private func handleResetWalletDestination(_ destination: SecurityMenuResetWalletDestination) {
+        switch destination {
+        case .reset:
+            let controller = DWResetWalletInfoViewController.make()
+            controller.delegate = delegateInternal
+            vc.pushViewController(controller, animated: true)
+        case .multipleWallets:
+            showMultipleWalletsResetAlert = true
+        case .noWallet:
+            showNoWalletResetAlert = true
+        case .readError:
             showResetWalletInventoryError = true
         }
+
+        viewModel.resetWalletDestinationHandled()
     }
 
     private func openWallets() {

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuScreen.swift
@@ -26,6 +26,8 @@ struct SecurityMenuScreen: View {
     @StateObject private var viewModel = SecurityMenuViewModel()
     @StateObject private var recoveryPhraseFlow = RecoveryPhraseFlowViewModel()
     @State private var showBiometricsAlert = false
+    @State private var showMultipleWalletsResetAlert = false
+    @State private var showResetWalletInventoryError = false
     @State private var showResetWalletDebugAlert = false
     
     init(vc: UINavigationController, wipeDelegate: DWWipeDelegate? = nil) {
@@ -91,6 +93,32 @@ struct SecurityMenuScreen: View {
         } message: {
             Text(biometricsAlertMessage)
         }
+        .alert(
+            NSLocalizedString("Multiple Wallets Found", comment: "Security — reset wallet"),
+            isPresented: $showMultipleWalletsResetAlert
+        ) {
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) { }
+            Button(NSLocalizedString("Open Wallets", comment: "Security — reset wallet")) {
+                openWallets()
+            }
+        } message: {
+            Text(NSLocalizedString(
+                "Reset Wallet is unavailable while multiple wallets are stored. Open Wallets and remove each wallet individually using its recovery phrase.",
+                comment: "Security — reset wallet"))
+        }
+        .alert(
+            NSLocalizedString("Could Not Read Wallets", comment: "Security — reset wallet"),
+            isPresented: $showResetWalletInventoryError
+        ) {
+            Button(NSLocalizedString("Cancel", comment: ""), role: .cancel) { }
+            Button(NSLocalizedString("Retry", comment: "")) {
+                beginResetWallet()
+            }
+        } message: {
+            Text(NSLocalizedString(
+                "The wallets stored on this device could not be verified. Nothing was deleted. Please try again.",
+                comment: "Security — reset wallet"))
+        }
         .alert("Reset All Wallets (Debug)", isPresented: $showResetWalletDebugAlert) {
             Button("Cancel", role: .cancel) { }
             Button("Delete All", role: .destructive) {
@@ -141,9 +169,7 @@ struct SecurityMenuScreen: View {
                 }
             }
         case .resetWallet:
-            let controller = DWResetWalletInfoViewController.make()
-            controller.delegate = delegateInternal
-            vc.pushViewController(controller, animated: true)
+            beginResetWallet()
         case .resetWalletDebug:
             showResetWalletDebugAlert = true
         case .none:
@@ -194,6 +220,31 @@ struct SecurityMenuScreen: View {
            UIApplication.shared.canOpenURL(url) {
             UIApplication.shared.open(url)
         }
+    }
+
+    private func beginResetWallet() {
+        do {
+            switch try SwiftDashSDKHost.distinctStoredWalletCount() {
+            case 1:
+                let controller = DWResetWalletInfoViewController.make()
+                controller.delegate = delegateInternal
+                vc.pushViewController(controller, animated: true)
+            case 2...:
+                showMultipleWalletsResetAlert = true
+            default:
+                showResetWalletInventoryError = true
+            }
+        } catch {
+            showResetWalletInventoryError = true
+        }
+    }
+
+    private func openWallets() {
+        let controller = UIHostingController(
+            rootView: WalletsScreen(
+                vc: vc,
+                wipeDelegate: delegateInternal.wipeDelegate))
+        vc.pushViewController(controller, animated: true)
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
@@ -23,13 +23,20 @@ enum SecurityMenuNavigationDestination {
     case viewRecoveryPhrase
     case changePin
     case advancedSecurity
-    case resetWallet
     case resetWalletDebug
+}
+
+enum SecurityMenuResetWalletDestination {
+    case reset
+    case multipleWallets
+    case noWallet
+    case readError
 }
 
 @MainActor
 class SecurityMenuViewModel: ObservableObject {
     @Published var navigationDestination: SecurityMenuNavigationDestination?
+    @Published var resetWalletDestination: SecurityMenuResetWalletDestination?
     @Published var showBiometricsAlert = false
     @Published var items: [MenuItemModel] = []
     @Published var biometricsEnabled = false
@@ -123,7 +130,7 @@ class SecurityMenuViewModel: ObservableObject {
             title: NSLocalizedString("Reset Wallet", comment: ""),
             icon: .custom("image-menu-reset_wallet", maxHeight: 22),
             action: { [weak self] in
-                self?.navigationDestination = .resetWallet
+                self?.beginResetWallet()
             }
         ))
         
@@ -141,6 +148,25 @@ class SecurityMenuViewModel: ObservableObject {
         #endif
 
         items = menuItems
+    }
+
+    func beginResetWallet() {
+        do {
+            switch try SwiftDashSDKHost.distinctStoredWalletCount() {
+            case 0:
+                resetWalletDestination = .noWallet
+            case 1:
+                resetWalletDestination = .reset
+            default:
+                resetWalletDestination = .multipleWallets
+            }
+        } catch {
+            resetWalletDestination = .readError
+        }
+    }
+
+    func resetWalletDestinationHandled() {
+        resetWalletDestination = nil
     }
     
     private func toggleBiometrics(_ enabled: Bool) {

--- a/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/SecurityMenuViewModel.swift
@@ -23,6 +23,7 @@ enum SecurityMenuNavigationDestination {
     case viewRecoveryPhrase
     case changePin
     case advancedSecurity
+    case resetWallet
     case resetWalletDebug
 }
 
@@ -117,11 +118,19 @@ class SecurityMenuViewModel: ObservableObject {
                 self?.navigationDestination = .advancedSecurity
             }
         ))
+
+        menuItems.append(MenuItemModel(
+            title: NSLocalizedString("Reset Wallet", comment: ""),
+            icon: .custom("image-menu-reset_wallet", maxHeight: 22),
+            action: { [weak self] in
+                self?.navigationDestination = .resetWallet
+            }
+        ))
         
         // Dev-only: wipes every wallet with no phrase, bypassing the wipe
-        // authorization the release flows enforce — never ship it. Gated for
-        // dev builds of both schemes (the dashpay scheme has no DASH_TESTNET).
-        #if DEBUG || DASH_TESTNET
+        // authorization the release flows enforce — never ship it. Both the
+        // Debug and Testnet development configurations define DEBUG.
+        #if DEBUG
         menuItems.append(MenuItemModel(
             title: "Reset All Wallets (Debug)",
             icon: .custom("image-menu-reset_wallet", maxHeight: 22),


### PR DESCRIPTION
## Summary

- restore the recovery-phrase-gated Reset Wallet action in Security
- allow it only when strict SDK inventory contains one logical wallet
- treat the same seed stored under mainnet and testnet IDs as one wallet
- block global Settings reset for multiple distinct seeds and direct users to Wallets for individual phrase-authorized removal
- keep the phrase-less Reset All Wallets action restricted to DEBUG builds
- route the SDK inventory decision through SecurityMenuViewModel
- distinguish an empty inventory from a Keychain read failure

## Behavior

- one logical wallet: open the existing reset information and recovery-phrase flow
- multiple logical wallets: show Multiple Wallets Found with Open Wallets
- no stored wallets: show No Wallet Found
- unreadable inventory: fail closed with Retry/Cancel

The support-only emergency phrase remains outside this normal Settings flow.

## Verification

- Xcode build passed on the current revision
- the Reset Wallet behavior was manually smoke-tested
- git diff --check passes

## Scope

This PR contains only Reset Wallet UI/routing. Cross-network wallet provisioning remains in #1025.