### PR TITLE
fix(explore-dash): pluralise the ATM count subtitle

### DIFF
--- a/.bartycrouch.toml
+++ b/.bartycrouch.toml
@@ -1,11 +1,17 @@
 [update]
 tasks = ["interfaces", "code", "normalize"]
 
+# `.claude` holds agent worktrees: full copies of the project. Left alone, BartyCrouch
+# walks that duplicate source and imports keys from whatever branch is checked out
+# there into this branch's catalog. The other entries are BartyCrouch's own defaults,
+# repeated because setting this key replaces the default list rather than extending it.
+
 [update.interfaces]
 path = "."
 defaultToBase = true
 ignoreEmptyStrings = false
 unstripped = false
+subpathsToIgnore = [".git", "build", "carthage", "docs", "pods", ".claude"]
 
 [update.code]
 codePath = "."
@@ -13,14 +19,17 @@ localizablePath = "."
 defaultToKeys = true
 additive = false
 unstripped = false
+subpathsToIgnore = [".git", "build", "carthage", "docs", "pods", ".claude"]
 
 [update.normalize]
 path = "."
 sourceLocale = "en"
 harmonizeWithSource = true
 sortByKeys = true
+subpathsToIgnore = [".git", "build", "carthage", "docs", "pods", ".claude"]
 
 [lint]
 path = "."
 duplicateKeys = true
 emptyValues = true
+subpathsToIgnore = [".git", "build", "carthage", "docs", "pods", ".claude"]

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AtmListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AtmListViewController.swift
@@ -90,13 +90,19 @@ class AtmListViewController: ExplorePointOfUseListViewController {
     override func subtitleForFilterCell() -> String? {
         if DWLocationManager.shared.isAuthorized && currentSegment.showMap {
             if Locale.current.usesMetricSystem {
-                return String(format: NSLocalizedString("%d ATM(s) in %@", comment: "#bc-ignore!"), items.count,
-                              ExploreDash.distanceFormatter
-                                  .string(from: Measurement(value: model.currentRadius, unit: UnitLength.meters)))
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("%d ATM(s) in %@", comment: "#bc-ignore!"),
+                    items.count,
+                    ExploreDash.distanceFormatter
+                        .string(from: Measurement(value: model.currentRadius, unit: UnitLength.meters))
+                )
             } else {
-                return String(format: NSLocalizedString("%d ATM(s) in %@", comment: "#bc-ignore!"), items.count,
-                              ExploreDash.distanceFormatter
-                                  .string(from: Measurement(value: model.currentRadiusMiles, unit: UnitLength.miles)))
+                return String.localizedStringWithFormat(
+                    NSLocalizedString("%d ATM(s) in %@", comment: "#bc-ignore!"),
+                    items.count,
+                    ExploreDash.distanceFormatter
+                        .string(from: Measurement(value: model.currentRadiusMiles, unit: UnitLength.miles))
+                )
             }
         } else {
             return super.subtitleForFilterCell()

--- a/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
@@ -20,8 +20,8 @@
 //  limitations under the License.
 //
 
-import SwiftUI
 import DashUIKit
+import SwiftUI
 
 struct NavigationBar<Leading: View, Central: View, Trailing: View>: View {
     private let leading: Leading
@@ -293,7 +293,7 @@ struct NavBarClose: View {
                        .stroke(Color.dash.gray300Alpha30, lineWidth: 1.5)
                        .frame(width: 34, height: 34)
 
-                   Image("toolbar-close")
+                   Image(dash: .custom("navigationbar-close", bundle: .dashUIKit))
                        .resizable()
                        .aspectRatio(contentMode: .fit)
                        .frame(height: 11)

--- a/DashWallet/ar.lproj/Localizable.stringsdict
+++ b/DashWallet/ar.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ar.lproj/Localizable.stringsdict
+++ b/DashWallet/ar.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/bg.lproj/Localizable.stringsdict
+++ b/DashWallet/bg.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/bg.lproj/Localizable.stringsdict
+++ b/DashWallet/bg.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld използван</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ca.lproj/Localizable.stringsdict
+++ b/DashWallet/ca.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ca.lproj/Localizable.stringsdict
+++ b/DashWallet/ca.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/cs.lproj/Localizable.stringsdict
+++ b/DashWallet/cs.lproj/Localizable.stringsdict
@@ -22,6 +22,22 @@
 			<string>%ld použito</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/cs.lproj/Localizable.stringsdict
+++ b/DashWallet/cs.lproj/Localizable.stringsdict
@@ -25,7 +25,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -33,9 +33,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/da.lproj/Localizable.stringsdict
+++ b/DashWallet/da.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/da.lproj/Localizable.stringsdict
+++ b/DashWallet/da.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/de.lproj/Localizable.stringsdict
+++ b/DashWallet/de.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/de.lproj/Localizable.stringsdict
+++ b/DashWallet/de.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld verwendet</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/el.lproj/Localizable.stringsdict
+++ b/DashWallet/el.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld χρησιμοποιούνται</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/el.lproj/Localizable.stringsdict
+++ b/DashWallet/el.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/en.lproj/Localizable.stringsdict
+++ b/DashWallet/en.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%d evonodes</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d key(s)</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/en.lproj/Localizable.stringsdict
+++ b/DashWallet/en.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d key(s)</key>

--- a/DashWallet/eo.lproj/Localizable.stringsdict
+++ b/DashWallet/eo.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/eo.lproj/Localizable.stringsdict
+++ b/DashWallet/eo.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/es.lproj/Localizable.stringsdict
+++ b/DashWallet/es.lproj/Localizable.stringsdict
@@ -20,6 +20,24 @@
 			<string>%ld usadas</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/es.lproj/Localizable.stringsdict
+++ b/DashWallet/es.lproj/Localizable.stringsdict
@@ -23,7 +23,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -31,11 +31,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/et.lproj/Localizable.stringsdict
+++ b/DashWallet/et.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/et.lproj/Localizable.stringsdict
+++ b/DashWallet/et.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/fa.lproj/Localizable.stringsdict
+++ b/DashWallet/fa.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/fa.lproj/Localizable.stringsdict
+++ b/DashWallet/fa.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/fi.lproj/Localizable.stringsdict
+++ b/DashWallet/fi.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/fi.lproj/Localizable.stringsdict
+++ b/DashWallet/fi.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/fil.lproj/Localizable.stringsdict
+++ b/DashWallet/fil.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%Id ginamit</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/fil.lproj/Localizable.stringsdict
+++ b/DashWallet/fil.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/fr.lproj/Localizable.stringsdict
+++ b/DashWallet/fr.lproj/Localizable.stringsdict
@@ -23,7 +23,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -31,11 +31,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/fr.lproj/Localizable.stringsdict
+++ b/DashWallet/fr.lproj/Localizable.stringsdict
@@ -20,6 +20,24 @@
 			<string>%ld clés</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/hr.lproj/Localizable.stringsdict
+++ b/DashWallet/hr.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/hr.lproj/Localizable.stringsdict
+++ b/DashWallet/hr.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/hu.lproj/Localizable.stringsdict
+++ b/DashWallet/hu.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/hu.lproj/Localizable.stringsdict
+++ b/DashWallet/hu.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/id.lproj/Localizable.stringsdict
+++ b/DashWallet/id.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/id.lproj/Localizable.stringsdict
+++ b/DashWallet/id.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%ld digunakan</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/it.lproj/Localizable.stringsdict
+++ b/DashWallet/it.lproj/Localizable.stringsdict
@@ -20,6 +20,24 @@
 			<string>%lD in uso </string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/it.lproj/Localizable.stringsdict
+++ b/DashWallet/it.lproj/Localizable.stringsdict
@@ -23,7 +23,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -31,11 +31,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/ja.lproj/Localizable.stringsdict
+++ b/DashWallet/ja.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%ld 使用済み</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ja.lproj/Localizable.stringsdict
+++ b/DashWallet/ja.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/ko.lproj/Localizable.stringsdict
+++ b/DashWallet/ko.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%ld 사용됨</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ko.lproj/Localizable.stringsdict
+++ b/DashWallet/ko.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/mk.lproj/Localizable.stringsdict
+++ b/DashWallet/mk.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/mk.lproj/Localizable.stringsdict
+++ b/DashWallet/mk.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/ms.lproj/Localizable.stringsdict
+++ b/DashWallet/ms.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ms.lproj/Localizable.stringsdict
+++ b/DashWallet/ms.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/nb.lproj/Localizable.stringsdict
+++ b/DashWallet/nb.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/nb.lproj/Localizable.stringsdict
+++ b/DashWallet/nb.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/nl.lproj/Localizable.stringsdict
+++ b/DashWallet/nl.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/nl.lproj/Localizable.stringsdict
+++ b/DashWallet/nl.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld gebruikt</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/pl.lproj/Localizable.stringsdict
+++ b/DashWallet/pl.lproj/Localizable.stringsdict
@@ -25,7 +25,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -33,13 +33,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>few</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/pl.lproj/Localizable.stringsdict
+++ b/DashWallet/pl.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>%Id użyty</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>few</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/pt.lproj/Localizable.stringsdict
+++ b/DashWallet/pt.lproj/Localizable.stringsdict
@@ -20,6 +20,24 @@
 			<string>%ld utilizadas</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/pt.lproj/Localizable.stringsdict
+++ b/DashWallet/pt.lproj/Localizable.stringsdict
@@ -23,7 +23,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -31,11 +31,11 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/ro.lproj/Localizable.stringsdict
+++ b/DashWallet/ro.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ro.lproj/Localizable.stringsdict
+++ b/DashWallet/ro.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/ru.lproj/Localizable.stringsdict
+++ b/DashWallet/ru.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>%ld использовано</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>few</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/ru.lproj/Localizable.stringsdict
+++ b/DashWallet/ru.lproj/Localizable.stringsdict
@@ -25,7 +25,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -33,13 +33,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>few</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sk.lproj/Localizable.stringsdict
+++ b/DashWallet/sk.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>%ld použitých</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>few</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sk.lproj/Localizable.stringsdict
+++ b/DashWallet/sk.lproj/Localizable.stringsdict
@@ -25,7 +25,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -33,13 +33,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>few</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sl.lproj/Localizable.stringsdict
+++ b/DashWallet/sl.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sl.lproj/Localizable.stringsdict
+++ b/DashWallet/sl.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sl_SI.lproj/Localizable.stringsdict
+++ b/DashWallet/sl_SI.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sl_SI.lproj/Localizable.stringsdict
+++ b/DashWallet/sl_SI.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sq.lproj/Localizable.stringsdict
+++ b/DashWallet/sq.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sq.lproj/Localizable.stringsdict
+++ b/DashWallet/sq.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sr.lproj/Localizable.stringsdict
+++ b/DashWallet/sr.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sr.lproj/Localizable.stringsdict
+++ b/DashWallet/sr.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/sv.lproj/Localizable.stringsdict
+++ b/DashWallet/sv.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld used</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/sv.lproj/Localizable.stringsdict
+++ b/DashWallet/sv.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/th.lproj/Localizable.stringsdict
+++ b/DashWallet/th.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>รหัสที่ใช้ไปแล้ว</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/th.lproj/Localizable.stringsdict
+++ b/DashWallet/th.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/tr.lproj/Localizable.stringsdict
+++ b/DashWallet/tr.lproj/Localizable.stringsdict
@@ -18,6 +18,22 @@
 			<string>%ld kullanıldı</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/tr.lproj/Localizable.stringsdict
+++ b/DashWallet/tr.lproj/Localizable.stringsdict
@@ -21,7 +21,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -29,9 +29,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/uk.lproj/Localizable.stringsdict
+++ b/DashWallet/uk.lproj/Localizable.stringsdict
@@ -22,6 +22,26 @@
 			<string>%ld використано</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+			<key>few</key>
+			<string>%d ATMs in %@</string>
+			<key>many</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/uk.lproj/Localizable.stringsdict
+++ b/DashWallet/uk.lproj/Localizable.stringsdict
@@ -25,7 +25,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -33,13 +33,13 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>few</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 			<key>many</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/vi.lproj/Localizable.stringsdict
+++ b/DashWallet/vi.lproj/Localizable.stringsdict
@@ -16,6 +16,22 @@
 			<string>%ld đã sử dụng</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d ATM in %@</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/vi.lproj/Localizable.stringsdict
+++ b/DashWallet/vi.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,9 +27,9 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>%d ATM in %@</string>
+			<string>%1$d ATM in %2$@</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/zh-Hans.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hans.lproj/Localizable.stringsdict
@@ -5,7 +5,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -13,7 +13,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d key(s)</key>

--- a/DashWallet/zh-Hans.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hans.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d key(s)</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
@@ -5,7 +5,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -13,7 +13,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d key(s)</key>

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.stringsdict
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d key(s)</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/zh.lproj/Localizable.stringsdict
+++ b/DashWallet/zh.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/zh.lproj/Localizable.stringsdict
+++ b/DashWallet/zh.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%ld 已使用</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/DashWallet/zh_TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh_TW.lproj/Localizable.stringsdict
@@ -19,7 +19,7 @@
 	<key>%d ATM(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@atms@</string>
+		<string>%1$#@atms@</string>
 		<key>atms</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
@@ -27,7 +27,7 @@
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>other</key>
-			<string>%d ATMs in %@</string>
+			<string>%1$d ATMs in %2$@</string>
 		</dict>
 	</dict>
 	<key>%d merchant(s) in %@</key>

--- a/DashWallet/zh_TW.lproj/Localizable.stringsdict
+++ b/DashWallet/zh_TW.lproj/Localizable.stringsdict
@@ -16,6 +16,20 @@
 			<string>%ld 己使用</string>
 		</dict>
 	</dict>
+	<key>%d ATM(s) in %@</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@atms@</string>
+		<key>atms</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>other</key>
+			<string>%d ATMs in %@</string>
+		</dict>
+	</dict>
 	<key>%d merchant(s) in %@</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
## Issue being fixed or feature implemented

Partial backport of #855, which was merged into `master` on 2026-07-28 and never
reached `develop`. `master` has been frozen since 2026-07-29 and is no longer the
default branch.

The ATM list subtitle read "1 ATM(s) in 5 km" — the key was never pluralised, and
`String(format:)` bypasses the plural catalog even when one exists.

## What was done?

- `AtmListViewController` uses `String.localizedStringWithFormat`, so
  `"%d ATM(s) in %@"` resolves through `Localizable.stringsdict`. This is exactly how
  `"%d merchant(s) in %@"` already works in `MerchantListViewController`.
- Carried that plural entry into every locale catalog. This includes `zh-Hans` and
  `zh-Hant-TW`, the two Chinese catalogs the project actually builds — the original
  PR only updated the orphaned `zh`/`zh_TW` files, which are not referenced by
  `project.pbxproj`.
- `NavBarClose` draws the DashUIKit close icon instead of the local `toolbar-close`
  asset.
- `.bartycrouch.toml` ignores `.claude`, which holds full agent worktrees. Left
  alone, BartyCrouch walks that duplicate source tree and imports keys from whatever
  branch is checked out there into this branch's catalog.

**Deliberately not carried over from #855:**

- The regenerated `Localizable.strings` (43 files). That regeneration reflects
  `master`'s code; applying it here would delete the DashPay and shielded-wallet keys
  `develop` needs. If a refresh is wanted, BartyCrouch should be run against
  `develop` in its own PR.
- The `ExtendedPublicKeysView` title fix — `develop` deleted that view.
- `SwapOrder.providerExplorer` — `develop` already has the equivalent via
  `TxDetailModel.SwapExplorerLink`.

## How Has This Been Tested?

Built the `dashpay` scheme (the one CI archives) for the iOS Simulator with all
three backport branches merged together: **BUILD SUCCEEDED**. No errors or warnings
in any of the changed files.

Two local-environment caveats, neither caused by this change:
- `ARCHS=arm64` is required, because `platform/packages/swift-sdk/DashSDKFFI.xcframework`
  carries no x86_64 slice, so a generic simulator destination fails to link.
- The `dashwallet` and `dashwallet-dashpay` schemes can't be built locally at all —
  they pull the embedded WatchApp targets, and the SwiftLint build phase there fails
  on 220 pre-existing violations that are already present on a clean `develop`
  checkout. That is what blocks running the XCTest bundle locally.

SwiftLint was run directly on this branch and on a clean `develop` checkout and the
results diffed: this branch has **one violation fewer and none added** (removing a
duplicate `import DashUIKit` fixed a `sorted_imports` violation).

Every `Localizable.stringsdict` passes `plutil -lint`, and all 43 catalogs the
project builds now carry the `%d ATM(s) in %@` key — verified by cross-checking the
`.lproj` list in `project.pbxproj`.

Not exercised on device: the ATM list subtitle needs location permission plus the
map segment to render.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
