### PR TITLE
fix(dashpay): show user-facing identity ids in base58, not hex

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Contacts/ContactItem.swift
@@ -119,12 +119,12 @@ struct ContactItem: Identifiable, Equatable {
         if let username, !username.isEmpty {
             return username.withoutDashSuffix
         }
-        return String(contactIdentityId.map { String(format: "%02x", $0) }.joined().prefix(8)) + "…"
+        return String(identityIdBase58.prefix(8)) + "…"
     }
 
     /// The identity id as users see it elsewhere — Platform explorers, the
     /// wallet's own identity list and the `dashpay://user` QR payload all read
-    /// base58, so a contact's id is shown the same way rather than as the hex
-    /// `displayTitle`'s fallback happens to use.
+    /// base58. `displayTitle`'s last-resort fallback truncates this same
+    /// string, so a contact reads the same way everywhere.
     var identityIdBase58: String { contactIdentityId.toBase58String() }
 }

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Identity/DWCurrentUserIdentityInfo.swift
@@ -113,7 +113,6 @@ public final class DWCurrentUserIdentityInfo: NSObject {
     /// on the next property access after `currentRevision` advances.
     private struct Snapshot {
         let identityId: Data?
-        let identityIdHex: String?
         let username: String?
         let usernames: [String]
         let displayName: String?
@@ -122,7 +121,6 @@ public final class DWCurrentUserIdentityInfo: NSObject {
 
         static let empty = Snapshot(
             identityId: nil,
-            identityIdHex: nil,
             username: nil,
             usernames: [],
             displayName: nil,
@@ -239,18 +237,11 @@ public final class DWCurrentUserIdentityInfo: NSObject {
         snapshot.publicMessage
     }
 
-    /// 32-byte identity ID rendered as lowercase hex (64 chars), or
-    /// nil when no identity is registered. Mirrors the format used
-    /// by `SDKIdentityProfileSheet` and the coordinator logs.
-    @objc public var identityIdHex: String? {
-        snapshot.identityIdHex
-    }
-
     /// Raw 32-byte identity ID, or nil when no identity is registered.
-    /// Swift-only (SDK APIs take `Identifier` = `Data`); Obj-C callers
-    /// use `identityIdHex`. Added for the contacts service (Row #18),
-    /// which passes it as `ownerIdentityId` into the SwiftData
-    /// predicates and `ManagedPlatformWallet` contact calls.
+    /// Swift-only (SDK APIs take `Identifier` = `Data`). Added for the
+    /// contacts service (Row #18), which passes it as `ownerIdentityId`
+    /// into the SwiftData predicates and `ManagedPlatformWallet` contact
+    /// calls; the marketplace, invitation and send paths read it too.
     public var identityId: Data? {
         snapshot.identityId
     }
@@ -575,7 +566,6 @@ public final class DWCurrentUserIdentityInfo: NSObject {
 
         return Snapshot(
             identityId: identityId,
-            identityIdHex: hex,
             username: username,
             usernames: usernames,
             displayName: displayName,

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -14,7 +14,7 @@ import DashUIKit
 
 struct SDKIdentityProfileSheet: View {
     @Environment(\.dismiss) private var dismiss
-    @State private var identityIdHex: String? = nil
+    @State private var identityIdBase58: String? = nil
     /// Owner's profile picture, read from the same identity snapshot the rest
     /// of the app renders from. nil → the deterministic initials placeholder.
     @State private var avatarURL: String?
@@ -165,9 +165,9 @@ struct SDKIdentityProfileSheet: View {
         VStack(alignment: .leading, spacing: 16) {
             infoRow(
                 title: NSLocalizedString("Identity ID", comment: "SDK identity profile sheet"),
-                value: identityIdHex ?? NSLocalizedString("Loading…", comment: ""),
+                value: identityIdBase58 ?? NSLocalizedString("Loading…", comment: ""),
                 monospaced: true,
-                copyable: identityIdHex != nil
+                copyable: identityIdBase58 != nil
             )
             identityBalanceRow
         }
@@ -336,8 +336,9 @@ struct SDKIdentityProfileSheet: View {
     /// Look up the persisted identity ID from SwiftData. Mirrors the
     /// fetch pattern in `DWIdentityRegistrationCoordinator.lookupExistingIdentityId`
     /// (PersistentIdentity scoped to the active wallet); we render the
-    /// 32-byte id as lowercase hex matching the existing coordinator
-    /// logs (`identityId.map { String(format: "%02x", $0) }.joined()`).
+    /// 32-byte id as base58, the form Platform explorers, the contacts
+    /// list (`ContactItem.identityIdBase58`) and the `dashpay://user` QR
+    /// payload all use. Coordinator logs still print hex.
     private func loadIdentityId() {
         guard
             let walletId = SwiftDashSDKHost.shared.wallet?.walletId,
@@ -352,7 +353,7 @@ struct SDKIdentityProfileSheet: View {
         )
         descriptor.fetchLimit = 1
         if let identity = try? context.fetch(descriptor).first {
-            identityIdHex = identity.identityId.map { String(format: "%02x", $0) }.joined()
+            identityIdBase58 = identity.identityId.toBase58String()
             identitySeed = identity.identityId
             identityIdData = identity.identityId
             // Stored as the Int64 bit-pattern of the UInt64 credits (see

--- a/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
+++ b/DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift
@@ -94,8 +94,8 @@ struct ShieldedActivityItem: Identifiable {
     let minNotePosition: UInt64?
     /// Decoded UTF-8 text memo, when the 36-byte Dash memo is kind-1 text.
     let memoText: String?
-    /// Created identity id (hex) for `identityCreate` entries.
-    let createdIdentityIdHex: String?
+    /// Created identity id (base58) for `identityCreate` entries.
+    let createdIdentityIdBase58: String?
     /// Decoded destination, when the entry's counterparty names one:
     /// the Base58Check Core address for a withdrawal, the bech32m
     /// Platform address for an unshield. Nil for other kinds and for
@@ -144,8 +144,8 @@ struct ShieldedActivityItem: Identifiable {
             : .distantPast
         minNotePosition = row.hasMinNotePosition ? row.minNotePosition : nil
         memoText = Self.decodeTextMemo(row.memo)
-        createdIdentityIdHex = effectiveKind == .identityCreate && row.identityId.count == 32
-            ? row.identityId.map { String(format: "%02x", $0) }.joined()
+        createdIdentityIdBase58 = effectiveKind == .identityCreate && row.identityId.count == 32
+            ? row.identityId.toBase58String()
             : nil
     }
 
@@ -393,7 +393,7 @@ struct ShieldedActivityDetailsView: View {
                     }
                     .padding(.vertical, 10)
                 }
-                if let identityId = item.createdIdentityIdHex {
+                if let identityId = item.createdIdentityIdBase58 {
                     copyableRow(NSLocalizedString("Identity ID", comment: "Identities"), identityId)
                 }
                 infoRow(

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesViewModel.swift
@@ -356,7 +356,7 @@ final class IdentitiesViewModel: ObservableObject {
         let title = alias
             ?? displayedName
             ?? (pendingBelongsToIdentity ? pendingLabel : nil)
-            ?? (String(identity.identityIdString.prefix(12)) + "...")
+            ?? (String(identity.identityIdBase58.prefix(12)) + "...")
         let hasName = alias != nil || mainName != nil || preferredName != nil || !ownedNames.isEmpty
         // Balance is stored as Int64 bit-pattern of the UInt64 credits.
         let credits = UInt64(bitPattern: identity.balance)


### PR DESCRIPTION
## Summary

A Dash Platform identity id is 32 raw bytes; the string form is a presentation choice. Everywhere a user meets an identity id it should be **base58** — that is what Platform explorers use, and what the app already reached for whenever it had a dedicated property for the job (`ContactItem.identityIdBase58`, the row model's `idBase58`, the `dashpay://user` QR payload). Hex belongs in logs, cache keys and interop payloads.

The gap was in the places that formatted an id inline instead of using those properties — including two inside the contacts and identities screens that otherwise render base58.

Four user-facing surfaces were still rendering hex, so the id shown in the app could not be compared against an explorer without decoding it by hand. This PR moves all four to base58 and leaves every non-display use of hex alone.

## What changed

| Surface | Before | After |
|---|---|---|
| `SDKIdentityProfileSheet` — "Identity ID" row | 64-char hex | base58 |
| `ShieldedActivityHistory` — `identityCreate` detail "Identity ID" row | 64-char hex | base58 |
| `ContactItem.displayTitle` — last-resort fallback | 8-char hex prefix | 8-char base58 prefix |
| `IdentitiesViewModel` — unnamed identity row title | 12-char hex prefix | 12-char base58 prefix |

Both prefix lengths are unchanged. base58 carries more entropy per character than hex, so the truncations stay at least as collision-resistant.

## Why these were hex

The profile sheet said so in its own doc comment: it rendered hex "matching the existing coordinator logs". The format was inherited from log output rather than chosen for the reader. `IdentitiesViewModel` was internally inconsistent — the row model already carried `idBase58` for the full id while the title fell back to `identityIdString` (hex). `ContactItem` built its own hex prefix four lines above an `identityIdBase58` property whose comment already stated base58 is "the identity id as users see it elsewhere".

## Deliberately unchanged

- Logs (`DWIdentityRegistrationCoordinator`, contacts service)
- UserDefaults / cache keys (`DWCurrentUserIdentityInfo`, `SwiftDashSDKContactsService`)
- `Identifiable` conformances (`ContactCandidate.id`)
- The raw Storage Explorer — left untouched pending a decision from whoever owns that screen

`DWCurrentUserIdentityInfo.identityIdHex` (`@objc`) lost its only caller when the profile sheet moved to base58, so the second commit removes the property, its `Snapshot` field and both construction sites — nothing in the app read it, in Swift or Obj-C. The `hex` local in `rebuildSnapshot()` stays, since the snapshot log line still prints its first 8 characters.

One follow-up is left out of scope. In the Storage Explorer, most rows label the format explicitly (`ID (Hex)`, `Owner ID (Hex)`, `Contact ID (Hex)`) while `Identity ID`, `From`, `To` and `Performed By` render hex without that qualifier. We assumed hex is deliberate there — it is a raw storage inspector — but did not verify that intent, so nothing was changed. Worth a look from whoever owns the screen: either the labels should be consistent, or those rows belong in base58 like the rest of the app.

## Verification

Built clean against the `dashpay` scheme (`ARCHS=arm64`, iOS 26.5 simulator); each touched file confirmed recompiled with no new warnings.

Verified on device:

- **Profile sheet** — the id matches the Identities list and resolves on Platform Explorer.
- **Shielded `identityCreate` row** — displayed `AY4heGwy…4RxvDfTS`; the copied value is 44 characters, every character inside the base58 alphabet, decoding to exactly 32 bytes and round-tripping cleanly. No version byte, no checksum — plain base58, matching `Data.toBase58String()`.

Not exercised at runtime: the two truncated fallbacks, which require a contact with no alias/display name/username and an identity with no name at all. Both are build-verified only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Identity IDs are now consistently displayed in Base58 format across contacts, profiles, identity lists, and shielded activity details.
  * Identity IDs shown in activity details remain shortened for readability and can still be copied.
  * Identity information continues to support avatar and top-up functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->