### PR TITLE
fix(explore-dash): generate a merchant logo placeholder and re-sync explore.db on a network switch

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1111,6 +1111,7 @@
 		B3A1F2C4D5E6078901234569 /* ExtendedPublicKeySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A1F2C4D5E6078901234567 /* ExtendedPublicKeySheet.swift */; };
 		B420473EF13CB7EE5F339349 /* JoinDashPayReadinessScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AA6C01B7CED63D37D3652B /* JoinDashPayReadinessScreen.swift */; };
 		B453B34B871E4125607DACDC /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6615F1246B5935365B05BD /* NavigationBar.swift */; };
+		5E1C0A0100000000000000F2 /* MerchantLogoPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */; };
 		B56469D438692B0A0B771EA6 /* PinPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC52AE587802170368F6177 /* PinPromptView.swift */; };
 		B66294BFAF57B052A74EE77D /* CoinJoinRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478AD92C1F1C11D09645DF4 /* CoinJoinRecovery.swift */; };
 		B66D25CAD54ABDC1049BDDD5 /* DamerauLevenshtein.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CE60A95629A2883710A75C /* DamerauLevenshtein.swift */; };
@@ -1870,6 +1871,7 @@
 		EE0000042DUMMYID001234567 /* PercentageFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0000052DUMMYID001234567 /* PercentageFormatter.swift */; };
 		EE0000062DUMMYID001234567 /* PercentageFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0000052DUMMYID001234567 /* PercentageFormatter.swift */; };
 		EE5F3D5C458E92B69D14BFD8 /* NavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6615F1246B5935365B05BD /* NavigationBar.swift */; };
+		5E1C0A0100000000000000F3 /* MerchantLogoPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */; };
 		EF053C0D81A007CC015EB3EE /* InternalTransferViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7249AC40404B20F2AEE590F1 /* InternalTransferViewModel.swift */; };
 		EF8FE439EB96236940DFBDE7 /* SwiftDashSDKTransactionSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31271807D89A63FB9413C936 /* SwiftDashSDKTransactionSender.swift */; };
 		EFCF9D5D6630AD9BD0A62E29 /* InternalTransferScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A62C70E4EBB7458C362B7669 /* InternalTransferScreen.swift */; };
@@ -3088,6 +3090,7 @@
 		AA22BB33CC44DD55EE66FF77 /* BuyReceiveFlowUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyReceiveFlowUITests.swift; sourceTree = "<group>"; };
 		AA29A8515217AC4232F794C2 /* Pods-TodayExtension.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TodayExtension.testnet.xcconfig"; path = "Target Support Files/Pods-TodayExtension/Pods-TodayExtension.testnet.xcconfig"; sourceTree = "<group>"; };
 		AD6615F1246B5935365B05BD /* NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBar.swift; sourceTree = "<group>"; };
+		5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantLogoPlaceholder.swift; sourceTree = "<group>"; };
 		AE3B307E94B354351D4E3D3B /* PaymentProtocolTransport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentProtocolTransport.swift; sourceTree = "<group>"; };
 		B1100000B1100000B1100002 /* BuyEnterAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyEnterAmountView.swift; sourceTree = "<group>"; };
 		B1100000B1100000B1100003 /* BuyEnterAmountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuyEnterAmountViewModel.swift; sourceTree = "<group>"; };
@@ -6830,6 +6833,7 @@
 				75EBAA112BB99B6B004488E3 /* BottomSheet.swift */,
 				96CB7E093E994D2391D36DEC /* SelfSizingSheet.swift */,
 				AD6615F1246B5935365B05BD /* NavigationBar.swift */,
+				5E1C0A0100000000000000F1 /* MerchantLogoPlaceholder.swift */,
 				759ADD562BF3447400767ACD /* Button.swift */,
 				75CDD7852C08D61300F433D2 /* DashAmount.swift */,
 				750CEFA02CCA6EA100E87A32 /* TextInput.swift */,
@@ -9963,6 +9967,7 @@
 				75EBAA122BB99B6B004488E3 /* BottomSheet.swift in Sources */,
 				22E89B6C00B546D294D7F331 /* SelfSizingSheet.swift in Sources */,
 				B453B34B871E4125607DACDC /* NavigationBar.swift in Sources */,
+				5E1C0A0100000000000000F2 /* MerchantLogoPlaceholder.swift in Sources */,
 				75CED09E2ACFD0ED0095F10C /* CoinbaseDepositRequest.swift in Sources */,
 				C94D98212A4CC78F00F3BEE1 /* DashInputField.swift in Sources */,
 				2A8B9E6822FFE4CC00FF8653 /* DWPayOptionModel.m in Sources */,
@@ -10482,6 +10487,7 @@
 				75EBAA132BB99B6B004488E3 /* BottomSheet.swift in Sources */,
 				39DC037E9CF04CCFA3EFBB53 /* SelfSizingSheet.swift in Sources */,
 				EE5F3D5C458E92B69D14BFD8 /* NavigationBar.swift in Sources */,
+				5E1C0A0100000000000000F3 /* MerchantLogoPlaceholder.swift in Sources */,
 				C9D2C7082A320AA000D15901 /* DWPlaceholderFormCellModel.m in Sources */,
 				C9D2C7092A320AA000D15901 /* DWOverlapControl.m in Sources */,
 				C9D2C70A2A320AA000D15901 /* CoinsToAddressTxFilter.swift in Sources */,

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/Database Connection/ExploreDatabaseConnection.swift
@@ -56,6 +56,13 @@ class ExploreDatabaseConnection {
 
             // Add test merchant after database sync for TestFlight builds
             #if DEBUG || Testflight
+            // The database was just replaced on disk (a version update, or a re-download
+            // forced by a mainnet/testnet switch), so the file may no longer contain the
+            // test merchants even though they were seeded earlier this session. Clear the
+            // once-per-session guard so seeding re-evaluates against the new file; the
+            // count check inside `addPiggyCardsTestMerchants` still avoids redundant
+            // trigger churn when they are already present.
+            self?.didInsertTestMerchants = false
             self?.addTestMerchantAfterSync()
             #endif
         }

--- a/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/ExploreDatabaseSyncManager.swift
@@ -45,7 +45,16 @@ public class ExploreDatabaseSyncManager {
     static let databaseWillBeUpdatedNotification = NSNotification.Name(rawValue: "databaseWillBeUpdatedNotification")
 
     private let storage = Storage.storage()
-    private let storageRef: StorageReference
+
+    // Computed per access so a mainnet/testnet switch always targets the current network's archive.
+    // Caching this in `init()` meant the singleton kept downloading the launch-network's database
+    // after a chain switch, so the wrong network's merchants stayed on disk.
+    private var storageRef: StorageReference {
+        let databasePath = currentNetworkName == "mainnet"
+            ? "gs://dash-wallet-firebase.appspot.com/explore/explore-v4.db"
+            : "gs://dash-wallet-firebase.appspot.com/explore/explore-v4-testnet.db"
+        return storage.reference(forURL: databasePath)
+    }
 
     private var timer: Timer!
 
@@ -55,42 +64,37 @@ public class ExploreDatabaseSyncManager {
     var syncState: State
     var lastServerUpdateDate: Date { Date(timeIntervalSince1970: exploreDatabaseLastVersion) }
 
-    // Network-specific name for the downloaded archive only — the database itself always unzips to
-    // the single `explore.db`, so see `installedDatabaseNetwork` for the mainnet/testnet conflict.
-    private var networkSpecificFileName: String {
-        let isMainnet = WalletEnvironment.isMainnet
-        return isMainnet ? "explore-mainnet" : "explore-testnet"
-    }
-
     // Network the sync bookkeeping expects, from the SDK (DWEnvironment is frozen post-M6).
     private var currentNetworkName: String {
         WalletEnvironment.isMainnet ? "mainnet" : "testnet"
     }
 
-    // Network whose data currently sits in the shared explore.db (see comment on
-    // networkSpecificFileName); lets a chain switch force a re-download.
+    // Network whose data currently sits in the shared explore.db. Both networks share that one
+    // file while the sync bookkeeping (`versionKey`) is per-network, so after a chain switch the
+    // saved version reads as up to date while the file on disk still holds the other network's
+    // merchants. This marker is what lets a chain switch force a re-download.
     private var installedDatabaseNetwork: String? {
         get { UserDefaults.standard.string(forKey: kExploreDatabaseInstalledNetworkKey) }
         set { UserDefaults.standard.setValue(newValue, forKey: kExploreDatabaseInstalledNetworkKey) }
     }
 
+    private var networkDidChangeObserver: NSObjectProtocol?
+
     init() {
         syncState = .inititialing
-
-        // Initialize storageRef with computed database path
-        let databasePath: String
-        let isMainnet = WalletEnvironment.isMainnet
-        if isMainnet {
-            databasePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v4.db"
-        } else {
-            databasePath = "gs://dash-wallet-firebase.appspot.com/explore/explore-v4-testnet.db"
-        }
-
-        storageRef = storage.reference(forURL: databasePath)
     }
 
     public func start() {
         syncIfNeeded()
+
+        // A chain switch at runtime otherwise goes unnoticed until the next launch: the
+        // version check only runs from here and the 24h timer. Re-run it on a network
+        // change so the installedDatabaseNetwork mismatch forces a same-session re-download.
+        networkDidChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.DWCurrentNetworkDidChange, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.syncIfNeeded()
+        }
 
         // Try to sync every 24h
         timer = Timer.scheduledTimer(withTimeInterval: 60*60*24, repeats: true) { [weak self] _ in
@@ -101,8 +105,18 @@ public class ExploreDatabaseSyncManager {
     private func syncIfNeeded() {
         syncState = .fetchingInfo
 
-        storageRef.getMetadata { [weak self] metadata, _ in
+        // Snapshot the network and its storage reference for the whole operation. `storageRef`
+        // and `currentNetworkName` are computed from the live chain, so a switch between the
+        // metadata fetch, the data fetch and the marker save would otherwise mix one archive's
+        // timestamp/checksum with another's bytes, or record the marker for a network whose
+        // archive was never extracted. Everything below uses this snapshot, and each async hop
+        // bails if the chain has moved on — the switch already scheduled its own syncIfNeeded.
+        let syncNetwork = currentNetworkName
+        let syncStorageRef = storageRef
+
+        syncStorageRef.getMetadata { [weak self] metadata, _ in
             guard let wSelf = self else { return }
+            guard syncNetwork == wSelf.currentNetworkName else { return }
 
             guard let metadata else {
                 wSelf.syncState = .error(Date(), nil)
@@ -123,16 +137,16 @@ public class ExploreDatabaseSyncManager {
             // regardless of saved version timestamp to avoid falling back to in-memory DB.
             if !localDatabaseExists {
                 DWLogger.log("ExploreDash: local explore.db missing, forcing cloud database download")
-                wSelf.downloadDatabase(metadata: metadata)
+                wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
                 return
             }
 
             // The file on disk may belong to the other network (the chain was switched since it was
             // downloaded). Its version is tracked under that network's key, so the check below would
             // read as up to date and leave us serving the wrong network's merchants.
-            if wSelf.installedDatabaseNetwork != wSelf.currentNetworkName {
-                DWLogger.log("ExploreDash: explore.db belongs to \(wSelf.installedDatabaseNetwork ?? "an unknown network"), current network is \(wSelf.currentNetworkName) — forcing download")
-                wSelf.downloadDatabase(metadata: metadata)
+            if wSelf.installedDatabaseNetwork != syncNetwork {
+                DWLogger.log("ExploreDash: explore.db belongs to \(wSelf.installedDatabaseNetwork ?? "an unknown network"), current network is \(syncNetwork) — forcing download")
+                wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
                 return
             }
 
@@ -141,20 +155,23 @@ public class ExploreDatabaseSyncManager {
                 return
             }
 
-            wSelf.downloadDatabase(metadata: metadata)
+            wSelf.downloadDatabase(metadata: metadata, network: syncNetwork, storageRef: syncStorageRef)
         }
     }
 
     deinit {
         timer.invalidate()
         timer = nil
+        if let networkDidChangeObserver {
+            NotificationCenter.default.removeObserver(networkDidChangeObserver)
+        }
     }
 
     static let share = ExploreDatabaseSyncManager()
 }
 
 extension ExploreDatabaseSyncManager {
-    private func downloadDatabase(metadata: StorageMetadata) {
+    private func downloadDatabase(metadata: StorageMetadata, network: String, storageRef: StorageReference) {
         guard let timestamp = metadata.customMetadata?[timestampKey],
               let checksum = metadata.customMetadata?[checksumKey],
               let timeIntervalMillesecond = TimeInterval(timestamp) else {
@@ -163,8 +180,11 @@ extension ExploreDatabaseSyncManager {
         }
 
         syncState = .syncing
-        let urlToSave = getDocumentsDirectory().appendingPathComponent("\(networkSpecificFileName)-\(timestamp).zip")
+        let fileName = network == "mainnet" ? "explore-mainnet" : "explore-testnet"
+        let urlToSave = getDocumentsDirectory().appendingPathComponent("\(fileName)-\(timestamp).zip")
 
+        // The same snapshot's reference the metadata came from, so timestamp/checksum and bytes
+        // always describe one archive.
         storageRef.getData(maxSize: metadata.size) { [weak self] data, error in
             let date = Date()
             let now = date.timeIntervalSince1970
@@ -176,6 +196,15 @@ extension ExploreDatabaseSyncManager {
                 
                 Task {
                     do {
+                        // The chain may have switched while the archive downloaded. Unzipping now
+                        // would overwrite explore.db with the wrong network's data and save a
+                        // marker that hides the mismatch; the switch already scheduled a fresh
+                        // sync, so drop this one instead.
+                        guard network == self?.currentNetworkName else {
+                            try? FileManager.default.removeItem(at: URL(fileURLWithPath: urlToSave.path))
+                            return
+                        }
+
                         // The archive unzips straight over the live `explore.db`. Let the open
                         // connection go first, and drop the -wal/-shm sidecars: they describe the
                         // *old* file, and SQLite replaying that WAL against the new one is what
@@ -188,7 +217,7 @@ extension ExploreDatabaseSyncManager {
                         try await self?.unzipFile(at: urlToSave.path, password: checksum)
                         self?.exploreDatabaseLastSyncTimestamp = now
                         self?.exploreDatabaseLastVersion = timeIntervalMillesecond / 1000
-                        self?.installedDatabaseNetwork = self?.currentNetworkName
+                        self?.installedDatabaseNetwork = network
                         self?.syncState = .synced(date)
 
                         NotificationCenter.default.post(name: ExploreDatabaseSyncManager.databaseHasBeenUpdatedNotification, object: nil)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
@@ -119,9 +119,7 @@ struct POIDetailsView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                 } else {
-                    Image(merchant.emptyLogoImageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                    MerchantLogoPlaceholder(merchantName: merchant.title ?? "", usableFraction: 0.84)
                 }
             }
             .frame(width: 50, height: 50)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift
@@ -110,16 +110,28 @@ struct POIDetailsView: View {
     
     // MARK: - Header View
     
+    // Rounded square, so the text may use almost the whole box.
+    private var logoPlaceholder: some View {
+        MerchantLogoPlaceholder(merchantName: merchant.title ?? "", usableFraction: 0.84)
+    }
+
     private var headerView: some View {
         HStack(spacing: 20) {
             // Logo
             Group {
                 if let logoUrl = merchant.logoLocation, let url = URL(string: logoUrl) {
-                    WebImage(url: url)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                    // The placeholder also covers loading and load failures (a 404 or a timeout
+                    // leaves the image nil), so a broken logo URL still renders the generated icon
+                    // rather than an empty box — matching AllMerchantLocationsView.
+                    WebImage(url: url) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                        logoPlaceholder
+                    }
                 } else {
-                    MerchantLogoPlaceholder(merchantName: merchant.title ?? "", usableFraction: 0.84)
+                    logoPlaceholder
                 }
             }
             .frame(width: 50, height: 50)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift
@@ -106,13 +106,17 @@ private struct MerchantHeaderView: View {
         HStack(spacing: Layout.contentSpacing) {
             Group {
                 if let logoUrl = pointOfUse.logoLocation, let url = URL(string: logoUrl) {
-                    WebImage(url: url)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                    // The placeholder also covers load failures (a 404 or a timeout leaves
+                    // the image nil), so a broken logo URL still renders the empty asset.
+                    WebImage(url: url) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                    } placeholder: {
+                        emptyLogo
+                    }
                 } else {
-                    Image(pointOfUse.emptyLogoImageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                    emptyLogo
                 }
             }
             .frame(width: Layout.logoSize, height: Layout.logoSize)
@@ -132,6 +136,12 @@ private struct MerchantHeaderView: View {
 
             Spacer()
         }
+    }
+
+    // Rounded square, so the text may use almost the whole box — same fraction as the
+    // POI details header.
+    private var emptyLogo: some View {
+        MerchantLogoPlaceholder(merchantName: pointOfUse.name, usableFraction: 0.84)
     }
 }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Cells/PointOfUseItemCell.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Cells/PointOfUseItemCell.swift
@@ -46,10 +46,13 @@ class PointOfUseItemCell: UITableViewCell {
     func update(with pointOfUse: ExplorePointOfUse) {
         nameLabel.text = pointOfUse.name
 
+        let logoPlaceholder = MerchantLogoPlaceholder.image(merchantName: pointOfUse.name,
+                                                            size: CGSize(width: 36, height: 36),
+                                                            cornerRadius: 8)
         if let urlString = pointOfUse.logoLocation, let url = URL(string: urlString) {
-            logoImageView.sd_setImage(with: url)
+            logoImageView.sd_setImage(with: url, placeholderImage: logoPlaceholder)
         } else {
-            logoImageView.image = UIImage(named: pointOfUse.emptyLogoImageName)
+            logoImageView.image = logoPlaceholder
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapAnnotationView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapAnnotationView.swift
@@ -64,10 +64,13 @@ final class ExploreMapAnnotationView: MKAnnotationView {
     }
 
     public func update(with pointOfUse: ExplorePointOfUse) {
+        let logoPlaceholder = MerchantLogoPlaceholder.image(merchantName: pointOfUse.name,
+                                                            size: CGSize(width: 36, height: 36),
+                                                            cornerRadius: 18)
         if let str = pointOfUse.logoLocation, let url = URL(string: str) {
-            imageView.sd_setImage(with: url, completed: nil)
+            imageView.sd_setImage(with: url, placeholderImage: logoPlaceholder, completed: nil)
         } else {
-            imageView.image = UIImage(named: pointOfUse.emptyLogoImageName)
+            imageView.image = logoPlaceholder
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
@@ -48,9 +48,9 @@ struct DashSpendPayIntro: View {
                 .scaledToFit()
                 .clipShape(Circle())
         } placeholder: {
-            // No icon yet (missing URL or still loading): show a grey circle of the same size.
-            Circle()
-                .fill(Color.dash.gray300Alpha50)
+            // No icon yet (missing URL or still loading): show the generated name placeholder.
+            MerchantLogoPlaceholder(merchantName: merchantTitle)
+                .clipShape(Circle())
         }
         .frame(width: Layout.merchantIconSize, height: Layout.merchantIconSize)
     }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/Components/DashSpendPayIntro.swift
@@ -48,8 +48,10 @@ struct DashSpendPayIntro: View {
                 .scaledToFit()
                 .clipShape(Circle())
         } placeholder: {
-            // No icon yet (missing URL or still loading): show the generated name placeholder.
-            MerchantLogoPlaceholder(merchantName: merchantTitle)
+            // No icon yet (missing URL or still loading): show the generated placeholder.
+            // Initials rather than the full name — at 18pt the name style bottoms out at the
+            // 6pt font floor and clips, whereas initials scale to fit.
+            MerchantLogoPlaceholder(merchantName: merchantTitle, style: .initials)
                 .clipShape(Circle())
         }
         .frame(width: Layout.merchantIconSize, height: Layout.merchantIconSize)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -95,8 +95,11 @@ struct DashSpendConfirmationDialog: View {
                                     .scaledToFit()
                             } placeholder: {
                                 // Rounded-rect clip (below), so the text may fill almost the
-                                // whole box — same fraction as the other rounded-rect sites.
-                                MerchantLogoPlaceholder(merchantName: merchantName, usableFraction: 0.84)
+                                // whole box. Initials rather than the full name — at 20pt the
+                                // name style hits the 6pt font floor and clips.
+                                MerchantLogoPlaceholder(merchantName: merchantName,
+                                                        style: .initials,
+                                                        usableFraction: 0.84)
                             }
                             .transition(.fade(duration: 0.3))
                             .frame(width: 20, height: 20)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -87,13 +87,20 @@ struct DashSpendConfirmationDialog: View {
 
                     detailsRow(title: NSLocalizedString("To", comment: "DashSpend")) {
                         HStack(spacing: 8) {
-                            WebImage(url: URL(string: merchantIconUrl))
-                                .resizable()
-                                .indicator(.activity)
-                                .transition(.fade(duration: 0.3))
-                                .scaledToFit()
-                                .frame(width: 20, height: 20)
-                                .clipShape(RoundedRectangle(cornerRadius: 7))
+                            // The placeholder stands in while loading and on failure, so a
+                            // missing or broken icon URL still shows the merchant's initials.
+                            WebImage(url: URL(string: merchantIconUrl)) { image in
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                            } placeholder: {
+                                // Rounded-rect clip (below), so the text may fill almost the
+                                // whole box — same fraction as the other rounded-rect sites.
+                                MerchantLogoPlaceholder(merchantName: merchantName, usableFraction: 0.84)
+                            }
+                            .transition(.fade(duration: 0.3))
+                            .frame(width: 20, height: 20)
+                            .clipShape(RoundedRectangle(cornerRadius: 7))
                             Text(merchantName)
                                 .font(.subhead)
                                 .foregroundColor(.dash.primaryText)

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsMerchantHeader.swift
@@ -34,10 +34,9 @@ struct GiftCardDetailsMerchantHeader: View {
                         .frame(width: 50, height: 50)
                         .clipShape(Circle())
                 } else {
-                    Image("image.explore.dash.wts.payment.gift-card")
-                        .resizable()
-                        .scaledToFit()
+                    MerchantLogoPlaceholder(merchantName: merchantName)
                         .frame(width: 50, height: 50)
+                        .clipShape(Circle())
                 }
 
                 if merchantIcon != nil {

--- a/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift
@@ -1,0 +1,191 @@
+//
+//  Copyright © 2026 Dash Core Group. All rights reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  https://opensource.org/licenses/MIT
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+
+/// A generated fallback icon for a merchant that has no logo: the merchant's name (or
+/// initials) in white on a circle/rounded square whose colour is derived deterministically
+/// from the name, so the same merchant always looks the same.
+///
+/// Mirrors the Android implementation (`MerchantInitialIcon.kt`, dash-wallet #1506):
+/// HSV with fixed 30% saturation / 60% brightness, hue spread over a hash of the name.
+/// The hash replicates Java's `String.hashCode()` so a merchant gets the same colour on
+/// both platforms.
+struct MerchantLogoPlaceholder: View {
+    enum Style {
+        /// Full name, one word per line ("Home Depot" -> "Home" / "Depot").
+        case name
+        /// Initials of up to the first two words ("Home Depot" -> "HD").
+        case initials
+    }
+
+    let merchantName: String
+    var style: Style = .name
+    /// Fraction of the box the text may use. A circle only exposes its inscribed square
+    /// (~0.66 of the diameter); a rounded square exposes almost the whole box (~0.84).
+    var usableFraction: CGFloat = 0.66
+
+    var body: some View {
+        GeometryReader { geo in
+            let side = min(geo.size.width, geo.size.height)
+            ZStack {
+                MerchantLogoPlaceholder.color(for: merchantName)
+                text(side: side)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(style == .name ? max(words.count, 1) : 1)
+                    .padding(side * (1 - usableFraction) / 2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func text(side: CGFloat) -> some View {
+        switch style {
+        case .initials:
+            Text(MerchantLogoPlaceholder.initials(merchantName))
+                .font(.system(size: side * 0.4, weight: .semibold))
+        case .name:
+            Text(words.joined(separator: "\n"))
+                .font(.system(size: fittedFontSize(side: side), weight: .semibold))
+        }
+    }
+
+    private var words: [String] {
+        merchantName.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+    }
+
+    /// Estimate-based fit (no measurement pass): constrained by line count (height) and the
+    /// longest word (width) against the usable area, then capped so short names aren't oversized.
+    private func fittedFontSize(side: CGFloat) -> CGFloat {
+        MerchantLogoPlaceholder.fittedFontSize(words: words, side: side, usableFraction: usableFraction)
+    }
+
+    // MARK: - Deterministic name → colour / initials (shared logic, matches Android)
+
+    /// Deterministic background colour for a merchant name. HSV(hue, 0.3, 0.6) where the hue
+    /// is spread over a Java-compatible hash of the lowercased name.
+    static func color(for name: String) -> Color {
+        let key = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let hue = key.isEmpty ? 0 : ((javaHashCode(key) % 360) + 360) % 360
+        return Color(hue: Double(hue) / 360.0, saturation: 0.3, brightness: 0.6)
+    }
+
+    /// Initials: first letter of up to the first two words. "Home Depot" -> "HD", "Brinker" -> "B".
+    static func initials(_ name: String) -> String {
+        let words = name.split(whereSeparator: { $0.isWhitespace })
+        switch words.count {
+        case 0: return ""
+        case 1: return words[0].prefix(1).uppercased()
+        default: return (words[0].prefix(1) + words[1].prefix(1)).uppercased()
+        }
+    }
+
+    /// Replicates `java.lang.String.hashCode()`: `h = 31*h + c` over UTF-16 code units, with
+    /// 32-bit wrapping overflow. Kept in sync with Android so colours match across platforms.
+    private static func javaHashCode(_ s: String) -> Int {
+        var hash: Int32 = 0
+        for unit in s.utf16 {
+            hash = 31 &* hash &+ Int32(unit)
+        }
+        return Int(hash)
+    }
+}
+
+// MARK: - UIKit rendering
+
+extension MerchantLogoPlaceholder {
+    /// `UIColor` counterpart of `color(for:)` for UIKit call sites.
+    static func uiColor(for name: String) -> UIColor {
+        let key = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let hue = key.isEmpty ? 0 : ((javaHashCode(key) % 360) + 360) % 360
+        return UIColor(hue: CGFloat(hue) / 360.0, saturation: 0.3, brightness: 0.6, alpha: 1)
+    }
+
+    /// Renders the full-name placeholder as a `UIImage`, for UIKit spots (list cell, map marker).
+    /// Mirrors the SwiftUI `.name` style: white words (one per line, auto-fitted) on the
+    /// deterministic colour, clipped to a circle or rounded square.
+    static func image(merchantName: String, size: CGSize, cornerRadius: CGFloat) -> UIImage {
+        let side = min(size.width, size.height)
+        // A circle only exposes its inscribed square (~0.66); a rounded square exposes ~0.84.
+        let isCircle = cornerRadius >= side / 2
+        let usableFraction: CGFloat = isCircle ? 0.66 : 0.84
+
+        let words = merchantName.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        let fontSize = fittedFontSize(words: words, side: side, usableFraction: usableFraction)
+
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { _ in
+            let rect = CGRect(origin: .zero, size: size)
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: min(cornerRadius, side / 2))
+            uiColor(for: merchantName).setFill()
+            path.fill()
+
+            guard !words.isEmpty else { return }
+
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.alignment = .center
+            paragraph.lineBreakMode = .byClipping
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: fontSize, weight: .semibold),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: paragraph
+            ]
+            let text = words.joined(separator: "\n") as NSString
+            let usable = side * usableFraction
+            let bounding = CGSize(width: usable, height: side)
+            let textRect = text.boundingRect(with: bounding,
+                                             options: [.usesLineFragmentOrigin, .usesFontLeading],
+                                             attributes: attrs, context: nil)
+            let drawRect = CGRect(x: (size.width - textRect.width) / 2,
+                                  y: (size.height - textRect.height) / 2,
+                                  width: textRect.width, height: textRect.height)
+            text.draw(with: drawRect, options: [.usesLineFragmentOrigin, .usesFontLeading],
+                      attributes: attrs, context: nil)
+        }
+    }
+
+    /// Shared with the SwiftUI view: estimate-based font fit (no measurement pass).
+    fileprivate static func fittedFontSize(words: [String], side: CGFloat, usableFraction: CGFloat) -> CGFloat {
+        guard !words.isEmpty else { return 1 }
+        let usable = side * usableFraction
+        let longestWord = CGFloat(words.map(\.count).max() ?? 1)
+        let byHeight = usable / (CGFloat(words.count) * 1.15)
+        let byWidth = usable / (longestWord * 0.58)
+        let maxFont = side * 0.4
+        return max(min(byHeight, byWidth, maxFont), 6)
+    }
+}
+
+#if DEBUG
+struct MerchantLogoPlaceholder_Previews: PreviewProvider {
+    static var previews: some View {
+        HStack(spacing: 12) {
+            MerchantLogoPlaceholder(merchantName: "Home Depot")
+                .frame(width: 50, height: 50).clipShape(Circle())
+            MerchantLogoPlaceholder(merchantName: "Brinker")
+                .frame(width: 50, height: 50).clipShape(Circle())
+            MerchantLogoPlaceholder(merchantName: "Mortons The Steak House", usableFraction: 0.84)
+                .frame(width: 50, height: 50).clipShape(RoundedRectangle(cornerRadius: 8))
+            MerchantLogoPlaceholder(merchantName: "Amazon", style: .initials)
+                .frame(width: 50, height: 50).clipShape(Circle())
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif


### PR DESCRIPTION
## Issue being fixed or feature implemented

Backport of #856, which was merged into `master` on 2026-07-29 and never reached
`develop`. `master` has been frozen since then and is no longer the default branch.

Two problems:

1. Merchants without a logo fell back to a flat placeholder asset, unlike Android,
   which draws a generated name/initials icon.
2. Switching between mainnet and testnet at runtime left the wrong network's
   merchants on screen. `ExploreDatabaseSyncManager` captured its Firebase
   `StorageReference` in `init()`, so the singleton kept downloading the launch
   network's archive for the rest of the process lifetime, and the version check
   only ran at launch and on the 24h timer.

## What was done?

- **`MerchantLogoPlaceholder`** — a deterministic name/initials icon whose colour is
  derived from a Java-`String.hashCode()`-compatible hash of the merchant name, so a
  merchant looks the same on iOS and Android (mirrors `MerchantInitialIcon.kt`).
  Wired into the POI details header, the all-locations list, the POI list cell, the
  map annotation (UIKit path, also as the `sd_setImage` placeholder), and the three
  DashSpend surfaces.
- **`ExploreDatabaseSyncManager`** — `storageRef` is now computed per access. The
  network and its reference are snapshotted for one sync run and re-checked at every
  async hop, so a switch mid-download can't mix one archive's timestamp/checksum with
  another's bytes or record a marker for a network that was never extracted. A
  `DWCurrentNetworkDidChange` observer re-runs the version check in-session.
- **`ExploreDatabaseConnection`** — clears the once-per-session test-merchant guard
  when the database file is replaced, so seeding re-evaluates against the new file.
  The count check inside `addPiggyCardsTestMerchants` still avoids trigger churn.

Note: `installedDatabaseNetwork` already landed on `develop` separately, so it is
reused here rather than re-added, and the now-unused `networkSpecificFileName` was
removed.

## How Has This Been Tested?

Built the `dashpay` scheme (the one CI archives) for the iOS Simulator with all
three backport branches merged together: **BUILD SUCCEEDED**. No errors or warnings
in any of the changed files.

Two local-environment caveats, neither caused by this change:
- `ARCHS=arm64` is required, because `platform/packages/swift-sdk/DashSDKFFI.xcframework`
  carries no x86_64 slice, so a generic simulator destination fails to link.
- The `dashwallet` and `dashwallet-dashpay` schemes can't be built locally at all —
  they pull the embedded WatchApp targets, and the SwiftLint build phase there fails
  on 220 pre-existing violations that are already present on a clean `develop`
  checkout. That is what blocks running the XCTest bundle locally.

SwiftLint was run directly on this branch and on a clean `develop` checkout and the
results diffed: this branch has **one violation fewer and none added** (removing a
duplicate `import DashUIKit` fixed a `sorted_imports` violation).

Not exercised on device: the mainnet/testnet Explore re-sync path needs a real
network switch against Firebase, and the placeholder rendering needs merchants with
no logo. Worth a manual pass before merge.

## Breaking Changes

None. The `explore.db` re-download on a network mismatch is a one-off cost the first
time an existing install switches networks.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized merchant logo placeholders using merchant names or initials and consistent colors.
  * Improved fallback visuals across merchant lists, maps, details, DashSpend, and gift card screens.

* **Bug Fixes**
  * Test merchants can be reconsidered after database replacement.
  * Explore data now synchronizes correctly when switching networks and avoids applying outdated downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->