### PR TITLE
fix(explore-dash): populate the Where to Spend map when entering on the All tab

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -112,16 +112,11 @@ class ExplorePointOfUseListViewController: UIViewController {
 
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveLinear) {
             self.contentViewTopLayoutConstraint.constant = kDefaultOpenedMapPosition
-            self.mapView.contentInset = .init(top: 0, left: 0, bottom: self.mapView.frame.height - kDefaultOpenedMapPosition,
-                                              right: 0)
+            self.mapView.contentInset = self.mapContentInsets(sheetTop: kDefaultOpenedMapPosition)
             self.view.layoutIfNeeded()
         } completion: { [weak self] _ in
             self?.updateTableViewInsetsForCurrentSheetPosition()
             self?.updateShowMapButtonVisibility()
-            // The pre-reveal setCenter ran with no inset, centering the location in the
-            // full frame — most of which the sheet now covers. Re-center it within the
-            // visible strip.
-            self?.mapView.recenterForCurrentInsets()
         }
     }
 
@@ -130,8 +125,7 @@ class ExplorePointOfUseListViewController: UIViewController {
 
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveLinear) {
             self.contentViewTopLayoutConstraint.constant = kDefaultClosedMapPosition
-            self.mapView.contentInset = .init(top: 0, left: 0, bottom: self.mapView.frame.height - kDefaultClosedMapPosition,
-                                              right: 0)
+            self.mapView.contentInset = self.mapContentInsets(sheetTop: kDefaultClosedMapPosition)
             self.view.layoutIfNeeded()
         } completion: { [weak self] _ in
             self?.updateTableViewInsetsForCurrentSheetPosition()
@@ -144,6 +138,15 @@ class ExplorePointOfUseListViewController: UIViewController {
             .shared.isAuthorized
 
         showMapButton.isHidden = !isVisible
+    }
+
+    private func mapContentInsets(sheetTop: CGFloat) -> UIEdgeInsets {
+        UIEdgeInsets(
+            top: expandedTableTopInset,
+            left: 0,
+            bottom: max(0, mapView.bounds.height - sheetTop),
+            right: 0
+        )
     }
 
     // MARK: life cycle
@@ -359,10 +362,9 @@ extension ExplorePointOfUseListViewController {
         filterCell?.subtitle = subtitleForFilterCell()
 
         if DWLocationManager.shared.isAuthorized && currentSegment.showReversedLocation {
-            let visibleCenter = mapView.visibleCenterCoordinate
             DWLocationManager.shared
-                .reverseGeocodeLocation(CLLocation(latitude: visibleCenter.latitude,
-                                                   longitude: visibleCenter.longitude)) { [weak self] (location, _) in
+                .reverseGeocodeLocation(CLLocation(latitude: mapView.centerCoordinate.latitude,
+                                                   longitude: mapView.centerCoordinate.longitude)) { [weak self] (location, _) in
                     if self?.model.showMap ?? false {
                         self?.filterCell?.title = location
                     }
@@ -658,7 +660,7 @@ extension ExplorePointOfUseListViewController {
             let animationDuration: CGFloat = (abs(velocityY)*0.0002)+0.2;
 
             UIView.animate(withDuration: animationDuration, delay: 0, options: .curveEaseOut) {
-                self.mapView.contentInset = .init(top: 0, left: 0, bottom: self.mapView.frame.height - finalY, right: 0)
+                self.mapView.contentInset = self.mapContentInsets(sheetTop: finalY)
                 self.contentViewTopLayoutConstraint.constant = finalY
                 self.view.layoutIfNeeded()
             } completion: { _ in
@@ -729,9 +731,8 @@ extension ExplorePointOfUseListViewController: ExploreMapViewDelegate {
         // Update the search radius on the map view to match current filter
         mapView.searchRadius = model.currentRadius
 
-        // Update the search center to the center of the visible part of the map
-        // (not the device GPS location, and not the frame center hidden under the sheet)
-        model.searchCenterCoordinate = mapView.visibleCenterCoordinate
+        // Update the search center to the map camera center (not the device GPS location)
+        model.searchCenterCoordinate = mapView.centerCoordinate
 
         // Get bounds based on the current filter radius and new center location
         let newBounds = mapView.mapBounds(with: model.currentRadius)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -543,6 +543,12 @@ extension ExplorePointOfUseListViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateTableViewInsetsForCurrentSheetPosition()
+
+        // The inset depends on mapView.bounds.height, so recompute it whenever layout
+        // changes (rotation, split view) — not only in the sheet animations.
+        if mapView != nil, contentViewTopLayoutConstraint != nil {
+            mapView.contentInset = mapContentInsets(sheetTop: contentViewTopLayoutConstraint.constant)
+        }
     }
 
     internal func updateTableViewInsetsForCurrentSheetPosition() {

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -118,6 +118,10 @@ class ExplorePointOfUseListViewController: UIViewController {
         } completion: { [weak self] _ in
             self?.updateTableViewInsetsForCurrentSheetPosition()
             self?.updateShowMapButtonVisibility()
+            // The pre-reveal setCenter ran with no inset, centering the location in the
+            // full frame — most of which the sheet now covers. Re-center it within the
+            // visible strip.
+            self?.mapView.recenterForCurrentInsets()
         }
     }
 
@@ -355,9 +359,10 @@ extension ExplorePointOfUseListViewController {
         filterCell?.subtitle = subtitleForFilterCell()
 
         if DWLocationManager.shared.isAuthorized && currentSegment.showReversedLocation {
+            let visibleCenter = mapView.visibleCenterCoordinate
             DWLocationManager.shared
-                .reverseGeocodeLocation(CLLocation(latitude: mapView.centerCoordinate.latitude,
-                                                   longitude: mapView.centerCoordinate.longitude)) { [weak self] (location, _) in
+                .reverseGeocodeLocation(CLLocation(latitude: visibleCenter.latitude,
+                                                   longitude: visibleCenter.longitude)) { [weak self] (location, _) in
                     if self?.model.showMap ?? false {
                         self?.filterCell?.title = location
                     }
@@ -719,24 +724,19 @@ extension ExplorePointOfUseListViewController: ExploreMapViewDelegate {
             return
         }
 
-        print("🔍 MAP: Map region changed")
-        print("🔍 MAP: Center = \(mapView.centerCoordinate.latitude), \(mapView.centerCoordinate.longitude)")
-        print("🔍 MAP: Current radius = \(model.currentRadius) meters")
-
         refreshFilterCell()
 
         // Update the search radius on the map view to match current filter
         mapView.searchRadius = model.currentRadius
 
-        // Update the search center to the map center (not the device GPS location)
-        model.searchCenterCoordinate = mapView.centerCoordinate
+        // Update the search center to the center of the visible part of the map
+        // (not the device GPS location, and not the frame center hidden under the sheet)
+        model.searchCenterCoordinate = mapView.visibleCenterCoordinate
 
         // Get bounds based on the current filter radius and new center location
         let newBounds = mapView.mapBounds(with: model.currentRadius)
-        print("🔍 MAP: New bounds NE=(\(newBounds.neCoordinate.latitude), \(newBounds.neCoordinate.longitude)), SW=(\(newBounds.swCoordinate.latitude), \(newBounds.swCoordinate.longitude))")
 
         model.currentMapBounds = newBounds
-        print("🔍 MAP: Calling refreshItems()")
         model.refreshItems()
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -280,15 +280,11 @@ extension ExplorePointOfUseListViewController {
 
 extension ExplorePointOfUseListViewController: DWLocationObserver {
     func locationManagerDidChangeCurrentLocation(_ manager: DWLocationManager, location: CLLocation) {
-        print("🔍 LOCATION: GPS location changed to \(location.coordinate.latitude), \(location.coordinate.longitude)")
-
         // Set the map center first
         mapView.setCenter(location, animated: false)
-        print("🔍 LOCATION: Set map center to GPS location")
 
         // Clear search center to use actual GPS location
         model.searchCenterCoordinate = nil
-        print("🔍 LOCATION: Cleared searchCenterCoordinate - will use GPS")
 
         // Update the model's map bounds to match the new center
         if model.showMap {
@@ -299,12 +295,12 @@ extension ExplorePointOfUseListViewController: DWLocationObserver {
 
             let newBounds = mapView.mapBounds(with: radiusToUse)
             model.currentMapBounds = newBounds
-            print("🔍 LOCATION: Updated map bounds with radius \(radiusToUse)")
-        }
 
-        // If we're on the nearby tab and the model shows map, refresh the search with the new location
-        if currentSegment.tag == MerchantsListSegment.nearby.rawValue && model.showMap {
-            print("🔍 LOCATION: Fetching merchants for new GPS location")
+            // Refresh the search with the new location for every map-showing segment.
+            // This is what seeds the map when GPS gets its first fix after the screen
+            // is already visible (e.g. entering directly on the merchants All tab, or
+            // any ATM tab — the previous nearby-tag check matched only the ATM "Buy"
+            // segment by accident).
             model.fetch(query: nil)
         }
     }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift
@@ -24,6 +24,7 @@ private let kExploreWhereToSpendSectionCount = 5
 private let kHandlerHeight: CGFloat = 24.0
 internal let kDefaultOpenedMapPosition: CGFloat = 260.0
 private let kDefaultClosedMapPosition: CGFloat = -kHandlerHeight
+private let kSignificantLocationChange: CLLocationDistance = 500
 
 // MARK: - ExplorePointOfUseSections
 
@@ -65,6 +66,7 @@ class ExplorePointOfUseListViewController: UIViewController {
     internal var items: [ExplorePointOfUse] { model.items }
 
     internal var radius = 20 // In miles //Move to model
+    private var lastLocationDrivenFetch: CLLocation?
     internal var mapView: ExploreMapView!
     internal var showMapButton: UIButton!
     internal var syncBannerView: ExploreSyncBannerView?
@@ -305,10 +307,15 @@ extension ExplorePointOfUseListViewController: DWLocationObserver {
 
             // Refresh the search with the new location for every map-showing segment.
             // This is what seeds the map when GPS gets its first fix after the screen
-            // is already visible (e.g. entering directly on the merchants All tab, or
-            // any ATM tab — the previous nearby-tag check matched only the ATM "Buy"
-            // segment by accident).
-            model.fetch(query: nil)
+            // is already visible. Later fixes can arrive every ~100 m, which is too
+            // chatty to requery and reload the list for — only refetch once the user
+            // has moved a significant distance.
+            let movedSignificantly = lastLocationDrivenFetch
+                .map { location.distance(from: $0) > kSignificantLocationChange } ?? true
+            if movedSignificantly {
+                lastLocationDrivenFetch = location
+                model.fetch(query: nil)
+            }
         }
     }
 
@@ -418,6 +425,9 @@ extension ExplorePointOfUseListViewController {
 
         mapView = ExploreMapView(frame: .zero)
         mapView.delegate = self
+        // This screen searches around mapView.centerCoordinate, so the rendered map is
+        // shifted to keep the frame center inside the strip exposed by the list sheet.
+        mapView.movesMapWithContentInset = true
         mapView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(mapView)
 
@@ -643,6 +653,10 @@ extension ExplorePointOfUseListViewController {
         contentViewTopLayoutConstraint.constant += translatedPoint.y
 
         sender.setTranslation(.zero, in: view)
+
+        // Keep the map viewport in sync while the finger is still down; otherwise the
+        // area uncovered by the sheet renders empty until the gesture ends.
+        mapView.contentInset = mapContentInsets(sheetTop: contentViewTopLayoutConstraint.constant)
 
         if sender.state == .ended {
             let velocityInView = sender.velocity(in: view)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -331,10 +331,7 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
         // Clear search center coordinate when actually leaving the screen
         // (not when navigating to a child view like merchant detail)
         if isMovingFromParent || isBeingDismissed {
-            print("🔍 VIEW: viewWillDisappear - leaving screen, clearing searchCenterCoordinate")
             model.searchCenterCoordinate = nil
-        } else {
-            print("🔍 VIEW: viewWillDisappear - navigating to child view, preserving searchCenterCoordinate")
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -252,11 +252,11 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
     }
 
     override func configureModel() {
-        model = PointOfUseListModel(segments: [
+        let segments = [
             MerchantsListSegment.online.pointOfUseListSegment,
             MerchantsListSegment.nearby.pointOfUseListSegment,
             MerchantsListSegment.all.pointOfUseListSegment,
-        ])
+        ]
 
         // Determine which segment should be default based on caller override or location permission
         let defaultSegmentIndex: Int
@@ -283,11 +283,14 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
             denominationType: .both // Default to both fixed and flexible
         )
 
-        // Store the default filters BEFORE making the segment current: switching segments
-        // triggers a fetch, and that fetch must already carry the filters — otherwise the
-        // first render shows unfiltered results while the UI claims the defaults are applied.
-        model.setFilters(defaultFilters, for: model.segments[defaultSegmentIndex])
-        model.currentSegment = model.segments[defaultSegmentIndex]
+        // Configure the initial segment and its filters before the model starts its first
+        // fetch. This prevents the Online default from racing an unfiltered constructor
+        // fetch against the filtered request.
+        model = PointOfUseListModel(
+            segments: segments,
+            initialSegment: segments[defaultSegmentIndex],
+            initialFilters: defaultFilters
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -294,42 +294,29 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        print("🔍 VIEW: viewWillAppear called")
-        print("🔍 VIEW: Current GPS location = \(DWLocationManager.shared.currentLocation?.coordinate.latitude ?? 0), \(DWLocationManager.shared.currentLocation?.coordinate.longitude ?? 0)")
-        print("🔍 VIEW: Current searchCenterCoordinate = \(model.searchCenterCoordinate?.latitude ?? 0), \(model.searchCenterCoordinate?.longitude ?? 0)")
-
         // Check if we're coming from within the same screen (e.g., returning from merchant detail)
         // vs. entering the screen fresh (e.g., switching from home screen or another tab)
         let isReturningFromWithinFlow = model.searchCenterCoordinate != nil
 
-        // Only recenter to GPS if entering the screen fresh
+        // Only recenter to GPS if entering the screen fresh.
+        // Applies to every map-showing segment (Nearby and All): without seeding the
+        // bounds here, the All tab's map stays empty until the user pans it.
         if !isReturningFromWithinFlow {
-            print("🔍 VIEW: No search center set, will recenter to GPS")
-            // If we have a GPS location and are on Nearby tab, update map center and fetch
             if let gpsLocation = DWLocationManager.shared.currentLocation,
-               currentSegment.tag == MerchantsListSegment.nearby.rawValue,
                model.showMap {
-                print("🔍 VIEW: Setting map center to GPS location: \(gpsLocation.coordinate.latitude), \(gpsLocation.coordinate.longitude)")
-
                 // Set initialCenterLocation so mapViewDidFinishLoadingMap will use the correct location
                 mapView.initialCenterLocation = gpsLocation
                 mapView.setCenter(gpsLocation, animated: false)
-
-                print("🔍 VIEW: After setCenter, mapView.centerCoordinate = \(mapView.centerCoordinate.latitude), \(mapView.centerCoordinate.longitude)")
 
                 let radiusToUse = model.filters?.currentRadius ?? kDefaultRadius
                 mapView.searchRadius = radiusToUse
 
                 // Use GPS location directly instead of relying on mapView.centerCoordinate
                 let newBounds = ExploreMapBounds(rect: MKCircle(center: gpsLocation.coordinate, radius: radiusToUse).boundingMapRect)
-                print("🔍 VIEW: Created bounds from GPS location - NE=(\(newBounds.neCoordinate.latitude), \(newBounds.neCoordinate.longitude)), SW=(\(newBounds.swCoordinate.latitude), \(newBounds.swCoordinate.longitude))")
                 model.currentMapBounds = newBounds
 
-                print("🔍 VIEW: Refreshing items with GPS location")
                 model.fetch(query: nil)
             }
-        } else {
-            print("🔍 VIEW: Returning from within flow, preserving panned location at (\(model.searchCenterCoordinate!.latitude), \(model.searchCenterCoordinate!.longitude))")
         }
 
         // Ensure filter status is visible on initial load
@@ -393,7 +380,10 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
         guard model.showMap else { return }
 
         guard let bounds = model.currentMapBounds, let center = model.userCoordinates else {
-            mapView.show(merchants: model.items)
+            // No search area yet — only physical items are meaningful on the map. On the
+            // All tab the list also contains online merchants from anywhere, which must
+            // not be plotted.
+            mapView.show(merchants: model.items.filter { $0.isPhysical })
             return
         }
 
@@ -409,7 +399,7 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
                 case .success(let locations):
                     self.mapView.show(merchants: locations)
                 case .failure:
-                    self.mapView.show(merchants: self.model.items)
+                    self.mapView.show(merchants: self.model.items.filter { $0.isPhysical })
                 }
             }
         }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift
@@ -268,10 +268,6 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
             defaultSegmentIndex = MerchantsListSegment.online.rawValue
         }
 
-        // Set the current segment FIRST, then apply defaults based on that segment
-        model.currentSegment = model.segments[defaultSegmentIndex]
-
-        // Now set defaults based on the ACTUAL current segment
         let defaultSortBy: PointOfUseListFilters.SortBy = defaultSegmentIndex == MerchantsListSegment.nearby.rawValue ? .distance : .name
 
         var defaultPaymentTypes: [PointOfUseListFilters.SpendingOptions] = [.dash, .ctx]
@@ -287,8 +283,11 @@ class MerchantListViewController: ExplorePointOfUseListViewController, Navigatio
             denominationType: .both // Default to both fixed and flexible
         )
 
-        // Set filters but don't fetch yet - wait for map bounds to be set
-        model.filters = defaultFilters
+        // Store the default filters BEFORE making the segment current: switching segments
+        // triggers a fetch, and that fetch must already carry the filters — otherwise the
+        // first render shows unfiltered results while the UI claims the defaults are applied.
+        model.setFilters(defaultFilters, for: model.segments[defaultSegmentIndex])
+        model.currentSegment = model.segments[defaultSegmentIndex]
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
@@ -21,9 +21,22 @@ import Foundation
 // MARK: - AllMerchantsDataProvider
 
 class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
+    /// The result set ignores bounds entirely, and userPoint only picks each merchant's
+    /// representative closest location — movement below this threshold can't meaningfully
+    /// change the outcome, so it isn't worth a full-catalog refetch. GPS updates arrive
+    /// every ~100m (DWLocationManager.distanceFilter), and each one refetches every
+    /// map-showing segment.
+    private static let significantMoveDistance: CLLocationDistance = 500
+
     override func items(query: String?, in bounds: ExploreMapBounds?, userPoint: CLLocationCoordinate2D?,
                         with filters: PointOfUseListFilters?,
                         completion: @escaping (Result<[ExplorePointOfUse], Error>) -> Void) {
+        if lastQuery == query && !items.isEmpty && lastFilters == filters &&
+            !Self.movedSignificantly(from: lastUserPoint, to: userPoint) {
+            completion(.success(items))
+            return
+        }
+
         lastQuery = query
         lastUserPoint = userPoint
         lastBounds = bounds
@@ -33,6 +46,18 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
         // userPoint is still passed so each merchant is represented by its closest location.
         fetch(by: query, in: nil, userPoint: userPoint, with: filters, offset: 0) { [weak self] result in
             self?.handle(result: result, completion: completion)
+        }
+    }
+
+    private static func movedSignificantly(from old: CLLocationCoordinate2D?, to new: CLLocationCoordinate2D?) -> Bool {
+        switch (old, new) {
+        case (nil, nil):
+            return false
+        case (nil, .some), (.some, nil):
+            return true
+        case (.some(let old), .some(let new)):
+            return CLLocation(latitude: old.latitude, longitude: old.longitude)
+                .distance(from: CLLocation(latitude: new.latitude, longitude: new.longitude)) > significantMoveDistance
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
@@ -23,21 +23,16 @@ import Foundation
 class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
     /// The result set ignores bounds entirely, and userPoint only picks each merchant's
     /// representative closest location — movement below this threshold can't meaningfully
-    /// change the outcome, so it isn't worth a full-catalog refetch. GPS updates arrive
-    /// every ~100m (DWLocationManager.distanceFilter), and each one refetches every
-    /// map-showing segment.
+    /// change the outcome, so it isn't worth a full-catalog refetch.
     private static let significantMoveDistance: CLLocationDistance = 500
-    private var hasCachedResult = false
-
-    override func clearCache() {
-        super.clearCache()
-        hasCachedResult = false
-    }
 
     override func items(query: String?, in bounds: ExploreMapBounds?, userPoint: CLLocationCoordinate2D?,
                         with filters: PointOfUseListFilters?,
                         completion: @escaping (Result<[ExplorePointOfUse], Error>) -> Void) {
-        if lastQuery == query && hasCachedResult && lastFilters == filters &&
+        // Guarding on !items.isEmpty (like the sibling providers) keeps the cache honest:
+        // callers that invalidate by emptying `items` force a refetch, and an empty
+        // result is never sticky.
+        if lastQuery == query && !items.isEmpty && lastFilters == filters &&
             !Self.movedSignificantly(from: lastUserPoint, to: userPoint) {
             completion(.success(items))
             return
@@ -47,14 +42,10 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
         lastUserPoint = userPoint
         lastBounds = bounds
         lastFilters = filters
-        hasCachedResult = false
 
         // ALL TAB: Never filter by bounds - show ALL merchants regardless of location.
         // userPoint is still passed so each merchant is represented by its closest location.
         fetch(by: query, in: nil, userPoint: userPoint, with: filters, offset: 0) { [weak self] result in
-            if case .success = result {
-                self?.hasCachedResult = true
-            }
             self?.handle(result: result, completion: completion)
         }
     }
@@ -75,7 +66,7 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
         // ALL TAB: Never filter by bounds - show ALL merchants regardless of location.
         // userPoint is still passed so each merchant is represented by its closest location.
         fetch(by: lastQuery, in: nil, userPoint: lastUserPoint, with: lastFilters, offset: nextOffset) { [weak self] result in
-            self?.handle(result: result, completion: completion)
+            self?.handle(result: result, appending: true, completion: completion)
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
@@ -27,11 +27,17 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
     /// every ~100m (DWLocationManager.distanceFilter), and each one refetches every
     /// map-showing segment.
     private static let significantMoveDistance: CLLocationDistance = 500
+    private var hasCachedResult = false
+
+    override func clearCache() {
+        super.clearCache()
+        hasCachedResult = false
+    }
 
     override func items(query: String?, in bounds: ExploreMapBounds?, userPoint: CLLocationCoordinate2D?,
                         with filters: PointOfUseListFilters?,
                         completion: @escaping (Result<[ExplorePointOfUse], Error>) -> Void) {
-        if lastQuery == query && !items.isEmpty && lastFilters == filters &&
+        if lastQuery == query && hasCachedResult && lastFilters == filters &&
             !Self.movedSignificantly(from: lastUserPoint, to: userPoint) {
             completion(.success(items))
             return
@@ -41,10 +47,14 @@ class AllMerchantsDataProvider: NearbyMerchantsDataProvider {
         lastUserPoint = userPoint
         lastBounds = bounds
         lastFilters = filters
+        hasCachedResult = false
 
         // ALL TAB: Never filter by bounds - show ALL merchants regardless of location.
         // userPoint is still passed so each merchant is represented by its closest location.
         fetch(by: query, in: nil, userPoint: userPoint, with: filters, offset: 0) { [weak self] result in
+            if case .success = result {
+                self?.hasCachedResult = true
+            }
             self?.handle(result: result, completion: completion)
         }
     }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/MerchantsDataProvider.swift
@@ -88,43 +88,24 @@ class NearbyMerchantsDataProvider: PointOfUseDataProvider {
                         with filters: PointOfUseListFilters?,
                         completion: @escaping (Swift.Result<[ExplorePointOfUse], Error>) -> Void) {
         guard let bounds, let userLocation = userPoint, DWLocationManager.shared.isAuthorized else {
-            print("🔍 NEARBY: No bounds/location/auth - returning empty")
             items = []
             currentPage = nil
             completion(.success(items))
             return
         }
 
-        print("🔍 NEARBY: Checking cache...")
-        print("🔍 NEARBY: lastBounds == bounds? \(String(describing: lastBounds == bounds))")
-        print("🔍 NEARBY: lastQuery == query? \(lastQuery == query)")
-        print("🔍 NEARBY: !items.isEmpty? \(!items.isEmpty)")
-        print("🔍 NEARBY: lastFilters == filters? \(String(describing: lastFilters == filters))")
 
         if lastBounds == bounds && lastQuery == query && !items.isEmpty && lastFilters == filters {
-            print("🔍 NEARBY: Cache hit - returning \(items.count) cached items")
             completion(.success(items))
             return
         }
 
-        print("🔍 NEARBY: Cache miss - fetching new data")
-        print("🔍 NEARBY: Bounds - NE=(\(bounds.neCoordinate.latitude), \(bounds.neCoordinate.longitude)), SW=(\(bounds.swCoordinate.latitude), \(bounds.swCoordinate.longitude))")
-        print("🔍 NEARBY: User location = \(userLocation.latitude), \(userLocation.longitude)")
         lastQuery = query
         lastUserPoint = userPoint
         lastBounds = bounds
         lastFilters = filters
 
         fetch(by: query, in: bounds, userPoint: userLocation, with: filters, offset: 0) { [weak self] result in
-            switch result {
-            case .success(let page):
-                print("🔍 NEARBY: Fetch succeeded - got \(page.items.count) items")
-                if let firstItem = page.items.first {
-                    print("🔍 NEARBY: First merchant: \(firstItem.name)")
-                }
-            case .failure(let error):
-                print("🔍 NEARBY: Fetch failed - \(error)")
-            }
             self?.handle(result: result, completion: completion)
         }
     }

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
@@ -168,11 +168,9 @@ final class PointOfUseListModel {
         // Use the search center if available (map center when panning)
         // Otherwise fall back to device's GPS location
         if let searchCenter = searchCenterCoordinate {
-            print("🔍 MODEL: Using searchCenterCoordinate = \(searchCenter.latitude), \(searchCenter.longitude)")
             return searchCenter
         }
         let location = DWLocationManager.shared.currentLocation
-        print("🔍 MODEL: Using device GPS location = \(location?.coordinate.latitude ?? 0), \(location?.coordinate.longitude ?? 0)")
         return location?.coordinate
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
@@ -211,13 +211,17 @@ final class PointOfUseListModel {
 
     var territories: [Territory] = []
 
-    init(segments: [PointOfUseListSegment]) {
+    init(segments: [PointOfUseListSegment], initialSegment: PointOfUseListSegment? = nil,
+         initialFilters: PointOfUseListFilters? = nil) {
         self.segments = segments
         for segment in segments {
             dataProviders[segment] = segment.dataProvider
         }
 
-        currentSegment = segments.first!
+        currentSegment = initialSegment ?? segments.first!
+        if let initialFilters {
+            segmentFilters[currentSegment] = initialFilters
+        }
         segmentDidUpdate()
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
@@ -219,9 +219,7 @@ final class PointOfUseListModel {
         }
 
         currentSegment = initialSegment ?? segments.first!
-        if let initialFilters {
-            segmentFilters[currentSegment] = initialFilters
-        }
+        setFilters(initialFilters, for: currentSegment)
         segmentDidUpdate()
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Model/PointOfUseListModel.swift
@@ -136,11 +136,18 @@ final class PointOfUseListModel {
             return segmentFilters[currentSegment]
         }
         set {
-            if let newValue = newValue {
-                segmentFilters[currentSegment] = newValue
-            } else {
-                segmentFilters.removeValue(forKey: currentSegment)
-            }
+            setFilters(newValue, for: currentSegment)
+        }
+    }
+
+    /// Stores filters for a segment without fetching. Lets callers configure a segment's
+    /// filters before making it current, so the fetch triggered by the segment switch
+    /// already runs with them.
+    func setFilters(_ newFilters: PointOfUseListFilters?, for segment: PointOfUseListSegment) {
+        if let newFilters {
+            segmentFilters[segment] = newFilters
+        } else {
+            segmentFilters.removeValue(forKey: segment)
         }
     }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
@@ -153,6 +153,20 @@ class ExploreMapView: UIView {
         }
     }
 
+    /// When enabled, contentInset physically shifts the rendered map so the frame
+    /// center — which drives `centerCoordinate` and `mapBounds(with:)` — coincides with
+    /// the center of the exposed strip. The merchant/ATM list screen needs this because
+    /// it searches around `centerCoordinate`. When disabled (the default), contentInset
+    /// only feeds `layoutMargins`: hosts with their own bottom sheets (POI details,
+    /// all-merchant locations) rely on that behavior, where the map always renders
+    /// edge to edge no matter where their sheet currently sits.
+    var movesMapWithContentInset = false {
+        didSet {
+            clipsToBounds = movesMapWithContentInset
+            updateMapViewport()
+        }
+    }
+
     var userRadius: Double? {
         guard mapView.isUserLocationVisible else { return nil }
         guard let userLocation else { return nil }
@@ -352,8 +366,6 @@ class ExploreMapView: UIView {
     }
 
     private func configureHierarchy() {
-        clipsToBounds = true
-
         mapView = MKMapView(frame: bounds)
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.showsUserLocation = true
@@ -398,27 +410,44 @@ class ExploreMapView: UIView {
     private func updateMapViewport() {
         guard mapView != nil, bounds.width > 0, bounds.height > 0 else { return }
 
+        guard movesMapWithContentInset else {
+            mapView.transform = .identity
+            mapView.layoutMargins = contentInset
+            setMyLocationButtonTop(contentInset.top + 8)
+            return
+        }
+
         let top = min(max(contentInset.top, 0), bounds.height)
         let bottom = min(max(contentInset.bottom, 0), bounds.height - top)
         let left = min(max(contentInset.left, 0), bounds.width)
         let right = min(max(contentInset.right, 0), bounds.width - left)
 
+        // With the sheet covering (nearly) the whole map there is no viewport to center
+        // in — keep the last meaningful one rather than collapse MapKit's layout area to
+        // a sliver, which would pin any setRegion issued meanwhile at maximum zoom.
+        guard bounds.height - top - bottom >= 44 else { return }
+
         mapView.transform = CGAffineTransform(
             translationX: (left - right) / 2,
             y: (top - bottom) / 2
         )
-        myLocationButtonTopConstraint.constant = top + 8
+        setMyLocationButtonTop(top + 8)
 
         // Symmetric margins keep MapKit controls and attribution inside the exposed
         // viewport without making setRegion shift the requested camera center.
-        let verticalMargin = min((top + bottom) / 2, max(0, (bounds.height - 1) / 2))
-        let horizontalMargin = min((left + right) / 2, max(0, (bounds.width - 1) / 2))
         mapView.layoutMargins = UIEdgeInsets(
-            top: verticalMargin,
-            left: horizontalMargin,
-            bottom: verticalMargin,
-            right: horizontalMargin
+            top: (top + bottom) / 2,
+            left: (left + right) / 2,
+            bottom: (top + bottom) / 2,
+            right: (left + right) / 2
         )
+    }
+
+    // updateMapViewport runs from layoutSubviews; dirtying the constraint with an
+    // unchanged value there would schedule layout passes forever.
+    private func setMyLocationButtonTop(_ constant: CGFloat) {
+        guard myLocationButtonTopConstraint.constant != constant else { return }
+        myLocationButtonTopConstraint.constant = constant
     }
 }
 

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
@@ -149,7 +149,7 @@ class ExploreMapView: UIView {
     var centerRadius: Double = 20
     var contentInset: UIEdgeInsets = .zero {
         didSet {
-            mapView.layoutMargins = contentInset
+            updateMapViewport()
         }
     }
 
@@ -164,6 +164,7 @@ class ExploreMapView: UIView {
     }
 
     private var mapView: MKMapView!
+    private var myLocationButtonTopConstraint: NSLayoutConstraint!
 
     var mapBounds: ExploreMapBounds {
         mapBounds(with: searchRadius)
@@ -172,18 +173,8 @@ class ExploreMapView: UIView {
     // Search radius in meters - defaults to 32km
     var searchRadius: Double = kDefaultRadius
 
-    /// The coordinate in the middle of the portion of the map NOT covered by the list
-    /// sheet (`contentInset.bottom`). The frame center is under the sheet whenever the
-    /// sheet is open, so search areas and reverse-geocoded titles anchor here instead.
-    /// Falls back to the frame center before layout or while the map is fully covered.
-    var visibleCenterCoordinate: CLLocationCoordinate2D {
-        let visibleHeight = bounds.height - contentInset.bottom
-        guard bounds.height > 0, visibleHeight > 0 else { return mapView.centerCoordinate }
-        return mapView.convert(CGPoint(x: bounds.midX, y: visibleHeight / 2), toCoordinateFrom: self)
-    }
-
     func mapBounds(with radius: Double) -> ExploreMapBounds {
-        .init(rect: MKCircle(center: visibleCenterCoordinate, radius: radius).boundingMapRect)
+        .init(rect: MKCircle(center: centerCoordinate, radius: radius).boundingMapRect)
     }
 
     private var shownMerchantsAnnotations: [MerchantAnnotation] = []
@@ -191,7 +182,6 @@ class ExploreMapView: UIView {
     private var hasSetInitialCenter = false
     private var isSettingInitialRegion = false
     private var desiredCenter: CLLocationCoordinate2D?
-    private var lastRequestedCenter: CLLocation?
     private var pendingMerchantsToShow: [ExplorePointOfUse]?
     private var regionStabilizationTimer: Timer?
 
@@ -287,22 +277,13 @@ class ExploreMapView: UIView {
 
     public func setCenter(_ location: CLLocation, animated: Bool) {
         isSettingInitialRegion = true
-        lastRequestedCenter = location
+        desiredCenter = location.coordinate
         let miles: Double = centerRadius
         let scalingFactor: Double = abs(cos(2*Double.pi * location.coordinate.latitude/360.0))
 
         let span = MKCoordinateSpan(latitudeDelta: miles/69.0, longitudeDelta: miles/(scalingFactor*69.0))
 
-        // The list sheet covers the bottom `contentInset.bottom` points of the map, so
-        // shift the frame center south until `location` lands in the middle of the
-        // visible strip instead of the middle of the (partially hidden) full frame.
-        var center = location.coordinate
-        if contentInset.bottom > 0, bounds.height > 0 {
-            center.latitude -= span.latitudeDelta * (contentInset.bottom / (2 * bounds.height))
-        }
-
-        desiredCenter = center
-        let region: MKCoordinateRegion = .init(center: center, span: span)
+        let region: MKCoordinateRegion = .init(center: location.coordinate, span: span)
         mapView.setRegion(region, animated: animated)
         hasSetInitialCenter = true
 
@@ -354,14 +335,6 @@ class ExploreMapView: UIView {
         }
     }
 
-    /// Re-applies the last requested center honoring the current `contentInset`.
-    /// `setCenter` can run before the sheet's covering height is known (e.g. from
-    /// viewWillAppear, before layout) — call this once the inset is established.
-    public func recenterForCurrentInsets() {
-        guard let location = lastRequestedCenter else { return }
-        setCenter(location, animated: false)
-    }
-
     public func setContentInsets(_ inset: UIEdgeInsets, animated: Bool) {
         if animated {
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
@@ -379,6 +352,8 @@ class ExploreMapView: UIView {
     }
 
     private func configureHierarchy() {
+        clipsToBounds = true
+
         mapView = MKMapView(frame: bounds)
         mapView.translatesAutoresizingMaskIntoConstraints = false
         mapView.showsUserLocation = true
@@ -397,6 +372,8 @@ class ExploreMapView: UIView {
         myLocationButton.setImage(UIImage(named: "image.explore.dash.wts.map.my-location"), for: .normal)
         myLocationButton.addTarget(self, action: #selector(myLocationButtonAction), for: .touchUpInside)
         addSubview(myLocationButton)
+        myLocationButtonTopConstraint = myLocationButton.topAnchor.constraint(equalTo: topAnchor, constant: 8)
+
         NSLayoutConstraint.activate([
             mapView.topAnchor.constraint(equalTo: topAnchor),
             mapView.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -405,9 +382,43 @@ class ExploreMapView: UIView {
 
             myLocationButton.widthAnchor.constraint(equalToConstant: 40),
             myLocationButton.heightAnchor.constraint(equalToConstant: 40),
-            myLocationButton.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            myLocationButtonTopConstraint,
             myLocationButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        updateMapViewport()
+    }
+
+    /// Keeps the map camera centered in the portion of this view that is actually
+    /// visible between the navigation bar and the list sheet. This mirrors Android's
+    /// bottom-sheet behavior: move the rendered map instead of changing coordinates.
+    private func updateMapViewport() {
+        guard mapView != nil, bounds.width > 0, bounds.height > 0 else { return }
+
+        let top = min(max(contentInset.top, 0), bounds.height)
+        let bottom = min(max(contentInset.bottom, 0), bounds.height - top)
+        let left = min(max(contentInset.left, 0), bounds.width)
+        let right = min(max(contentInset.right, 0), bounds.width - left)
+
+        mapView.transform = CGAffineTransform(
+            translationX: (left - right) / 2,
+            y: (top - bottom) / 2
+        )
+        myLocationButtonTopConstraint.constant = top + 8
+
+        // Symmetric margins keep MapKit controls and attribution inside the exposed
+        // viewport without making setRegion shift the requested camera center.
+        let verticalMargin = min((top + bottom) / 2, max(0, (bounds.height - 1) / 2))
+        let horizontalMargin = min((left + right) / 2, max(0, (bounds.width - 1) / 2))
+        mapView.layoutMargins = UIEdgeInsets(
+            top: verticalMargin,
+            left: horizontalMargin,
+            bottom: verticalMargin,
+            right: horizontalMargin
+        )
     }
 }
 
@@ -486,11 +497,6 @@ extension ExploreMapView: MKMapViewDelegate {
             return
         }
 
-        // A region change outside setCenter's setup lock is user-driven (pan/zoom):
-        // stop treating the last programmatic center as current so a later
-        // recenterForCurrentInsets() can't yank the map away from where the user panned.
-        lastRequestedCenter = nil
-
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(_mapViewDidChangeVisibleRegion), object: nil)
         perform(#selector(_mapViewDidChangeVisibleRegion), with: nil, afterDelay: 1)
     }
@@ -538,5 +544,3 @@ extension ExploreMapView: MKMapViewDelegate {
         }
     }
 }
-
-

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
@@ -172,8 +172,18 @@ class ExploreMapView: UIView {
     // Search radius in meters - defaults to 32km
     var searchRadius: Double = kDefaultRadius
 
+    /// The coordinate in the middle of the portion of the map NOT covered by the list
+    /// sheet (`contentInset.bottom`). The frame center is under the sheet whenever the
+    /// sheet is open, so search areas and reverse-geocoded titles anchor here instead.
+    /// Falls back to the frame center before layout or while the map is fully covered.
+    var visibleCenterCoordinate: CLLocationCoordinate2D {
+        let visibleHeight = bounds.height - contentInset.bottom
+        guard bounds.height > 0, visibleHeight > 0 else { return mapView.centerCoordinate }
+        return mapView.convert(CGPoint(x: bounds.midX, y: visibleHeight / 2), toCoordinateFrom: self)
+    }
+
     func mapBounds(with radius: Double) -> ExploreMapBounds {
-        .init(rect: MKCircle(center: centerCoordinate, radius: radius).boundingMapRect)
+        .init(rect: MKCircle(center: visibleCenterCoordinate, radius: radius).boundingMapRect)
     }
 
     private var shownMerchantsAnnotations: [MerchantAnnotation] = []
@@ -181,6 +191,7 @@ class ExploreMapView: UIView {
     private var hasSetInitialCenter = false
     private var isSettingInitialRegion = false
     private var desiredCenter: CLLocationCoordinate2D?
+    private var lastRequestedCenter: CLLocation?
     private var pendingMerchantsToShow: [ExplorePointOfUse]?
     private var regionStabilizationTimer: Timer?
 
@@ -275,15 +286,23 @@ class ExploreMapView: UIView {
     }
 
     public func setCenter(_ location: CLLocation, animated: Bool) {
-        print("🔍 MAP: setCenter called with \(location.coordinate.latitude), \(location.coordinate.longitude)")
         isSettingInitialRegion = true
-        desiredCenter = location.coordinate
+        lastRequestedCenter = location
         let miles: Double = centerRadius
         let scalingFactor: Double = abs(cos(2*Double.pi * location.coordinate.latitude/360.0))
 
         let span = MKCoordinateSpan(latitudeDelta: miles/69.0, longitudeDelta: miles/(scalingFactor*69.0))
 
-        let region: MKCoordinateRegion = .init(center: location.coordinate, span: span)
+        // The list sheet covers the bottom `contentInset.bottom` points of the map, so
+        // shift the frame center south until `location` lands in the middle of the
+        // visible strip instead of the middle of the (partially hidden) full frame.
+        var center = location.coordinate
+        if contentInset.bottom > 0, bounds.height > 0 {
+            center.latitude -= span.latitudeDelta * (contentInset.bottom / (2 * bounds.height))
+        }
+
+        desiredCenter = center
+        let region: MKCoordinateRegion = .init(center: center, span: span)
         mapView.setRegion(region, animated: animated)
         hasSetInitialCenter = true
 
@@ -333,6 +352,14 @@ class ExploreMapView: UIView {
         if let loc = mapView.userLocation.location {
             setCenter(loc, animated: true)
         }
+    }
+
+    /// Re-applies the last requested center honoring the current `contentInset`.
+    /// `setCenter` can run before the sheet's covering height is known (e.g. from
+    /// viewWillAppear, before layout) — call this once the inset is established.
+    public func recenterForCurrentInsets() {
+        guard let location = lastRequestedCenter else { return }
+        setCenter(location, animated: false)
     }
 
     public func setContentInsets(_ inset: UIEdgeInsets, animated: Bool) {
@@ -458,6 +485,11 @@ extension ExploreMapView: MKMapViewDelegate {
             }
             return
         }
+
+        // A region change outside setCenter's setup lock is user-driven (pan/zoom):
+        // stop treating the last programmatic center as current so a later
+        // recenterForCurrentInsets() can't yank the map away from where the user panned.
+        lastRequestedCenter = nil
 
         NSObject.cancelPreviousPerformRequests(withTarget: self, selector: #selector(_mapViewDidChangeVisibleRegion), object: nil)
         perform(#selector(_mapViewDidChangeVisibleRegion), with: nil, afterDelay: 1)

--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift
@@ -200,23 +200,15 @@ class ExploreMapView: UIView {
     private var regionStabilizationTimer: Timer?
 
     private lazy var showCurrentLocationOnce: Void = {
-        print("🔍 MAP: showCurrentLocationOnce called")
-        print("🔍 MAP: hasSetInitialCenter = \(hasSetInitialCenter)")
-        print("🔍 MAP: initialCenterLocation = \(initialCenterLocation?.coordinate.latitude ?? 0), \(initialCenterLocation?.coordinate.longitude ?? 0)")
-        print("🔍 MAP: mapView.userLocation.location = \(mapView.userLocation.location?.coordinate.latitude ?? 0), \(mapView.userLocation.location?.coordinate.longitude ?? 0)")
-
         // Only auto-center if we haven't already set a center
         guard !hasSetInitialCenter else {
-            print("🔍 MAP: Skipping auto-center - already set")
             return
         }
 
         if let loc = initialCenterLocation {
-            print("🔍 MAP: Using initialCenterLocation")
             self.setCenter(loc, animated: false)
             hasSetInitialCenter = true
         } else if let loc = mapView.userLocation.location {
-            print("🔍 MAP: Using mapView.userLocation.location")
             self.setCenter(loc, animated: false)
             hasSetInitialCenter = true
         }
@@ -235,11 +227,8 @@ class ExploreMapView: UIView {
     public func reloadAnnotations() { }
 
     public func show(merchants: [ExplorePointOfUse]) {
-        print("🔍 ANNOTATIONS: show() called with \(merchants.count) merchants")
-
         // If we're still setting the initial region, defer adding annotations
         if isSettingInitialRegion {
-            print("🔍 ANNOTATIONS: Deferring annotation updates until initial region is set")
             pendingMerchantsToShow = merchants
             return
         }
@@ -248,16 +237,12 @@ class ExploreMapView: UIView {
     }
 
     private func _showAnnotations(merchants: [ExplorePointOfUse]) {
-        print("🔍 ANNOTATIONS: _showAnnotations called with \(merchants.count) merchants")
-
         // Filter to only merchants with valid coordinates
         let merchantsWithCoords = merchants.filter { $0.latitude != nil && $0.longitude != nil }
-        print("🔍 ANNOTATIONS: \(merchantsWithCoords.count) have coordinates")
 
         if shownMerchantsAnnotations.isEmpty {
             let newAnnotations = merchantsWithCoords
                 .map { MerchantAnnotation(merchant: $0, location: .init(latitude: $0.latitude!, longitude: $0.longitude!)) }
-            print("🔍 ANNOTATIONS: Initial load - adding \(newAnnotations.count) annotations")
             shownMerchantsAnnotations = newAnnotations
             mapView.addAnnotations(newAnnotations)
         } else {
@@ -272,7 +257,6 @@ class ExploreMapView: UIView {
                 let toDelete = currentAnnotations.subtracting(newMerchants)
                 let toKeep = currentAnnotations.subtracting(toDelete)
 
-                print("🔍 ANNOTATIONS: Update - keeping \(toKeep.count), adding \(toAdd.count), removing \(toDelete.count)")
 
                 wSelf.shownMerchantsAnnotations = Array(toKeep.union(toAdd))
 
@@ -303,11 +287,8 @@ class ExploreMapView: UIView {
 
         // Allow region change callbacks after a short delay to ensure map settles
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            print("🔍 MAP: Initial region setup complete, now adding pending merchants")
-
             // Add pending merchants while STILL blocking region changes
             if let pending = self.pendingMerchantsToShow {
-                print("🔍 MAP: Adding \(pending.count) pending merchants now that region is set")
                 self.pendingMerchantsToShow = nil
                 // Call internal method to bypass the isSettingInitialRegion check
                 self._showAnnotations(merchants: pending)
@@ -315,13 +296,11 @@ class ExploreMapView: UIView {
                 // After annotations are added, force the region back and start monitoring for stabilization
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                     if let desired = self.desiredCenter {
-                        print("🔍 MAP: Annotations added, forcing region back to \(desired.latitude), \(desired.longitude)")
                         let miles: Double = self.centerRadius
                         let scalingFactor: Double = abs(cos(2*Double.pi * desired.latitude/360.0))
                         let span = MKCoordinateSpan(latitudeDelta: miles/69.0, longitudeDelta: miles/(scalingFactor*69.0))
                         let region = MKCoordinateRegion(center: desired, span: span)
                         self.mapView.setRegion(region, animated: false)
-                        print("🔍 MAP: Region forced back, current center = \(self.mapView.centerCoordinate.latitude), \(self.mapView.centerCoordinate.longitude)")
 
                         // Start monitoring for stabilization - lock will be released when region stabilizes
                         self.regionStabilizationTimer?.invalidate()
@@ -330,13 +309,11 @@ class ExploreMapView: UIView {
                         }
                     } else {
                         // No desired center, just release immediately
-                        print("🔍 MAP: No desired center to maintain, releasing lock")
                         self.isSettingInitialRegion = false
                     }
                 }
             } else {
                 // No pending merchants, just release the lock
-                print("🔍 MAP: No pending merchants, releasing lock")
                 self.isSettingInitialRegion = false
                 self.desiredCenter = nil
             }
@@ -408,7 +385,8 @@ class ExploreMapView: UIView {
     /// visible between the navigation bar and the list sheet. This mirrors Android's
     /// bottom-sheet behavior: move the rendered map instead of changing coordinates.
     private func updateMapViewport() {
-        guard mapView != nil, bounds.width > 0, bounds.height > 0 else { return }
+        guard mapView != nil, myLocationButtonTopConstraint != nil,
+              bounds.width > 0, bounds.height > 0 else { return }
 
         guard movesMapWithContentInset else {
             mapView.transform = .identity
@@ -427,6 +405,10 @@ class ExploreMapView: UIView {
         // a sliver, which would pin any setRegion issued meanwhile at maximum zoom.
         guard bounds.height - top - bottom >= 44 else { return }
 
+        // The map is shifted, not resized, so a strip of height (bottom - top) / 2 along
+        // the bottom edge of this view has no map content. The sheet always hides it:
+        // it overlaps the map by `bottom` points, at least twice the strip's height. The
+        // mirrored overhang past the top edge is hidden by clipsToBounds.
         mapView.transform = CGAffineTransform(
             translationX: (left - right) / 2,
             y: (top - bottom) / 2
@@ -469,7 +451,6 @@ extension ExploreMapView: MKMapViewDelegate {
                                 abs(mapView.centerCoordinate.longitude - desired.longitude)
             // If map has drifted more than 0.01 degrees (~1km), recenter it
             if currentDistance > 0.01 {
-                print("🔍 MAP: Annotations caused drift, recentering to \(desired.latitude), \(desired.longitude)")
                 let miles: Double = centerRadius
                 let scalingFactor: Double = abs(cos(2*Double.pi * desired.latitude/360.0))
                 let span = MKCoordinateSpan(latitudeDelta: miles/69.0, longitudeDelta: miles/(scalingFactor*69.0))
@@ -494,14 +475,11 @@ extension ExploreMapView: MKMapViewDelegate {
     func mapViewDidChangeVisibleRegion(_ mapView: MKMapView) {
         // Don't respond to region changes during initial setup
         guard !isSettingInitialRegion else {
-            print("🔍 MAP: Ignoring region change during initial setup (center=\(mapView.centerCoordinate.latitude), \(mapView.centerCoordinate.longitude))")
-
             // If we have a desired center and the map has drifted significantly, force it back
             if let desired = desiredCenter {
                 let currentDistance = abs(mapView.centerCoordinate.latitude - desired.latitude) +
                                     abs(mapView.centerCoordinate.longitude - desired.longitude)
                 if currentDistance > 0.01 {
-                    print("🔍 MAP: Map drifted during setup, forcing back to \(desired.latitude), \(desired.longitude)")
                     let miles: Double = centerRadius
                     let scalingFactor: Double = abs(cos(2*Double.pi * desired.latitude/360.0))
                     let span = MKCoordinateSpan(latitudeDelta: miles/69.0, longitudeDelta: miles/(scalingFactor*69.0))
@@ -516,7 +494,6 @@ extension ExploreMapView: MKMapViewDelegate {
                 } else {
                     // Region is close enough to desired, start stabilization check
                     if regionStabilizationTimer == nil {
-                        print("🔍 MAP: Region close to desired, starting stabilization check")
                         regionStabilizationTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
                             self?.checkRegionStabilization()
                         }
@@ -537,12 +514,10 @@ extension ExploreMapView: MKMapViewDelegate {
                             abs(mapView.centerCoordinate.longitude - desired.longitude)
 
         if currentDistance < 0.001 {
-            print("🔍 MAP: Region stabilized at desired center, releasing lock")
             isSettingInitialRegion = false
             desiredCenter = nil
             regionStabilizationTimer = nil
         } else {
-            print("🔍 MAP: Region not yet stable (distance=\(currentDistance)), waiting longer")
             // Not stable yet, force it back and wait again
             let miles: Double = centerRadius
             let scalingFactor: Double = abs(cos(2*Double.pi * desired.latitude/360.0))


### PR DESCRIPTION
## Issue being fixed or feature implemented

Opening "Where to Spend" from the home shortcut defaults to the **All** tab so online merchants remain visible, but the map was empty until the user panned it. When populated, the map was also centered against its fullscreen frame instead of the area exposed between the custom navigation bar and list sheet.

## What was done?

- Seed the physical-location map query on every map-showing segment, including **All**, while preserving the unbounded All-tab list containing online merchants.
- Restrict the no-bounds map fallback to physical merchants.
- Avoid redundant full-catalog All-tab fetches on location updates, including successful empty results.
- Configure the initial segment and its default filters atomically before the model starts its first fetch.
- Keep the MapKit camera centered directly on the requested GPS coordinate.
- Translate the rendered map so its geometric center matches the actual visible viewport between the custom navigation bar and list sheet, mirroring Android's `ExploreMapBottomSheetBehavior` instead of applying latitude corrections.
- Keep MapKit attribution and controls inside that viewport and move the "my location" button below the custom navigation bar.
- Keep pan-driven search bounds and reverse geocoding anchored to the unmodified camera center.

## How Has This Been Tested?

- Built the `dashpay` scheme successfully for an iPhone 17 Pro simulator at commit `65148e08093c7858c3ff8983f95ff12685b6b505`.
- Installed and launch-liveness checked as `org.dashfoundation.dash` on iOS Simulator 26.0.1.
- Prepared the existing wallet fixture with identical Dallas GPS coordinates (`32.7767, -96.7970`) for before/after recording. Visual evidence will be attached separately.
- Completed a focused correctness, architecture, and reliability review of the viewport and data-initialization changes.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map content now stays aligned with the visible area while the merchant sheet is expanded or dragged.
  * Explore searches refresh across all map-enabled segments as location changes.
  * Additional merchant results load seamlessly without replacing existing results.
  * Initial segments and filters are applied consistently when opening Explore.

* **Bug Fixes**
  * Reduced unnecessary searches when users have moved less than 500 meters.
  * Improved map behavior when location data or map bounds are unavailable.
  * Physical merchant locations are shown more reliably in fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->