### PR TITLE
ci(dashpay): reuse a persistent Apple Development certificate

### DIFF
--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -84,6 +84,8 @@ jobs:
         env:
           APPLE_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
           APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          APPLE_DEVELOPMENT_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_BASE64 }}
+          APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_PRIVATE_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY_BASE64 }}
@@ -117,6 +119,23 @@ jobs:
               missing=1
             fi
           done
+
+          # The development certificate pair is optional, but must be set
+          # together. Without it, automatic signing mints a brand-new Apple
+          # Development certificate on every run (the runner keychain is
+          # ephemeral) until the team hits Apple's certificate limit and
+          # archiving fails with "Choose a certificate to revoke".
+          if [[ -n "${APPLE_DEVELOPMENT_CERTIFICATE_BASE64:-}" && -z "${APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD:-}" ]]; then
+            echo "::error::APPLE_DEVELOPMENT_CERTIFICATE_BASE64 is set but APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD is missing."
+            missing=1
+          fi
+          if [[ -z "${APPLE_DEVELOPMENT_CERTIFICATE_BASE64:-}" && -n "${APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD:-}" ]]; then
+            echo "::error::APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD is set but APPLE_DEVELOPMENT_CERTIFICATE_BASE64 is missing."
+            missing=1
+          fi
+          if [[ -z "${APPLE_DEVELOPMENT_CERTIFICATE_BASE64:-}" ]]; then
+            echo "::warning::APPLE_DEVELOPMENT_CERTIFICATE_BASE64 is not set. Automatic signing will create a new Apple Development certificate for this run, which eventually exhausts the team's certificate quota."
+          fi
 
           if [[ "$missing" -ne 0 ]]; then
             exit 1
@@ -410,10 +429,12 @@ jobs:
             DashWallet/Uphold-Info.plist \
             DashWallet/SwapKit-Info.plist
 
-      - name: Install Apple distribution certificate
+      - name: Install Apple signing certificates
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          DEVELOPMENT_CERTIFICATE_BASE64: ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_BASE64 }}
+          DEVELOPMENT_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -452,6 +473,23 @@ jobs:
             -t cert \
             -f pkcs12 \
             -k "$keychain_path"
+
+          # A persistent development certificate lets automatic signing sign
+          # the archive without minting a new Apple Development certificate
+          # on every run.
+          if [[ -n "${DEVELOPMENT_CERTIFICATE_BASE64:-}" ]]; then
+            development_certificate_path="$RUNNER_TEMP/apple-development.p12"
+            printf '%s' "$DEVELOPMENT_CERTIFICATE_BASE64" | base64 --decode -o "$development_certificate_path"
+            security import "$development_certificate_path" \
+              -P "$DEVELOPMENT_CERTIFICATE_PASSWORD" \
+              -T /usr/bin/codesign \
+              -T /usr/bin/security \
+              -t cert \
+              -f pkcs12 \
+              -k "$keychain_path"
+            rm -f "$development_certificate_path"
+          fi
+
           security set-key-partition-list \
             -S apple-tool:,apple:,codesign: \
             -s \
@@ -746,6 +784,7 @@ jobs:
             "${FASTLANE_API_KEY_PATH:-}" \
             "${ORIGINAL_KEYCHAINS_PATH:-}" \
             "$RUNNER_TEMP/apple-distribution.p12" \
+            "$RUNNER_TEMP/apple-development.p12" \
             DashWallet/GoogleService-Info.plist \
             DashWallet/Coinbase-Info.plist \
             DashWallet/Topper-Info.plist \


### PR DESCRIPTION
## Why the TestFlight job started failing

[Run 32590706922](https://github.com/dashpay/dashwallet-ios/actions/runs/32590706922) (and every run since Aug 19 ~17:00 UTC) fails at **Archive dashpay** with:

> Choose a certificate to revoke. Your account has reached the maximum number of certificates.
> No profiles for 'org.dashfoundation.dash' were found: … iOS App Development provisioning profiles …

Root cause: the workflow installs only the **Apple Distribution** certificate, but `xcodebuild archive` with `CODE_SIGN_STYLE=Automatic` signs the archive with an **Apple Development** identity (the re-sign to Distribution happens at export). The runner keychain is ephemeral, so `-allowProvisioningUpdates` minted a **brand-new Apple Development certificate on every run**. After the successful runs of Aug 13–19 the team hit Apple's certificate quota, and archiving has failed ever since. Re-running changes nothing.

## Fix

Import an optional persistent development certificate (`APPLE_DEVELOPMENT_CERTIFICATE_BASE64` + `APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD`, same p12+base64 format as the distribution pair) into the signing keychain, so automatic signing reuses it instead of creating one per run. The pair is validated together; when absent, the workflow warns and keeps the previous mint-per-run behavior, so this merge does not break runs before the secrets exist.

## Manual follow-up required (Apple Developer portal + repo secrets)

1. In [Certificates](https://developer.apple.com/account/resources/certificates/list), **revoke the stale CI-minted Apple Development certificates** (created via API, dated Aug 13–19). This is safe — each was used by a single ephemeral runner.
2. Export an Apple Development certificate (with private key) for team `44RJ69WHFF` as a password-protected `.p12`.
3. Add `APPLE_DEVELOPMENT_CERTIFICATE_BASE64` (base64 of the p12) and `APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD` to the `testflight` environment secrets.

Note: revoking the stale certificates alone (step 1) also unblocks the workflow without this PR — but it will hit the quota again after a handful of runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TestFlight release signing by supporting optional Apple Development certificates.
  * Added validation and warnings for incomplete or missing certificate credentials.
  * Enhanced cleanup of temporary signing files after release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->