### PR TITLE
feat(dashpay): name the contact on a contact payment's details

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -334,6 +334,8 @@
 		30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */; };
 		A1FA10C00000000000000002 /* AssetLockRecoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */; };
 		UTR0B0002FA0000000000002 /* UnconfirmedTransactionRemover.swift in Sources */ = {isa = PBXBuildFile; fileRef = UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */; };
+		INSGT0001000000000000002 /* InsightExplorerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = INSGT0001000000000000001 /* InsightExplorerAPI.swift */; };
+		INSGT0001000000000000003 /* InsightExplorerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = INSGT0001000000000000001 /* InsightExplorerAPI.swift */; };
 		3116F910F54D310002090CBB /* PinPromptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D385FC174E5B887CF3398CCD /* PinPromptPresenter.swift */; };
 		35BFE3D1C0B8999FBC8AB180 /* PaymentRequestVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59D5720437F8A4137605940 /* PaymentRequestVerifier.swift */; };
 		3705C73F15BCD91AF70940B9 /* PlatformCreditsFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C830DD6D63115525925F75 /* PlatformCreditsFormatter.swift */; };
@@ -1723,6 +1725,7 @@
 		C9D2C8EE2A320AA000D15901 /* WelcomeToCrowdNodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1141E4C4291FDC7A00ACDA9E /* WelcomeToCrowdNodeViewController.swift */; };
 		C9D2C8F02A320AA000D15901 /* DWProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A4E531C22EA49FE00E5168A /* DWProgressView.m */; };
 		C9D2C8F12A320AA000D15901 /* TxDetailCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A5146328491C60005A8E3E /* TxDetailCells.swift */; };
+		A1C0DE0000000000000BADA2 /* TxDetailContactViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C0DE0000000000000BADA1 /* TxDetailContactViews.swift */; };
 		C9D2C8F22A320AA000D15901 /* BaseViewController+NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477F501629543834003C7508 /* BaseViewController+NetworkReachability.swift */; };
 		C9D2C8F32A320AA000D15901 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 75D5F3CD191EC270004AB296 /* main.m */; settings = {COMPILER_FLAGS = "-DASHPAY"; }; };
 		C9D2C90B2A320AA000D15901 /* DWShortcutCollectionViewCell~ipad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2A1AF6DC23C7681B00442AF5 /* DWShortcutCollectionViewCell~ipad.xib */; };
@@ -2685,6 +2688,7 @@
 		47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailViewController.swift; sourceTree = "<group>"; };
 		47A514612848FEAD005A8E3E /* Tx.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Tx.storyboard; sourceTree = "<group>"; };
 		47A5146328491C60005A8E3E /* TxDetailCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailCells.swift; sourceTree = "<group>"; };
+		A1C0DE0000000000000BADA1 /* TxDetailContactViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TxDetailContactViews.swift; sourceTree = "<group>"; };
 		47AC8412297822E000BD1B49 /* SpecifyAmountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyAmountViewController.swift; sourceTree = "<group>"; };
 		47AE8B9428BFACA100490F5E /* ExploreDash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreDash.swift; sourceTree = "<group>"; };
 		47AE8B9B28BFAD2800490F5E /* ExplorePointOfUse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplorePointOfUse.swift; sourceTree = "<group>"; };
@@ -3589,6 +3593,7 @@
 		E6E56673B2BFED8EC0181A1F /* PlatformAddressSyncCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformAddressSyncCoordinator.swift; sourceTree = "<group>"; };
 		A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetLockRecoveryService.swift; sourceTree = "<group>"; };
 		UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnconfirmedTransactionRemover.swift; sourceTree = "<group>"; };
+		INSGT0001000000000000001 /* InsightExplorerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InsightExplorerAPI.swift; sourceTree = "<group>"; };
 		E7333F2D05D0DD2D4373FF9B /* StorageExplorerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StorageExplorerView.swift; sourceTree = "<group>"; };
 		E735446F9E918618E97EDD38 /* PaymentsLandingScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentsLandingScreen.swift; sourceTree = "<group>"; };
 		E83D8CEAFF69B6D666C02116 /* Pods-WatchApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WatchApp.release.xcconfig"; path = "Target Support Files/Pods-WatchApp/Pods-WatchApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -4238,6 +4243,7 @@
 			isa = PBXGroup;
 			children = (
 				47A5146328491C60005A8E3E /* TxDetailCells.swift */,
+				A1C0DE0000000000000BADA1 /* TxDetailContactViews.swift */,
 				474C720C298A19D100475CA6 /* TxDetailHeaderCell.xib */,
 				474C720E298A1A3E00475CA6 /* TxDetailTaxCategoryCell.xib */,
 				474C7212298A1EFC00475CA6 /* TxDetailInfoCell.xib */,
@@ -7131,6 +7137,7 @@
 				UM00B0032FA0000000000001 /* UsernameMarketplaceService.swift */,
 				A1FA10C00000000000000001 /* AssetLockRecoveryService.swift */,
 				UTR0B0002FA0000000000001 /* UnconfirmedTransactionRemover.swift */,
+				INSGT0001000000000000001 /* InsightExplorerAPI.swift */,
 				51AA000D2F97000D005A000D /* ShieldedSyncMonitor.swift */,
 				43C830DD6D63115525925F75 /* PlatformCreditsFormatter.swift */,
 				44DCDC3A2B92601BB1E61FD9 /* PlatformSendExecutor.swift */,
@@ -10160,6 +10167,7 @@
 				8EAA05FA797008525050A2A7 /* PlatformAddressSyncCoordinator.swift in Sources */,
 				A1FA10C00000000000000003 /* AssetLockRecoveryService.swift in Sources */,
 				UTR0B0002FA0000000000003 /* UnconfirmedTransactionRemover.swift in Sources */,
+				INSGT0001000000000000003 /* InsightExplorerAPI.swift in Sources */,
 				2D354A4D6053027CA27F02CB /* PlatformSyncStatusScreen.swift in Sources */,
 				51AA00222F970022005A0022 /* MasternodesScreen.swift in Sources */,
 				51AA00022F970002005A0002 /* SyncInfoMenuScreen.swift in Sources */,
@@ -11080,6 +11088,7 @@
 				51A577492FBB3A6000FB4097 /* OrderPreviewViewModel.swift in Sources */,
 				C9D2C8F02A320AA000D15901 /* DWProgressView.m in Sources */,
 				C9D2C8F12A320AA000D15901 /* TxDetailCells.swift in Sources */,
+				A1C0DE0000000000000BADA2 /* TxDetailContactViews.swift in Sources */,
 				75D9EBC22DE5CD9C009416A2 /* GiftCardsDAO.swift in Sources */,
 				754565D12DABA5F300DA4E8E /* MerchantTypesDialog.swift in Sources */,
 				C9D2C8F22A320AA000D15901 /* BaseViewController+NetworkReachability.swift in Sources */,
@@ -11168,6 +11177,7 @@
 				30C7DE2E26E849E0D76319FA /* PlatformAddressSyncCoordinator.swift in Sources */,
 				A1FA10C00000000000000002 /* AssetLockRecoveryService.swift in Sources */,
 				UTR0B0002FA0000000000002 /* UnconfirmedTransactionRemover.swift in Sources */,
+				INSGT0001000000000000002 /* InsightExplorerAPI.swift in Sources */,
 				0308E777B29CC6DE1DB30FDD /* PlatformSyncStatusScreen.swift in Sources */,
 				51AA00212F970021005A0021 /* MasternodesScreen.swift in Sources */,
 				51AA00032F970003005A0003 /* SyncInfoMenuScreen.swift in Sources */,

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -11385,7 +11385,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -11422,7 +11422,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -11458,7 +11458,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -11494,7 +11494,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -11655,7 +11655,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
@@ -11684,7 +11684,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -11776,7 +11776,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -11815,7 +11815,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -11904,7 +11904,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/dashwallet.app/dashwallet";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -11936,7 +11936,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/dashwallet.app/dashwallet";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -11968,12 +11968,12 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -11990,12 +11990,12 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -12010,7 +12010,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3BA20785E162F1AF2F455D9C /* Pods-WatchApp Extension.debug.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -12020,7 +12020,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -12037,7 +12037,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4457C976B1DB0CF402FF3C5F /* Pods-WatchApp Extension.release.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -12047,7 +12047,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -12065,7 +12065,7 @@
 			baseConfigurationReference = 3B0E86557754B86DD3A389CC /* Pods-TodayExtension.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwalletTodayExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
@@ -12079,7 +12079,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -12094,7 +12094,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwalletTodayExtension.entitlements;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
@@ -12108,7 +12108,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -12126,7 +12126,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
@@ -12155,7 +12155,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12247,7 +12247,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -12275,7 +12275,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12367,7 +12367,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -12406,7 +12406,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12497,7 +12497,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -12536,7 +12536,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12690,7 +12690,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -12728,7 +12728,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -12817,7 +12817,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwalletTodayExtension.entitlements;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
@@ -12831,7 +12831,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -12847,7 +12847,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/dashwallet.app/dashwallet";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -12879,12 +12879,12 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -12899,7 +12899,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EE15E7C0EEFF1E6930A90DA6 /* Pods-WatchApp Extension.testflight.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -12909,7 +12909,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -12998,7 +12998,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwallet.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -13026,7 +13026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -13114,7 +13114,7 @@
 			baseConfigurationReference = AA29A8515217AC4232F794C2 /* Pods-TodayExtension.testnet.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = dashwallet/dashwalletTodayExtension.entitlements;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
@@ -13128,7 +13128,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.TodayExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -13143,7 +13143,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/dashwallet.app/dashwallet";
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -13175,12 +13175,12 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				EXCLUDED_ARCHS = "";
 				IBSC_MODULE = WatchApp_Extension;
 				INFOPLIST_FILE = WatchApp/Info.plist;
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -13195,7 +13195,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E2A832899A499C24C7A43E47 /* Pods-WatchApp Extension.testnet.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 44RJ69WHFF;
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "";
@@ -13205,7 +13205,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 9.0.0;
+				MARKETING_VERSION = 9.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.dash.watchkitapp.watchkitextension;
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/InsightExplorerAPI.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/InsightExplorerAPI.swift
@@ -1,0 +1,68 @@
+//
+//  InsightExplorerAPI.swift
+//  DashWallet
+//
+
+import Foundation
+import SwiftDashSDK
+
+/// Minimal read-only client for the network's Insight API — the one
+/// third-party source the wallet consults about a transaction it cannot
+/// answer for itself.
+///
+/// Every call sends a transaction id to a third party, so callers must have
+/// a reason the local data cannot serve: today the never-accepted-transaction
+/// removal check (is this tx known to the network at all?) and the fee of a
+/// received transaction whose parent transactions this wallet doesn't hold.
+enum InsightExplorerAPI {
+    static func baseURL(network: Network) -> String {
+        network == .mainnet
+            ? "https://insight.dash.org/insight-api"
+            : "https://insight.testnet.networks.dash.org/insight-api"
+    }
+
+    /// GET `/tx/<txid>`. Returns the HTTP status and, for a 200, the decoded
+    /// JSON object. `nil` means the request never produced a response —
+    /// transport failure, a malformed URL, or a body that isn't a JSON
+    /// object — and is deliberately distinct from a 404 (an answer: the
+    /// explorer doesn't know this transaction).
+    static func transaction(displayTxid: String, network: Network) async -> (statusCode: Int, body: [String: Any])? {
+        guard let url = URL(string: "\(baseURL(network: network))/tx/\(displayTxid)") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse else {
+            return nil
+        }
+        guard http.statusCode == 200 else {
+            return (http.statusCode, [:])
+        }
+        let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        return (http.statusCode, body ?? [:])
+    }
+
+    /// Fee in duffs from a `/tx` body. Insight reports `fees` in whole DASH
+    /// as a JSON number; `valueIn - valueOut` is the fallback for bodies that
+    /// omit it. Nil when neither is present (a coinbase has no `fees`).
+    static func feeDuffs(fromTransactionBody body: [String: Any]) -> UInt64? {
+        if let fees = body["fees"] as? Double, fees >= 0 {
+            return duffs(fromDash: fees)
+        }
+        if let valueIn = body["valueIn"] as? Double,
+           let valueOut = body["valueOut"] as? Double,
+           valueIn >= valueOut {
+            return duffs(fromDash: valueIn - valueOut)
+        }
+        return nil
+    }
+
+    /// DASH → duffs. Rounded rather than truncated: the JSON number is a
+    /// binary float, so 2.27e-06 arrives as 227.00000000000003 duffs.
+    private static func duffs(fromDash dash: Double) -> UInt64 {
+        UInt64((dash * 1e8).rounded())
+    }
+}

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/InsightExplorerAPI.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/InsightExplorerAPI.swift
@@ -21,12 +21,17 @@ enum InsightExplorerAPI {
             : "https://insight.testnet.networks.dash.org/insight-api"
     }
 
-    /// GET `/tx/<txid>`. Returns the HTTP status and, for a 200, the decoded
-    /// JSON object. `nil` means the request never produced a response —
-    /// transport failure, a malformed URL, or a body that isn't a JSON
-    /// object — and is deliberately distinct from a 404 (an answer: the
-    /// explorer doesn't know this transaction).
-    static func transaction(displayTxid: String, network: Network) async -> (statusCode: Int, body: [String: Any])? {
+    /// GET `/tx/<txid>`. Returns the HTTP status and, for a 200 whose body
+    /// decodes to a JSON object, that object.
+    ///
+    /// A `nil` result means the request never produced a response at all —
+    /// transport failure or a malformed URL — and is deliberately distinct
+    /// from a 404, which is an answer: the explorer doesn't know this
+    /// transaction. A `nil` *body* on a 200 means the explorer answered but
+    /// said nothing usable; it stays separate from an empty object so a
+    /// caller that only needs "does this transaction exist" is not made to
+    /// fail on an unparseable body.
+    static func transaction(displayTxid: String, network: Network) async -> (statusCode: Int, body: [String: Any]?)? {
         guard let url = URL(string: "\(baseURL(network: network))/tx/\(displayTxid)") else {
             return nil
         }
@@ -39,15 +44,15 @@ enum InsightExplorerAPI {
             return nil
         }
         guard http.statusCode == 200 else {
-            return (http.statusCode, [:])
+            return (http.statusCode, nil)
         }
-        let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
-        return (http.statusCode, body ?? [:])
+        return (http.statusCode, (try? JSONSerialization.jsonObject(with: data)) as? [String: Any])
     }
 
     /// Fee in duffs from a `/tx` body. Insight reports `fees` in whole DASH
     /// as a JSON number; `valueIn - valueOut` is the fallback for bodies that
-    /// omit it. Nil when neither is present (a coinbase has no `fees`).
+    /// omit it. Nil when neither is present (a coinbase has no `fees`) or
+    /// when the number is not a plausible duff amount.
     static func feeDuffs(fromTransactionBody body: [String: Any]) -> UInt64? {
         if let fees = body["fees"] as? Double, fees >= 0 {
             return duffs(fromDash: fees)
@@ -62,7 +67,16 @@ enum InsightExplorerAPI {
 
     /// DASH → duffs. Rounded rather than truncated: the JSON number is a
     /// binary float, so 2.27e-06 arrives as 227.00000000000003 duffs.
-    private static func duffs(fromDash dash: Double) -> UInt64 {
-        UInt64((dash * 1e8).rounded())
+    ///
+    /// Failable because the input is a number a third party chose:
+    /// `UInt64(_: Double)` traps — in release builds too — on NaN, on an
+    /// infinity, and on anything outside `UInt64`'s range, so a nonsense
+    /// `fees` would crash the detail sheet rather than fail to fill one row.
+    /// The ceiling is Dash's max supply, well below the 2^64 trap boundary:
+    /// nothing above it is a fee.
+    private static func duffs(fromDash dash: Double) -> UInt64? {
+        let duffs = (dash * 1e8).rounded()
+        guard duffs.isFinite, duffs >= 0, duffs <= Double(kMaxDashSupplyDuffs) else { return nil }
+        return UInt64(duffs)
     }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/UnconfirmedTransactionRemover.swift
@@ -308,26 +308,10 @@ struct UnconfirmedTransactionRemover {
     /// (including transport failure) refuses the removal rather than
     /// guessing.
     private static func explorerKnowsTransaction(displayTxid: String, network: Network) async throws -> Bool {
-        let base = network == .mainnet
-            ? "https://insight.dash.org/insight-api"
-            : "https://insight.testnet.networks.dash.org/insight-api"
-        guard let url = URL(string: "\(base)/tx/\(displayTxid)") else {
+        guard let result = await InsightExplorerAPI.transaction(displayTxid: displayTxid, network: network) else {
             throw RemovalError.verificationUnavailable
         }
-        var request = URLRequest(url: url)
-        request.timeoutInterval = 20
-        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        let http: HTTPURLResponse
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw RemovalError.verificationUnavailable
-            }
-            http = httpResponse
-        } catch {
-            throw RemovalError.verificationUnavailable
-        }
-        switch http.statusCode {
+        switch result.statusCode {
         case 200: return true
         case 404: return false
         default: throw RemovalError.verificationUnavailable

--- a/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/RawTransactionInspector.swift
@@ -107,6 +107,21 @@ enum RawTransactionInspector {
         return try? container.mainContext.fetch(descriptor).first
     }
 
+    /// Value of a spent outpoint read from the parent transaction's own
+    /// stored bytes. This is dashj's "connect the input to a known
+    /// transaction" step: the wallet keeps whole transactions, so an input
+    /// spending an output that is not ours — a counterparty paying us back
+    /// with coins we sent them, say — still has a knowable value, and with it
+    /// a computable fee. Nil when we don't hold the parent, which is the
+    /// ordinary case for a payment from someone we've never paid.
+    @MainActor
+    private static func parentOutputValue(prevTxid: Data, vout: UInt32) -> UInt64? {
+        guard let row = fetchRow(txidWire: prevTxid), !row.transactionData.isEmpty,
+              let parsed = try? ParsedRawTransaction(data: row.transactionData),
+              Int(vout) < parsed.outputs.count else { return nil }
+        return parsed.outputs[Int(vout)].valueDuffs
+    }
+
     @MainActor
     private static func details(from row: PersistentTransaction) -> RawTransactionDetails? {
         let data = row.transactionData
@@ -123,7 +138,7 @@ enum RawTransactionInspector {
             decodedInputs = decoded.inputs
         }
 
-        // Wallet-owned spent TXOs, keyed by outpoint — the only source of
+        // Wallet-owned spent TXOs, keyed by outpoint — the first source of
         // input values (the raw tx carries none).
         var ownedByOutpoint: [Data: PersistentTxo] = [:]
         for txo in row.inputs {
@@ -142,7 +157,8 @@ enum RawTransactionInspector {
                 scriptSig: input.scriptSig,
                 sequence: input.sequence,
                 address: owned?.address.isEmpty == false ? owned?.address : decodedAddress,
-                amountDuffs: owned?.amount,
+                amountDuffs: owned?.amount
+                    ?? Self.parentOutputValue(prevTxid: input.prevTxid, vout: input.prevVout),
                 isCoinbase: isCoinbase)
         }
 

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -810,7 +810,11 @@ struct HomeViewContent<Content: View>: View {
                     AnyView(Image(uiImage: $0).resizable().scaledToFit().clipShape(Circle()))
                 } ?? contactAvatar ?? routeSymbols.map { transferRouteIcon($0.source) },
                 secondaryIcon: routeSymbols.map { DashIconSource.system($0.destination) }
-                    ?? icons.secondary?.dashIconSource,
+                    ?? icons.secondary?.dashIconSource
+                    // A contact avatar takes the icon slot, so the direction
+                    // moves into the corner badge instead of being dropped —
+                    // matching Android and the tx-detail header.
+                    ?? (contactAvatar == nil ? nil : icons.primary.dashIconSource),
                 title: metadata?.title ?? txItem.stateTitle,
                 subtitle: txItem.shortTimeString,
                 details: txItem.isPendingShieldedTransfer

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -621,20 +621,24 @@ extension TxDetailModel {
     /// parent transactions those inputs spend, which is exactly when the fee
     /// becomes computable (and is how Android's dashj, through its
     /// input-to-known-transaction connection, gets one).
-    private var localFeeDuffs: UInt64 {
+    ///
+    /// Optional on purpose: a fee of zero is a fact about the transaction,
+    /// and conflating it with "we could not work the fee out" is what turns
+    /// an answer into a shrug.
+    private var localFeeDuffs: UInt64? {
         if hasFee { return transaction.feeUsed }
-        return computedRawFee ?? 0
+        return computedRawFee
     }
 
     func fee(with font: UIFont, tintColor: UIColor) -> DWTitleDetailItem {
         let title = NSLocalizedString("Network fee", comment: "")
-        let feeValue = localFeeDuffs != 0 ? localFeeDuffs : (explorerFeeDuffs ?? 0)
+        let feeValue = localFeeDuffs ?? explorerFeeDuffs
 
         // Nothing local and nothing from the explorer (yet, or at all): the
         // sender spent outputs of transactions this wallet has never seen, so
         // their values — and with them the fee — are not recoverable here.
         // Say whose fee it was instead of printing a fabricated zero.
-        if feeValue == 0, direction == .received {
+        if feeValue == nil, direction == .received {
             let detail = NSLocalizedString("Paid by sender", comment: "Network fee on a received transaction")
             return DWTitleDetailCellModel(style: .default, title: title, plainDetail: detail)
         }
@@ -642,7 +646,7 @@ extension TxDetailModel {
         // Always DASH, never duffs: the Dash formatter carries all 8 fraction
         // digits, so a 226-duff fee reads as 0.00000226 rather than rounding
         // to zero — and every amount on this screen is then in one unit.
-        let detail = NSAttributedString.dashAttributedString(for: feeValue, tintColor: tintColor, font: font)
+        let detail = NSAttributedString.dashAttributedString(for: feeValue ?? 0, tintColor: tintColor, font: font)
 
         return DWTitleDetailCellModel(style: .default, title: title, attributedDetail: detail)
     }
@@ -659,14 +663,13 @@ extension TxDetailModel {
     /// second call. `completion` runs only when a fee actually arrived, so a
     /// failed lookup rebuilds nothing.
     func resolveExplorerFee(completion: @escaping () -> Void) {
-        guard direction == .received, localFeeDuffs == 0, explorerFeeDuffs == nil,
+        guard direction == .received, localFeeDuffs == nil, explorerFeeDuffs == nil,
               let network = WalletEnvironment.network else { return }
         let displayTxid = transactionId
         Task {
             guard let result = await InsightExplorerAPI.transaction(displayTxid: displayTxid, network: network),
-                  result.statusCode == 200,
-                  let duffs = InsightExplorerAPI.feeDuffs(fromTransactionBody: result.body),
-                  duffs > 0 else { return }
+                  result.statusCode == 200, let body = result.body,
+                  let duffs = InsightExplorerAPI.feeDuffs(fromTransactionBody: body) else { return }
             await MainActor.run {
                 self.explorerFeeDuffs = duffs
                 completion()

--- a/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Model/TxDetailModel.swift
@@ -30,6 +30,10 @@ class TxDetailModel: NSObject {
     private var didComputeRawFee = false
     fileprivate var rawFeeCache: UInt64?
 
+    /// Fee recovered from the block explorer, once `resolveExplorerFee` has
+    /// landed one. Nil while unresolved and when the explorer had no answer.
+    fileprivate(set) var explorerFeeDuffs: UInt64?
+
     var title: String {
         // Identity fundings and balance transfers carry their own identity —
         // the generic direction titles ("Moved to Address") hide what
@@ -42,7 +46,48 @@ class TxDetailModel: NSObject {
         if let route = transaction.internalTransferRoute, route != .coreToCore {
             return NSLocalizedString("Internal Transfer", comment: "Transaction within the wallet, transfer of own funds")
         }
+        // A DashPay contact payment keeps the plain "Amount Sent" heading: the
+        // counterparty is carried by the header avatar and named in full by
+        // the Sent to / Received from row, so repeating it here would say the
+        // same thing three times.
         return direction.title
+    }
+
+    /// The DashPay counterparty of this transaction, when it is a recorded
+    /// contact payment. Drives the header avatar and the contact row that
+    /// stands in for the counterparty's raw address.
+    lazy var contactParty: ContactParty? = ContactParty(payment: transaction.dashPayPayment)
+
+    /// Display model for the contact on the other end of a DashPay payment.
+    struct ContactParty: Hashable {
+        let identityId: Data
+        /// Primary line: owner-set alias, else profile display name, else
+        /// the DPNS username.
+        let name: String
+        /// Secondary line: whichever of the profile name / username the
+        /// primary line did not already use. Nil when there is nothing to add.
+        let secondaryName: String?
+        let avatarURL: String?
+        let isOutgoing: Bool
+
+        init?(payment: DashPayPaymentTxLookup.PaymentInfo?) {
+            guard let payment else { return nil }
+            // No cached name at all: an avatar over a truncated identity id
+            // says less than the plain address rows already do, so this stays
+            // a regular transaction until the profile sync catches up.
+            guard let name = payment.titleName else { return nil }
+
+            identityId = payment.counterpartyIdentityId
+            self.name = name
+            // Prefer their real profile name under an owner-set alias, then
+            // the username — never repeat what the primary line says.
+            let candidates = [payment.counterpartyName, payment.counterpartyUsername]
+            secondaryName = candidates
+                .compactMap { $0 }
+                .first { !$0.isEmpty && $0 != name }
+            avatarURL = payment.counterpartyAvatarURL
+            isOutgoing = payment.isOutgoing
+        }
     }
 
     var direction: TransactionDirection {
@@ -233,30 +278,22 @@ extension TxDetailModel {
 }
 
 extension TxDetailModel {
-    // TODO(dashpay-e2e): contact attribution for a tx (source/destination
-    // identity) returns once the DashPay migration models it on SDK rows.
-    // Constant false is today's actual behavior — the legacy reads went
-    // through the DSTransaction escape hatch, which was nil for every
-    // reachable row.
+    /// Contact attribution comes from the SDK's DashPay payment history
+    /// (`DashPayPaymentTxLookup`), which records the counterparty identity
+    /// and the true direction at send/sync time.
     var hasSourceUser: Bool {
-        false
+        contactParty?.isOutgoing == false
     }
 
     var hasDestinationUser: Bool {
-        false
+        contactParty?.isOutgoing == true
     }
 
+    /// A recorded fee on this row. Not gated on direction: the SDK stores a
+    /// fee whenever it could derive one, and an incoming transaction that
+    /// happens to carry one should show it rather than hide it.
     var hasFee: Bool {
-        if direction == .received {
-            return false
-        }
-
-        let feeValue = transaction.feeUsed
-        if feeValue == 0 {
-            return false
-        }
-
-        return true
+        transaction.feeUsed != 0 && transaction.feeUsed != UInt64.max
     }
 
     var hasDate: Bool {
@@ -329,8 +366,10 @@ extension TxDetailModel {
         return models
     }
 
-    // TODO(dashpay-e2e): user rows come back with contact attribution —
-    // unreachable today (`hasSourceUser`/`hasDestinationUser` are false).
+    // The contact itself is not a `DWTitleDetailItem` row: it renders as a
+    // dedicated avatar cell (`TxDetailContactCell`) built straight from
+    // `contactParty`, so these deliberately return nothing and the address
+    // group they would have replaced is simply dropped.
     private func sourceUsers(with title: String, font: UIFont) -> [DWTitleDetailItem] {
         []
     }
@@ -339,6 +378,14 @@ extension TxDetailModel {
         []
     }
 
+
+    /// Row title for the contact row — the same wording the address group
+    /// it replaces would have used.
+    var contactRowTitle: String {
+        contactParty?.isOutgoing == true
+            ? NSLocalizedString("Sent to", comment: "")
+            : NSLocalizedString("Received from", comment: "")
+    }
 
     func inputAddresses(with font: UIFont) -> [DWTitleDetailItem] {
         if !shouldDisplayInputAddresses {
@@ -567,39 +614,72 @@ extension TxDetailModel {
             vout: info.vout)
     }
 
-    /// Below this (0.0001 DASH) a fee renders as plain duffs — the
-    /// DASH-formatted form reads as zero at a glance.
-    private static let duffsDisplayThreshold: UInt64 = 10_000
+    /// Fee this wallet can establish from its own data: the value the SDK
+    /// recorded, else the one computed from the stored raw transaction when
+    /// every input's value is known. Incoming rows go through the computed
+    /// path too — their inputs aren't ours, but the wallet may hold the
+    /// parent transactions those inputs spend, which is exactly when the fee
+    /// becomes computable (and is how Android's dashj, through its
+    /// input-to-known-transaction connection, gets one).
+    private var localFeeDuffs: UInt64 {
+        if hasFee { return transaction.feeUsed }
+        return computedRawFee ?? 0
+    }
 
     func fee(with font: UIFont, tintColor: UIColor) -> DWTitleDetailItem {
         let title = NSLocalizedString("Network fee", comment: "")
-        var feeValue: UInt64 = 0
+        let feeValue = localFeeDuffs != 0 ? localFeeDuffs : (explorerFeeDuffs ?? 0)
 
-        if hasFee {
-            feeValue = transaction.feeUsed
-            feeValue = feeValue == UInt64.max ? 0 : feeValue
-        }
-        if feeValue == 0, direction != .received, let computed = computedRawFee {
-            // Rows without a persisted fee (asset-lock fundings) still have a
-            // real one — recover it from the raw transaction.
-            feeValue = computed
-        }
-
-        if feeValue > 0, feeValue < Self.duffsDisplayThreshold {
-            let detail = String(format: NSLocalizedString("%d duffs", comment: "Network fee in duffs (1 DASH = 100,000,000 duffs)"), feeValue)
+        // Nothing local and nothing from the explorer (yet, or at all): the
+        // sender spent outputs of transactions this wallet has never seen, so
+        // their values — and with them the fee — are not recoverable here.
+        // Say whose fee it was instead of printing a fabricated zero.
+        if feeValue == 0, direction == .received {
+            let detail = NSLocalizedString("Paid by sender", comment: "Network fee on a received transaction")
             return DWTitleDetailCellModel(style: .default, title: title, plainDetail: detail)
         }
 
+        // Always DASH, never duffs: the Dash formatter carries all 8 fraction
+        // digits, so a 226-duff fee reads as 0.00000226 rather than rounding
+        // to zero — and every amount on this screen is then in one unit.
         let detail = NSAttributedString.dashAttributedString(for: feeValue, tintColor: tintColor, font: font)
 
         return DWTitleDetailCellModel(style: .default, title: title, attributedDetail: detail)
     }
 
+    // MARK: - Block-explorer fee fallback
+
+    /// Looks the fee up on the network's Insight API for the one case local
+    /// data cannot answer: a received transaction whose inputs spend outputs
+    /// of transactions this wallet does not hold.
+    ///
+    /// This sends the transaction id to a third-party explorer, so it is
+    /// deliberately narrow — nothing is requested for a transaction whose fee
+    /// is already known, for an outgoing row (whose inputs are ours), or on a
+    /// second call. `completion` runs only when a fee actually arrived, so a
+    /// failed lookup rebuilds nothing.
+    func resolveExplorerFee(completion: @escaping () -> Void) {
+        guard direction == .received, localFeeDuffs == 0, explorerFeeDuffs == nil,
+              let network = WalletEnvironment.network else { return }
+        let displayTxid = transactionId
+        Task {
+            guard let result = await InsightExplorerAPI.transaction(displayTxid: displayTxid, network: network),
+                  result.statusCode == 200,
+                  let duffs = InsightExplorerAPI.feeDuffs(fromTransactionBody: result.body),
+                  duffs > 0 else { return }
+            await MainActor.run {
+                self.explorerFeeDuffs = duffs
+                completion()
+            }
+        }
+    }
+
     /// Fee derived from the stored raw transaction as Σ(input values) −
     /// Σ(output values) — the consensus definition, computable exactly when
-    /// every input value is known (all inputs are the wallet's own TXOs,
-    /// which holds for any tx we authored). Nil when any input value is
-    /// unknown, the bytes are unavailable, or the difference is negative
+    /// every input value is known: the input is one of the wallet's own TXOs,
+    /// or the wallet holds the parent transaction it spends (see
+    /// `RawTransactionInspector.parentOutputValue`). Nil when any input value
+    /// is unknown, the bytes are unavailable, or the difference is negative
     /// (mis-matched data — never guessed). Memoized: the detail sheet
     /// reloads on tax-category toggles and the parse isn't free.
     private var computedRawFee: UInt64? {

--- a/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
+++ b/DashWallet/Sources/UI/Tx/Details/TxDetailViewController.swift
@@ -51,6 +51,7 @@ class BaseTxDetailsViewController: BaseViewController {
         tableView.registerNib(for: TxDetailTaxCategoryCell.self)
         tableView.registerNib(for: TxDetailInfoCell.self)
         tableView.registerNib(for: TxDetailActionCell.self)
+        tableView.registerClass(for: TxDetailContactCell.self)
         tableView.backgroundColor = UIColor.dw_secondaryBackground()
         tableView.delegate = self
 
@@ -127,6 +128,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
         case sentTo([DWTitleDetailItem])
         case movedFrom([DWTitleDetailItem])
         case movedTo([DWTitleDetailItem])
+        case contact(String, TxDetailModel.ContactParty)
         case networkFee(DWTitleDetailItem)
         case date(DWTitleDetailItem)
         case taxCategory(DWTitleDetailItem)
@@ -151,6 +153,7 @@ class TXDetailViewController: BaseTxDetailsViewController {
             case .sentTo(let items): return ["SentTo"] + Self.identity(of: items)
             case .movedFrom(let items): return ["MovedFrom"] + Self.identity(of: items)
             case .movedTo(let items): return ["MovedTo"] + Self.identity(of: items)
+            case .contact(let title, let party): return ["Contact", title, party.name, party.secondaryName ?? "", party.avatarURL ?? ""]
             case .networkFee(let item): return ["NetworkFee"] + Self.identity(of: [item])
             case .date(let item): return ["Date"] + Self.identity(of: [item])
             case .taxCategory(let item): return ["TaxCategory"] + Self.identity(of: [item])
@@ -206,6 +209,13 @@ class TXDetailViewController: BaseTxDetailsViewController {
         // Dash DEX swap legs get an extra "View NEAR/Maya Explorer" action; the order lookup
         // is async (DAO reads), so resolve then rebuild the rows when it lands.
         model.resolveSwapExplorerLink { [weak self] in
+            self?.reloadDataSource()
+        }
+
+        // A received transaction whose fee this wallet can't derive asks the
+        // block explorer for it; the row reads "Paid by sender" until (and
+        // unless) an answer lands.
+        model.resolveExplorerFee { [weak self] in
             self?.reloadDataSource()
         }
     }
@@ -363,6 +373,21 @@ extension TXDetailViewController {
         reloadDataSource()
     }
 
+    /// Opens the counterparty's contact profile. The contact is resolved
+    /// from the contacts service's live snapshot; a payment whose contact is
+    /// no longer in it says so rather than silently doing nothing.
+    private func openContactProfile(_ party: TxDetailModel.ContactParty) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let contact = SwiftDashSDKContactsService.shared.contactItem(for: party.identityId) else {
+                self.view.dw_showInfoHUD(withText: NSLocalizedString("Contact is no longer available",
+                                                                     comment: "DashPay Contacts"))
+                return
+            }
+            self.present(UIHostingController(rootView: ContactProfileSheet(contact: contact)), animated: true)
+        }
+    }
+
     /// Copies the serialized transaction hex. A missing row (bytes not
     /// stored on this device) reports itself rather than copying nothing.
     private func copyRawTransaction() {
@@ -397,6 +422,12 @@ extension TXDetailViewController {
 
                     return cell
                 case .info:
+                    if case .contact(let title, let party) = item {
+                        let cell = tableView.dequeueReusableCell(type: TxDetailContactCell.self, for: indexPath)
+                        cell.update(title: title, contact: party)
+                        cell.separatorInset = .init(top: 0, left: 2000, bottom: 0, right: 0)
+                        return cell
+                    }
                     let cell = tableView.dequeueReusableCell(withIdentifier: TxDetailInfoCell.reuseIdentifier,
                                                              for: indexPath) as! TxDetailInfoCell
                     cell.update(with: item)
@@ -460,6 +491,15 @@ extension TXDetailViewController {
             currentSnapshot.appendItems([.shieldedInfo(item)], toSection: .info)
         }
 
+        // A DashPay payment's counterparty is a contact row rather than an
+        // address group, appended in the slot that group would have occupied
+        // (see `TxDetailModel.hasSourceUser` / `hasDestinationUser`), so the
+        // section still reads source-then-destination.
+        let appendContact: () -> Void = { [weak self] in
+            guard let self, let party = self.model.contactParty else { return }
+            self.currentSnapshot.appendItems([.contact(self.model.contactRowTitle, party)], toSection: .info)
+        }
+
         // Empty address groups are skipped: SDK rows often carry no linked
         // input addresses and a sent row's external outputs may be unknown —
         // an empty .sentFrom/.sentTo would render a blank cell.
@@ -485,12 +525,18 @@ extension TXDetailViewController {
             if !sentTo.isEmpty {
                 currentSnapshot.appendItems([.sentTo(sentTo)], toSection: .info)
             }
+            appendContact()
             currentSnapshot.appendItems([.networkFee(fee)], toSection: .info)
         case .received:
+            appendContact()
             let receivedAt = model.outputAddresses(with: detailFont)
             if !receivedAt.isEmpty {
                 currentSnapshot.appendItems([.receivedAt(receivedAt)], toSection: .info)
             }
+            // Incoming rows carry the fee row too — it reads "Paid by sender"
+            // unless a real fee was recorded for this transaction.
+            currentSnapshot.appendItems([.networkFee(model.fee(with: detailFont, tintColor: UIColor.label))],
+                                        toSection: .info)
         case .notAccountFunds:
             break
         }
@@ -534,6 +580,10 @@ extension TXDetailViewController {
         let section = currentSnapshot.sectionIdentifiers[indexPath.section]
 
         switch section {
+        case .info:
+            if case .contact(_, let party)? = dataSource.itemIdentifier(for: indexPath) {
+                openContactProfile(party)
+            }
         case .taxCategory:
             model.toggleTaxCategoryOnCurrentTransaction()
             reloadDataSource()

--- a/DashWallet/Sources/UI/Tx/Details/Views/TxDetailCells.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Views/TxDetailCells.swift
@@ -16,6 +16,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 // MARK: - TxDetailHeaderCellDataProvider
 
@@ -24,6 +25,10 @@ protocol TxDetailHeaderCellDataProvider {
     var fiatAmount: String { get }
     var icon: UIImage { get }
     var tintColor: UIColor { get }
+    /// Non-nil for a recorded DashPay payment: the header then shows the
+    /// counterparty's avatar with the direction icon badged into its corner,
+    /// instead of the bare direction icon.
+    var contactParty: TxDetailModel.ContactParty? { get }
 
     func dashAmountString(with font: UIFont) -> NSAttributedString
 }
@@ -37,14 +42,59 @@ class TxDetailHeaderCell: UITableViewCell {
 
     @IBOutlet var iconImageView: UIImageView!
 
+    /// The avatar overlays the nib's icon slot, so the header keeps its
+    /// geometry. Slightly wider than the 50pt avatar because the corner
+    /// badge is drawn outside it.
+    private static let avatarSlotSide: CGFloat = 62
+
+    /// SwiftUI avatar, hosted only for contact payments. `nil` for every
+    /// other transaction, which keeps the nib's plain image view.
+    private var avatarContentView: (UIView & UIContentView)?
+
     func updateView(with data: TxDetailHeaderCellDataProvider) {
         let font = UIFont.preferredFont(forTextStyle: .largeTitle).withWeight(UIFont.Weight.medium.rawValue)
         dashAmountLabel.attributedText = data.dashAmountString(with: font)
         fiatAmountLabel.text = data.fiatAmount;
 
         titleLabel.text = data.title
-        iconImageView.image = data.icon
-        iconImageView.tintColor = data.tintColor
+
+        if let contact = data.contactParty {
+            iconImageView.image = nil
+            updateContactAvatar(contact: contact, directionIcon: data.icon)
+        } else {
+            avatarContentView?.isHidden = true
+            iconImageView.image = data.icon
+            iconImageView.tintColor = data.tintColor
+        }
+    }
+
+    private func updateContactAvatar(contact: TxDetailModel.ContactParty, directionIcon: UIImage) {
+        let configuration = UIHostingConfiguration {
+            TxDetailContactAvatar(contact: contact, directionIcon: directionIcon)
+        }
+        .margins(.all, 0)
+
+        if let existing = avatarContentView {
+            existing.configuration = configuration
+            existing.isHidden = false
+            return
+        }
+
+        // `makeContentView()` hosts SwiftUI without a hosting controller, so
+        // there is no detached view-controller hierarchy to keep alive.
+        let view = configuration.makeContentView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        contentView.addSubview(view)
+
+        NSLayoutConstraint.activate([
+            view.centerXAnchor.constraint(equalTo: iconImageView.centerXAnchor),
+            view.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            view.widthAnchor.constraint(equalToConstant: Self.avatarSlotSide),
+            view.heightAnchor.constraint(equalToConstant: Self.avatarSlotSide),
+        ])
+
+        avatarContentView = view
     }
 
     override func awakeFromNib() {
@@ -122,6 +172,18 @@ class TxDetailInfoCell: TxDetailTitleDetailsCell {
         for view in views {
             valueLabelsStack.removeArrangedSubview(view)
             view.removeFromSuperview()
+        }
+    }
+}
+
+// MARK: - TxDetailContactCell
+
+/// "Sent to / Received from <contact>" row — a SwiftUI cell in the
+/// otherwise nib-driven info section.
+class TxDetailContactCell: UITableViewCell {
+    func update(title: String, contact: TxDetailModel.ContactParty) {
+        contentConfiguration = UIHostingConfiguration {
+            TxDetailContactRow(title: title, contact: contact)
         }
     }
 }

--- a/DashWallet/Sources/UI/Tx/Details/Views/TxDetailContactViews.swift
+++ b/DashWallet/Sources/UI/Tx/Details/Views/TxDetailContactViews.swift
@@ -1,0 +1,97 @@
+//
+//  TxDetailContactViews.swift
+//  DashWallet
+//
+//  Contact-aware pieces of the transaction-details screen, for
+//  transactions that are recorded DashPay payments. Mirrors the Android
+//  dash-wallet transaction result design (`transaction_result_content.xml`
+//  + `TransactionResultViewBinder`): the counterparty's avatar carries the
+//  direction icon as a corner badge, and the counterparty row stands in
+//  for the raw address the payment went to.
+//
+
+import SwiftUI
+import DashUIKit
+
+// MARK: - TxDetailContactAvatar
+
+/// Header avatar: the contact's picture with the transaction's direction
+/// icon badged into the bottom-trailing corner (Android `check_icon` +
+/// `secondary_icon`).
+struct TxDetailContactAvatar: View {
+    let contact: TxDetailModel.ContactParty
+    let directionIcon: UIImage
+    var size: CGFloat = 50
+
+    /// Same badge-to-icon ratio (14/30) and ring as `DashUIKit
+    /// .TransactionView`, so the header badge and the home row's badge read
+    /// as the same token at their different sizes.
+    private var badgeSize: CGFloat { size * 14 / 30 }
+
+    var body: some View {
+        ContactAvatarView(
+            title: contact.name,
+            avatarURL: contact.avatarURL,
+            identitySeed: contact.identityId,
+            size: size
+        )
+        .overlay(alignment: .bottomTrailing) {
+            Image(uiImage: directionIcon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: badgeSize, height: badgeSize)
+                .padding(2)
+                .background(Circle().fill(Color(uiColor: .dw_secondaryBackground())))
+                .offset(x: 3, y: 3)
+        }
+    }
+}
+
+// MARK: - TxDetailContactRow
+
+/// The "Sent to / Received from <contact>" row. Replaces the counterparty
+/// address group — an address says nothing a contact payment's own record
+/// doesn't say better — and opens the contact's profile on tap.
+///
+/// Name only, no avatar: the header already carries the contact's picture,
+/// and a second copy of it here competes with the plain right-aligned values
+/// the rest of the section uses.
+struct TxDetailContactRow: View {
+    let title: String
+    let contact: TxDetailModel.ContactParty
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.dash.footnoteMedium)
+                .foregroundColor(.dash.secondaryText)
+                .lineLimit(1)
+                // The row label is short and fixed; a long contact name is
+                // what gives way when the row runs out of width.
+                .fixedSize(horizontal: true, vertical: false)
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 0) {
+                Text(contact.name)
+                    .font(.dash.footnote)
+                    .foregroundColor(.dash.primaryText)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                if let secondaryName = contact.secondaryName {
+                    Text(secondaryName)
+                        .font(.dash.caption1)
+                        .foregroundColor(.dash.secondaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.dash.tertiaryText)
+        }
+        .padding(.vertical, 4)
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

The transaction details sheet had no contact attribution at all. `TxDetailModel.hasSourceUser` / `hasDestinationUser` were hardcoded `false` behind a migration TODO, so a DashPay contact payment showed the counterparty's raw payment address — while the very home row you tapped to get there already read "Sent to Alice" with her avatar.

The same screen also got two things wrong about the network fee:

- a fee below 0.0001 DASH rendered as raw duffs ("226 duffs"). That fallback predates the Dash formatter being widened to all 8 fraction digits, so it now hides a perfectly displayable number in a unit nothing else on the screen uses.
- received transactions had no fee row at all.

Reference for the visual design is the Android `dash-wallet` transaction result screen (`transaction_result_content.xml` + `TransactionResultViewBinder`). `develop-old` carried an earlier contact path, but it rendered the counterparty as a plain right-aligned label — there was no avatar design to restore.

## What was done?

**Contact attribution.** `hasSourceUser` / `hasDestinationUser` now derive from the SDK's DashPay payment history (`DashPayPaymentTxLookup`), which records the counterparty identity and the true direction at send/sync time. A new `TxDetailModel.ContactParty` carries the counterparty for the view layer.

**Header.** For a contact payment the icon slot shows the contact's avatar with the direction icon badged into its bottom-trailing corner, using the same badge-to-icon ratio and ring as `DashUIKit.TransactionView`, so the header badge and the home row badge read as one token at their different sizes. The heading stays "Amount Sent" / "Amount received" (Android parity) — the contact is named once, in the row below.

**Info section.** A "Sent to" / "Received from" row names the contact — owner-set alias first, with their profile name or DPNS username underneath when it adds something — and opens `ContactProfileSheet` on tap. It stands in for the counterparty address group, which is dropped. Rows stay in source → destination order in both directions. A payment whose counterparty has no cached name is deliberately left as a plain transaction with its address rows: an avatar over a truncated identity id says less than the address does.

**Home row.** A contact avatar takes the icon slot, which previously meant the direction was dropped entirely (`secondaryIcon` was nil). It now moves into the corner badge, matching Android and the new header.

**Fee.** Three related fixes:

- Fees always render in DASH; the duffs branch is gone.
- Received transactions get a fee row. Their inputs aren't ours, but an input's value is knowable whenever the wallet holds the parent transaction it spends — a counterparty paying us back with coins we sent them, say. `RawTransactionInspector` now resolves outpoint values from stored parent transactions, not only from our own spent TXOs. This is the same "connect the input to a known transaction" step that lets dashj produce a fee on Android (`Transaction.getFee()` returns nil the moment one input value is unknown).
- When even that can't answer, the row reads "Paid by sender" instead of a fabricated `0`, and a single Insight lookup fills in the real number.

**`InsightExplorerAPI`.** The explorer GET that `UnconfirmedTransactionRemover` had inline is extracted and shared rather than copied, per the "never copy-then-adapt" guardrail.

### One decision worth a reviewer's opinion

The explorer fee fallback sends a transaction id to a third-party explorer when you open the details of a received transaction whose fee isn't locally derivable. Today the app only contacts an explorer on an explicit "View in Block Explorer" tap and in the stuck-transaction removal check. The call is deliberately narrow — received only, unknown fee only, once per sheet, and a failure changes nothing on screen — but it is a new automatic outbound request for a privacy-focused wallet. Happy to drop it and keep only the local computation if that trade isn't wanted.

## How Has This Been Tested?

Testnet, iPhone 17 Pro simulator, `dashpay` scheme.

- Clean build: `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` → **BUILD SUCCEEDED**.
- Sent and received DashPay contact payments rendered in the details sheet: avatar + direction badge in the header, named contact row, profile sheet opening from it, addresses and fee/date rows in the expected order.
- The fee path was verified against real wallet data rather than by eye. For a received contact payment whose fee showed as unknown, the wallet's own store confirmed its single input spends an outpoint of a transaction the wallet does not hold — so the fee genuinely is not locally derivable — and the explorer reported `valueIn 0.68999277 − valueOut 0.6899905`, i.e. 227 duffs, which is what the row now shows.
- The unit-test target is broken on `develop` (pre-existing), so no tests were run.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction details now show DashPay contact avatars, names, payment direction, and profile navigation.
  * Added clearer “Sent to” and “Received from” contact information.
  * Transaction fees are displayed in DASH, including recovered or estimated fees when available.
  * Added improved transaction explorer verification and fee lookup.

* **Bug Fixes**
  * Preserved transaction direction icons alongside contact avatars.
  * Improved input amount resolution when wallet data is incomplete.
  * Received transactions now consistently display fee information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->