### PR TITLE
fix(wallet): guard preview-only state in Release

### DIFF
--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -259,7 +259,9 @@ class HomeViewModel: ObservableObject {
     /// Routine refresh trigger (screen appear): throttled by the monitor.
     @MainActor
     func refreshEvonodeEpochBlocks() {
+        #if DEBUG
         guard !isPreviewMode else { return }
+        #endif
         evonodeEpochBlocksMonitor.refresh()
     }
 


### PR DESCRIPTION
## Summary
- guard the preview-only `isPreviewMode` access with `#if DEBUG`
- keep Release builds from referencing a DEBUG-only property

## Context
The follow-up TestFlight run 32706880873 imported both signing identities successfully, then failed while compiling `HomeViewModel.swift` in Release because `isPreviewMode` is only declared in DEBUG builds.

## Verification
- `git diff --check`
- full `dashpay` Release build with code signing disabled using Xcode 26.6 and the current `v4.2-dev` Platform XCFramework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-build behavior when refreshing Evonode epoch blocks.
  * Preview-only handling is now limited to development builds, preventing unintended preview state processing in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->