### PR TITLE
feat: show "received" receipts in real time

### DIFF
--- a/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIViewController+DashWallet.swift
@@ -161,12 +161,16 @@ extension UIViewController {
         activityItems: [Any],
         sourceView: UIView? = nil,
         sourceRect: CGRect? = nil,
-        completion: (() -> Void)? = nil
+        completion: (() -> Void)? = nil,
+        dismissal: (() -> Void)? = nil
     ) {
         let activityViewController = UIActivityViewController(
             activityItems: activityItems,
             applicationActivities: nil
         )
+        activityViewController.completionWithItemsHandler = { _, _, _, _ in
+            dismissal?()
+        }
 
         if let popover = activityViewController.popoverPresentationController {
             let anchor = sourceView ?? view!

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -40,8 +40,9 @@ import UIKit
 struct ShieldedSyncFreshnessPolicy {
     static let watchdogInterval: TimeInterval = 15
     static let maximumFullScanAge: TimeInterval = 90
-    /// Matches the SDK's caught-up cooldown. Requesting a forced pass sooner
-    /// would only produce `cooldownSkip` and leave the external spend unseen.
+    /// The ordinary background loop observes the SDK's caught-up cooldown.
+    /// Explicit `syncShieldedNow()` requests use the SDK's `force=true` path
+    /// and bypass it; attended Receive sessions use that path independently.
     static let foregroundFreshnessGrace: TimeInterval = 30
 
     static func shouldRefreshForWatchdog(
@@ -1146,7 +1147,7 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         requestShieldedRefresh(using: manager, reason: "stale watchdog")
     }
 
-    private func requestShieldedRefresh(
+    func requestShieldedRefresh(
         using manager: PlatformWalletManager,
         reason: String
     ) {

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -58,6 +58,7 @@ extension ObservedTransaction {
         ownOutputsAmount = row.outputs.reduce(0) { $0 + $1.amount }
         ownOutputAddresses = decoded.outputs.compactMap { $0.address }.filter { ownAddresses.contains($0) }
         isChainAccepted = row.context >= 1 || row.blockHeight > 0
+        context = row.context
         // firstSeen first (device-clock stamp at first observation — the
         // ordering key the observer's freshness floor uses), blockTimestamp
         // as the fallback for rows restored from chain data.
@@ -118,32 +119,34 @@ public final class TransactionObserver {
         fetchLimit: Int? = nil,
         firstSeenAtOrAfter: UInt64? = nil
     ) -> [ObservedTransaction] {
-        let handles = { @MainActor () -> HostHandles? in
-            guard let container = SwiftDashSDKHost.shared.modelContainer,
-                  let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
-                logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
-                return nil
-            }
-            guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
-                logger.error("🅾 OBSERVER :: unsupported network — empty scan")
-                return nil
-            }
-            return HostHandles(container: container, walletId: walletId, network: network)
-        }
-
-        let resolved: HostHandles?
-        if Thread.isMainThread {
-            resolved = MainActor.assumeIsolated { handles() }
-        } else {
-            resolved = DispatchQueue.main.sync { MainActor.assumeIsolated { handles() } }
-        }
-        guard let resolved else { return [] }
+        guard let resolved = resolveHostHandles() else { return [] }
         return scan(
             container: resolved.container,
             walletId: resolved.walletId,
             network: resolved.network,
             fetchLimit: fetchLimit,
             firstSeenAtOrAfter: firstSeenAtOrAfter)
+    }
+
+    /// Active-wallet transaction IDs without consensus decoding. Receive
+    /// sessions snapshot these at start so a restore burst cannot present an
+    /// already-persisted transaction as a new payment merely because its
+    /// device-clock `firstSeen` is recent.
+    static func persistedTransactionIDs() -> Set<Data> {
+        guard let resolved = resolveHostHandles() else { return [] }
+        let context = ModelContext(resolved.container)
+        let walletId = resolved.walletId
+        let descriptor = FetchDescriptor<PersistentTransaction>(
+            predicate: #Predicate {
+                $0.outputs.contains { $0.walletId == walletId } ||
+                    $0.inputs.contains { $0.walletId == walletId }
+            })
+        do {
+            return Set(try context.fetch(descriptor).map(\.txid))
+        } catch {
+            logger.error("🅾 OBSERVER :: txid snapshot failed: \(String(describing: error), privacy: .public)")
+            return []
+        }
     }
 
     /// Total persisted transaction count, or nil when the SDK host has no
@@ -226,21 +229,73 @@ public final class TransactionObserver {
     /// been persisted before the await started), then rescans on every
     /// SwiftData save.
     func observe(filters: [TransactionFilter], after: Date) -> AnyPublisher<ObservedTransaction, Never> {
-        let floor = UInt64(max(0, after.timeIntervalSince1970 - Self.matchFloorSkew))
         return Deferred {
             var seenTxids = Set<Data>()
-            return NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
-                .map { _ in () }
-                .prepend(()) // immediate initial scan
-                .receive(on: RunLoop.main)
-                .flatMap { _ in
-                    Self.fetchObserved(fetchLimit: Self.rescanFetchLimit, firstSeenAtOrAfter: floor)
-                        .filter { tx in filters.contains { $0.matches(tx) } }
-                        .publisher
-                }
+            return self.matchingTransactions(filters: filters, after: after)
                 .filter { seenTxids.insert($0.txid).inserted }
         }
         .eraseToAnyPublisher()
+    }
+
+    /// Emits each matching transaction context once. Unlike `observe`, this
+    /// preserves mempool → InstantSend → mined → ChainLocked updates for a
+    /// single txid. `excludingTxids` is the session-start snapshot that guards
+    /// against old transactions receiving a fresh device-clock timestamp during
+    /// restore or resync.
+    func observeUpdates(
+        filters: [TransactionFilter],
+        after: Date,
+        excludingTxids: Set<Data>
+    ) -> AnyPublisher<ObservedTransaction, Never> {
+        struct ObservationKey: Hashable {
+            let txid: Data
+            let context: UInt32
+        }
+
+        return Deferred {
+            var seen = Set<ObservationKey>()
+            return self.matchingTransactions(filters: filters, after: after)
+                .filter { !excludingTxids.contains($0.txid) }
+                .filter { seen.insert(ObservationKey(txid: $0.txid, context: $0.context)).inserted }
+        }
+        .eraseToAnyPublisher()
+    }
+
+    private func matchingTransactions(
+        filters: [TransactionFilter],
+        after: Date
+    ) -> AnyPublisher<ObservedTransaction, Never> {
+        let floor = UInt64(max(0, after.timeIntervalSince1970 - Self.matchFloorSkew))
+        return NotificationCenter.default.publisher(for: .NSManagedObjectContextDidSave)
+            .map { _ in () }
+            .prepend(()) // immediate initial scan
+            .receive(on: RunLoop.main)
+            .flatMap { _ in
+                Self.fetchObserved(fetchLimit: Self.rescanFetchLimit, firstSeenAtOrAfter: floor)
+                    .filter { tx in filters.contains { $0.matches(tx) } }
+                    .publisher
+            }
+            .eraseToAnyPublisher()
+    }
+
+    private static func resolveHostHandles() -> HostHandles? {
+        let resolve = { @MainActor () -> HostHandles? in
+            guard let container = SwiftDashSDKHost.shared.modelContainer,
+                  let walletId = SwiftDashSDKHost.shared.wallet?.walletId else {
+                logger.info("🅾 OBSERVER :: no model container / active wallet yet — empty scan")
+                return nil
+            }
+            guard case .success(let network) = SwiftDashSDKWalletRuntime.shared.resolveCurrentNetwork() else {
+                logger.error("🅾 OBSERVER :: unsupported network — empty scan")
+                return nil
+            }
+            return HostHandles(container: container, walletId: walletId, network: network)
+        }
+
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated { resolve() }
+        }
+        return DispatchQueue.main.sync { MainActor.assumeIsolated { resolve() } }
     }
 
     /// Waits for the first persisted tx that matches any filter. Capture

--- a/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
+++ b/DashWallet/Sources/Models/CrowdNode/Services/TransactionObserver.swift
@@ -136,11 +136,12 @@ public final class TransactionObserver {
         guard let resolved = resolveHostHandles() else { return [] }
         let context = ModelContext(resolved.container)
         let walletId = resolved.walletId
-        let descriptor = FetchDescriptor<PersistentTransaction>(
+        var descriptor = FetchDescriptor<PersistentTransaction>(
             predicate: #Predicate {
                 $0.outputs.contains { $0.walletId == walletId } ||
                     $0.inputs.contains { $0.walletId == walletId }
             })
+        descriptor.propertiesToFetch = [\.txid]
         do {
             return Set(try context.fetch(descriptor).map(\.txid))
         } catch {

--- a/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
+++ b/DashWallet/Sources/Models/CrowdNode/TxFilters/TransactionFilter.swift
@@ -54,6 +54,9 @@ struct ObservedTransaction {
     /// (context ≥ 1) or carrying a block height (rows restored from chain
     /// data). SDK-side stand-in for DashSync's `account.transactionIsValid`.
     let isChainAccepted: Bool
+    /// SwiftDashSDK transaction context: 0=mempool, 1=InstantSend,
+    /// 2=in-block, 3=ChainLocked.
+    let context: UInt32
     /// Display wrapper; supplies direction/dashAmount with the existing
     /// FFI → TransactionDirection mapping (including the outgoing → moved
     /// fee-only promotion the top-up matcher relies on).
@@ -64,4 +67,28 @@ struct ObservedTransaction {
 
 protocol TransactionFilter {
     func matches(_ tx: ObservedTransaction) -> Bool
+}
+
+/// Matches an external incoming Core transaction that pays the exact address
+/// displayed by an attended Receive session. The SDK's direction classifier is
+/// authoritative here: internal payouts such as asset unlocks are `.moved`, so
+/// they cannot be mistaken for a new payment merely because they pay one of the
+/// wallet's addresses.
+struct ReceivedAtAddressTransactionFilter: TransactionFilter {
+    let address: String
+
+    func matches(_ tx: ObservedTransaction) -> Bool {
+        Self.matches(
+            direction: tx.direction,
+            ownOutputAddresses: tx.ownOutputAddresses,
+            address: address)
+    }
+
+    static func matches(
+        direction: TransactionDirection,
+        ownOutputAddresses: [String],
+        address: String
+    ) -> Bool {
+        direction == .received && ownOutputAddresses.contains(address)
+    }
 }

--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -64,6 +64,17 @@ struct PlatformAddressActivityUnitPolicy {
         Int64(clamping: credits / creditsPerDuff)
     }
 
+    /// A first observation is a complete baseline, including zero-balance
+    /// addresses. Omitting zeroes leaves an all-zero wallet looking perpetually
+    /// uninitialized and causes its first payment to be swallowed as seeding.
+    static func initialBaselineBalances(
+        addresses: [DerivedPlatformAddress]
+    ) -> [String: Int64] {
+        Dictionary(
+            addresses.map { ($0.address, duffs(fromCredits: $0.balance)) },
+            uniquingKeysWith: { _, latest in latest })
+    }
+
     /// True when an observed balance increase is explainable by an own
     /// unshield of `creditedAmountCredits`: the delta equals the credited
     /// principal, or is SMALLER — an own follow-on spend (e.g. the
@@ -240,12 +251,48 @@ final class PlatformAddressActivityDAO {
             S.colObservedAt <- Date().timeIntervalSince1970))
     }
 
+    /// Stable append-only position for an attended receive-session snapshot.
+    /// Row IDs are used instead of wall-clock observation timestamps.
+    func latestActivityId(walletId: Data, networkRaw: Int64) -> Int64 {
+        typealias S = PlatformAddressActivitySchema
+        let query = S.activity
+            .select(S.colId)
+            .filter(S.colWalletId == walletId && S.colNetwork == networkRaw)
+            .order(S.colId.desc)
+            .limit(1)
+        return (try? db.pluck(query))?[S.colId] ?? 0
+    }
+
+    /// New activity for one frozen receive address, oldest first so a burst is
+    /// presented deterministically.
+    func activities(
+        walletId: Data,
+        networkRaw: Int64,
+        address: String,
+        afterId: Int64
+    ) -> [PlatformAddressActivityRecord] {
+        typealias S = PlatformAddressActivitySchema
+        let query = S.activity
+            .filter(
+                S.colWalletId == walletId &&
+                    S.colNetwork == networkRaw &&
+                    S.colAddress == address &&
+                    S.colId > afterId)
+            .order(S.colId.asc)
+        return records(for: query)
+    }
+
     /// All received-activity rows for the wallet+network, newest first.
     func activities(walletId: Data, networkRaw: Int64) -> [PlatformAddressActivityRecord] {
         typealias S = PlatformAddressActivitySchema
         let query = S.activity
             .filter(S.colWalletId == walletId && S.colNetwork == networkRaw)
             .order(S.colObservedAt.desc)
+        return records(for: query)
+    }
+
+    private func records(for query: Table) -> [PlatformAddressActivityRecord] {
+        typealias S = PlatformAddressActivitySchema
         guard let rows = try? db.prepare(query) else { return [] }
         return rows.map { row in
             PlatformAddressActivityRecord(
@@ -289,12 +336,12 @@ enum PlatformAddressActivityRecorder {
         // silently. Recording the whole standing balance as "received
         // today" would be fabricated history.
         guard !baseline.isEmpty else {
-            for entry in addresses where entry.balance > 0 {
+            for (address, balanceDuffs) in PlatformAddressActivityUnitPolicy
+                .initialBaselineBalances(addresses: addresses) {
                 dao.upsertBaseline(
                     walletId: walletId, networkRaw: networkRaw,
-                    address: entry.address,
-                    balanceDuffs: PlatformAddressActivityUnitPolicy.duffs(
-                        fromCredits: entry.balance))
+                    address: address,
+                    balanceDuffs: balanceDuffs)
             }
             return
         }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -29,6 +29,7 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
             onCopyAddress: { [weak self] in self?.copyCurrentAddress() },
             onShareAddress: { [weak self] in self?.shareCurrentAddress() },
             onSpecifyAmount: { [weak self] in self?.pushSpecifyAmount() },
+            onViewTransaction: { [weak self] txid in self?.showTransaction(txid: txid) },
             onScanQR: { [weak self] in self?.performScanQRCodeAction() },
             embeddedTransferViewModel: embeddedTransferViewModel,
             onTransferCompleted: { [weak self] in self?.dismiss(animated: true) },
@@ -91,9 +92,13 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
          visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
          embedInternalTransfer: Bool = false,
          sendNetwork: ChainNetwork? = nil,
-         showsHeader: Bool = true) {
+         showsHeader: Bool = true,
+         allowsTransactionDetails: Bool = true) {
         self.viewModel = PaymentsLandingViewModel(
-            activeTab: activeTab, network: receiveNetwork, visibleTabs: visibleTabs)
+            activeTab: activeTab,
+            network: receiveNetwork,
+            visibleTabs: visibleTabs,
+            allowsTransactionDetails: allowsTransactionDetails)
         self.showsHeader = showsHeader
         self.embeddedSendViewModel = SendViewModel(pinnedSource: sendNetwork)
         self.transferSendFrom = sendNetwork
@@ -126,7 +131,8 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         let controller = PaymentsLandingHostingController(
             activeTab: .receive,
             visibleTabs: [.receive],
-            showsHeader: false)
+            showsHeader: false,
+            allowsTransactionDetails: false)
         let navigationController = BaseNavigationController(rootViewController: controller)
         navigationController.isNavigationBarHidden = true
         navigationController.isModalInPresentation = false
@@ -188,10 +194,21 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        // Programmatic dismissal does not call
+        // `presentationControllerDidDismiss`. Clear the explicit sheet pause
+        // here as well so returning from transaction details can resume the
+        // same receive session (or start a fresh "Receive another" session).
+        viewModel.setReceiptWatchingObscured(false)
+        viewModel.setReceiveSurfaceVisible(true)
         if timingSheetPendingAppearance {
             timingSheetPendingAppearance = false
             presentTransferTimingSheetIfNeeded()
         }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewModel.setReceiveSurfaceVisible(false)
     }
 
     // MARK: - Actions
@@ -208,7 +225,12 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         // The share control lives in the SwiftUI hierarchy, so there is no
         // sender view to anchor to — the helper's centred default carries the
         // popover anchor iPad requires.
-        dw_presentActivityViewController(activityItems: [address])
+        viewModel.setReceiptWatchingObscured(true)
+        dw_presentActivityViewController(
+            activityItems: [address],
+            dismissal: { [weak self] in
+                self?.viewModel.setReceiptWatchingObscured(false)
+            })
     }
 
     private func pushSpecifyAmount() {
@@ -238,16 +260,37 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         guard !UserDefaults.standard.bool(forKey: Self.shieldedBalanceTimingShownKey),
               presentedViewController == nil
         else { return }
+        viewModel.setReceiptWatchingObscured(true)
         let host = UIHostingController(
             rootView: TransferTimingSheet(onConfirm: { [weak self] in
                 UserDefaults.standard.set(true, forKey: Self.shieldedBalanceTimingShownKey)
-                self?.dismiss(animated: true)
+                self?.dismiss(animated: true) {
+                    self?.viewModel.setReceiptWatchingObscured(false)
+                }
             }))
         if let sheet = host.sheetPresentationController {
             sheet.detents = [.medium()]
             sheet.prefersGrabberVisible = true
         }
-        present(host, animated: true)
+        present(host, animated: true) { [weak self, weak host] in
+            host?.presentationController?.delegate = self
+        }
+    }
+
+    private func showTransaction(txid: Data) {
+        guard viewModel.allowsTransactionDetails,
+              let transaction = SwiftDashSDKWalletSource
+                  .fetch(txids: Set([txid]))?.transactions.first
+        else { return }
+        viewModel.setReceiptWatchingObscured(true)
+        let controller = ReceiptTransactionDetailViewController(model: TxDetailModel(transaction: transaction))
+        controller.onDismiss = { [weak self] in
+            self?.viewModel.setReceiptWatchingObscured(false)
+        }
+        let navigationController = BaseNavigationController(rootViewController: controller)
+        present(navigationController, animated: true) { [weak self, weak navigationController] in
+            navigationController?.presentationController?.delegate = self
+        }
     }
 
     private static func tabRawValue(for objcCase: Int) -> String {
@@ -279,7 +322,10 @@ extension PaymentsLandingHostingController: SpecifyAmountViewControllerDelegate 
 
         let requestController = DWRequestAmountViewController(model: model)
         requestController.delegate = self
-        present(requestController, animated: true)
+        viewModel.setReceiptWatchingObscured(true)
+        present(requestController, animated: true) { [weak self, weak requestController] in
+            requestController?.presentationController?.delegate = self
+        }
     }
 }
 
@@ -288,6 +334,7 @@ extension PaymentsLandingHostingController: SpecifyAmountViewControllerDelegate 
 extension PaymentsLandingHostingController: DWRequestAmountViewControllerDelegate {
     func requestAmountViewController(_ controller: DWRequestAmountViewController, didReceiveAmountWithInfo info: String) {
         controller.dismiss(animated: true) {
+            self.viewModel.setReceiptWatchingObscured(false)
             self.navigationController?.popViewController(animated: true)
 
             let popAnimationDuration = 300
@@ -295,5 +342,25 @@ extension PaymentsLandingHostingController: DWRequestAmountViewControllerDelegat
                 self.navigationController?.view.dw_showInfoHUD(withText: info)
             }
         }
+    }
+}
+
+// MARK: UIAdaptivePresentationControllerDelegate
+
+extension PaymentsLandingHostingController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        viewModel.setReceiptWatchingObscured(false)
+    }
+}
+
+/// `UIAdaptivePresentationControllerDelegate` is only notified for interactive
+/// dismissals. Transaction details close themselves programmatically, so carry
+/// that completion back to the attended receive session explicitly.
+private final class ReceiptTransactionDetailViewController: TXDetailViewController {
+    var onDismiss: (() -> Void)?
+
+    override func closeAction() {
+        let onDismiss = onDismiss
+        dismiss(animated: true, completion: onDismiss)
     }
 }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -15,6 +15,7 @@ struct PaymentsLandingScreen: View {
     var onCopyAddress: () -> Void
     var onShareAddress: () -> Void
     var onSpecifyAmount: () -> Void
+    var onViewTransaction: (Data) -> Void
     var onScanQR: () -> Void
     /// The Internal tab's embedded transfer form. The full landing shows it
     /// un-pinned (free From + To pickers); the balance-row receive/send
@@ -95,6 +96,8 @@ struct PaymentsLandingScreen: View {
         }
         .background(Color.dash.primaryBackground)
         .navigationBarHidden(true)
+        .animation(.spring(response: 0.45, dampingFraction: 0.82), value: viewModel.receipt?.id)
+        .sensoryFeedback(.success, trigger: viewModel.receipt?.id)
     }
 
     // MARK: - Header
@@ -170,20 +173,121 @@ struct PaymentsLandingScreen: View {
             ChainNetworkToggle(selection: $viewModel.network, options: ChainNetwork.allCases)
                 .padding(.horizontal, 20)
 
-            qrCard
+            if let receipt = viewModel.receipt {
+                receiptCard(receipt)
+                    .transition(.scale(scale: 0.94).combined(with: .opacity))
+            } else {
+                qrCard
+
+                HStack(spacing: 12) {
+                    Button(action: onShareAddress) {
+                        actionPill(title: NSLocalizedString("Share address", comment: ""))
+                    }
+                    .disabled(viewModel.currentAddress == nil)
+
+                    Button(action: onSpecifyAmount) {
+                        actionPill(title: NSLocalizedString("Specify amount", comment: ""))
+                    }
+                    .disabled(viewModel.currentAddress == nil || viewModel.network != .core)
+                }
+                .padding(.horizontal, 20)
+
+                if viewModel.isWatchingForReceipt {
+                    HStack(spacing: 8) {
+                        SwiftUI.ProgressView()
+                            .scaleEffect(0.8)
+                        Text(NSLocalizedString("Watching for a payment…", comment: "Receive screen activity"))
+                            .font(.caption)
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    .transition(.opacity)
+                }
+            }
+        }
+    }
+
+    private func receiptCard(_ receipt: ReceiveReceipt) -> some View {
+        VStack(spacing: 14) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 58, weight: .semibold))
+                .foregroundColor(.dash.green)
+
+            VStack(spacing: 5) {
+                Text(NSLocalizedString("Payment received", comment: "Receive success title"))
+                    .font(.title3.weight(.semibold))
+                    .foregroundColor(.dash.primaryText)
+                Text(receipt.amountDuffs.formattedDashAmount)
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .foregroundColor(.dash.primaryText)
+                Text(CurrencyExchanger.shared.fiatAmountString(for: receipt.amountDuffs.dashAmount))
+                    .font(.subheadline)
+                    .foregroundColor(.dash.secondaryText)
+            }
+
+            VStack(spacing: 8) {
+                receiptInfoRow(
+                    title: NSLocalizedString("Balance", comment: "Receive receipt rail"),
+                    value: receipt.rail.balanceName)
+                receiptInfoRow(
+                    title: NSLocalizedString("Status", comment: "Receive receipt status"),
+                    value: receipt.statusTitle)
+                receiptInfoRow(
+                    title: NSLocalizedString("Time", comment: "Receive receipt time"),
+                    value: receipt.receivedAt.formatted(date: .omitted, time: .shortened))
+                if let memo = receipt.memo, !memo.isEmpty {
+                    receiptInfoRow(
+                        title: NSLocalizedString("Memo", comment: "Receive receipt memo"),
+                        value: memo)
+                }
+            }
+            .padding(14)
+            .background(Color.dash.secondaryBackground)
+            .cornerRadius(14)
+
+            if viewModel.canViewTransaction, let transactionId = receipt.transactionId {
+                Button {
+                    onViewTransaction(transactionId)
+                } label: {
+                    Text(NSLocalizedString("View transaction", comment: "Receive receipt action"))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.dash.blue)
+                }
+            }
 
             HStack(spacing: 12) {
-                Button(action: onShareAddress) {
-                    actionPill(title: NSLocalizedString("Share address", comment: ""))
+                Button(action: viewModel.receiveAnother) {
+                    actionPill(title: NSLocalizedString("Receive another", comment: "Receive receipt action"))
                 }
-                .disabled(viewModel.currentAddress == nil)
-
-                Button(action: onSpecifyAmount) {
-                    actionPill(title: NSLocalizedString("Specify amount", comment: ""))
+                Button(action: onClose) {
+                    Text(NSLocalizedString("Done", comment: "Receive receipt action"))
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.dash.whiteText)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.dash.blue)
+                        .cornerRadius(12)
                 }
-                .disabled(viewModel.currentAddress == nil || viewModel.network != .core)
             }
-            .padding(.horizontal, 20)
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(Color.dash.primaryBackground)
+                .shadow(color: Color.dash.shadow, radius: 12, x: 0, y: 4))
+        .padding(.horizontal, 20)
+    }
+
+    private func receiptInfoRow(title: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.dash.secondaryText)
+            Spacer()
+            Text(value)
+                .font(.caption.weight(.medium))
+                .foregroundColor(.dash.primaryText)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
         }
     }
 

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift
@@ -57,7 +57,9 @@ struct PaymentsLandingScreen: View {
             switch viewModel.activeTab {
             case .receive:
                 receiveContent
-                Spacer()
+                if viewModel.receipt == nil {
+                    Spacer()
+                }
             case .internalTransfer:
                 if let sendFrom = transferSendFrom {
                     // Send sheet: the From card is pinned by the tapped
@@ -207,22 +209,12 @@ struct PaymentsLandingScreen: View {
     }
 
     private func receiptCard(_ receipt: ReceiveReceipt) -> some View {
-        VStack(spacing: 14) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 58, weight: .semibold))
-                .foregroundColor(.dash.green)
-
-            VStack(spacing: 5) {
-                Text(NSLocalizedString("Payment received", comment: "Receive success title"))
-                    .font(.title3.weight(.semibold))
-                    .foregroundColor(.dash.primaryText)
-                Text(receipt.amountDuffs.formattedDashAmount)
-                    .font(.system(size: 30, weight: .bold, design: .rounded))
-                    .foregroundColor(.dash.primaryText)
-                Text(CurrencyExchanger.shared.fiatAmountString(for: receipt.amountDuffs.dashAmount))
-                    .font(.subheadline)
-                    .foregroundColor(.dash.secondaryText)
-            }
+        VStack(spacing: 16) {
+            PaymentSuccessHeader(
+                title: NSLocalizedString("Received", comment: "Receive success title"),
+                amountDuffs: Int64(clamping: receipt.amountDuffs),
+                fiatText: CurrencyExchanger.shared.fiatAmountString(
+                    for: receipt.amountDuffs.dashAmount))
 
             VStack(spacing: 8) {
                 receiptInfoRow(
@@ -243,6 +235,7 @@ struct PaymentsLandingScreen: View {
             .padding(14)
             .background(Color.dash.secondaryBackground)
             .cornerRadius(14)
+            .padding(.horizontal, 20)
 
             if viewModel.canViewTransaction, let transactionId = receipt.transactionId {
                 Button {
@@ -254,27 +247,19 @@ struct PaymentsLandingScreen: View {
                 }
             }
 
-            HStack(spacing: 12) {
-                Button(action: viewModel.receiveAnother) {
-                    actionPill(title: NSLocalizedString("Receive another", comment: "Receive receipt action"))
-                }
-                Button(action: onClose) {
-                    Text(NSLocalizedString("Done", comment: "Receive receipt action"))
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.dash.whiteText)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(Color.dash.blue)
-                        .cornerRadius(12)
-                }
-            }
+            Spacer(minLength: 12)
+
+            ButtonsGroup(
+                orientation: .horizontal,
+                size: .large,
+                positiveButtonText: NSLocalizedString("Done", comment: "Receive receipt action"),
+                positiveButtonAction: onClose,
+                negativeButtonText: NSLocalizedString("Receive another", comment: "Receive receipt action"),
+                negativeButtonAction: viewModel.receiveAnother)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
         }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.dash.primaryBackground)
-                .shadow(color: Color.dash.shadow, radius: 12, x: 0, y: 4))
-        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func receiptInfoRow(title: String, value: String) -> some View {

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -32,6 +32,83 @@ enum PaymentsLandingTab: String, CaseIterable, Identifiable {
     }
 }
 
+enum CoreReceiptSettlementStatus: Int, Comparable {
+    case mempool = 0
+    case instantSend = 1
+    case inBlock = 2
+    case chainLocked = 3
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .mempool:
+            return NSLocalizedString("Detected in mempool", comment: "Receive payment status")
+        case .instantSend:
+            return NSLocalizedString("InstantSend confirmed", comment: "Receive payment status")
+        case .inBlock:
+            return NSLocalizedString("Confirmed in block", comment: "Receive payment status")
+        case .chainLocked:
+            return NSLocalizedString("ChainLocked", comment: "Receive payment status")
+        }
+    }
+}
+
+struct ReceiveReceipt: Identifiable, Equatable {
+    let id: String
+    let rail: ChainNetwork
+    let amountDuffs: UInt64
+    let receivedAt: Date
+    let memo: String?
+    let transactionId: Data?
+    var coreStatus: CoreReceiptSettlementStatus?
+
+    var statusTitle: String {
+        coreStatus?.title ?? NSLocalizedString("Received", comment: "Receive payment status")
+    }
+}
+
+enum ReceiveReceiptPolicy {
+    static func coreStatus(context: UInt32) -> CoreReceiptSettlementStatus? {
+        CoreReceiptSettlementStatus(rawValue: Int(context))
+    }
+
+    /// Reorgs can move an in-block transaction back to mempool. The receive
+    /// card keeps the strongest status already presented instead of visibly
+    /// downgrading; ChainLocks are final.
+    static func strongestStatus(
+        current: CoreReceiptSettlementStatus,
+        observed: CoreReceiptSettlementStatus
+    ) -> CoreReceiptSettlementStatus {
+        max(current, observed)
+    }
+
+    static func shouldProjectShieldedResult(
+        success: Bool,
+        cooldownSkip: Bool
+    ) -> Bool {
+        success && !cooldownSkip
+    }
+
+    static func canRefreshPlatform(
+        isRunning: Bool,
+        availability: PlatformAccountAvailability
+    ) -> Bool {
+        isRunning && availability == .available
+    }
+}
+
+enum AttendedReceiveRefreshPolicy {
+    /// Platform address BLAST passes are relatively light but still real DAPI
+    /// work. Keep this named so testnet smoke results can tune it independently.
+    static let platformInterval: TimeInterval = 5
+    /// A forced Shielded pass walks notes and then rebuilds the projected
+    /// activity list, so its cadence is independently tunable.
+    static let shieldedInterval: TimeInterval = 5
+}
+
 @MainActor
 final class PaymentsLandingViewModel: ObservableObject {
 
@@ -43,15 +120,46 @@ final class PaymentsLandingViewModel: ObservableObject {
     @Published private(set) var coreAddress: String? = nil
     @Published private(set) var platformAddress: String? = nil
     @Published private(set) var shieldedAddress: String? = nil
+    @Published private(set) var displayedAddress: String? = nil
+    @Published private(set) var receipt: ReceiveReceipt? = nil
+    @Published private(set) var isWatchingForReceipt = false
+
+    let allowsTransactionDetails: Bool
+
+    private struct ReceiptSession {
+        let generation: UInt64
+        let rail: ChainNetwork
+        let address: String
+        let walletId: Data
+        let environment: Network
+        let startedAt: Date
+        let coreTransactionIds: Set<Data>
+        let platformActivityCursor: Int64
+        let shieldedActivityIds: Set<String>
+    }
 
     private var cancellables = Set<AnyCancellable>()
+    private var coreReceiptCancellable: AnyCancellable?
+    private var platformReceiptCancellable: AnyCancellable?
+    private var shieldedReceiptCancellable: AnyCancellable?
+    private var attendedRefreshTask: Task<Void, Never>?
+    private var shieldedProjectionTask: Task<Void, Never>?
+    private var shieldedProjectionRefreshPending = false
+    private var shieldedProjectionGeneration: UInt64 = 0
+    private var session: ReceiptSession?
+    private var generation: UInt64 = 0
+    private var surfaceIsVisible = false
+    private var presentationIsObscuring = false
+    private var appIsActive = UIApplication.shared.applicationState == .active
 
     init(activeTab: PaymentsLandingTab,
          network: ChainNetwork = .core,
-         visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases) {
+         visibleTabs: [PaymentsLandingTab] = PaymentsLandingTab.allCases,
+         allowsTransactionDetails: Bool = true) {
         self.activeTab = activeTab
         self.network = network
         self.visibleTabs = visibleTabs
+        self.allowsTransactionDetails = allowsTransactionDetails
 
         reloadCoreAddress()
         reloadShieldedAddress()
@@ -59,12 +167,21 @@ final class PaymentsLandingViewModel: ObservableObject {
         PlatformAddressSyncCoordinator.shared.$derivedAddresses
             .receive(on: RunLoop.main)
             .sink { [weak self] addresses in
-                self?.platformAddress = addresses.nextReceiveAddress?.address
+                guard let self else { return }
+                self.platformAddress = addresses.nextReceiveAddress?.address
                 // The shielded sub-wallet is bound by the same coordinator's
                 // startup, so a derived-addresses tick is also the retry
                 // signal for a shielded address that wasn't ready at init.
-                self?.reloadShieldedAddress()
+                self.reloadShieldedAddress()
+                self.reconcileReceiptWatching()
             }
+            .store(in: &cancellables)
+
+        Publishers.CombineLatest(
+            PlatformAddressSyncCoordinator.shared.$isRunning.removeDuplicates(),
+            PlatformAddressSyncCoordinator.shared.$platformAccountAvailability.removeDuplicates())
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _, _ in self?.reconcileReceiptWatching() }
             .store(in: &cancellables)
 
         platformAddress = PlatformAddressSyncCoordinator.shared
@@ -72,12 +189,56 @@ final class PaymentsLandingViewModel: ObservableObject {
 
         NotificationCenter.default.publisher(for: NSNotification.Name.DWCurrentNetworkDidChange)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.reloadCoreAddress() }
+            .sink { [weak self] _ in self?.handleWalletOrEnvironmentChange() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: SwiftDashSDKWalletState.activeWalletDidChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.handleWalletOrEnvironmentChange() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.appIsActive = true
+                self?.reconcileReceiptWatching()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.appIsActive = false
+                self?.suspendReceiptWatching()
+            }
+            .store(in: &cancellables)
+
+        $activeTab
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.resetForRouteChange() }
+            .store(in: &cancellables)
+
+        $network
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.resetForRouteChange() }
             .store(in: &cancellables)
     }
 
     var currentAddress: String? {
-        switch network {
+        if session?.rail == network, let displayedAddress {
+            return displayedAddress
+        }
+        return candidateAddress(for: network)
+    }
+
+    var canViewTransaction: Bool {
+        allowsTransactionDetails && receipt?.transactionId != nil
+    }
+
+    private func candidateAddress(for rail: ChainNetwork) -> String? {
+        switch rail {
         case .core: return coreAddress
         case .platform: return platformAddress
         case .shielded: return shieldedAddress
@@ -91,6 +252,35 @@ final class PaymentsLandingViewModel: ObservableObject {
     func copyCurrentAddressToPasteboard() {
         guard let address = currentAddress else { return }
         UIPasteboard.general.string = address
+    }
+
+    func setReceiveSurfaceVisible(_ visible: Bool) {
+        surfaceIsVisible = visible
+        if visible {
+            reconcileReceiptWatching()
+        } else {
+            suspendReceiptWatching()
+        }
+    }
+
+    func setReceiptWatchingObscured(_ obscured: Bool) {
+        presentationIsObscuring = obscured
+        if obscured {
+            suspendReceiptWatching()
+        } else {
+            reconcileReceiptWatching()
+        }
+    }
+
+    func receiveAnother() {
+        receipt = nil
+        invalidateReceiptSession()
+        reloadCoreAddress()
+        platformAddress = PlatformAddressSyncCoordinator.shared
+            .derivedAddresses.nextReceiveAddress?.address
+        shieldedAddress = nil
+        reloadShieldedAddress()
+        reconcileReceiptWatching()
     }
 
     private func reloadCoreAddress() {
@@ -115,6 +305,376 @@ final class PaymentsLandingViewModel: ObservableObject {
         shieldedAddress = Bech32m.encode(
             hrp: Bech32m.platformHrp(mainnet: network == .mainnet),
             data: Data([0x10]) + raw)
+    }
+
+    private var canActivelyWatch: Bool {
+        surfaceIsVisible &&
+            !presentationIsObscuring &&
+            appIsActive &&
+            activeTab == .receive
+    }
+
+    private func reconcileReceiptWatching() {
+        guard canActivelyWatch else {
+            suspendReceiptWatching()
+            return
+        }
+
+        if receipt != nil {
+            isWatchingForReceipt = false
+            if session?.rail == .core {
+                attachCoreObserverIfNeeded()
+            }
+            return
+        }
+
+        if session == nil {
+            startReceiptSession()
+        } else {
+            resumeReceiptWatching()
+        }
+    }
+
+    private func startReceiptSession() {
+        guard let address = candidateAddress(for: network),
+              let walletId = SwiftDashSDKHost.shared.wallet?.walletId,
+              let environment = WalletEnvironment.network,
+              SwiftDashSDKHost.shared.runningNetwork == environment
+        else {
+            displayedAddress = nil
+            isWatchingForReceipt = false
+            return
+        }
+
+        generation &+= 1
+        let sessionGeneration = generation
+        var coreTransactionIds = Set<Data>()
+        var platformActivityCursor: Int64 = 0
+        var shieldedActivityIds = Set<String>()
+
+        switch network {
+        case .core:
+            coreTransactionIds = TransactionObserver.persistedTransactionIDs()
+        case .platform:
+            platformActivityCursor = PlatformAddressActivityDAO.shared.latestActivityId(
+                walletId: walletId,
+                networkRaw: Int64(environment.rawValue))
+        case .shielded:
+            shieldedActivityIds = Set(Self.projectedShieldedActivity().map(\.id))
+        }
+
+        session = ReceiptSession(
+            generation: sessionGeneration,
+            rail: network,
+            address: address,
+            walletId: walletId,
+            environment: environment,
+            startedAt: Date(),
+            coreTransactionIds: coreTransactionIds,
+            platformActivityCursor: platformActivityCursor,
+            shieldedActivityIds: shieldedActivityIds)
+        displayedAddress = address
+        resumeReceiptWatching()
+    }
+
+    private func resumeReceiptWatching() {
+        guard let session, isSessionCurrent(session) else {
+            invalidateReceiptSession()
+            startReceiptSession()
+            return
+        }
+
+        switch session.rail {
+        case .core:
+            isWatchingForReceipt = receipt == nil
+            attachCoreObserverIfNeeded()
+        case .platform:
+            guard ReceiveReceiptPolicy.canRefreshPlatform(
+                isRunning: PlatformAddressSyncCoordinator.shared.isRunning,
+                availability: PlatformAddressSyncCoordinator.shared.platformAccountAvailability)
+            else {
+                isWatchingForReceipt = false
+                return
+            }
+            isWatchingForReceipt = true
+            attachPlatformObserverIfNeeded(session: session)
+        case .shielded:
+            guard PlatformAddressSyncCoordinator.shared.isRunning,
+                  PlatformAddressSyncCoordinator.shared.platformWalletManager != nil else {
+                isWatchingForReceipt = false
+                return
+            }
+            isWatchingForReceipt = true
+            attachShieldedObserverIfNeeded(session: session)
+        }
+    }
+
+    private func attachCoreObserverIfNeeded() {
+        guard coreReceiptCancellable == nil, let session, session.rail == .core else { return }
+        let filter = ReceivedAtAddressTransactionFilter(address: session.address)
+        coreReceiptCancellable = TransactionObserver()
+            .observeUpdates(
+                filters: [filter],
+                after: session.startedAt,
+                excludingTxids: session.coreTransactionIds)
+            .sink { [weak self] transaction in
+                self?.handleCoreTransaction(transaction, session: session)
+            }
+    }
+
+    private func handleCoreTransaction(
+        _ transaction: ObservedTransaction,
+        session: ReceiptSession
+    ) {
+        guard canActivelyWatch,
+              isSessionCurrent(session),
+              let status = ReceiveReceiptPolicy.coreStatus(context: transaction.context)
+        else { return }
+
+        if var existing = receipt, existing.transactionId == transaction.txid {
+            guard let current = existing.coreStatus else { return }
+            let strongest = ReceiveReceiptPolicy.strongestStatus(current: current, observed: status)
+            guard strongest != current else { return }
+            existing.coreStatus = strongest
+            receipt = existing
+            return
+        }
+        guard receipt == nil else { return }
+
+        let amount = transaction.outputs
+            .filter { $0.address == session.address }
+            .reduce(UInt64(0)) { partial, output in
+                let (sum, overflow) = partial.addingReportingOverflow(output.amount)
+                return overflow ? UInt64.max : sum
+            }
+        guard amount > 0 else { return }
+        acceptReceipt(ReceiveReceipt(
+            id: "core-\(transaction.txidHexDisplay)",
+            rail: .core,
+            amountDuffs: amount,
+            receivedAt: transaction.timestamp ?? Date(),
+            memo: nil,
+            transactionId: transaction.txid,
+            coreStatus: status))
+    }
+
+    private func attachPlatformObserverIfNeeded(session: ReceiptSession) {
+        guard platformReceiptCancellable == nil else { return }
+        platformReceiptCancellable = NotificationCenter.default
+            .publisher(for: .platformAddressActivityRecorded)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.checkPlatformActivity(session: session) }
+        checkPlatformActivity(session: session)
+        requestPlatformRefresh(session: session)
+        startAttendedRefreshLoop(interval: AttendedReceiveRefreshPolicy.platformInterval) { [weak self] in
+            self?.requestPlatformRefresh(session: session)
+        }
+    }
+
+    private func checkPlatformActivity(session: ReceiptSession) {
+        guard canActivelyWatch, receipt == nil, isSessionCurrent(session) else { return }
+        guard let record = PlatformAddressActivityDAO.shared.activities(
+            walletId: session.walletId,
+            networkRaw: Int64(session.environment.rawValue),
+            address: session.address,
+            afterId: session.platformActivityCursor).first,
+            record.amountDuffs > 0
+        else { return }
+
+        acceptReceipt(ReceiveReceipt(
+            id: "platform-\(record.id)",
+            rail: .platform,
+            amountDuffs: UInt64(record.amountDuffs),
+            receivedAt: record.observedAt,
+            memo: nil,
+            transactionId: nil,
+            coreStatus: nil))
+    }
+
+    private func requestPlatformRefresh(session: ReceiptSession) {
+        guard receipt == nil,
+              isSessionCurrent(session),
+              ReceiveReceiptPolicy.canRefreshPlatform(
+                  isRunning: PlatformAddressSyncCoordinator.shared.isRunning,
+                  availability: PlatformAddressSyncCoordinator.shared.platformAccountAvailability)
+        else { return }
+        Task { [weak self] in
+            await PlatformAddressSyncCoordinator.shared.syncNow()
+            guard let self else { return }
+            self.checkPlatformActivity(session: session)
+        }
+    }
+
+    private func attachShieldedObserverIfNeeded(session: ReceiptSession) {
+        guard let manager = PlatformAddressSyncCoordinator.shared.platformWalletManager else { return }
+        guard shieldedReceiptCancellable == nil else { return }
+        shieldedReceiptCancellable = manager.$lastShieldedSyncEvent
+            .receive(on: RunLoop.main)
+            .sink { [weak self] event in
+                guard let result = event?.result(for: session.walletId),
+                      ReceiveReceiptPolicy.shouldProjectShieldedResult(
+                          success: result.success,
+                          cooldownSkip: result.cooldownSkip)
+                else { return }
+                self?.requestShieldedProjectionRefresh(session: session)
+            }
+        requestShieldedProjectionRefresh(session: session)
+        PlatformAddressSyncCoordinator.shared.requestShieldedRefresh(
+            using: manager,
+            reason: "attended receive")
+        startAttendedRefreshLoop(interval: AttendedReceiveRefreshPolicy.shieldedInterval) {
+            [weak self, weak manager] in
+            guard let self, let manager,
+                  self.receipt == nil,
+                  self.isSessionCurrent(session)
+            else { return }
+            PlatformAddressSyncCoordinator.shared.requestShieldedRefresh(
+                using: manager,
+                reason: "attended receive")
+        }
+    }
+
+    private func requestShieldedProjectionRefresh(session: ReceiptSession) {
+        guard canActivelyWatch, receipt == nil, isSessionCurrent(session) else { return }
+        guard shieldedProjectionTask == nil else {
+            shieldedProjectionRefreshPending = true
+            return
+        }
+
+        shieldedProjectionGeneration &+= 1
+        let projectionGeneration = shieldedProjectionGeneration
+        shieldedProjectionTask = Task { [weak self] in
+            let items = await Task.detached(priority: .userInitiated) {
+                Self.projectedShieldedActivity()
+            }.value
+            guard let self else { return }
+            guard self.shieldedProjectionGeneration == projectionGeneration else { return }
+            self.shieldedProjectionTask = nil
+            guard !Task.isCancelled,
+                  self.canActivelyWatch,
+                  self.receipt == nil,
+                  self.isSessionCurrent(session)
+            else { return }
+
+            let received = items
+                .filter {
+                    $0.kind == .received &&
+                        !session.shieldedActivityIds.contains($0.id)
+                }
+                .sorted {
+                    if $0.date == $1.date { return $0.id < $1.id }
+                    return $0.date < $1.date
+                }
+                .first
+            if let received {
+                self.acceptReceipt(ReceiveReceipt(
+                    id: received.id,
+                    rail: .shielded,
+                    amountDuffs: received.amountDuffs,
+                    receivedAt: received.hasKnownDate ? received.date : Date(),
+                    memo: received.memoText,
+                    transactionId: nil,
+                    coreStatus: nil))
+                return
+            }
+
+            if self.shieldedProjectionRefreshPending {
+                self.shieldedProjectionRefreshPending = false
+                self.requestShieldedProjectionRefresh(session: session)
+            }
+        }
+    }
+
+    nonisolated private static func projectedShieldedActivity() -> [ShieldedActivityItem] {
+        let coreTransactions = SwiftDashSDKWalletSource
+            .fetchCurrentWalletSnapshot()?.transactions ?? []
+        return SwiftDashSDKWalletSource.fetchShieldedActivity(
+            coreTransactions: coreTransactions)
+    }
+
+    private func startAttendedRefreshLoop(
+        interval: TimeInterval,
+        refresh: @escaping @MainActor () -> Void
+    ) {
+        guard attendedRefreshTask == nil else { return }
+        attendedRefreshTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(interval * 1_000_000_000))
+                } catch {
+                    return
+                }
+                guard let self, self.canActivelyWatch else { return }
+                refresh()
+            }
+        }
+    }
+
+    private func acceptReceipt(_ newReceipt: ReceiveReceipt) {
+        guard receipt == nil else { return }
+        receipt = newReceipt
+        isWatchingForReceipt = false
+        attendedRefreshTask?.cancel()
+        attendedRefreshTask = nil
+        platformReceiptCancellable?.cancel()
+        platformReceiptCancellable = nil
+        shieldedReceiptCancellable?.cancel()
+        shieldedReceiptCancellable = nil
+        shieldedProjectionTask?.cancel()
+        shieldedProjectionTask = nil
+        shieldedProjectionGeneration &+= 1
+        shieldedProjectionRefreshPending = false
+    }
+
+    private func suspendReceiptWatching() {
+        isWatchingForReceipt = false
+        coreReceiptCancellable?.cancel()
+        coreReceiptCancellable = nil
+        platformReceiptCancellable?.cancel()
+        platformReceiptCancellable = nil
+        shieldedReceiptCancellable?.cancel()
+        shieldedReceiptCancellable = nil
+        attendedRefreshTask?.cancel()
+        attendedRefreshTask = nil
+        shieldedProjectionTask?.cancel()
+        shieldedProjectionTask = nil
+        shieldedProjectionGeneration &+= 1
+        shieldedProjectionRefreshPending = false
+    }
+
+    private func invalidateReceiptSession() {
+        suspendReceiptWatching()
+        generation &+= 1
+        session = nil
+        displayedAddress = nil
+    }
+
+    private func resetForRouteChange() {
+        receipt = nil
+        invalidateReceiptSession()
+        reconcileReceiptWatching()
+    }
+
+    private func handleWalletOrEnvironmentChange() {
+        receipt = nil
+        invalidateReceiptSession()
+        coreAddress = nil
+        platformAddress = nil
+        shieldedAddress = nil
+        reloadCoreAddress()
+        platformAddress = PlatformAddressSyncCoordinator.shared
+            .derivedAddresses.nextReceiveAddress?.address
+        reloadShieldedAddress()
+        reconcileReceiptWatching()
+    }
+
+    private func isSessionCurrent(_ candidate: ReceiptSession) -> Bool {
+        session?.generation == candidate.generation &&
+            generation == candidate.generation &&
+            network == candidate.rail &&
+            SwiftDashSDKHost.shared.wallet?.walletId == candidate.walletId &&
+            WalletEnvironment.network == candidate.environment
     }
 
 }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingViewModel.swift
@@ -561,11 +561,10 @@ final class PaymentsLandingViewModel: ObservableObject {
                     $0.kind == .received &&
                         !session.shieldedActivityIds.contains($0.id)
                 }
-                .sorted {
+                .min {
                     if $0.date == $1.date { return $0.id < $1.id }
                     return $0.date < $1.date
                 }
-                .first
             if let received {
                 self.acceptReceipt(ReceiveReceipt(
                     id: received.id,

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -830,27 +830,10 @@ struct SendConfirmSheet: View {
 
     private var successBody: some View {
         VStack(spacing: 16) {
-            Image(systemName: "checkmark.circle.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 64, height: 64)
-                .foregroundColor(.green)
-                .padding(.top, 24)
-
-            Text(NSLocalizedString("Sent", comment: "Send confirm sheet"))
-                .font(.title3)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-
-            DashAmount(
-                amount: dashDuffs,
-                font: .title,
-                dashSymbolFactor: 0.7,
-                showDirection: false)
-
-            Text(fiatText)
-                .font(.subheadline)
-                .foregroundColor(.dash.secondaryText)
+            PaymentSuccessHeader(
+                title: NSLocalizedString("Sent", comment: "Send confirm sheet"),
+                amountDuffs: dashDuffs,
+                fiatText: fiatText)
 
             Spacer(minLength: 12)
 

--- a/DashWallet/Sources/UI/SwiftUI Components/DashAmount.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/DashAmount.swift
@@ -80,3 +80,38 @@ struct DashAmount: View {
         return result
     }
 }
+
+/// Shared visual hierarchy for completed sends and attended receives. Keeping
+/// the success icon, amount renderer, typography, and spacing in one place
+/// prevents the two halves of a payment from drifting apart visually.
+struct PaymentSuccessHeader: View {
+    let title: String
+    let amountDuffs: Int64
+    let fiatText: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 64, height: 64)
+                .foregroundColor(.green)
+                .padding(.top, 24)
+
+            Text(title)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundColor(.dash.primaryText)
+
+            DashAmount(
+                amount: amountDuffs,
+                font: .title,
+                dashSymbolFactor: 0.7,
+                showDirection: false)
+
+            Text(fiatText)
+                .font(.subheadline)
+                .foregroundColor(.dash.secondaryText)
+        }
+    }
+}

--- a/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
+++ b/DashWalletTests/SwiftDashSDKCoreLifecycleTests.swift
@@ -314,6 +314,81 @@ final class SwiftDashSDKCoreLifecycleTests: XCTestCase {
         XCTAssertEqual(NormalizePlatformAddressActivityUnits().version, 20260727140000)
     }
 
+    func testPlatformActivityInitialBaselineIncludesZeroBalanceAddresses() {
+        let balances = PlatformAddressActivityUnitPolicy.initialBaselineBalances(addresses: [
+            DerivedPlatformAddress(
+                address: "tdash1zero",
+                accountIndex: 0,
+                addressIndex: 0,
+                isUsed: false,
+                balance: 0),
+            DerivedPlatformAddress(
+                address: "tdash1funded",
+                accountIndex: 0,
+                addressIndex: 1,
+                isUsed: true,
+                balance: 5_000),
+        ])
+
+        XCTAssertEqual(balances["tdash1zero"], 0)
+        XCTAssertEqual(balances["tdash1funded"], 5)
+    }
+
+    func testReceiveFilterAcceptsOnlySDKClassifiedExternalReceives() {
+        XCTAssertTrue(ReceivedAtAddressTransactionFilter.matches(
+            direction: .received,
+            ownOutputAddresses: ["yReceive"],
+            address: "yReceive"))
+        XCTAssertFalse(ReceivedAtAddressTransactionFilter.matches(
+            direction: .moved,
+            ownOutputAddresses: ["yReceive"],
+            address: "yReceive"))
+        XCTAssertFalse(ReceivedAtAddressTransactionFilter.matches(
+            direction: .received,
+            ownOutputAddresses: ["yDifferent"],
+            address: "yReceive"))
+    }
+
+    func testReceiveCoreContextMappingAndStatusNeverRegresses() {
+        XCTAssertEqual(ReceiveReceiptPolicy.coreStatus(context: 0), .mempool)
+        XCTAssertEqual(ReceiveReceiptPolicy.coreStatus(context: 1), .instantSend)
+        XCTAssertEqual(ReceiveReceiptPolicy.coreStatus(context: 2), .inBlock)
+        XCTAssertEqual(ReceiveReceiptPolicy.coreStatus(context: 3), .chainLocked)
+        XCTAssertNil(ReceiveReceiptPolicy.coreStatus(context: 4))
+        XCTAssertEqual(
+            ReceiveReceiptPolicy.strongestStatus(
+                current: .inBlock,
+                observed: .mempool),
+            .inBlock)
+    }
+
+    func testReceiveShieldedCooldownSkipIsNotProjected() {
+        XCTAssertFalse(ReceiveReceiptPolicy.shouldProjectShieldedResult(
+            success: true,
+            cooldownSkip: true))
+        XCTAssertFalse(ReceiveReceiptPolicy.shouldProjectShieldedResult(
+            success: false,
+            cooldownSkip: false))
+        XCTAssertTrue(ReceiveReceiptPolicy.shouldProjectShieldedResult(
+            success: true,
+            cooldownSkip: false))
+    }
+
+    func testAttendedPlatformRefreshRequiresRunningAvailableAccount() {
+        XCTAssertFalse(ReceiveReceiptPolicy.canRefreshPlatform(
+            isRunning: false,
+            availability: .available))
+        XCTAssertFalse(ReceiveReceiptPolicy.canRefreshPlatform(
+            isRunning: true,
+            availability: .unknown))
+        XCTAssertFalse(ReceiveReceiptPolicy.canRefreshPlatform(
+            isRunning: true,
+            availability: .unavailable))
+        XCTAssertTrue(ReceiveReceiptPolicy.canRefreshPlatform(
+            isRunning: true,
+            availability: .available))
+    }
+
     func testCoreToShieldedPoolFeeDuffsRoundsUpToCoverTheCreditFee() {
         // A 200-credit remainder rounds up to the next whole duff…
         XCTAssertEqual(


### PR DESCRIPTION
## Issue being fixed or feature implemented

The receive screen shows an address but does not acknowledge a payment that arrives while someone is actively presenting it. This makes in-person handoffs feel uncertain and can leave Platform or Shielded receipts invisible until a later background sync.

## What was done?

- Added attended receive sessions for Core, Platform, and Shielded balances, freezing the displayed destination and snapshotting existing activity so only new external receipts are celebrated.
- Added a receipt state with amount, fiat value, balance, status, time, optional memo, transaction navigation, and receive-another/done actions.
- Reused one success header and button structure across sent and received states so icon color/size, amount rendering, typography, spacing, and bottom action placement stay aligned.
- Reused SDK-classified Core transaction direction, Platform activity recorder suppressions, and projected Shielded activity to avoid celebrating internal wallet moves, top-ups, or unshields.
- Added status-aware Core observation so mempool, InstantSend, in-block, and ChainLocked state can upgrade without duplicate receipts or visible status regression.
- Added guarded five-second attended refresh passes for Platform and Shielded while the receive UI is visible, active, and unobscured; lifecycle and generation guards cancel stale work across rail, wallet, network, sheet, and background changes.
- Fixed Platform activity baselining for zero-balance addresses so the first real incoming payment is not swallowed, while existing funded installs establish a baseline without fabricating a receipt.


## Screenshots

| Watching for a payment | Payment received |
| --- | --- |
| ![Attended Core receive screen watching for a payment](https://raw.githubusercontent.com/PastaPastaPasta/dashwallet-ios/adc12580a043204c6488658291982bcacb47811e/pr-assets/1041/after-watching-core.png) | ![Attended Core receive receipt showing 0.01 tDASH and InstantSend confirmation](https://raw.githubusercontent.com/PastaPastaPasta/dashwallet-ios/adc12580a043204c6488658291982bcacb47811e/pr-assets/1041/after-received-core.png) |

Captured on an iPhone 17 Pro / iOS 26.5 simulator from PR head `6dc9a5aa1ef37a809c15b41d49d31e97dc083538`. The watching state uses the live testnet wallet. The completed receipt uses a temporary screenshot-only Core fixture (0.01 tDASH, InstantSend) because receipt state is intentionally ephemeral; the fixture was removed and the production build restored before publication.

## How Has This Been Tested?

- Clean `dashpay` arm64 build for an iPhone 17 Pro / iOS 26.5 simulator.
- Live testnet simulator smoke testing of attended Core, Platform, and Shielded receive flows and the resulting receipt UI.
- Added compile-ready policy tests for zero-balance Platform baselines, external-only Core filtering, Core context/status handling, Shielded cooldown skips, and Platform refresh guards. The repository's unit-test target remains blocked by its pre-existing build failure.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.

