### PR TITLE
ci(dashpay): add internal TestFlight release channel

### DIFF
--- a/.github/scripts/app_store_connect_release.rb
+++ b/.github/scripts/app_store_connect_release.rb
@@ -1,0 +1,428 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "base64"
+require "json"
+require "net/http"
+require "openssl"
+require "time"
+require "uri"
+
+module AppStoreConnectRelease
+  class Error < StandardError; end
+
+  class MarketingVersion
+    include Comparable
+
+    attr_reader :value
+
+    def initialize(value)
+      @value = String(value)
+      unless @value.match?(/\A\d+(?:\.\d+){0,2}\z/)
+        raise Error, "Invalid app version '#{@value}'. Expected one to three dot-separated integers."
+      end
+
+      @components = @value.split(".").map(&:to_i)
+    end
+
+    def <=>(other)
+      padded_components <=> other.padded_components
+    end
+
+    protected
+
+    def padded_components
+      @components + Array.new(3 - @components.length, 0)
+    end
+  end
+
+  class Paginator
+    def self.collect(initial_url, max_pages: 50)
+      records = []
+      next_url = initial_url
+      page_count = 0
+
+      while next_url
+        page_count += 1
+        raise Error, "App Store Connect pagination exceeded #{max_pages} pages." if page_count > max_pages
+
+        page = yield(next_url)
+        records.concat(page.fetch("data"))
+        next_url = page.dig("links", "next")
+      end
+
+      records
+    end
+  end
+
+  LIVE_APP_STORE_STATES = %w[
+    READY_FOR_DISTRIBUTION
+    READY_FOR_SALE
+  ].freeze
+
+  module_function
+
+  def validate_release_channel(channel)
+    return channel if %w[internal external].include?(channel)
+
+    raise Error, "Invalid release channel '#{channel}'. Expected 'internal' or 'external'."
+  end
+
+  def validate_external_group(requested_group, groups)
+    return requested_group if groups.include?(requested_group)
+
+    available = groups.empty? ? "(none)" : groups.sort.join(", ")
+    raise Error, "External TestFlight group '#{requested_group}' does not exist. Available groups: #{available}"
+  end
+
+  def maximum_version(values)
+    values.map { |value| MarketingVersion.new(value) }.max
+  end
+
+  def resolve_effective_version(requested:, testflight_versions:, production_versions:)
+    latest_testflight = maximum_version(testflight_versions)
+    latest_production = maximum_version(production_versions)
+    baseline = [latest_testflight, latest_production].compact.max
+
+    if requested == "auto"
+      unless baseline
+        raise Error, "No TestFlight or live App Store version exists. Provide an explicit app_version input."
+      end
+
+      return {
+        effective: baseline.value,
+        latest_testflight: latest_testflight&.value,
+        latest_production: latest_production&.value,
+        bumped: false
+      }
+    end
+
+    requested_version = MarketingVersion.new(requested)
+    effective = baseline && requested_version <= baseline ? baseline : requested_version
+
+    {
+      effective: effective.value,
+      latest_testflight: latest_testflight&.value,
+      latest_production: latest_production&.value,
+      bumped: baseline ? requested_version < baseline : false
+    }
+  end
+
+  def next_build_number(build_numbers)
+    numbers = build_numbers.map do |value|
+      string = String(value)
+      unless string.match?(/\A\d+\z/)
+        raise Error, "Build number '#{string}' is not a non-negative integer. Refusing to guess the next number."
+      end
+
+      string.to_i
+    end
+
+    (numbers.max || 0) + 1
+  end
+
+  class Client
+    def self.parse_response(status, body)
+      unless status.between?(200, 299)
+        raise Error, "App Store Connect API returned HTTP #{status}: #{body}"
+      end
+
+      JSON.parse(body)
+    rescue JSON::ParserError => e
+      raise Error, "App Store Connect API returned invalid JSON: #{e.message}"
+    end
+
+    def initialize(key_id:, issuer_id:, private_key_path:)
+      @key_id = key_id
+      @issuer_id = issuer_id
+      @private_key_path = private_key_path
+      @token = nil
+      @token_expires_at = 0
+    end
+
+    def find_app(bundle_id)
+      url = api_url("/v1/apps", "filter[bundleId]" => bundle_id, "limit" => 1)
+      app = get_json(url).fetch("data").first
+      raise Error, "No App Store Connect app found for bundle ID #{bundle_id}." unless app
+
+      app
+    end
+
+    def testflight_versions(app_id)
+      pre_release_versions(app_id).filter_map do |version|
+        version.fetch("attributes").fetch("version") if builds_for_pre_release_version(version.fetch("id")).any?
+      end
+    end
+
+    def production_versions(app_id)
+      url = api_url(
+        "/v1/apps/#{app_id}/appStoreVersions",
+        "filter[platform]" => "IOS",
+        "limit" => 200
+      )
+      get_all(url).filter_map do |version|
+        attributes = version.fetch("attributes")
+        attributes.fetch("versionString") if LIVE_APP_STORE_STATES.include?(attributes["appStoreState"])
+      end
+    end
+
+    def external_group_names(app_id)
+      url = api_url("/v1/betaGroups", "filter[app]" => app_id, "limit" => 200)
+      get_all(url).filter_map do |group|
+        attributes = group.fetch("attributes")
+        attributes.fetch("name") unless attributes["isInternalGroup"]
+      end
+    end
+
+    def build_numbers(app_id, version_string)
+      version = pre_release_versions(app_id).find do |candidate|
+        candidate.fetch("attributes").fetch("version") == version_string
+      end
+      return [] unless version
+
+      builds_for_pre_release_version(version.fetch("id")).map do |build|
+        build.fetch("attributes").fetch("version")
+      end
+    end
+
+    def wait_for_build(app_id:, version_string:, build_number:, timeout_seconds:, interval_seconds:)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
+
+      loop do
+        version = pre_release_versions(app_id).find do |candidate|
+          candidate.fetch("attributes").fetch("version") == version_string
+        end
+        if version
+          build = builds_for_pre_release_version(version.fetch("id")).find do |candidate|
+            candidate.fetch("attributes").fetch("version") == build_number
+          end
+          if build
+            state = build.fetch("attributes")["processingState"]
+            return build if state == "VALID"
+            raise Error, "Uploaded build #{version_string} (#{build_number}) failed processing." if state == "FAILED"
+
+            puts "Build #{version_string} (#{build_number}) is #{state || 'not processed yet'}; waiting..."
+          else
+            puts "Waiting for build #{version_string} (#{build_number}) to appear in App Store Connect..."
+          end
+        else
+          puts "Waiting for TestFlight version #{version_string} to appear in App Store Connect..."
+        end
+
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+          raise Error, "Timed out waiting for build #{version_string} (#{build_number}) to become valid."
+        end
+
+        sleep interval_seconds
+      end
+    end
+
+    private
+
+    def pre_release_versions(app_id)
+      url = api_url(
+        "/v1/preReleaseVersions",
+        "filter[app]" => app_id,
+        "filter[platform]" => "IOS",
+        "limit" => 200
+      )
+      get_all(url)
+    end
+
+    def builds_for_pre_release_version(version_id)
+      get_all(api_url("/v1/preReleaseVersions/#{version_id}/builds", "limit" => 200))
+    end
+
+    def get_all(url)
+      Paginator.collect(url) { |page_url| get_json(page_url) }
+    end
+
+    def api_url(path, query = {})
+      uri = URI("https://api.appstoreconnect.apple.com#{path}")
+      uri.query = URI.encode_www_form(query) unless query.empty?
+      uri.to_s
+    end
+
+    def get_json(url)
+      uri = URI(url)
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = "Bearer #{authorization_token}"
+      request["Content-Type"] = "application/json"
+      response = Net::HTTP.start(
+        uri.hostname,
+        uri.port,
+        use_ssl: true,
+        open_timeout: 15,
+        read_timeout: 30
+      ) do |http|
+        http.request(request)
+      end
+      self.class.parse_response(response.code.to_i, response.body)
+    end
+
+    def build_token
+      private_key = OpenSSL::PKey.read(File.binread(@private_key_path))
+      unless private_key.is_a?(OpenSSL::PKey::EC) && private_key.group.curve_name == "prime256v1"
+        raise Error, "App Store Connect API key is not a P-256 EC key."
+      end
+
+      issued_at = Time.now.to_i
+      @token_expires_at = issued_at + 1_200
+      header = { alg: "ES256", kid: @key_id, typ: "JWT" }
+      payload = {
+        iss: @issuer_id,
+        iat: issued_at,
+        exp: @token_expires_at,
+        aud: "appstoreconnect-v1"
+      }
+      signing_input = [header, payload].map { |part| base64url(JSON.generate(part)) }.join(".")
+      der_signature = private_key.sign(OpenSSL::Digest::SHA256.new, signing_input)
+      sequence = OpenSSL::ASN1.decode(der_signature)
+      raw_signature = sequence.value.map do |integer|
+        [integer.value.to_i.to_s(16).rjust(64, "0")].pack("H*")
+      end.join
+      "#{signing_input}.#{base64url(raw_signature)}"
+    end
+
+    def authorization_token
+      if @token.nil? || Time.now.to_i >= @token_expires_at - 60
+        @token = build_token
+      end
+      @token
+    end
+
+    def base64url(value)
+      Base64.urlsafe_encode64(value, padding: false)
+    end
+  end
+
+  class Command
+    def initialize(arguments, env: ENV, output: $stdout)
+      @arguments = arguments
+      @env = env
+      @output = output
+    end
+
+    def run
+      command = @arguments.fetch(0) { raise Error, "Missing command." }
+      client = Client.new(
+        key_id: fetch_env("API_KEY_ID"),
+        issuer_id: fetch_env("API_ISSUER_ID"),
+        private_key_path: fetch_env("APP_STORE_CONNECT_API_KEY_PATH")
+      )
+      app = client.find_app(fetch_env("BUNDLE_ID"))
+      app_id = app.fetch("id")
+
+      case command
+      when "resolve-version"
+        resolve_version(client, app_id)
+      when "resolve-build"
+        resolve_build(client, app_id)
+      when "assert-build-free"
+        assert_build_free(client, app_id)
+      when "wait-build"
+        wait_build(client, app_id)
+      else
+        raise Error, "Unknown command '#{command}'."
+      end
+    end
+
+    private
+
+    def resolve_version(client, app_id)
+      channel = AppStoreConnectRelease.validate_release_channel(fetch_env("RELEASE_CHANNEL"))
+      requested = fetch_env("REQUESTED_VERSION")
+      testflight_versions = client.testflight_versions(app_id)
+      production_versions = client.production_versions(app_id)
+      result = AppStoreConnectRelease.resolve_effective_version(
+        requested: requested,
+        testflight_versions: testflight_versions,
+        production_versions: production_versions
+      )
+
+      if channel == "external"
+        AppStoreConnectRelease.validate_external_group(
+          fetch_env("TESTFLIGHT_GROUP"),
+          client.external_group_names(app_id)
+        )
+      end
+
+      if result.fetch(:bumped)
+        @output.puts "::warning::Requested app version #{requested} is below App Store Connect. Using #{result.fetch(:effective)}."
+      end
+
+      write_outputs(
+        "requested_version" => requested,
+        "latest_testflight_version" => result[:latest_testflight] || "none",
+        "latest_production_version" => result[:latest_production] || "none",
+        "effective_version" => result.fetch(:effective),
+        "release_channel" => channel
+      )
+    end
+
+    def resolve_build(client, app_id)
+      version = fetch_env("EFFECTIVE_VERSION")
+      build_numbers = client.build_numbers(app_id, version)
+      next_number = AppStoreConnectRelease.next_build_number(build_numbers)
+      write_outputs(
+        "previous_build_number" => build_numbers.empty? ? "none" : build_numbers.map(&:to_i).max,
+        "build_number" => next_number
+      )
+    end
+
+    def assert_build_free(client, app_id)
+      version = fetch_env("EFFECTIVE_VERSION")
+      expected = fetch_env("BUILD_NUMBER")
+      build_numbers = client.build_numbers(app_id, version)
+      if build_numbers.include?(expected)
+        next_number = AppStoreConnectRelease.next_build_number(build_numbers)
+        raise Error, "Build #{version} (#{expected}) now exists. Re-run the workflow to use build #{next_number}."
+      end
+
+      @output.puts "Confirmed that TestFlight build #{version} (#{expected}) is available."
+    end
+
+    def wait_build(client, app_id)
+      version = fetch_env("EFFECTIVE_VERSION")
+      build_number = fetch_env("BUILD_NUMBER")
+      build = client.wait_for_build(
+        app_id: app_id,
+        version_string: version,
+        build_number: build_number,
+        timeout_seconds: Integer(@env.fetch("WAIT_TIMEOUT_SECONDS", "1800")),
+        interval_seconds: Integer(@env.fetch("WAIT_INTERVAL_SECONDS", "15"))
+      )
+      write_outputs(
+        "id" => build.fetch("id"),
+        "number" => build_number,
+        "processing_state" => build.fetch("attributes").fetch("processingState")
+      )
+    end
+
+    def fetch_env(name)
+      value = @env[name]
+      raise Error, "Missing environment variable #{name}." if value.nil? || value.empty?
+
+      value
+    end
+
+    def write_outputs(values)
+      values.each { |key, value| @output.puts "#{key}=#{value}" }
+      output_path = @env["GITHUB_OUTPUT"]
+      return if output_path.nil? || output_path.empty?
+
+      File.open(output_path, "a") do |file|
+        values.each { |key, value| file.puts "#{key}=#{value}" }
+      end
+    end
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    AppStoreConnectRelease::Command.new(ARGV).run
+  rescue AppStoreConnectRelease::Error, KeyError, ArgumentError => e
+    warn "::error::#{e.message}"
+    exit 1
+  end
+end

--- a/.github/scripts/app_store_connect_release.rb
+++ b/.github/scripts/app_store_connect_release.rb
@@ -10,6 +10,7 @@ require "uri"
 
 module AppStoreConnectRelease
   class Error < StandardError; end
+  class TransientError < Error; end
 
   class MarketingVersion
     include Comparable
@@ -75,6 +76,11 @@ module AppStoreConnectRelease
     raise Error, "External TestFlight group '#{requested_group}' does not exist. Available groups: #{available}"
   end
 
+  def live_app_store_version?(attributes)
+    LIVE_APP_STORE_STATES.include?(attributes["appVersionState"]) ||
+      LIVE_APP_STORE_STATES.include?(attributes["appStoreState"])
+  end
+
   def maximum_version(values)
     values.map { |value| MarketingVersion.new(value) }.max
   end
@@ -124,7 +130,8 @@ module AppStoreConnectRelease
   class Client
     def self.parse_response(status, body)
       unless status.between?(200, 299)
-        raise Error, "App Store Connect API returned HTTP #{status}: #{body}"
+        error_class = status == 429 || status >= 500 ? TransientError : Error
+        raise error_class, "App Store Connect API returned HTTP #{status}: #{body}"
       end
 
       JSON.parse(body)
@@ -162,7 +169,7 @@ module AppStoreConnectRelease
       )
       get_all(url).filter_map do |version|
         attributes = version.fetch("attributes")
-        attributes.fetch("versionString") if LIVE_APP_STORE_STATES.include?(attributes["appStoreState"])
+        attributes.fetch("versionString") if AppStoreConnectRelease.live_app_store_version?(attributes)
       end
     end
 
@@ -189,24 +196,29 @@ module AppStoreConnectRelease
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout_seconds
 
       loop do
-        version = pre_release_versions(app_id).find do |candidate|
-          candidate.fetch("attributes").fetch("version") == version_string
-        end
-        if version
-          build = builds_for_pre_release_version(version.fetch("id")).find do |candidate|
-            candidate.fetch("attributes").fetch("version") == build_number
+        begin
+          version = pre_release_versions(app_id).find do |candidate|
+            candidate.fetch("attributes").fetch("version") == version_string
           end
-          if build
-            state = build.fetch("attributes")["processingState"]
-            return build if state == "VALID"
-            raise Error, "Uploaded build #{version_string} (#{build_number}) failed processing." if state == "FAILED"
+          if version
+            build = builds_for_pre_release_version(version.fetch("id")).find do |candidate|
+              candidate.fetch("attributes").fetch("version") == build_number
+            end
+            if build
+              state = build.fetch("attributes")["processingState"]
+              return build if state == "VALID"
+              raise Error, "Uploaded build #{version_string} (#{build_number}) failed processing." if state == "FAILED"
 
-            puts "Build #{version_string} (#{build_number}) is #{state || 'not processed yet'}; waiting..."
+              puts "Build #{version_string} (#{build_number}) is #{state || 'not processed yet'}; waiting..."
+            else
+              puts "Waiting for build #{version_string} (#{build_number}) to appear in App Store Connect..."
+            end
           else
-            puts "Waiting for build #{version_string} (#{build_number}) to appear in App Store Connect..."
+            puts "Waiting for TestFlight version #{version_string} to appear in App Store Connect..."
           end
-        else
-          puts "Waiting for TestFlight version #{version_string} to appear in App Store Connect..."
+        rescue TransientError, IOError, SystemCallError, SocketError,
+               Net::OpenTimeout, Net::ReadTimeout, OpenSSL::SSL::SSLError => e
+          puts "Transient App Store Connect error while polling (#{e.class}: #{e.message}); retrying..."
         end
 
         if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline

--- a/.github/scripts/app_store_connect_release_test.rb
+++ b/.github/scripts/app_store_connect_release_test.rb
@@ -94,6 +94,27 @@ class AppStoreConnectReleaseTest < Minitest::Test
     end
   end
 
+  def test_live_app_store_version_accepts_new_state_attribute
+    attributes = { "appVersionState" => "READY_FOR_DISTRIBUTION" }
+
+    assert AppStoreConnectRelease.live_app_store_version?(attributes)
+  end
+
+  def test_live_app_store_version_accepts_deprecated_state_attribute
+    attributes = { "appStoreState" => "READY_FOR_SALE" }
+
+    assert AppStoreConnectRelease.live_app_store_version?(attributes)
+  end
+
+  def test_live_state_in_either_attribute_wins
+    attributes = {
+      "appVersionState" => "IN_REVIEW",
+      "appStoreState" => "READY_FOR_SALE"
+    }
+
+    assert AppStoreConnectRelease.live_app_store_version?(attributes)
+  end
+
   def test_paginator_collects_all_pages
     pages = {
       "first" => { "data" => [1], "links" => { "next" => "second" } },
@@ -119,5 +140,14 @@ class AppStoreConnectReleaseTest < Minitest::Test
     end
 
     assert_match "HTTP 500", error.message
+  end
+
+  def test_rate_limits_and_server_errors_are_transient
+    assert_raises(AppStoreConnectRelease::TransientError) do
+      AppStoreConnectRelease::Client.parse_response(429, '{"errors":[]}')
+    end
+    assert_raises(AppStoreConnectRelease::TransientError) do
+      AppStoreConnectRelease::Client.parse_response(503, '{"errors":[]}')
+    end
   end
 end

--- a/.github/scripts/app_store_connect_release_test.rb
+++ b/.github/scripts/app_store_connect_release_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "app_store_connect_release"
+
+class AppStoreConnectReleaseTest < Minitest::Test
+  def resolve(requested:, testflight: [], production: [])
+    AppStoreConnectRelease.resolve_effective_version(
+      requested: requested,
+      testflight_versions: testflight,
+      production_versions: production
+    )
+  end
+
+  def test_auto_uses_latest_testflight_version
+    result = resolve(requested: "auto", testflight: %w[9.0.1 9.1.0], production: ["9.0.1"])
+
+    assert_equal "9.1.0", result.fetch(:effective)
+    refute result.fetch(:bumped)
+  end
+
+  def test_auto_uses_production_when_it_is_higher
+    result = resolve(requested: "auto", testflight: ["9.1.0"], production: ["9.2.0"])
+
+    assert_equal "9.2.0", result.fetch(:effective)
+  end
+
+  def test_lower_explicit_version_is_bumped
+    result = resolve(requested: "9.0.1", testflight: ["9.1.0"], production: [])
+
+    assert_equal "9.1.0", result.fetch(:effective)
+    assert result.fetch(:bumped)
+  end
+
+  def test_higher_explicit_version_opens_new_train
+    result = resolve(requested: "9.2.0", testflight: ["9.1.0"], production: [])
+
+    assert_equal "9.2.0", result.fetch(:effective)
+    refute result.fetch(:bumped)
+  end
+
+  def test_versions_are_compared_numerically
+    result = resolve(requested: "auto", testflight: %w[9.2 9.10], production: [])
+
+    assert_equal "9.10", result.fetch(:effective)
+  end
+
+  def test_existing_train_spelling_wins_for_equivalent_version
+    result = resolve(requested: "9.1.0", testflight: ["9.1"], production: [])
+
+    assert_equal "9.1", result.fetch(:effective)
+  end
+
+  def test_auto_without_existing_versions_fails
+    error = assert_raises(AppStoreConnectRelease::Error) do
+      resolve(requested: "auto")
+    end
+
+    assert_match "Provide an explicit app_version", error.message
+  end
+
+  def test_invalid_version_fails
+    assert_raises(AppStoreConnectRelease::Error) do
+      resolve(requested: "v9.1", testflight: ["9.0.0"])
+    end
+  end
+
+  def test_next_build_number_starts_at_one
+    assert_equal 1, AppStoreConnectRelease.next_build_number([])
+  end
+
+  def test_next_build_number_uses_highest_existing_number
+    assert_equal 8, AppStoreConnectRelease.next_build_number(%w[1 7 3])
+  end
+
+  def test_non_integer_build_number_fails
+    assert_raises(AppStoreConnectRelease::Error) do
+      AppStoreConnectRelease.next_build_number(["1.2"])
+    end
+  end
+
+  def test_release_channel_validation
+    assert_equal "internal", AppStoreConnectRelease.validate_release_channel("internal")
+    assert_equal "external", AppStoreConnectRelease.validate_release_channel("external")
+    assert_raises(AppStoreConnectRelease::Error) do
+      AppStoreConnectRelease.validate_release_channel("upload-only")
+    end
+  end
+
+  def test_external_group_validation
+    assert_equal "Public Beta", AppStoreConnectRelease.validate_external_group("Public Beta", ["Public Beta"])
+    assert_raises(AppStoreConnectRelease::Error) do
+      AppStoreConnectRelease.validate_external_group("Missing", ["Public Beta"])
+    end
+  end
+
+  def test_paginator_collects_all_pages
+    pages = {
+      "first" => { "data" => [1], "links" => { "next" => "second" } },
+      "second" => { "data" => [2], "links" => { "next" => nil } }
+    }
+
+    records = AppStoreConnectRelease::Paginator.collect("first") { |url| pages.fetch(url) }
+
+    assert_equal [1, 2], records
+  end
+
+  def test_paginator_has_a_page_limit
+    assert_raises(AppStoreConnectRelease::Error) do
+      AppStoreConnectRelease::Paginator.collect("loop", max_pages: 2) do
+        { "data" => [], "links" => { "next" => "loop" } }
+      end
+    end
+  end
+
+  def test_api_errors_are_reported
+    error = assert_raises(AppStoreConnectRelease::Error) do
+      AppStoreConnectRelease::Client.parse_response(500, '{"errors":[]}')
+    end
+
+    assert_match "HTTP 500", error.message
+  end
+end

--- a/.github/workflows/release-dashpay-testflight.yml
+++ b/.github/workflows/release-dashpay-testflight.yml
@@ -1,8 +1,8 @@
 name: Release dashpay to TestFlight
 
 run-name: >-
-  dashpay TestFlight from ${{ inputs.wallet_ref }}
-  → ${{ inputs.testflight_group }} (platform ${{ inputs.platform_ref }})
+  dashpay ${{ inputs.release_channel }} TestFlight from ${{ inputs.wallet_ref }}
+  → ${{ inputs.app_version }} (platform ${{ inputs.platform_ref }})
 
 on:
   workflow_dispatch:
@@ -17,8 +17,21 @@ on:
         required: true
         default: v4.2-dev
         type: string
+      release_channel:
+        description: "TestFlight distribution channel"
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - external
+      app_version:
+        description: "App version, or 'auto' to follow the latest TestFlight/App Store version"
+        required: true
+        default: auto
+        type: string
       testflight_group:
-        description: "Exact external TestFlight group name, or 'Upload only'"
+        description: "Exact external TestFlight group name (ignored for internal releases)"
         required: true
         default: Public Beta v9.0
         type: string
@@ -187,113 +200,18 @@ jobs:
           chmod 600 "$fastlane_api_key_path"
           echo "FASTLANE_API_KEY_PATH=$fastlane_api_key_path" >> "$GITHUB_ENV"
 
-      - name: Validate TestFlight group
-        if: inputs.testflight_group != 'Upload only'
+      - name: Resolve TestFlight release version
+        id: release-version
         env:
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           BUNDLE_ID: ${{ env.DASHPAY_BUNDLE_ID }}
+          RELEASE_CHANNEL: ${{ inputs.release_channel }}
+          REQUESTED_VERSION: ${{ inputs.app_version }}
           TESTFLIGHT_GROUP: ${{ inputs.testflight_group }}
         run: |
           set -euo pipefail
-
-          ruby <<'RUBY'
-          require "base64"
-          require "json"
-          require "net/http"
-          require "openssl"
-          require "uri"
-
-          def base64url(value)
-            Base64.urlsafe_encode64(value, padding: false)
-          end
-
-          def jwt_signature(private_key_path, signing_input)
-            private_key = OpenSSL::PKey.read(File.binread(private_key_path))
-            unless private_key.is_a?(OpenSSL::PKey::EC) && private_key.group.curve_name == "prime256v1"
-              warn "::error::App Store Connect API key is not a P-256 EC key."
-              exit 1
-            end
-            der_signature = private_key.sign(OpenSSL::Digest::SHA256.new, signing_input)
-            sequence = OpenSSL::ASN1.decode(der_signature)
-            sequence.value.map do |integer|
-              [integer.value.to_i.to_s(16).rjust(64, "0")].pack("H*")
-            end.join
-          end
-
-          issued_at = Time.now.to_i
-          header = { alg: "ES256", kid: ENV.fetch("API_KEY_ID"), typ: "JWT" }
-          payload = {
-            iss: ENV.fetch("API_ISSUER_ID"),
-            iat: issued_at,
-            exp: issued_at + 1_200,
-            aud: "appstoreconnect-v1"
-          }
-          signing_input = [header, payload].map { |part| base64url(JSON.generate(part)) }.join(".")
-          token = "#{signing_input}.#{base64url(jwt_signature(ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH"), signing_input))}"
-
-          def get_json(url, token)
-            uri = URI(url)
-            request = Net::HTTP::Get.new(uri)
-            request["Authorization"] = "Bearer #{token}"
-            request["Content-Type"] = "application/json"
-            response = Net::HTTP.start(
-              uri.hostname,
-              uri.port,
-              use_ssl: true,
-              open_timeout: 15,
-              read_timeout: 30
-            ) do |http|
-              http.request(request)
-            end
-            unless response.is_a?(Net::HTTPSuccess)
-              warn "::error::App Store Connect API returned HTTP #{response.code}: #{response.body}"
-              exit 1
-            end
-            JSON.parse(response.body)
-          end
-
-          bundle_id = ENV.fetch("BUNDLE_ID")
-          apps_url = URI("https://api.appstoreconnect.apple.com/v1/apps")
-          apps_url.query = URI.encode_www_form("filter[bundleId]" => bundle_id, "limit" => 1)
-          app = get_json(apps_url.to_s, token).fetch("data").first
-          unless app
-            warn "::error::No App Store Connect app found for bundle ID #{bundle_id}."
-            exit 1
-          end
-
-          groups_url = URI("https://api.appstoreconnect.apple.com/v1/betaGroups")
-          groups_url.query = URI.encode_www_form("filter[app]" => app.fetch("id"), "limit" => 200)
-          groups = []
-          next_url = groups_url.to_s
-          page_count = 0
-          max_pages = 20
-          while next_url
-            page_count += 1
-            if page_count > max_pages
-              warn "::error::App Store Connect beta group pagination exceeded #{max_pages} pages."
-              exit 1
-            end
-            page = get_json(next_url, token)
-            groups.concat(page.fetch("data"))
-            next_url = page.dig("links", "next")
-          end
-
-          external_group_names = groups.map do |group|
-            attributes = group.fetch("attributes")
-            attributes.fetch("name") unless attributes["isInternalGroup"]
-          end.compact.sort
-          requested_group = ENV.fetch("TESTFLIGHT_GROUP")
-
-          unless external_group_names.include?(requested_group)
-            warn "::error::External TestFlight group '#{requested_group}' does not exist."
-            warn "Available external TestFlight groups:"
-            external_group_names.each { |name| warn "  - #{name}" }
-            exit 1
-          end
-
-          puts "Validated external TestFlight group: #{requested_group}"
-          RUBY
+          ruby .github/scripts/app_store_connect_release.rb resolve-version
 
       - name: Select Xcode 26.6
         uses: maxim-lobanov/setup-xcode@v1
@@ -429,6 +347,17 @@ jobs:
             DashWallet/Uphold-Info.plist \
             DashWallet/SwapKit-Info.plist
 
+      - name: Resolve next TestFlight build number
+        id: release-build
+        env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          BUNDLE_ID: ${{ env.DASHPAY_BUNDLE_ID }}
+          EFFECTIVE_VERSION: ${{ steps.release-version.outputs.effective_version }}
+        run: |
+          set -euo pipefail
+          ruby .github/scripts/app_store_connect_release.rb resolve-build
+
       - name: Install Apple signing certificates
         env:
           CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
@@ -505,6 +434,8 @@ jobs:
         env:
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          EFFECTIVE_VERSION: ${{ steps.release-version.outputs.effective_version }}
+          BUILD_NUMBER: ${{ steps.release-build.outputs.build_number }}
         run: |
           set -euo pipefail
 
@@ -522,12 +453,16 @@ jobs:
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID" \
             DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
-            CODE_SIGN_STYLE=Automatic
+            CODE_SIGN_STYLE=Automatic \
+            MARKETING_VERSION="$EFFECTIVE_VERSION" \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
 
       - name: Read archived app version
         id: app-version
         env:
           EXPECTED_BUNDLE_ID: ${{ env.DASHPAY_BUNDLE_ID }}
+          EXPECTED_VERSION: ${{ steps.release-version.outputs.effective_version }}
+          EXPECTED_BUILD: ${{ steps.release-build.outputs.build_number }}
         run: |
           set -euo pipefail
 
@@ -538,15 +473,25 @@ jobs:
           fi
 
           version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app_path/Info.plist")
+          build=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app_path/Info.plist")
           bundle_id=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")
 
           if [[ "$bundle_id" != "$EXPECTED_BUNDLE_ID" ]]; then
             echo "::error::Archived bundle ID '$bundle_id' does not match expected '$EXPECTED_BUNDLE_ID'."
             exit 1
           fi
+          if [[ "$version" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::Archived version '$version' does not match planned version '$EXPECTED_VERSION'."
+            exit 1
+          fi
+          if [[ "$build" != "$EXPECTED_BUILD" ]]; then
+            echo "::error::Archived build '$build' does not match planned build '$EXPECTED_BUILD'."
+            exit 1
+          fi
 
           {
             echo "version=$version"
+            echo "build=$build"
             echo "bundle_id=$bundle_id"
           } >> "$GITHUB_OUTPUT"
 
@@ -576,40 +521,18 @@ jobs:
           GEM_PATH="$fastlane_gem_home" \
             "$fastlane_gem_home/bin/fastlane" "_${FASTLANE_VERSION}_" --version
 
-      - name: Snapshot existing TestFlight builds
-        id: existing-builds
+      - name: Verify TestFlight build number is still available
         env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           BUNDLE_ID: ${{ steps.app-version.outputs.bundle_id }}
-          VERSION: ${{ steps.app-version.outputs.version }}
+          EFFECTIVE_VERSION: ${{ steps.app-version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.app-version.outputs.build }}
         run: |
           set -euo pipefail
-          cd "$RUNNER_TEMP"
-
-          "$FASTLANE_RUBY" <<'RUBY'
-          require "spaceship"
-
-          Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from_json_file(
-            ENV.fetch("FASTLANE_API_KEY_PATH")
-          )
-          app = Spaceship::ConnectAPI::App.find(ENV.fetch("BUNDLE_ID"))
-          unless app
-            warn "::error::App Store Connect app not found for #{ENV.fetch('BUNDLE_ID')}."
-            exit 1
-          end
-
-          builds = Spaceship::ConnectAPI::Build.all(
-            app_id: app.id,
-            version: ENV.fetch("VERSION"),
-            platform: "IOS",
-            limit: 30
-          )
-          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
-            output.puts "ids=#{builds.map(&:id).join(',')}"
-          end
-          RUBY
+          ruby .github/scripts/app_store_connect_release.rb assert-build-free
 
       - name: Upload archive to TestFlight
-        id: upload
         env:
           API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -621,10 +544,8 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Add :method string app-store-connect' "$export_options"
           /usr/libexec/PlistBuddy -c 'Add :signingStyle string automatic' "$export_options"
           /usr/libexec/PlistBuddy -c "Add :teamID string $APPLE_TEAM_ID" "$export_options"
-          /usr/libexec/PlistBuddy -c 'Add :manageAppVersionAndBuildNumber bool true' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :manageAppVersionAndBuildNumber bool false' "$export_options"
           /usr/libexec/PlistBuddy -c 'Add :uploadSymbols bool true' "$export_options"
-
-          echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
@@ -635,74 +556,44 @@ jobs:
             -authenticationKeyID "$API_KEY_ID" \
             -authenticationKeyIssuerID "$API_ISSUER_ID"
 
-      - name: Resolve App Store Connect build number
+      - name: Wait for uploaded TestFlight build
         id: uploaded-build
         env:
+          API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           BUNDLE_ID: ${{ steps.app-version.outputs.bundle_id }}
-          VERSION: ${{ steps.app-version.outputs.version }}
-          EXISTING_BUILD_IDS: ${{ steps.existing-builds.outputs.ids }}
-          UPLOAD_STARTED_AT: ${{ steps.upload.outputs.started_at }}
+          EFFECTIVE_VERSION: ${{ steps.app-version.outputs.version }}
+          BUILD_NUMBER: ${{ steps.app-version.outputs.build }}
         run: |
           set -euo pipefail
-          cd "$RUNNER_TEMP"
+          ruby .github/scripts/app_store_connect_release.rb wait-build
 
-          "$FASTLANE_RUBY" <<'RUBY'
-          require "spaceship"
-          require "set"
-          require "time"
+      - name: Finalize internal TestFlight build
+        if: inputs.release_channel == 'internal'
+        env:
+          WHAT_TO_TEST: ${{ inputs.what_to_test }}
+          VERSION: ${{ steps.app-version.outputs.version }}
+          BUILD: ${{ steps.uploaded-build.outputs.number }}
+          BUNDLE_ID: ${{ steps.app-version.outputs.bundle_id }}
+        run: |
+          set -euo pipefail
 
-          Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from_json_file(
-            ENV.fetch("FASTLANE_API_KEY_PATH")
-          )
-
-          app = Spaceship::ConnectAPI::App.find(ENV.fetch("BUNDLE_ID"))
-          unless app
-            warn "::error::App Store Connect app not found for #{ENV.fetch('BUNDLE_ID')}."
-            exit 1
-          end
-
-          upload_started_at = Time.iso8601(ENV.fetch("UPLOAD_STARTED_AT"))
-          existing_build_ids = ENV.fetch("EXISTING_BUILD_IDS").split(",").to_set
-          deadline = Time.now + 1_800
-          uploaded_build = nil
-
-          loop do
-            builds = Spaceship::ConnectAPI::Build.all(
-              app_id: app.id,
-              version: ENV.fetch("VERSION"),
-              platform: "IOS",
-              limit: 30
-            )
-            new_builds = builds
-              .reject { |build| existing_build_ids.include?(build.id) }
-              .select { |build| Time.parse(build.uploaded_date.to_s) >= upload_started_at }
-            if new_builds.size > 1
-              candidates = new_builds.map { |build| "#{build.version} (#{build.id})" }.join(", ")
-              warn "::error::Multiple builds appeared after this upload: #{candidates}. Refusing to distribute an ambiguous build."
-              exit 1
-            end
-
-            uploaded_build = new_builds.first
-            break if uploaded_build
-
-            if Time.now >= deadline
-              warn "::error::Timed out waiting for the uploaded build to appear in App Store Connect."
-              exit 1
-            end
-
-            puts "Waiting for App Store Connect to expose the uploaded build number..."
-            sleep 15
-          end
-
-          puts "Apple assigned build number #{uploaded_build.version}."
-          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
-            output.puts "number=#{uploaded_build.version}"
-            output.puts "id=#{uploaded_build.id}"
-          end
-          RUBY
+          "$FASTLANE_BIN" "_${FASTLANE_VERSION}_" run upload_to_testflight \
+            api_key_path:"$FASTLANE_API_KEY_PATH" \
+            app_identifier:"$BUNDLE_ID" \
+            app_platform:ios \
+            app_version:"$VERSION" \
+            build_number:"$BUILD" \
+            distribute_only:true \
+            distribute_external:false \
+            notify_external_testers:false \
+            submit_beta_review:false \
+            changelog:"$WHAT_TO_TEST" \
+            wait_processing_interval:30 \
+            wait_processing_timeout_duration:7200
 
       - name: Distribute build to external TestFlight group
-        if: inputs.testflight_group != 'Upload only'
+        if: inputs.release_channel == 'external'
         env:
           TESTFLIGHT_GROUP: ${{ inputs.testflight_group }}
           WHAT_TO_TEST: ${{ inputs.what_to_test }}
@@ -733,26 +624,36 @@ jobs:
           PLATFORM_SHA: ${{ steps.release-info.outputs.platform_sha }}
           REQUESTED_WALLET_REF: ${{ inputs.wallet_ref }}
           REQUESTED_PLATFORM_REF: ${{ inputs.platform_ref }}
+          REQUESTED_VERSION: ${{ steps.release-version.outputs.requested_version }}
+          LATEST_TESTFLIGHT_VERSION: ${{ steps.release-version.outputs.latest_testflight_version }}
+          LATEST_PRODUCTION_VERSION: ${{ steps.release-version.outputs.latest_production_version }}
           VERSION: ${{ steps.app-version.outputs.version }}
           BUILD: ${{ steps.uploaded-build.outputs.number }}
           BUNDLE_ID: ${{ steps.app-version.outputs.bundle_id }}
+          RELEASE_CHANNEL: ${{ inputs.release_channel }}
           TESTFLIGHT_GROUP: ${{ inputs.testflight_group }}
         run: |
           {
             echo '## dashpay uploaded to TestFlight'
             echo
             echo "- App: ${VERSION} (${BUILD})"
+            echo "- Requested version: \`${REQUESTED_VERSION}\`"
+            echo "- Latest TestFlight version: \`${LATEST_TESTFLIGHT_VERSION}\`"
+            echo "- Latest production version: \`${LATEST_PRODUCTION_VERSION}\`"
             echo "- Bundle ID: \`${BUNDLE_ID}\`"
             echo "- dashwallet-ios: \`${WALLET_SHA}\` (requested: \`${REQUESTED_WALLET_REF}\`)"
             echo "- platform: \`${PLATFORM_SHA}\` (requested: \`${REQUESTED_PLATFORM_REF}\`)"
-            if [[ "$TESTFLIGHT_GROUP" == 'Upload only' ]]; then
-              echo '- Distribution: upload only'
+            echo "- Channel: \`${RELEASE_CHANNEL}\`"
+            if [[ "$RELEASE_CHANNEL" == 'internal' ]]; then
+              echo '- Internal group: `App Store Connect Users`'
+              echo '- External distribution: disabled'
+              echo '- Beta App Review: not submitted'
             else
               echo "- External group: \`${TESTFLIGHT_GROUP}\`"
               echo '- External tester notifications: enabled'
             fi
             echo
-            echo 'App Store Connect may need additional time to process the uploaded build.'
+            echo 'The uploaded build is processed and ready for TestFlight.'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove temporary signing material


### PR DESCRIPTION
## Summary
- add explicit internal/external TestFlight release channels, defaulting to internal
- resolve the effective app version from TestFlight and the live App Store version
- assign and verify deterministic build numbers before upload
- make internal builds available to App Store Connect Users without external review or notifications

## Verification
- `ruby -c .github/scripts/app_store_connect_release.rb`
- `ruby -w .github/scripts/app_store_connect_release_test.rb` (16 tests, 26 assertions)
- YAML parse validation
- `git diff --check`

After merge, an internal release with `app_version=auto` will verify the App Store Connect integration end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal and external TestFlight release channel options.
  * Added automatic app version selection and build number generation, with support for specifying an explicit version.
  * External releases can target an exact TestFlight group; internal releases skip external distribution.
  * Release summaries now include version details and channel-specific distribution information.

* **Bug Fixes**
  * Improved validation of app versions, build numbers, archived bundles, and TestFlight build availability.
  * Added clearer reporting for release, API, processing, and timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->