### PR TITLE
fix(wallet): stop reserved coins from zeroing the spendable balance

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -52,12 +52,29 @@ public struct WalletBalance: Equatable, Sendable {
     }
 
     /// Total user-visible balance: confirmed + unconfirmed + immature.
-    /// `locked` is a subset of `confirmed` (the InstantSend-locked portion
-    /// of the confirmed balance) so it is NOT added separately.
+    ///
+    /// `locked` is a bucket of its own — `key-wallet`'s `WalletCoreBalance`
+    /// documents it as "UTXOs reserved for specific purposes like CoinJoin"
+    /// and sums all four fields for its own total. Those coins are surfaced
+    /// separately (`coinJoinBalanceDuffs` and the mixed-coins screens), so
+    /// they stay out of this figure.
     public var total: UInt64 { confirmed + unconfirmed + immature }
 
-    /// Spendable balance: confirmed minus the InstantSend-locked subset.
-    public var spendable: UInt64 { confirmed > locked ? confirmed - locked : 0 }
+    /// Balance a send can draw on right now: the confirmed bucket (mature
+    /// UTXOs in a block or InstantSend-locked).
+    ///
+    /// `locked` is NOT subtracted. It is disjoint from `confirmed` (see
+    /// `total`), so taking it off removed coins that were never in there —
+    /// with enough reserved UTXOs this floored a funded wallet's spendable
+    /// balance at 0, which silently disabled "Max" and reported insufficient
+    /// funds for every amount.
+    ///
+    /// `unconfirmed` stays out even though `key-wallet`'s own `spendable()`
+    /// counts it and ordinary spends do admit mempool inputs: the asset-lock
+    /// builders behind the shield routes take confirmed inputs only, and
+    /// every core "Max" in the app is held to that stricter bar rather than
+    /// offering an amount some routes cannot fund.
+    public var spendable: UInt64 { confirmed }
 
     /// Conservative fee headroom reserved on top of a fixed-amount send so a
     /// "Max"/affordability value stays sendable. Approximate — Core has no

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletState.swift
@@ -51,29 +51,36 @@ public struct WalletBalance: Equatable, Sendable {
         self.locked = locked
     }
 
-    /// Total user-visible balance: confirmed + unconfirmed + immature.
-    ///
-    /// `locked` is a bucket of its own — `key-wallet`'s `WalletCoreBalance`
-    /// documents it as "UTXOs reserved for specific purposes like CoinJoin"
-    /// and sums all four fields for its own total. Those coins are surfaced
-    /// separately (`coinJoinBalanceDuffs` and the mixed-coins screens), so
-    /// they stay out of this figure.
-    public var total: UInt64 { confirmed + unconfirmed + immature }
+    // The four fields are DISJOINT buckets. `key-wallet`'s
+    // `ManagedCoreFundsAccount::update_balance` sorts every UTXO with a single
+    // if / else-if chain — locked first, then immature, then
+    // confirmed-or-InstantSend-locked-or-trusted, else unconfirmed — so a UTXO
+    // contributes to exactly one of them.
+    //
+    // In particular `locked` is NOT the InstantSend-locked part of `confirmed`:
+    // IS-locked funds land in `confirmed`, while `locked` is a separate
+    // reserved bucket (`Utxo.is_locked`, intended for CoinJoin-style coin
+    // locking). Nothing in production sets that flag today, so it reads 0 —
+    // which is why the earlier arithmetic could be wrong here without anyone
+    // noticing.
 
-    /// Balance a send can draw on right now: the confirmed bucket (mature
-    /// UTXOs in a block or InstantSend-locked).
+    /// Total user-visible balance — every bucket, matching
+    /// `WalletCoreBalance::total()`.
+    public var total: UInt64 { confirmed + unconfirmed + immature + locked }
+
+    /// Spendable balance — `confirmed` only.
     ///
-    /// `locked` is NOT subtracted. It is disjoint from `confirmed` (see
-    /// `total`), so taking it off removed coins that were never in there —
-    /// with enough reserved UTXOs this floored a funded wallet's spendable
-    /// balance at 0, which silently disabled "Max" and reported insufficient
-    /// funds for every amount.
+    /// Deliberately NOT `WalletCoreBalance::spendable()` (confirmed +
+    /// unconfirmed). What gates a real send is the transaction builder's coin
+    /// selection, and that is the stricter set: `Utxo::is_spendable`'s own doc
+    /// tells callers that want "the spendable balance bucket or conservative
+    /// coin selection" to check `is_confirmed || is_instantlocked` — which is
+    /// what the `confirmed` bucket already holds (plus trusted change).
+    /// Reporting untrusted 0-conf here would offer the user money that coin
+    /// selection then refuses, failing the send with "Insufficient funds".
     ///
-    /// `unconfirmed` stays out even though `key-wallet`'s own `spendable()`
-    /// counts it and ordinary spends do admit mempool inputs: the asset-lock
-    /// builders behind the shield routes take confirmed inputs only, and
-    /// every core "Max" in the app is held to that stricter bar rather than
-    /// offering an amount some routes cannot fund.
+    /// `locked` is absent from the sum rather than subtracted: the buckets are
+    /// disjoint, so it never overlapped `confirmed` to begin with.
     public var spendable: UInt64 { confirmed }
 
     /// Conservative fee headroom reserved on top of a fixed-amount send so a

--- a/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceModel.swift
@@ -77,9 +77,10 @@ final class BalanceModel: ObservableObject {
         // DWEnvironment.sharedInstance().currentWallet.balance. After M6
         // (commit 86ed72706), DashSync's SPV no longer runs and
         // DSWallet.balance is frozen — SwiftDashSDK is the authoritative
-        // source. `WalletBalance.total` = confirmed + unconfirmed + immature,
-        // matching the "everything user-visible" semantic dashwallet's
-        // UI displays. Function #5 of the DashSync migration.
+        // source. `WalletBalance.total` sums every bucket — confirmed,
+        // unconfirmed, immature and locked — matching the "everything
+        // user-visible" semantic dashwallet's UI displays.
+        // Function #5 of the DashSync migration.
         let walletBalance = SwiftDashSDKWalletState.shared.balance
         let balanceValue = walletBalance?.total ?? 0
 

--- a/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
+++ b/DashWallet/Sources/UI/Payments/Amount/Model/Send/SendAmountModel.swift
@@ -23,9 +23,14 @@ enum SendAmountError: Error, ColorizedText, LocalizedError {
     case insufficientFunds
     case syncingChain
     case networkUnavailable
+    /// "Max" had nothing to fill in, carrying the reason (empty balance,
+    /// funds still confirming, or a balance below the fee reserve). Built by
+    /// `InternalTransferViewModel.coreZeroMaxMessage`.
+    case maxUnavailable(String)
 
     var errorDescription: String? {
         switch self {
+        case .maxUnavailable(let message): return message
         case .insufficientFunds: return NSLocalizedString("Insufficient funds", comment: "Send screen")
         case .syncingChain: return NSLocalizedString("Wait until wallet is synced to complete the transaction",
                                                      comment: "Send screen")
@@ -38,6 +43,9 @@ enum SendAmountError: Error, ColorizedText, LocalizedError {
         case .insufficientFunds: return .systemRed
         case .syncingChain: return .secondaryLabel
         case .networkUnavailable: return .secondaryLabel
+        // Informational, not a failure the user caused — same weight as the
+        // syncing notice rather than the red insufficient-funds text.
+        case .maxUnavailable: return .secondaryLabel
         }
     }
 }
@@ -81,9 +89,22 @@ class SendAmountModel: BaseAmountModel {
         // leaves no room for the fee, so the send fails to build.
         let allAvailableFunds = SwiftDashSDKWalletState.shared.feeAwareMaxSendable()
 
-        if allAvailableFunds > 0 {
-            updateCurrentAmountObject(with: allAvailableFunds)
+        guard allAvailableFunds > 0 else {
+            // A Max that can't fill anything must say why. Silently ignoring
+            // the tap left the amount at 0 with no feedback, so an empty
+            // balance, funds that are still confirming, and a balance too
+            // small to also cover the fee were indistinguishable from a dead
+            // button. Same three states, same wording, as the internal
+            // transfer's Core Max.
+            let balance = SwiftDashSDKWalletState.shared.balance
+            error = SendAmountError.maxUnavailable(
+                InternalTransferViewModel.coreZeroMaxMessage(
+                    totalDuffs: balance?.total ?? 0,
+                    confirmedSpendableDuffs: balance?.spendable ?? 0))
+            return
         }
+
+        updateCurrentAmountObject(with: allAvailableFunds)
     }
 
     override func checkAmountForErrors() {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -1365,7 +1365,12 @@ final class InternalTransferViewModel: ObservableObject {
     /// Why a Core Max produced nothing, told apart by the three states that
     /// reach it: no funds at all, funds that are still confirming, and a
     /// confirmed balance too small to also cover the L1 fee.
-    private static func coreZeroMaxMessage(
+    ///
+    /// Shared with the classic send amount screen (`SendAmountModel`), which
+    /// runs the same Core Max against the same balance and must explain a
+    /// zero result in the same words. `nonisolated` so that caller — which
+    /// is not main-actor bound — can reach it; the body is pure string work.
+    nonisolated static func coreZeroMaxMessage(
         totalDuffs: UInt64,
         confirmedSpendableDuffs: UInt64
     ) -> String {
@@ -1428,7 +1433,7 @@ final class InternalTransferViewModel: ObservableObject {
 
     /// Shared with `SendViewModel`'s Core → Shielded Max (same fee-on-top
     /// envelope) — keep `internal`.
-    static func feeReserveExceedsBalanceMessage(_ source: ChainNetwork) -> String {
+    nonisolated static func feeReserveExceedsBalanceMessage(_ source: ChainNetwork) -> String {
         String.localizedStringWithFormat(
             NSLocalizedString(
                 "Your %@ balance is too low to cover the transfer fee.",
@@ -1436,7 +1441,7 @@ final class InternalTransferViewModel: ObservableObject {
             source.balanceName)
     }
 
-    private static func emptyBalanceMessage(_ source: ChainNetwork) -> String {
+    nonisolated private static func emptyBalanceMessage(_ source: ChainNetwork) -> String {
         String.localizedStringWithFormat(
             NSLocalizedString(
                 "Your %@ balance is empty.",


### PR DESCRIPTION
## Issue being fixed or feature implemented

`WalletBalance` treated `locked` as the InstantSend-locked *subset* of
`confirmed` — its comment said so, and `spendable` subtracted it while `total`
left it out. Both readings are wrong.

The four fields are disjoint buckets. `key-wallet`'s
`ManagedCoreFundsAccount::update_balance` sorts every UTXO with a single
if / else-if chain — locked first, then immature, then
confirmed-or-InstantSend-locked-or-trusted, else unconfirmed — so a UTXO
contributes to exactly one of them. IS-locked funds land in `confirmed`;
`locked` is a separate reserved bucket (`Utxo.is_locked`, intended for
CoinJoin-style coin locking).

So `spendable` subtracted coins that were never in `confirmed`, and `total`
omitted a bucket that belongs in it. **Nothing in production sets `is_locked`
today, so the field reads 0 and neither error is currently observable** — which
is how the arithmetic stayed wrong without anyone noticing. It becomes a real
defect the moment coin locking starts populating that bucket: `spendable` would
floor at 0 once reserved UTXOs exceed the confirmed bucket, silently disabling
"Max" and rejecting every amount as insufficient funds while the balance on
screen still showed the full figure.

## What was done?

- `total` now sums every bucket, matching `WalletCoreBalance::total()`.
- `spendable` is the `confirmed` bucket. `locked` is absent from the sum rather
  than subtracted, since the buckets never overlapped.
- `spendable` deliberately does **not** match `WalletCoreBalance::spendable()`
  (confirmed + unconfirmed). What gates a real send is the transaction builder's
  coin selection, and that is the stricter set: `Utxo::is_spendable`'s own doc
  points callers wanting "the spendable balance bucket or conservative coin
  selection" at `is_confirmed || is_instantlocked`, which is what `confirmed`
  already holds plus trusted change. Reporting untrusted 0-conf here would offer
  money that coin selection then refuses.
- The reasoning is written into the doc comments so the next reader does not
  "restore" the subtraction, and `BalanceModel`'s comment — which spelled out the
  old three-bucket formula — was corrected to match.
- Separately, a Core "Max" that legitimately yields nothing now says why.
  `SendAmountModel` gains a `.maxUnavailable` case carrying the reason;
  previously the tap was ignored, so an empty balance, funds still confirming,
  and a balance too small to also cover the fee were indistinguishable from a
  dead button. It renders in `.secondaryLabel` rather than red — informational,
  not a user error. The wording is not duplicated:
  `InternalTransferViewModel.coreZeroMaxMessage` already told those same three
  states apart, so it (and the `feeReserveExceedsBalanceMessage` it calls) became
  `nonisolated` and the send screen reuses it, per the repo's
  "never copy-then-adapt" guardrail.

## How Has This Been Tested?

`xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator
-destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` — clean build.

The unit-test target is currently broken repo-wide, so no test was added; the
verification standard while it is broken is a clean `dashpay` build.

Because `is_locked` is never set today, this is not reproducible on-device as a
user-visible bug — the change is a correctness fix to the arithmetic and its
documentation ahead of the flag being used.

Worth a reviewer's eye on two judgement calls: including `locked` in `total`
(it changes what the home balance would show once the bucket is populated), and
holding `spendable` stricter than `key-wallet`'s own `spendable()`.

## Breaking Changes

None. `WalletBalance` is app-internal and every caller wants the corrected
figures.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
