### PR TITLE
feat(dashpay): show the whole contact on the contact screens

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
@@ -11,6 +11,7 @@
 //
 
 import Foundation
+import SwiftDashSDK
 
 extension String {
     /// DPNS labels render without the implied ".dash" parent domain
@@ -120,4 +121,10 @@ struct ContactItem: Identifiable, Equatable {
         }
         return String(contactIdentityId.map { String(format: "%02x", $0) }.joined().prefix(8)) + "…"
     }
+
+    /// The identity id as users see it elsewhere — Platform explorers, the
+    /// wallet's own identity list and the `dashpay://user` QR payload all read
+    /// base58, so a contact's id is shown the same way rather than as the hex
+    /// `displayTitle`'s fallback happens to use.
+    var identityIdBase58: String { contactIdentityId.toBase58String() }
 }

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift
@@ -680,11 +680,17 @@ struct AddContactPreviewSheet: View {
                     Text(title)
                         .font(.system(size: 22, weight: .bold))
                         .foregroundColor(.dash.primaryText)
-                    if username != title {
-                        Text(username)
-                            .font(.system(size: 14))
-                            .foregroundColor(.dash.secondaryText)
-                    }
+                    // Kept even when it equals the title: the title may be an
+                    // alias for an already-known contact, and the registered
+                    // username is what the request is actually addressed to.
+                    Text(username)
+                        .font(.system(size: 14))
+                        .foregroundColor(.dash.secondaryText)
+                    // Before accepting a request or sending one, the id is the
+                    // only field that distinguishes two identities presenting
+                    // the same DPNS label.
+                    ContactIdentityIdView(identityId: result.identityId)
+                        .padding(.top, 2)
                     if let message = contact?.publicMessage, !message.isEmpty {
                         Text(message)
                             .font(.system(size: 14))

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift
@@ -7,6 +7,7 @@
 //  design (wallet/res/layout/dashpay_contact_row.xml and friends).
 //
 
+import SwiftDashSDK
 import SwiftUI
 import DashUIKit
 
@@ -202,3 +203,62 @@ struct ContactsCard<Content: View>: View {
 }
 
 #endif
+
+// MARK: - Identity ID
+
+/// The contact's Platform identity id, in the centred style the contact sheets
+/// already use for the lines under the name.
+///
+/// A username is a DPNS label — it can be contested, transferred, or released
+/// and taken by somebody else — so it does not identify a person on its own.
+/// The identity id does, which is why it belongs next to the name rather than
+/// only inside the QR payload.
+///
+/// Shown in full base58: that is how identities read on Platform explorers, in
+/// the wallet's own identity list and in the `dashpay://user` link, and a
+/// reader who needs it at all usually needs to paste the whole value.
+struct ContactIdentityIdView: View {
+    let identityId: Data
+    /// Called once the value is on the pasteboard, for a host that shows its
+    /// own confirmation. Without one the button acknowledges the copy itself.
+    var onCopy: (() -> Void)? = nil
+
+    @State private var didCopy = false
+
+    private var base58: String { identityId.toBase58String() }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(NSLocalizedString("Identity ID", comment: "DashPay Contacts"))
+                .font(.system(size: 12))
+                .foregroundColor(.dash.tertiaryText)
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text(base58)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.dash.secondaryText)
+                    .multilineTextAlignment(.center)
+                    .textSelection(.enabled)
+                Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 11))
+                    .foregroundColor(.dash.tertiaryText)
+            }
+        }
+        .padding(.horizontal, 32)
+        .contentShape(Rectangle())
+        .onTapGesture { copyToPasteboard() }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func copyToPasteboard() {
+        UIPasteboard.general.string = base58
+        if let onCopy {
+            onCopy()
+            return
+        }
+        withAnimation { didCopy = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            withAnimation { didCopy = false }
+        }
+    }
+}

--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift
@@ -40,10 +40,15 @@ struct ContactProfileSheet: View {
     /// looked up from `resolvedByTxid` in the destination builder
     /// (`Transaction` itself isn't `Hashable`).
     @State private var selectedPaymentId: String? = nil
-    @State private var metaSavedToast = false
-    /// Contact settings (alias / note) stay collapsed until the user
-    /// taps the contact header; tapping again collapses them.
-    @State private var showContactSettings = false
+    /// Transient confirmation shown at the bottom of the sheet — a saved edit
+    /// or a copied identity id. One slot, so a second message replaces the
+    /// first instead of stacking.
+    @State private var toastMessage: String? = nil
+    /// Contact settings (alias / note) are part of what the sheet is for, so
+    /// they open with it; tapping the header still folds them away. They were
+    /// collapsed by default, which left an alias the user had already written
+    /// invisible on the one screen that shows everything about the contact.
+    @State private var showContactSettings = true
 
     private let service = SwiftDashSDKContactsService.shared
 
@@ -58,6 +63,12 @@ struct ContactProfileSheet: View {
                 ScrollView {
                     VStack(spacing: 20) {
                         header
+                        // Sibling of `header` rather than part of it: the
+                        // header's tap toggles the contact-settings card, and
+                        // this row's tap copies.
+                        ContactIdentityIdView(
+                            identityId: contact.contactIdentityId,
+                            onCopy: { showToast(NSLocalizedString("Copied", comment: "")) })
                         if let message = contact.publicMessage, !message.isEmpty {
                             Text(message)
                                 .font(.system(size: 14))
@@ -138,8 +149,8 @@ struct ContactProfileSheet: View {
                 }
             }
             .overlay(alignment: .bottom) {
-                if metaSavedToast {
-                    Text(NSLocalizedString("Saved", comment: ""))
+                if let toastMessage {
+                    Text(toastMessage)
                         .font(.system(size: 13, weight: .medium))
                         .padding(.horizontal, 16)
                         .padding(.vertical, 10)
@@ -161,9 +172,12 @@ struct ContactProfileSheet: View {
             Text(contact.displayTitle)
                 .font(.system(size: 20, weight: .bold))
                 .foregroundColor(.dash.primaryText)
-            if let username = contact.username?.withoutDashSuffix,
-               !username.isEmpty,
-               username != contact.displayTitle {
+            // Shown even when it matches the title above. The title can be an
+            // owner-set alias or a profile display name, and both are free
+            // text — so "the name I gave them" and "the name they registered"
+            // looking identical is itself information, and hiding the username
+            // then left the user unable to tell which one they were reading.
+            if let username = contact.username?.withoutDashSuffix, !username.isEmpty {
                 Text(username)
                     .font(.system(size: 14))
                     .foregroundColor(.dash.secondaryText)
@@ -362,6 +376,21 @@ struct ContactProfileSheet: View {
         .padding(.horizontal, 15)
     }
 
+    /// Show a confirmation and clear it after a beat. `@MainActor` because it
+    /// mutates published sheet state from callers on both the main actor and a
+    /// view's tap handler.
+    @MainActor
+    private func showToast(_ message: String) {
+        withAnimation { toastMessage = message }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            // A later toast may have replaced this one; only retract our own.
+            if toastMessage == message {
+                withAnimation { toastMessage = nil }
+            }
+        }
+    }
+
     private var metaChanged: Bool {
         aliasText != (contact.alias ?? "") || noteText != (contact.note ?? "")
     }
@@ -377,9 +406,7 @@ struct ContactProfileSheet: View {
                     note: noteText.trimmingCharacters(in: .whitespaces),
                     hidden: isHidden,
                     for: contact.contactIdentityId)
-                withAnimation { metaSavedToast = true }
-                try? await Task.sleep(nanoseconds: 1_200_000_000)
-                withAnimation { metaSavedToast = false }
+                showToast(NSLocalizedString("Saved", comment: ""))
             } catch {
                 errorMessage = errorMessageIfNotCancelled(error)
             }
@@ -445,7 +472,7 @@ struct ContactProfileSheet: View {
 
     private var paymentsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(NSLocalizedString("Payments", comment: "DashPay Contacts"))
+            Text(NSLocalizedString("Activity", comment: "DashPay Contacts"))
                 .font(.system(size: 17, weight: .semibold))
                 .foregroundColor(.dash.primaryText)
             // Legacy profile's info tooltip, inlined: only payments
@@ -454,14 +481,19 @@ struct ContactProfileSheet: View {
             Text(NSLocalizedString("Payments made directly to an address aren't retained here.", comment: "DashPay Contacts"))
                 .font(.system(size: 12))
                 .foregroundColor(.dash.tertiaryText)
-            if payments.isEmpty {
+            if activityEntries.isEmpty {
                 Text(NSLocalizedString("No payments with this contact yet", comment: "DashPay Contacts"))
                     .font(.system(size: 14))
                     .foregroundColor(.dash.secondaryText)
                     .padding(.top, 2)
             } else {
-                ForEach(payments) { payment in
-                    paymentRow(payment)
+                ForEach(activityEntries) { entry in
+                    switch entry {
+                    case .payment(let payment):
+                        paymentRow(payment)
+                    case .request(let request):
+                        requestRow(request)
+                    }
                 }
             }
         }
@@ -472,6 +504,125 @@ struct ContactProfileSheet: View {
                 .fill(Color.dash.secondaryBackground))
         .padding(.horizontal, 15)
     }
+
+    // MARK: - Activity
+
+    /// A moment in the history with this contact. Payments are only part of it:
+    /// before the first one there is still the request that opened the channel,
+    /// and a profile that showed nothing until money moved read as empty for a
+    /// contact the user had just added.
+    private enum ActivityEntry: Identifiable {
+        case payment(SwiftDashSDKContactsService.ContactPayment)
+        case request(RequestEvent)
+
+        var date: Date {
+            switch self {
+            case .payment(let payment): payment.date
+            case .request(let request): request.date
+            }
+        }
+
+        var id: String {
+            switch self {
+            case .payment(let payment): "payment-\(payment.id)"
+            case .request(let request): "request-\(request.id)"
+            }
+        }
+    }
+
+    /// A contact-request milestone, derived from the pair's own timestamps
+    /// rather than a feed: `incomingCreatedAt` / `outgoingCreatedAt` are the two
+    /// halves of a DashPay friendship, so the earlier is the request and — once
+    /// established — the later is the reply that completed it.
+    private struct RequestEvent: Identifiable {
+        enum Kind {
+            case theyAsked
+            case weAsked
+            case theyAccepted
+            case weAccepted
+        }
+
+        let kind: Kind
+        let date: Date
+        var id: String { "\(kind)-\(date.timeIntervalSince1970)" }
+    }
+
+    private var requestEvents: [RequestEvent] {
+        let incoming = contact.incomingCreatedAt
+        let outgoing = contact.outgoingCreatedAt
+
+        switch (incoming, outgoing) {
+        case let (incoming?, outgoing?):
+            // Both halves exist, so this pair is established. The older row is
+            // the original ask; the newer one is the acceptance, and which side
+            // accepted follows from which row is newer.
+            return incoming <= outgoing
+                ? [RequestEvent(kind: .theyAsked, date: incoming),
+                   RequestEvent(kind: .weAccepted, date: outgoing)]
+                : [RequestEvent(kind: .weAsked, date: outgoing),
+                   RequestEvent(kind: .theyAccepted, date: incoming)]
+        case let (incoming?, nil):
+            return [RequestEvent(kind: .theyAsked, date: incoming)]
+        case let (nil, outgoing?):
+            return [RequestEvent(kind: .weAsked, date: outgoing)]
+        case (nil, nil):
+            return []
+        }
+    }
+
+    private var activityEntries: [ActivityEntry] {
+        let entries = payments.map { ActivityEntry.payment($0) }
+            + requestEvents.map { ActivityEntry.request($0) }
+        return entries.sorted { $0.date > $1.date }
+    }
+
+    /// Wording matches the notifications screen key-for-key so the same event
+    /// reads the same in both places and shares one translation.
+    private func requestText(_ event: RequestEvent) -> String {
+        switch event.kind {
+        case .theyAsked:
+            String(
+                format: NSLocalizedString("%@ has sent you a contact request", comment: "DashPay Notifications"),
+                contact.displayTitle)
+        case .weAsked:
+            String(
+                format: NSLocalizedString("You sent a contact request to %@", comment: "DashPay Notifications"),
+                contact.displayTitle)
+        case .theyAccepted:
+            String(
+                format: NSLocalizedString("%@ accepted your contact request", comment: "DashPay Notifications"),
+                contact.displayTitle)
+        case .weAccepted:
+            String(
+                format: NSLocalizedString("You added %@ as a contact", comment: "DashPay Notifications"),
+                contact.displayTitle)
+        }
+    }
+
+    private func requestRow(_ event: RequestEvent) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "person.crop.circle.badge.plus")
+                .foregroundColor(.dash.blue)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(requestText(event))
+                    .font(.system(size: 14))
+                    .foregroundColor(.dash.primaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(Self.activityDateFormatter.string(from: event.date))
+                    .font(.system(size: 11))
+                    .foregroundColor(.dash.secondaryText)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private static let activityDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
 
     /// One payment row. Tappable → the standard tx-detail screen when
     /// the on-chain transaction resolves in this wallet's store; a plain


### PR DESCRIPTION
## Issue being fixed or feature implemented

QA asked for the identity ID to be shown next to a contact's name. The reason
generalises past that one field: a username is a DPNS label — it can be
contested, transferred, or released and taken by someone else — so it does not
identify a person. Two contacts can present the same name at different times,
and the contact screens showed nothing that told them apart.

Looking at the screens with that in mind, the identity ID was not the only
thing missing. A contact's profile stayed empty until money had moved through
it, even when the request that opened the channel was days old; the username
was hidden whenever it matched the title, so the user could not tell whether
they were reading a registered name or an alias they had written themselves;
and that alias was folded away behind a tap on the header, on the one screen
meant to show everything about the contact.

## What was done?

The screens keep their layout. Nothing here restyles them — each field is added
in the shape the screen already uses for the lines under the name.

- **Identity ID** on the contact profile and on the add-contact preview: a
  caption, the full base58 value, tap to copy. Base58 because that is how
  identities read on Platform explorers, in the wallet's own identity list and
  in the `dashpay://user` link. Untruncated because a reader who wants it at all
  usually wants to paste it somewhere. `ContactIdentityIdView` joins the other
  shared contact components in `ContactAvatarView.swift`; hosts with their own
  confirmation pass `onCopy`, and the rest get a checkmark on the icon.
- **The username is no longer hidden when it equals the title.** The title may
  be an owner-set alias or a profile display name, both free text, so the two
  reading identically is itself worth seeing.
- **Contact settings (alias, note) open with the sheet** instead of staying
  folded behind a tap on the header. Tapping the header still folds them away —
  only the default changed.
- **Payments became Activity**, carrying the contact-request milestones
  alongside the payments, newest first. No new feed was needed:
  `incomingCreatedAt` and `outgoingCreatedAt` are the two halves of a DashPay
  friendship, so the older row is the request and — once the pair is
  established — the newer one is the reply that completed it, with the side that
  replied following from which row is newer. The wording reuses the
  notifications screen's localisation keys, so one event reads the same in both
  places and shares a single translation.

### Considered and rejected

Abbreviating the identity ID (`5rTJhbA…9Xk2Qd`). The app already has five
different truncations of an id across marketplace, voting, storage explorer and
`ContactItem`'s own fallback; adding a sixth would not have helped, and the
people who read this field are copying it into a report or a query.

## How Has This Been Tested?

`xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator
-destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` — clean build.

**Not verified on a device or simulator run.** The unit-test target is broken
repo-wide, so the standard here is a clean `dashpay` build, and that is what
this has. What a reviewer should look at with a real contact on screen: the full
base58 wraps to two lines in the centred layout, and the Activity list is worth
sanity-checking against a pair whose request and acceptance happened on
different days.

## Breaking Changes

None. No model or persistence change — `identityIdBase58` is a computed
convenience over the `contactIdentityId` the models already carried, and the
request milestones are derived from timestamps that were already there.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone