### PR TITLE
fix: disable Firebase diagnostics data collection

### DIFF
--- a/DashPay/dashpay-info.plist
+++ b/DashPay/dashpay-info.plist
@@ -110,6 +110,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FirebaseDataCollectionDefaultEnabled</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/DashWallet/Info.plist
+++ b/DashWallet/Info.plist
@@ -83,6 +83,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FirebaseDataCollectionDefaultEnabled</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
## What

Adds `FirebaseDataCollectionDefaultEnabled = false` to both app targets' Info.plists.

## Why

This came out of a community question in the Russian Telegram group asking whether analytics/tracking are enabled in the new iOS build. The good news is there is **no analytics SDK** in the iOS app — no FirebaseAnalytics, no GoogleAppMeasurement, Crashlytics, Mixpanel, Amplitude, Sentry or AppsFlyer are linked, there are zero `logEvent`/`trackEvent` call sites, and there is no IDFA/ATT surface at all.

But `FirebaseCoreDiagnostics` **is** linked into both targets (it is a transitive dependency of `FirebaseCore`), and it starts from the unconditional `[FIRApp configure]` at `DashWallet/AppDelegate.m:113`. Up to once per day it sends Google a proto over GoogleDataTransport containing:

- bundle identifier
- device model
- iOS version
- Firebase SDK versions
- which Firebase services are installed

`FIRCoreDiagnostics.sendDiagnosticsData` returns early when `FirebaseDataCollectionDefaultEnabled` is false:

```objc
NSNumber *isDataCollectionDefaultEnabled =
    diagnosticObjects[kFIRCDIsDataCollectionDefaultEnabledKey];
if (isDataCollectionDefaultEnabled && ![isDataCollectionDefaultEnabled boolValue]) {
  return;
}
```

That key was absent from both `DashWallet/Info.plist` and `DashPay/dashpay-info.plist`, so it defaulted to enabled. This PR sets it explicitly.

## Scope

The flag gates Firebase's diagnostics/telemetry collection only. Firebase Storage operations — the Explore Dash merchant database download from `gs://dash-wallet-firebase.appspot.com` — are unaffected, as is everything else in the app.

## Verification

- `plutil -lint` passes on both plists.
- `plutil -extract FirebaseDataCollectionDefaultEnabled raw` returns `false` for both.

Info.plist-only change; no source or build-setting changes.

## Related

Two companion PRs address the other two outbound channels found in the same audit: the unused Firebase Dynamic Links SDK (which fingerprints the device on first launch) and a per-foreground IP geolocation lookup to ip-api.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy**
  * Firebase data collection is now disabled by default in the apps.
  * Data collection occurs only after it is explicitly enabled.
  * Updated Firebase configuration improves privacy defaults and removes legacy deep-link configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->