### PR TITLE
fix(explore-dash): show actually-nearby spend locations (closest per merchant in SQL, individual map pins)

### DIFF
--- a/DashWallet/Sources/Models/Explore Dash/ExploreDash.swift
+++ b/DashWallet/Sources/Models/Explore Dash/ExploreDash.swift
@@ -205,6 +205,14 @@ extension ExploreDash {
         merchantDAO.allMerchants(by: query, in: bounds, userPoint: userPoint, paymentMethods: paymentMethods, sortBy: sortBy, territory: territory, denominationType: denominationType, offset: offset, completion: completion)
     }
 
+    func merchantPhysicalLocations(in bounds: ExploreMapBounds, center: CLLocationCoordinate2D,
+                                   paymentMethods: [PointOfUseListFilters.SpendingOptions]?,
+                                   denominationType: PointOfUseListFilters.DenominationType?,
+                                   completion: @escaping (Swift.Result<[ExplorePointOfUse], Error>) -> Void) {
+        merchantDAO.physicalLocations(in: bounds, center: center, paymentMethods: paymentMethods,
+                                      denominationType: denominationType, completion: completion)
+    }
+
     func allLocations(for merchantId: String, in bounds: ExploreMapBounds?, userPoint: CLLocationCoordinate2D?, offset: Int = 0,
                       completion: @escaping (Swift.Result<PaginationResult<ExplorePointOfUse>, Error>) -> Void) {
         merchantDAO.allLocations(for: merchantId, in: bounds, userPoint: userPoint, offset: offset, completion: completion)

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
@@ -79,116 +79,10 @@ class MerchantDAO: PointOfUseDAO {
 
             let merchantTable = Table("merchant")
             let name = ExplorePointOfUse.name
-            let typeColumn = ExplorePointOfUse.type
-            let paymentMethodColumn = ExplorePointOfUse.paymentMethod
-            let territoryColumn = ExplorePointOfUse.territory
-
-            var queryFilter = Expression<Bool>(value: true)
-
-            // Add query
-            if let query {
-                queryFilter = queryFilter && name.like("%\(query)%")
-            }
-
-            queryFilter = queryFilter && types.map { $0.rawValue }.contains(typeColumn) // Add types
-
-            // Add payment methods
-            if let methods = paymentMethods {
-                var tempMethods: [ExplorePointOfUse.Merchant.PaymentMethod] = []
-
-                if methods.contains(PointOfUseListFilters.SpendingOptions.dash) {
-                    tempMethods.append(ExplorePointOfUse.Merchant.PaymentMethod.dash)
-                }
-
-                let hasCTX = methods.contains(PointOfUseListFilters.SpendingOptions.ctx)
-                #if PIGGYCARDS_ENABLED
-                let hasPiggy = methods.contains(PointOfUseListFilters.SpendingOptions.piggyCards)
-                #else
-                let hasPiggy = false
-                #endif
-
-                if hasCTX || hasPiggy {
-                    tempMethods.append(ExplorePointOfUse.Merchant.PaymentMethod.giftCard)
-                }
-
-                queryFilter = queryFilter && tempMethods.map { $0.rawValue }.contains(paymentMethodColumn)
-
-                // If only specific gift card providers are selected (not both), add merchantId filter
-                if !methods.contains(PointOfUseListFilters.SpendingOptions.dash) && (hasCTX != hasPiggy) {
-                    var providerList: [String] = []
-                    if hasCTX {
-                        providerList.append("'CTX'")
-                    }
-                    #if PIGGYCARDS_ENABLED
-                    if hasPiggy {
-                        providerList.append("'PiggyCards'")
-                    }
-                    #endif
-                    
-                    let providerString = providerList.joined(separator: ", ")
-                    queryFilter = queryFilter && Expression<Bool>(literal: "merchantId IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider IN (\(providerString)))")
-                }
-            }
-            
-            // Filter out URL-based redemption merchants (not supported)
-            // Using literal expression to handle cases where redeemType column might not exist
-            queryFilter = queryFilter && Expression<Bool>(literal: "(redeemType IS NULL OR redeemType != 'url')")
-
-            // Filter out PiggyCards-only merchants when:
-            // 1. PIGGYCARDS_ENABLED is not defined, OR
-            // 2. PIGGYCARDS_ENABLED is defined but user is in a restricted region (Russia or Cuba)
-            #if PIGGYCARDS_ENABLED
-            if isPiggyCardsGeoRestricted() {
-                queryFilter = queryFilter && Expression<Bool>(literal: "merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider = 'PiggyCards' AND merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider != 'PiggyCards'))")
-            }
-            #else
-            queryFilter = queryFilter && Expression<Bool>(literal: "merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider = 'PiggyCards' AND merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider != 'PiggyCards'))")
-            #endif
-            
-            // Add denomination type filter (only applies to gift card merchants)
-            if let denominationType = denominationType {
-                switch denominationType {
-                case .fixed:
-                    // Include all dash merchants OR gift card merchants with "fixed" denomination
-                    queryFilter = queryFilter && (paymentMethodColumn == "dash" || Expression<Bool>(literal: "denominationsType = 'fixed'"))
-                case .flexible:
-                    // Include all dash merchants OR gift card merchants with "min-max" denomination
-                    queryFilter = queryFilter && (paymentMethodColumn == "dash" || Expression<Bool>(literal: "denominationsType = 'min-max'"))
-                case .both:
-                    // No additional filter needed - include all
-                    break
-                }
-            }
-
-            if let territory {
-                queryFilter = queryFilter && territoryColumn.like(territory)
-            } else if let bounds {
-                // Make the rectangular bounds more generous to ensure we don't exclude locations
-                // that should be within the circular radius. Add 50% buffer to each dimension.
-                let latBuffer = (bounds.neCoordinate.latitude - bounds.swCoordinate.latitude) * 0.5
-                let lonBuffer = (bounds.neCoordinate.longitude - bounds.swCoordinate.longitude) * 0.5
-
-                let expandedSWLat = bounds.swCoordinate.latitude - latBuffer
-                let expandedNELat = bounds.neCoordinate.latitude + latBuffer
-                let expandedSWLon = bounds.swCoordinate.longitude - lonBuffer
-                let expandedNELon = bounds.neCoordinate.longitude + lonBuffer
-
-                // Build the bounds filter for physical locations
-                let physicalBoundsFilter = Expression<Bool>(literal: "latitude > \(expandedSWLat)") &&
-                    Expression<Bool>(literal: "latitude < \(expandedNELat)") &&
-                    Expression<Bool>(literal: "longitude > \(expandedSWLon)") &&
-                    Expression<Bool>(literal: "longitude < \(expandedNELon)")
-
-                // If we're querying for online merchants (e.g., "All" tab), include them regardless of bounds
-                // Online merchants don't have physical locations so they shouldn't be filtered by bounds
-                if types.contains(.online) {
-                    let boundsFilter = physicalBoundsFilter || Expression<Bool>(literal: "type = 'online'")
-                    queryFilter = queryFilter && boundsFilter
-                } else {
-                    // For nearby tab (physical only), just use the bounds filter
-                    queryFilter = queryFilter && physicalBoundsFilter
-                }
-            }
+            let queryFilter = wSelf.merchantQueryFilter(query: query, bounds: bounds, types: types,
+                                                        paymentMethods: paymentMethods,
+                                                        denominationType: denominationType,
+                                                        territory: territory)
 
             var query = merchantTable
                 .select(merchantTable[*])
@@ -269,101 +163,8 @@ class MerchantDAO: PointOfUseDAO {
 
             do {
                 var items: [ExplorePointOfUse] = try wSelf.connection.execute(query: query)
-                
-                // Fetch gift card providers for each merchant that accepts gift cards
-                #if PIGGYCARDS_ENABLED
-                let excludePiggyCards = isPiggyCardsGeoRestricted()
-                #endif
-                for (index, item) in items.enumerated() {
-                    if let merchant = item.merchant, merchant.paymentMethod == .giftCard {
-                        // Only fetch CTX providers when PiggyCards is disabled or user is in restricted region
-                        #if PIGGYCARDS_ENABLED
-                        let providersQuery: String
-                        if excludePiggyCards {
-                            providersQuery = """
-                                SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                WHERE merchantId = '\(merchant.merchantId)' AND provider != 'PiggyCards'
-                            """
-                        } else {
-                            providersQuery = """
-                                SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                WHERE merchantId = '\(merchant.merchantId)'
-                            """
-                        }
-                        #else
-                        let providersQuery = """
-                            SELECT provider, savingsPercentage, denominationsType FROM gift_card_providers
-                            WHERE merchantId = '\(merchant.merchantId)' AND provider = 'CTX'
-                        """
-                        #endif
 
-                        do {
-                            guard let db = wSelf.connection.db else {
-                                continue
-                            }
-
-                            let rows = try db.prepare(providersQuery)
-                            var providers: [ExplorePointOfUse.Merchant.GiftCardProviderInfo] = []
-                            var rowCount = 0
-
-                            for row in rows {
-                                rowCount += 1
-                                if let providerId = row[0] as? String,
-                                   let savingsPercentage = row[1] as? Int64,
-                                   let denominationsType = row[2] as? String {
-
-                                    providers.append(ExplorePointOfUse.Merchant.GiftCardProviderInfo(
-                                        providerId: providerId,
-                                        savingsPercentage: Int(savingsPercentage),
-                                        denominationsType: denominationsType,
-                                        sourceId: wSelf.extractSourceId(from: row, at: 3)
-                                    ))
-                                }
-                            }
-
-
-                            if !providers.isEmpty {
-                                // Create updated merchant with providers
-                                let updatedMerchant = ExplorePointOfUse.Merchant(
-                                    merchantId: merchant.merchantId,
-                                    paymentMethod: merchant.paymentMethod,
-                                    type: merchant.type,
-                                    deeplink: merchant.deeplink,
-                                    savingsBasisPoints: merchant.savingsBasisPoints,
-                                    denominationsType: merchant.denominationsType,
-                                    denominations: merchant.denominations,
-                                    redeemType: merchant.redeemType,
-                                    giftCardProviders: providers
-                                )
-                                
-                                // Create updated ExplorePointOfUse
-                                let updatedItem = ExplorePointOfUse(
-                                    id: item.id,
-                                    name: item.name,
-                                    category: .merchant(updatedMerchant),
-                                    active: item.active,
-                                    city: item.city,
-                                    territory: item.territory,
-                                    address1: item.address1,
-                                    address2: item.address2,
-                                    address3: item.address3,
-                                    address4: item.address4,
-                                    latitude: item.latitude,
-                                    longitude: item.longitude,
-                                    website: item.website,
-                                    phone: item.phone,
-                                    logoLocation: item.logoLocation,
-                                    coverImage: item.coverImage,
-                                    source: item.source
-                                )
-                                
-                                items[index] = updatedItem
-                            }
-                        } catch {
-                            // If we can't fetch providers, just continue with empty providers
-                        }
-                    }
-                }
+                items = wSelf.enrichedWithGiftCardProviders(items)
 
                 completion(.success(PaginationResult(items: items, offset: offset)))
             } catch {
@@ -371,6 +172,238 @@ class MerchantDAO: PointOfUseDAO {
                 completion(.failure(error))
             }
         }
+    }
+
+    /// Builds the shared WHERE clause for merchant queries: name search, merchant types,
+    /// payment/provider filters, redeemType/PiggyCards exclusions, denomination type and
+    /// the territory-or-bounds region filter.
+    private func merchantQueryFilter(query: String?,
+                                     bounds: ExploreMapBounds?,
+                                     types: [ExplorePointOfUse.Merchant.`Type`],
+                                     paymentMethods: [PointOfUseListFilters.SpendingOptions]?,
+                                     denominationType: PointOfUseListFilters.DenominationType?,
+                                     territory: Territory?) -> Expression<Bool> {
+        let name = ExplorePointOfUse.name
+        let typeColumn = ExplorePointOfUse.type
+        let paymentMethodColumn = ExplorePointOfUse.paymentMethod
+        let territoryColumn = ExplorePointOfUse.territory
+
+        var queryFilter = Expression<Bool>(value: true)
+
+        // Add query
+        if let query {
+            queryFilter = queryFilter && name.like("%\(query)%")
+        }
+
+        queryFilter = queryFilter && types.map { $0.rawValue }.contains(typeColumn) // Add types
+
+        // Add payment methods
+        if let methods = paymentMethods {
+            var tempMethods: [ExplorePointOfUse.Merchant.PaymentMethod] = []
+
+            if methods.contains(PointOfUseListFilters.SpendingOptions.dash) {
+                tempMethods.append(ExplorePointOfUse.Merchant.PaymentMethod.dash)
+            }
+
+            let hasCTX = methods.contains(PointOfUseListFilters.SpendingOptions.ctx)
+            #if PIGGYCARDS_ENABLED
+            let hasPiggy = methods.contains(PointOfUseListFilters.SpendingOptions.piggyCards)
+            #else
+            let hasPiggy = false
+            #endif
+
+            if hasCTX || hasPiggy {
+                tempMethods.append(ExplorePointOfUse.Merchant.PaymentMethod.giftCard)
+            }
+
+            queryFilter = queryFilter && tempMethods.map { $0.rawValue }.contains(paymentMethodColumn)
+
+            // If only specific gift card providers are selected (not both), add merchantId filter
+            if !methods.contains(PointOfUseListFilters.SpendingOptions.dash) && (hasCTX != hasPiggy) {
+                var providerList: [String] = []
+                if hasCTX {
+                    providerList.append("'CTX'")
+                }
+                #if PIGGYCARDS_ENABLED
+                if hasPiggy {
+                    providerList.append("'PiggyCards'")
+                }
+                #endif
+
+                let providerString = providerList.joined(separator: ", ")
+                queryFilter = queryFilter && Expression<Bool>(literal: "merchantId IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider IN (\(providerString)))")
+            }
+        }
+
+        // Filter out URL-based redemption merchants (not supported)
+        // Using literal expression to handle cases where redeemType column might not exist
+        queryFilter = queryFilter && Expression<Bool>(literal: "(redeemType IS NULL OR redeemType != 'url')")
+
+        // Filter out PiggyCards-only merchants when:
+        // 1. PIGGYCARDS_ENABLED is not defined, OR
+        // 2. PIGGYCARDS_ENABLED is defined but user is in a restricted region (Russia or Cuba)
+        #if PIGGYCARDS_ENABLED
+        if isPiggyCardsGeoRestricted() {
+            queryFilter = queryFilter && Expression<Bool>(literal: "merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider = 'PiggyCards' AND merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider != 'PiggyCards'))")
+        }
+        #else
+        queryFilter = queryFilter && Expression<Bool>(literal: "merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider = 'PiggyCards' AND merchantId NOT IN (SELECT DISTINCT merchantId FROM gift_card_providers WHERE provider != 'PiggyCards'))")
+        #endif
+
+        // Add denomination type filter (only applies to gift card merchants)
+        if let denominationType = denominationType {
+            switch denominationType {
+            case .fixed:
+                // Include all dash merchants OR gift card merchants with "fixed" denomination
+                queryFilter = queryFilter && (paymentMethodColumn == "dash" || Expression<Bool>(literal: "denominationsType = 'fixed'"))
+            case .flexible:
+                // Include all dash merchants OR gift card merchants with "min-max" denomination
+                queryFilter = queryFilter && (paymentMethodColumn == "dash" || Expression<Bool>(literal: "denominationsType = 'min-max'"))
+            case .both:
+                // No additional filter needed - include all
+                break
+            }
+        }
+
+        if let territory {
+            queryFilter = queryFilter && territoryColumn.like(territory)
+        } else if let bounds {
+            // Make the rectangular bounds more generous to ensure we don't exclude locations
+            // that should be within the circular radius. Add 50% buffer to each dimension.
+            let latBuffer = (bounds.neCoordinate.latitude - bounds.swCoordinate.latitude) * 0.5
+            let lonBuffer = (bounds.neCoordinate.longitude - bounds.swCoordinate.longitude) * 0.5
+
+            let expandedSWLat = bounds.swCoordinate.latitude - latBuffer
+            let expandedNELat = bounds.neCoordinate.latitude + latBuffer
+            let expandedSWLon = bounds.swCoordinate.longitude - lonBuffer
+            let expandedNELon = bounds.neCoordinate.longitude + lonBuffer
+
+            // Build the bounds filter for physical locations
+            let physicalBoundsFilter = Expression<Bool>(literal: "latitude > \(expandedSWLat)") &&
+                Expression<Bool>(literal: "latitude < \(expandedNELat)") &&
+                Expression<Bool>(literal: "longitude > \(expandedSWLon)") &&
+                Expression<Bool>(literal: "longitude < \(expandedNELon)")
+
+            // If we're querying for online merchants (e.g., "All" tab), include them regardless of bounds
+            // Online merchants don't have physical locations so they shouldn't be filtered by bounds
+            if types.contains(.online) {
+                let boundsFilter = physicalBoundsFilter || Expression<Bool>(literal: "type = 'online'")
+                queryFilter = queryFilter && boundsFilter
+            } else {
+                // For nearby tab (physical only), just use the bounds filter
+                queryFilter = queryFilter && physicalBoundsFilter
+            }
+        }
+
+        return queryFilter
+    }
+
+    /// Attaches gift card provider info to every gift-card merchant in `items`.
+    private func enrichedWithGiftCardProviders(_ items: [ExplorePointOfUse]) -> [ExplorePointOfUse] {
+        var items = items
+
+        #if PIGGYCARDS_ENABLED
+        let excludePiggyCards = isPiggyCardsGeoRestricted()
+        #endif
+        for (index, item) in items.enumerated() {
+            if let merchant = item.merchant, merchant.paymentMethod == .giftCard {
+                // Filter out PiggyCards providers when user is in restricted region
+                #if PIGGYCARDS_ENABLED
+                let providersQuery: String
+                if excludePiggyCards {
+                    providersQuery = """
+                        SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
+                        WHERE merchantId = ? AND provider != 'PiggyCards'
+                    """
+                } else {
+                    providersQuery = """
+                        SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
+                        WHERE merchantId = ?
+                    """
+                }
+                #else
+                let providersQuery = """
+                    SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
+                    WHERE merchantId = ? AND provider = 'CTX'
+                """
+                #endif
+
+                do {
+                    guard let db = self.connection.db else {
+                        print("Error: Database connection is nil for merchant \(merchant.merchantId)")
+                        continue
+                    }
+
+                    let statement = try db.prepare(providersQuery, merchant.merchantId)
+                    var providers: [ExplorePointOfUse.Merchant.GiftCardProviderInfo] = []
+                    var rowCount = 0
+
+                    for row in statement {
+                        rowCount += 1
+                        // Access columns by index
+                        let providerId = row[0] as? String
+                        let savingsPercentage = row[1] as? Int64
+                        let denominationsType = row[2] as? String
+
+                        if let providerId = providerId,
+                           let savingsPercentage = savingsPercentage,
+                           let denominationsType = denominationsType {
+
+                            providers.append(ExplorePointOfUse.Merchant.GiftCardProviderInfo(
+                                providerId: providerId,
+                                savingsPercentage: Int(savingsPercentage),
+                                denominationsType: denominationsType,
+                                sourceId: self.extractSourceId(from: row, at: 3)
+                            ))
+                        }
+                    }
+
+
+                    if !providers.isEmpty {
+                        // Create updated merchant with providers
+                        let updatedMerchant = ExplorePointOfUse.Merchant(
+                            merchantId: merchant.merchantId,
+                            paymentMethod: merchant.paymentMethod,
+                            type: merchant.type,
+                            deeplink: merchant.deeplink,
+                            savingsBasisPoints: merchant.savingsBasisPoints,
+                            denominationsType: merchant.denominationsType,
+                            denominations: merchant.denominations,
+                            redeemType: merchant.redeemType,
+                            giftCardProviders: providers
+                        )
+
+                        // Create updated ExplorePointOfUse
+                        let updatedItem = ExplorePointOfUse(
+                            id: item.id,
+                            name: item.name,
+                            category: .merchant(updatedMerchant),
+                            active: item.active,
+                            city: item.city,
+                            territory: item.territory,
+                            address1: item.address1,
+                            address2: item.address2,
+                            address3: item.address3,
+                            address4: item.address4,
+                            latitude: item.latitude,
+                            longitude: item.longitude,
+                            website: item.website,
+                            phone: item.phone,
+                            logoLocation: item.logoLocation,
+                            coverImage: item.coverImage,
+                            source: item.source
+                        )
+
+                        items[index] = updatedItem
+                    }
+                } catch {
+                    // If we can't fetch providers, just continue with empty providers
+                    print("Error fetching gift card providers for merchant \(merchant.merchantId): \(error)")
+                }
+            }
+        }
+
+        return items
     }
 }
 
@@ -495,109 +528,51 @@ extension MerchantDAO {
                     }
                 }
 
-                // Fetch gift card provider information for gift card merchants
-                #if PIGGYCARDS_ENABLED
-                let excludePiggyCards = isPiggyCardsGeoRestricted()
-                #endif
-                for (index, item) in items.enumerated() {
-                    if let merchant = item.merchant, merchant.paymentMethod == .giftCard {
-                        // Filter out PiggyCards providers when user is in restricted region
-                        #if PIGGYCARDS_ENABLED
-                        let providersQuery: String
-                        if excludePiggyCards {
-                            providersQuery = """
-                                SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                WHERE merchantId = ? AND provider != 'PiggyCards'
-                            """
-                        } else {
-                            providersQuery = """
-                                SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                WHERE merchantId = ?
-                            """
-                        }
-                        #else
-                        let providersQuery = """
-                            SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                            WHERE merchantId = ? AND provider = 'CTX'
-                        """
-                        #endif
-
-                        do {
-                            guard let db = wSelf.connection.db else {
-                                print("Error: Database connection is nil for merchant \(merchant.merchantId)")
-                                continue
-                            }
-
-                            let statement = try db.prepare(providersQuery, merchant.merchantId)
-                            var providers: [ExplorePointOfUse.Merchant.GiftCardProviderInfo] = []
-                            var rowCount = 0
-
-                            for row in statement {
-                                rowCount += 1
-                                // Access columns by index
-                                let providerId = row[0] as? String
-                                let savingsPercentage = row[1] as? Int64
-                                let denominationsType = row[2] as? String
-
-                                if let providerId = providerId,
-                                   let savingsPercentage = savingsPercentage,
-                                   let denominationsType = denominationsType {
-
-                                    providers.append(ExplorePointOfUse.Merchant.GiftCardProviderInfo(
-                                        providerId: providerId,
-                                        savingsPercentage: Int(savingsPercentage),
-                                        denominationsType: denominationsType,
-                                        sourceId: wSelf.extractSourceId(from: row, at: 3)
-                                    ))
-                                }
-                            }
-
-
-                            if !providers.isEmpty {
-                                // Create updated merchant with providers
-                                let updatedMerchant = ExplorePointOfUse.Merchant(
-                                    merchantId: merchant.merchantId,
-                                    paymentMethod: merchant.paymentMethod,
-                                    type: merchant.type,
-                                    deeplink: merchant.deeplink,
-                                    savingsBasisPoints: merchant.savingsBasisPoints,
-                                    denominationsType: merchant.denominationsType,
-                                    denominations: merchant.denominations,
-                                    redeemType: merchant.redeemType,
-                                    giftCardProviders: providers
-                                )
-
-                                // Create updated ExplorePointOfUse
-                                let updatedItem = ExplorePointOfUse(
-                                    id: item.id,
-                                    name: item.name,
-                                    category: .merchant(updatedMerchant),
-                                    active: item.active,
-                                    city: item.city,
-                                    territory: item.territory,
-                                    address1: item.address1,
-                                    address2: item.address2,
-                                    address3: item.address3,
-                                    address4: item.address4,
-                                    latitude: item.latitude,
-                                    longitude: item.longitude,
-                                    website: item.website,
-                                    phone: item.phone,
-                                    logoLocation: item.logoLocation,
-                                    coverImage: item.coverImage,
-                                    source: item.source
-                                )
-
-                                items[index] = updatedItem
-                            }
-                        } catch {
-                            // If we can't fetch providers, just continue with empty providers
-                            print("Error fetching gift card providers for merchant \(merchant.merchantId): \(error)")
-                        }
-                    }
-                }
+                items = wSelf.enrichedWithGiftCardProviders(items)
 
                 completion(.success(PaginationResult(items: items, offset: offset)))
+            } catch {
+                print(error)
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Feeds the map: every physical location inside `bounds`, closest `limit` to `center`
+    /// first — mirroring Android, where the map shows individual locations while the list
+    /// shows one row per merchant.
+    func physicalLocations(in bounds: ExploreMapBounds,
+                           center: CLLocationCoordinate2D,
+                           paymentMethods: [PointOfUseListFilters.SpendingOptions]?,
+                           denominationType: PointOfUseListFilters.DenominationType?,
+                           limit: Int = 100,
+                           completion: @escaping (Swift.Result<[ExplorePointOfUse], Error>) -> Void) {
+        serialQueue.async { [weak self] in
+            guard let wSelf = self else { return }
+
+            let merchantTable = Table("merchant")
+            let queryFilter = wSelf.merchantQueryFilter(query: nil, bounds: bounds,
+                                                        types: [.physical, .onlineAndPhysical],
+                                                        paymentMethods: paymentMethods,
+                                                        denominationType: denominationType,
+                                                        territory: nil)
+
+            let metersPerLatitudeDegree = 111_111.0
+            let metersPerLongitudeDegree = 111_111.0 * cos(center.latitude * .pi / 180)
+            let distanceSq =
+                "((latitude - \(center.latitude)) * \(metersPerLatitudeDegree) * (latitude - \(center.latitude)) * \(metersPerLatitudeDegree) + " +
+                "(longitude - \(center.longitude)) * \(metersPerLongitudeDegree) * (longitude - \(center.longitude)) * \(metersPerLongitudeDegree))"
+
+            let query = merchantTable
+                .select(merchantTable[*])
+                .filter(queryFilter)
+                .order([Expression<Bool>(literal: "\(distanceSq) ASC")])
+                .limit(limit)
+
+            do {
+                var items: [ExplorePointOfUse] = try wSelf.connection.execute(query: query)
+                items = wSelf.enrichedWithGiftCardProviders(items)
+                completion(.success(items))
             } catch {
                 print(error)
                 completion(.failure(error))

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
@@ -91,8 +91,11 @@ class MerchantDAO: PointOfUseDAO {
             // Collapse the location rows to one row per merchant. When the user's location is
             // known, SQLite picks the location closest to the user: in an aggregate query with a
             // single MIN() in the result set, bare columns take their values from the row where
-            // the minimum occurs. The distance is an equirectangular approximation in meters —
-            // accurate enough for ranking and radius filtering at the app's search scales.
+            // the minimum occurs. WARNING: that guarantee requires exactly ONE aggregate function
+            // in the query — adding another (e.g. a COUNT(*) location counter) silently reverts
+            // bare columns to arbitrary rows per merchant. The distance is an equirectangular
+            // approximation in meters — accurate enough for ranking and radius filtering at the
+            // app's search scales.
             var hasDistanceColumn = false
 
             if let anchorLatitude = userLocation?.latitude, let anchorLongitude = userLocation?.longitude {

--- a/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Infrastructure/DAO Impl/MerchantDAO.swift
@@ -194,222 +194,42 @@ class MerchantDAO: PointOfUseDAO {
                 .select(merchantTable[*])
                 .filter(queryFilter)
 
-            // For each merchant, we want to show only the closest location when userLocation is available
+            // Collapse the location rows to one row per merchant. When the user's location is
+            // known, SQLite picks the location closest to the user: in an aggregate query with a
+            // single MIN() in the result set, bare columns take their values from the row where
+            // the minimum occurs. The distance is an equirectangular approximation in meters —
+            // accurate enough for ranking and radius filtering at the app's search scales.
+            var hasDistanceColumn = false
+
             if let anchorLatitude = userLocation?.latitude, let anchorLongitude = userLocation?.longitude {
-                // Use a post-processing approach instead of complex SQL
-                // First get all matching locations, then filter to closest per merchant in Swift
+                let metersPerLatitudeDegree = 111_111.0
+                let metersPerLongitudeDegree = 111_111.0 * cos(anchorLatitude * .pi / 180)
+                let distanceSq =
+                    "((latitude - \(anchorLatitude)) * \(metersPerLatitudeDegree) * (latitude - \(anchorLatitude)) * \(metersPerLatitudeDegree) + " +
+                    "(longitude - \(anchorLongitude)) * \(metersPerLongitudeDegree) * (longitude - \(anchorLongitude)) * \(metersPerLongitudeDegree))"
 
-                // Execute the query to get all matching locations (without grouping)
-                let allLocationsQuery = query.limit(1000) // Increase limit to get more locations
+                query = merchantTable
+                    .select(merchantTable[*], Expression<Double?>(literal: "MIN(\(distanceSq)) AS minDistanceSq"))
+                    .filter(queryFilter)
+                hasDistanceColumn = true
 
-                do {
-                    var allItems: [ExplorePointOfUse] = try wSelf.connection.execute(query: allLocationsQuery)
-
-                    // Fetch gift card providers for each merchant that accepts gift cards
-                    #if PIGGYCARDS_ENABLED
-                    let excludePiggyCards = isPiggyCardsGeoRestricted()
-                    #endif
-                    for (index, item) in allItems.enumerated() {
-                        if let merchant = item.merchant, merchant.paymentMethod == .giftCard {
-                            // Only fetch CTX providers when PiggyCards is disabled or user is in restricted region
-                            #if PIGGYCARDS_ENABLED
-                            let providersQuery: String
-                            if excludePiggyCards {
-                                providersQuery = """
-                                    SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                    WHERE merchantId = '\(merchant.merchantId)' AND provider != 'PiggyCards'
-                                """
-                            } else {
-                                providersQuery = """
-                                    SELECT provider, savingsPercentage, denominationsType, sourceId FROM gift_card_providers
-                                    WHERE merchantId = '\(merchant.merchantId)'
-                                """
-                            }
-                            #else
-                            let providersQuery = """
-                                SELECT provider, savingsPercentage, denominationsType FROM gift_card_providers
-                                WHERE merchantId = '\(merchant.merchantId)' AND provider = 'CTX'
-                            """
-                            #endif
-
-                            do {
-                                guard let db = wSelf.connection.db else {
-                                    continue
-                                }
-                                let rows = try db.prepare(providersQuery)
-                                var providers: [ExplorePointOfUse.Merchant.GiftCardProviderInfo] = []
-                                var rowCount = 0
-
-                                for row in rows {
-                                    rowCount += 1
-                                    if let providerId = row[0] as? String,
-                                       let savingsPercentage = row[1] as? Int64,
-                                       let denominationsType = row[2] as? String {
-
-                                        providers.append(ExplorePointOfUse.Merchant.GiftCardProviderInfo(
-                                            providerId: providerId,
-                                            savingsPercentage: Int(savingsPercentage),
-                                            denominationsType: denominationsType,
-                                            sourceId: wSelf.extractSourceId(from: row, at: 3)
-                                        ))
-                                    }
-                                }
-
-                                if !providers.isEmpty {
-                                    // Create updated merchant with providers
-                                    let updatedMerchant = ExplorePointOfUse.Merchant(
-                                        merchantId: merchant.merchantId,
-                                        paymentMethod: merchant.paymentMethod,
-                                        type: merchant.type,
-                                        deeplink: merchant.deeplink,
-                                        savingsBasisPoints: merchant.savingsBasisPoints,
-                                        denominationsType: merchant.denominationsType,
-                                        denominations: merchant.denominations,
-                                        redeemType: merchant.redeemType,
-                                        giftCardProviders: providers
-                                    )
-
-                                    // Create updated ExplorePointOfUse
-                                    let updatedItem = ExplorePointOfUse(
-                                        id: item.id,
-                                        name: item.name,
-                                        category: .merchant(updatedMerchant),
-                                        active: item.active,
-                                        city: item.city,
-                                        territory: item.territory,
-                                        address1: item.address1,
-                                        address2: item.address2,
-                                        address3: item.address3,
-                                        address4: item.address4,
-                                        latitude: item.latitude,
-                                        longitude: item.longitude,
-                                        website: item.website,
-                                        phone: item.phone,
-                                        logoLocation: item.logoLocation,
-                                        coverImage: item.coverImage,
-                                        source: item.source
-                                    )
-
-                                    allItems[index] = updatedItem
-                                }
-                            } catch {
-                                // Error fetching gift card providers
-                            }
-                        }
-                    }
-
-                    // Apply distance filtering if we have bounds (which indicates radius filtering is intended)
-                    // The bounds are created as a bounding rectangle around a circle, but we want true circular filtering
-                    if let bounds = bounds {
-                        // Calculate the radius from the bounds diagonal divided by √2
-                        // Since bounds are square around a circle, diagonal = 2 * radius
-                        let latDiff = bounds.neCoordinate.latitude - bounds.swCoordinate.latitude
-                        let lonDiff = bounds.neCoordinate.longitude - bounds.swCoordinate.longitude
-                        let boundsRadius = min(latDiff, lonDiff) * 111000 / 2 // Convert degrees to meters, divide by 2
-                        let filterRadius = boundsRadius
-
-                        // Filter items by actual circular distance from user location
-                        let userLocation = CLLocation(latitude: anchorLatitude, longitude: anchorLongitude)
-                        allItems = allItems.filter { item in
-                            guard let lat = item.latitude, let lon = item.longitude else { return false }
-                            let distance = userLocation.distance(from: CLLocation(latitude: lat, longitude: lon))
-                            return distance <= filterRadius
-                        }
-                    }
-
-                    // Group locations by merchant and find closest location for each merchant
-                    let userCoord = CLLocation(latitude: anchorLatitude, longitude: anchorLongitude)
-                    var merchantToClosestLocation: [String: ExplorePointOfUse] = [:]
-
-                    for item in allItems {
-                        guard let merchant = item.merchant else { continue }
-
-                        // Handle online merchants (no coordinates) separately
-                        if item.latitude == nil || item.longitude == nil {
-                            // Online merchants don't have coordinates, just include them once
-                            if merchantToClosestLocation[merchant.merchantId] == nil {
-                                merchantToClosestLocation[merchant.merchantId] = item
-                            }
-                            continue
-                        }
-
-                        let lat = item.latitude!
-                        let lon = item.longitude!
-                        let locationCoord = CLLocation(latitude: lat, longitude: lon)
-                        let distance = userCoord.distance(from: locationCoord)
-
-                        if let existingItem = merchantToClosestLocation[merchant.merchantId],
-                           let existingLat = existingItem.latitude,
-                           let existingLon = existingItem.longitude {
-                            let existingLocationCoord = CLLocation(latitude: existingLat, longitude: existingLon)
-                            let existingDistance = userCoord.distance(from: existingLocationCoord)
-
-                            if distance < existingDistance {
-                                merchantToClosestLocation[merchant.merchantId] = item
-                            }
-                        } else {
-                            merchantToClosestLocation[merchant.merchantId] = item
-                        }
-                    }
-
-
-                    // Convert back to array and apply sorting
-                    var items = Array(merchantToClosestLocation.values)
-
-                    if let sortBy = sortBy {
-                        switch sortBy {
-                        case .name:
-                            items.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                        case .distance:
-                            items.sort { item1, item2 in
-                                let dist1 = item1.latitude.flatMap { lat in item1.longitude.map { lon in userCoord.distance(from: CLLocation(latitude: lat, longitude: lon)) } } ?? Double.greatestFiniteMagnitude
-                                let dist2 = item2.latitude.flatMap { lat in item2.longitude.map { lon in userCoord.distance(from: CLLocation(latitude: lat, longitude: lon)) } } ?? Double.greatestFiniteMagnitude
-                                return dist1 < dist2
-                            }
-                        case .discount:
-                            items.sort { ($0.merchant?.savingsBasisPoints ?? 0) > ($1.merchant?.savingsBasisPoints ?? 0) }
-                        }
-                    } else {
-                        // Default to distance sorting when userLocation is available
-                        items.sort { item1, item2 in
-                            let dist1 = item1.latitude.flatMap { lat in item1.longitude.map { lon in userCoord.distance(from: CLLocation(latitude: lat, longitude: lon)) } } ?? Double.greatestFiniteMagnitude
-                            let dist2 = item2.latitude.flatMap { lat in item2.longitude.map { lon in userCoord.distance(from: CLLocation(latitude: lat, longitude: lon)) } } ?? Double.greatestFiniteMagnitude
-                            return dist1 < dist2
-                        }
-                    }
-
-                    // Apply pagination
-                    let startIndex = offset
-                    let endIndex = min(startIndex + pageLimit, items.count)
-                    let paginatedItems = startIndex < items.count ? Array(items[startIndex..<endIndex]) : []
-
-                    // Create pagination result
-                    let result = PaginationResult(items: paginatedItems, offset: offset)
-
-                    DispatchQueue.main.async {
-                        completion(.success(result))
-                    }
-                    return
-                } catch {
-                    DispatchQueue.main.async {
-                        completion(.failure(error))
-                    }
-                    return
+                if let bounds {
+                    // The WHERE clause only pre-filters with a generous rectangle; enforce the real
+                    // circular radius on each merchant's closest location here. Groups with a NULL
+                    // distance are online merchants without coordinates — keep them, the bounds
+                    // filter above already decided whether online rows belong in the result.
+                    let radius = wSelf.circularFilterRadius(for: bounds)
+                    let having = Expression<Bool>(literal: "(minDistanceSq IS NULL OR minDistanceSq <= \(radius * radius))")
+                    query = query.group([ExplorePointOfUse.merchantId], having: having)
+                } else {
+                    query = query.group([ExplorePointOfUse.merchantId])
                 }
             } else {
                 query = query.group([ExplorePointOfUse.merchantId])
             }
 
-            var distanceSorting = Expression<Bool>(value: true)
-
-            if let userLocation {
-                let anchorLatitude = userLocation.latitude
-                let anchorLongitude = userLocation.longitude
-
-                distanceSorting =
-                    Expression<Bool>(literal: "((latitude-\(anchorLatitude))*(latitude-\(anchorLatitude))) + ((longitude - \(anchorLongitude))*(longitude - \(anchorLongitude))) ASC")
-            }
-
+            // Closest locations first; merchants without coordinates (online) go last.
+            let distanceOrdering = Expression<Bool>(literal: "minDistanceSq IS NULL, minDistanceSq ASC")
             let nameOrdering = name.collate(.nocase).asc
             let discountOrdering = ExplorePointOfUse.savingPercentage.desc
 
@@ -418,17 +238,17 @@ class MerchantDAO: PointOfUseDAO {
                 case .name:
                     query = query.order(nameOrdering)
                 case .distance:
-                    if userLocation != nil {
-                        query = query.order([distanceSorting, nameOrdering])
+                    if hasDistanceColumn {
+                        query = query.order([distanceOrdering, nameOrdering])
                     } else {
                         query = query.order(nameOrdering)
                     }
                 case .discount:
                     query = query.order([discountOrdering, nameOrdering])
                 }
-            } else if userLocation != nil {
-                query = query.order([distanceSorting, nameOrdering])
             } else if bounds == nil && types.count == 3 {
+                // "All" tab default: online merchants first, then mixed, then physical — by name.
+                // The grouping above still represents each merchant by its closest location.
                 let typeOrdering = Expression<Void>(literal: """
                     CASE
                         WHEN type = 'online' THEN 1
@@ -439,6 +259,8 @@ class MerchantDAO: PointOfUseDAO {
                     """)
 
                 query = query.order([typeOrdering, nameOrdering])
+            } else if hasDistanceColumn {
+                query = query.order([distanceOrdering, nameOrdering])
             } else {
                 query = query.order(nameOrdering)
             }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -381,11 +381,37 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
                                     with: .none)
             }
 
-            if wSelf.model.showMap {
-                wSelf.mapView.show(merchants: wSelf.model.items)
-            }
+            wSelf.updateMapMerchants()
 
             wSelf.updateEmptyResultsForFilters()
+        }
+    }
+
+    // The map mirrors Android: it shows every physical location inside the search area
+    // (the closest ones to the search center), while the list keeps one row per merchant.
+    private func updateMapMerchants() {
+        guard model.showMap else { return }
+
+        guard let bounds = model.currentMapBounds, let center = model.userCoordinates else {
+            mapView.show(merchants: model.items)
+            return
+        }
+
+        ExploreDash.shared.merchantPhysicalLocations(in: bounds, center: center,
+                                                     paymentMethods: model.filters?.merchantPaymentTypes,
+                                                     denominationType: model.filters?.denominationType) { [weak self] result in
+            DispatchQueue.main.async {
+                // A pan/zoom may have started another fetch; only apply the response
+                // that matches the bounds currently shown.
+                guard let self, self.model.showMap, self.model.currentMapBounds == bounds else { return }
+
+                switch result {
+                case .success(let locations):
+                    self.mapView.show(merchants: locations)
+                case .failure:
+                    self.mapView.show(merchants: self.model.items)
+                }
+            }
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
@@ -29,17 +29,17 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
         lastBounds = bounds
         lastFilters = filters
 
-        // ALL TAB: Never filter by bounds or location - show ALL merchants regardless of location
-        // Don't pass userPoint to avoid the in-memory grouping path (which filters out online merchants)
-        fetch(by: query, in: nil, userPoint: nil, with: filters, offset: 0) { [weak self] result in
+        // ALL TAB: Never filter by bounds - show ALL merchants regardless of location.
+        // userPoint is still passed so each merchant is represented by its closest location.
+        fetch(by: query, in: nil, userPoint: userPoint, with: filters, offset: 0) { [weak self] result in
             self?.handle(result: result, completion: completion)
         }
     }
 
     override func nextPage(completion: @escaping (Result<[ExplorePointOfUse], Error>) -> Void) {
-        // ALL TAB: Never filter by bounds or location - show ALL merchants
-        // Don't pass userPoint to avoid the in-memory grouping path
-        fetch(by: lastQuery, in: nil, userPoint: nil, with: lastFilters, offset: nextOffset) { [weak self] result in
+        // ALL TAB: Never filter by bounds - show ALL merchants regardless of location.
+        // userPoint is still passed so each merchant is represented by its closest location.
+        fetch(by: lastQuery, in: nil, userPoint: lastUserPoint, with: lastFilters, offset: nextOffset) { [weak self] result in
             self?.handle(result: result, completion: completion)
         }
     }


### PR DESCRIPTION
## Problem

"Where to Spend" showed users bizarre far-away merchant locations instead of nearby ones, even with location permission granted:

- **All tab**: tapping a chain (e.g. Ace Hardware) showed an arbitrary location — for a user in Illinois, the detail card showed Anchorage, Alaska (2,873 mi away). The tab deliberately passed `userPoint: nil`, and the resulting bare `GROUP BY merchantId` let SQLite return an unspecified row per merchant.
- **Nearby tab**: the closest-location-per-merchant pass ran in Swift over `LIMIT 1000` rows fetched **with no ORDER BY**. In dense metros the bounds box holds far more than 1,000 rows, so the sample was arbitrary and geographically biased — around Chicago, nothing closer than ~33 mi appeared, with every pin clustered at the west edge of the 50-mile radius. (Less dense metros fit under the 1,000-row cap, which is why the bug looked intermittent across testers.)
- **Map**: rendered the same one-pin-per-chain list, hiding sibling locations of the same merchant.

## Fix

**Commit 1 — closest location per merchant, in SQL (`MerchantDAO.items`)**

Replaces both broken paths with one aggregate query: `SELECT *, MIN(distanceSq) … GROUP BY merchantId`. SQLite's documented bare-column behavior (with exactly one `MIN()`/`MAX()` aggregate, bare columns come from the row achieving the minimum) makes each merchant's returned row its closest location — no row cap, no in-memory sampling. The circular radius filter moves into `HAVING`, distance ordering reuses the aggregate alias, pagination now operates on merchants rather than an arbitrary location sample, and the All tab passes `userPoint` again while keeping its online-first ordering. This is the same approach the Android app uses for its list (`GROUP BY merchantId` + min-distance `HAVING` in `MerchantDao`).

**Commit 2 — individual locations on the map (Android parity)**

The map now runs its own ungrouped query (`MerchantDAO.physicalLocations`): every physical location inside the search bounds, ordered by distance to the search center, capped at the closest 100 — mirroring Android's `MerchantDao.observe` + `MAX_MARKERS = 100`. The list keeps one row per merchant; tapping a pin opens that specific location. Stale map responses are dropped after pan/zoom. As part of this, the WHERE-clause construction and the gift-card-provider enrichment loop (previously copy-pasted three times) are extracted into shared helpers, and the enrichment SQL now uses bound parameters instead of string interpolation. ATM behavior is unchanged.

## Validation

- The `GROUP BY` + `MIN()` bare-column semantics, alias-in-`HAVING`/`ORDER BY`, NULL-coordinate (online merchant) handling, and radius exclusion were verified against SQLite.swift 0.15.5 (the podfile-pinned version) with an in-memory database harness reproducing the exact query construction.
- Manually verified on a simulator located in Steger, IL (the failing scenario): Nearby now shows single-digit-mile distances, the All-tab detail card shows the closest store, and the map shows individual pins for each chain's locations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map results now display individual physical merchant locations within the visible map area.
  * Merchant locations can be filtered by payment method and denomination type.
  * Locations are ordered by proximity and limited to the requested result count.

* **Bug Fixes**
  * Merchant lists now show the closest location for each merchant based on the user’s position.
  * Map results remain consistent with the currently displayed area, with fallback results when location data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->