### PR TITLE
fix(ui): stop automatic clipboard access

### DIFF
--- a/DashWallet/Sources/UI/Main/MainTabbarController.swift
+++ b/DashWallet/Sources/UI/Main/MainTabbarController.swift
@@ -493,12 +493,10 @@ extension MainTabbarController: HomeViewControllerDelegate {
         }
     }
 
-    /// The "Send to Address" shortcut skips the payments landing: straight
-    /// to the send screen, with the address field prefilled when the
-    /// clipboard holds a valid Core/Platform address.
+    /// The "Send to Address" shortcut skips the payments landing and opens
+    /// the send screen directly.
     private func presentSendToAddressScreen() {
         let controller = SendScreenViewController()
-        controller.prefillsFromClipboard = true
         let navigationController = BaseNavigationController(rootViewController: controller)
         navigationController.isNavigationBarHidden = true
         navigationController.modalPresentationStyle = .fullScreen

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -52,10 +52,11 @@ struct SendScreen: View {
                     addressField
                         .padding(.top, 12)
 
-                    if let suggestion = viewModel.clipboardSuggestion,
-                       suggestion.address != viewModel.trimmedAddress {
-                        clipboardChip(for: suggestion)
+                    PasteButton(payloadType: String.self) { strings in
+                        viewModel.usePastedStrings(strings)
                     }
+                    .buttonStyle(.bordered)
+                    .tint(.blue)
 
                     scanRow
                 }
@@ -221,37 +222,6 @@ struct SendScreen: View {
         case .platform: return NSLocalizedString("Platform address", comment: "Send screen destination type")
         case .shielded: return NSLocalizedString("Shielded address", comment: "Send screen destination type")
         }
-    }
-
-    private func clipboardChip(for suggestion: SendViewModel.ClipboardSuggestion) -> some View {
-        Button(action: { viewModel.useClipboardSuggestion() }) {
-            HStack(spacing: 10) {
-                Image(systemName: "doc.on.doc.fill")
-                    .foregroundColor(.blue)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(NSLocalizedString("Send to copied address", comment: ""))
-                        .font(.caption)
-                        .foregroundColor(Color.dash.secondaryText)
-                    Text(truncateMiddle(suggestion.address))
-                        .font(.system(.footnote, design: .monospaced))
-                        .foregroundColor(.dash.primaryText)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                Spacer()
-                Text(destinationTitle(suggestion.kind))
-                    .font(.caption2)
-                    .foregroundColor(Color.dash.secondaryText)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(Color.dash.gray300.opacity(0.3))
-                    .cornerRadius(8)
-            }
-            .padding(12)
-            .background(Color.dash.blue.opacity(0.08))
-            .cornerRadius(10)
-        }
-        .padding(.horizontal, 20)
     }
 
     private var scanRow: some View {

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreenViewController.swift
@@ -10,11 +10,6 @@ import UIKit
 @objc(DWSendScreenViewController)
 final class SendScreenViewController: DWBasePayViewController {
 
-    /// Set by the "Send to Address" shortcut entry: on load, a valid address
-    /// on the clipboard is applied to the address field directly — the same
-    /// action as tapping the clipboard suggestion chip.
-    var prefillsFromClipboard = false
-
     /// Scan-routing prefill (`DWBasePayViewController`'s ObjC scan handler):
     /// a scanned bech32m Platform/Shielded destination opens this screen
     /// with the address (and BIP21 amount, when present) applied on load.
@@ -60,9 +55,6 @@ final class SendScreenViewController: DWBasePayViewController {
         ])
         hostingController.didMove(toParent: self)
 
-        if prefillsFromClipboard {
-            sendViewModel.useClipboardSuggestion()
-        }
         if let prefillAddress {
             sendViewModel.addressText = prefillAddress
             if prefillAmountDuffs > 0 {

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -6,7 +6,6 @@
 import Combine
 import Foundation
 import SwiftDashSDK
-import UIKit
 
 @MainActor
 final class SendViewModel: ObservableObject {
@@ -88,8 +87,6 @@ final class SendViewModel: ObservableObject {
             }
         }
     }
-    @Published private(set) var clipboardSuggestion: ClipboardSuggestion? = nil
-
     // Balances — same feeds as `InternalTransferViewModel` (BIP44 duffs,
     // DIP-17 credits, Orchard credits).
     @Published private(set) var coreBalanceDuffs: UInt64 = 0
@@ -141,18 +138,7 @@ final class SendViewModel: ObservableObject {
         if let pinnedSource {
             source = pinnedSource
         }
-        refreshClipboardSuggestion()
         SyncingActivityMonitor.shared.add(observer: self)
-
-        NotificationCenter.default.publisher(for: UIPasteboard.changedNotification)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.refreshClipboardSuggestion() }
-            .store(in: &cancellables)
-
-        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.refreshClipboardSuggestion() }
-            .store(in: &cancellables)
 
         coreBalanceDuffs = SwiftDashSDKWalletState.shared.balance?.total ?? 0
         platformCredits = PlatformAddressSyncCoordinator.shared.platformBalance
@@ -342,35 +328,17 @@ final class SendViewModel: ObservableObject {
 
     // MARK: - Clipboard
 
-    struct ClipboardSuggestion: Equatable {
-        let address: String
-        let kind: DestinationKind
-    }
-
-    func refreshClipboardSuggestion() {
-        guard let raw = UIPasteboard.general.string else {
-            clipboardSuggestion = nil
-            return
-        }
-        clipboardSuggestion = Self.detect(in: raw)
-    }
-
-    func useClipboardSuggestion() {
-        guard let suggestion = clipboardSuggestion else { return }
-        addressText = suggestion.address
-    }
-
-    private static func detect(in raw: String) -> ClipboardSuggestion? {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return nil }
-
-        for candidate in trimmed.split(whereSeparator: { !$0.isLetter && !$0.isNumber }) {
-            let word = String(candidate)
-            if let kind = classify(word) {
-                return ClipboardSuggestion(address: word, kind: kind)
+    func usePastedStrings(_ strings: [String]) {
+        for string in strings {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            for candidate in trimmed.split(whereSeparator: { !$0.isLetter && !$0.isNumber }) {
+                let address = String(candidate)
+                if Self.classify(address) != nil {
+                    addressText = address
+                    return
+                }
             }
         }
-        return nil
     }
 
     /// Scanned QR → address text. The classifier decides what it is; a


### PR DESCRIPTION
## Issue being fixed or feature implemented

Opening the Send flow caused the wallet to read the clipboard during view-model initialization, on pasteboard changes, and whenever the app became active. On recent iOS versions, those passive reads can repeatedly display the paste-permission prompt.

## What was done?

- Removed automatic clipboard reads and clipboard-change/app-activation observers from the Send flow.
- Removed automatic clipboard prefilling from the “Send to Address” shortcut.
- Replaced the passive copied-address suggestion with SwiftUI's user-initiated `PasteButton`.
- Preserved validation and extraction of Core, Platform, and Shielded addresses from explicitly pasted text.

## How Has This Been Tested?

- Parsed all four changed Swift files with `swiftc`.
- Built the `dashpay` Debug target for an arm64 iOS Simulator with code signing disabled. Private service plist resources, which are unavailable in this checkout, were excluded from the build.
- Verified with `git range-diff` that the patch remained identical after rebasing onto the latest `upstream/develop`.
- Confirmed the active Send flow contains no remaining automatic `UIPasteboard` reads.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Paste button to the send-address screen.
  * Pasted text is automatically scanned for and applies the first valid payment address.

* **Bug Fixes**
  * Removed automatic clipboard-based address prefilling when opening the send screen.
  * Preserved address and amount prefilling from scanned payment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->