### PR TITLE
fix(explore-dash): stop per-foreground IP geolocation lookup

### DIFF
--- a/DashWallet/AppDelegate.m
+++ b/DashWallet/AppDelegate.m
@@ -197,8 +197,8 @@ NS_ASSUME_NONNULL_BEGIN
     //
     [self.balanceNotifier updateBalance];
 
-    // Check geo-restriction for PiggyCards (if available)
-    // This logs location info each time the app becomes active for debugging
+    // Check geo-restriction for PiggyCards (if available). No-ops once the
+    // country has been resolved for this launch.
     SEL checkGeoRestrictionSelector = NSSelectorFromString(@"checkGeoRestriction");
     if ([ExploreDashObjcWrapper respondsToSelector:checkGeoRestrictionSelector]) {
 #pragma clang diagnostic push

--- a/DashWallet/Sources/Models/Explore Dash/ExploreDash.swift
+++ b/DashWallet/Sources/Models/Explore Dash/ExploreDash.swift
@@ -83,7 +83,9 @@ public class ExploreDashObjcWrapper: NSObject {
     }
 
     #if PIGGYCARDS_ENABLED
-    /// Check geo-restriction status. Call this when the app becomes active to log location info.
+    /// Resolve the user's country if it has not been resolved yet this launch.
+    /// Cheap to call repeatedly: `checkRestriction()` returns immediately once a
+    /// country has been determined.
     @objc public class func checkGeoRestriction() {
         Task { @MainActor in
             await GeoRestrictionService.shared.checkRestriction()

--- a/DashWallet/Sources/Models/Explore Dash/Services/GeoRestrictionService.swift
+++ b/DashWallet/Sources/Models/Explore Dash/Services/GeoRestrictionService.swift
@@ -41,8 +41,11 @@ func isPiggyCardsGeoRestricted() -> Bool {
 class GeoRestrictionService {
     static let shared = GeoRestrictionService()
 
-    /// Country codes that are restricted from using PiggyCards
-    private let restrictedCountryCodes: Set<String> = ["RU", "CU"]
+    /// Country codes that are restricted from using PiggyCards, listed in both
+    /// ISO 3166-1 alpha-2 and alpha-3 form because the sources disagree:
+    /// CoreLocation's `isoCountryCode` and `Locale.Region` are alpha-2, while
+    /// StoreKit's `Storefront.countryCode` is alpha-3.
+    private let restrictedCountryCodes: Set<String> = ["RU", "RUS", "CU", "CUB"]
 
     /// UserDefaults keys for thread-safe access
     private enum Keys {
@@ -75,8 +78,8 @@ class GeoRestrictionService {
 
     enum DetectionSource: String {
         case gpsLocation = "GPS Location"
-        case ipGeolocation = "IP Geolocation"
         case appStore = "App Store"
+        case deviceRegion = "Device Region"
         case unknown = "Unknown"
     }
 
@@ -90,11 +93,6 @@ class GeoRestrictionService {
         if let sourceString = UserDefaults.standard.string(forKey: Keys.detectionSource) {
             detectionSource = DetectionSource(rawValue: sourceString)
         }
-
-        DWLogger.log("🌍 GeoRestrictionService: Initialized")
-        DWLogger.log("🌍 GeoRestrictionService: Persisted restriction status: \(isPiggyCardsRestricted)")
-        DWLogger.log("🌍 GeoRestrictionService: Persisted country code: \(detectedCountryCode ?? "nil")")
-        DWLogger.log("🌍 GeoRestrictionService: Persisted detection source: \(detectionSource?.rawValue ?? "nil")")
 
         // Listen for location changes to update restriction status
         setupLocationObserver()
@@ -111,90 +109,49 @@ class GeoRestrictionService {
             .store(in: &cancellables)
     }
 
-    /// Check if PiggyCards is restricted for the current user
-    /// This should be called when the app needs to determine PiggyCards availability
+    /// Resolve the user's country and cache the resulting restriction status.
+    ///
+    /// Every source consulted here is local to the device — none of them
+    /// contacts a remote service, so opening the app does not disclose the
+    /// user's IP address to a third party.
+    ///
+    /// Runs at most once per launch: the first call that resolves a country
+    /// sets `hasCheckedRestriction`. Later GPS fixes still refresh the status
+    /// through `setupLocationObserver`, and `refreshRestriction()` forces a
+    /// re-check.
     func checkRestriction() async {
-        DWLogger.log("🌍 GeoRestrictionService: ========== LOCATION CHECK START ==========")
+        guard !hasCheckedRestriction else { return }
 
-        // Gather all location attributes for logging
-        let gpsAuthorized = DWLocationManager.shared.isAuthorized
-        let gpsCountry = DWLocationManager.shared.currentPlacemark?.isoCountryCode
-        let ipCountry = await fetchCountryFromIP()
-        let appStoreCountry = await fetchAppStoreCountry()
-
-        DWLogger.log("🌍 GeoRestrictionService: 1. GPS Location:")
-        DWLogger.log("🌍    - Permission granted: \(gpsAuthorized)")
-        DWLogger.log("🌍    - Country code: \(gpsCountry ?? "nil")")
-
-        DWLogger.log("🌍 GeoRestrictionService: 2. IP Geolocation:")
-        DWLogger.log("🌍    - Country code: \(ipCountry ?? "nil")")
-
-        DWLogger.log("🌍 GeoRestrictionService: 3. App Store:")
-        DWLogger.log("🌍    - Country code: \(appStoreCountry ?? "nil")")
-
-        DWLogger.log("🌍 GeoRestrictionService: ========================================")
-
-        // Priority: GPS -> IP -> App Store
-        if gpsAuthorized, let countryCode = gpsCountry {
-            DWLogger.log("🌍 GeoRestrictionService: ✅ Using GPS location: \(countryCode)")
+        // Priority: GPS -> App Store storefront -> device region.
+        if DWLocationManager.shared.isAuthorized,
+           let countryCode = DWLocationManager.shared.currentPlacemark?.isoCountryCode {
             updateRestrictionStatus(countryCode: countryCode, source: .gpsLocation)
             return
         }
 
-        if let countryCode = ipCountry {
-            DWLogger.log("🌍 GeoRestrictionService: ✅ Using IP geolocation: \(countryCode)")
-            updateRestrictionStatus(countryCode: countryCode, source: .ipGeolocation)
-            return
-        }
-
-        if let countryCode = appStoreCountry {
-            DWLogger.log("🌍 GeoRestrictionService: ✅ Using App Store country: \(countryCode)")
+        if let countryCode = await fetchAppStoreCountry() {
             updateRestrictionStatus(countryCode: countryCode, source: .appStore)
             return
         }
 
-        // If all methods fail, assume not restricted
-        DWLogger.log("🌍 GeoRestrictionService: ⚠️ Unable to determine country, assuming not restricted")
+        if let countryCode = Locale.current.region?.identifier {
+            updateRestrictionStatus(countryCode: countryCode, source: .deviceRegion)
+            return
+        }
+
+        // Nothing resolved. Leave `hasCheckedRestriction` false so a later call
+        // can retry once a source becomes available.
+        DWLogger.log("GeoRestrictionService: country undetermined, leaving PiggyCards unrestricted")
         isPiggyCardsRestricted = false
         detectedCountryCode = nil
         detectionSource = .unknown
     }
 
-    /// Fetch country code from IP geolocation service
-    private func fetchCountryFromIP() async -> String? {
-        // Using ip-api.com - free, no API key required, returns country code
-        guard let url = URL(string: "https://ip-api.com/json/?fields=countryCode") else {
-            return nil
-        }
-
-        do {
-            let (data, response) = try await URLSession.shared.data(from: url)
-
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode) else {
-                DWLogger.log("GeoRestrictionService: IP geolocation request failed")
-                return nil
-            }
-
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               let countryCode = json["countryCode"] as? String {
-                DWLogger.log("GeoRestrictionService: IP geolocation returned country: \(countryCode)")
-                return countryCode
-            }
-        } catch {
-            DWLogger.log("GeoRestrictionService: IP geolocation error: \(error.localizedDescription)")
-        }
-
-        return nil
-    }
-
-    /// Fetch country code from App Store storefront
+    /// Fetch country code from App Store storefront. Returns an ISO 3166-1
+    /// alpha-3 code, which `restrictedCountryCodes` accounts for.
     private func fetchAppStoreCountry() async -> String? {
-        if let storefront = await Storefront.current {
-            DWLogger.log("GeoRestrictionService: App Store country: \(storefront.countryCode)")
-            return storefront.countryCode
-        }
-        return nil
+        guard let storefront = await Storefront.current else { return nil }
+        return storefront.countryCode
     }
 
     /// Update the restriction status based on detected country
@@ -202,18 +159,12 @@ class GeoRestrictionService {
         let normalizedCode = countryCode.uppercased()
         let isRestricted = restrictedCountryCodes.contains(normalizedCode)
 
-        DWLogger.log("🌍 GeoRestrictionService: updateRestrictionStatus called")
-        DWLogger.log("🌍 GeoRestrictionService: Country code: \(normalizedCode)")
-        DWLogger.log("🌍 GeoRestrictionService: Source: \(source.rawValue)")
-        DWLogger.log("🌍 GeoRestrictionService: Is restricted country: \(isRestricted)")
-        DWLogger.log("🌍 GeoRestrictionService: Restricted countries list: \(restrictedCountryCodes)")
-
         self.detectedCountryCode = normalizedCode
         self.detectionSource = source
         self.isPiggyCardsRestricted = isRestricted
         self.hasCheckedRestriction = true
 
-        DWLogger.log("🌍 GeoRestrictionService: ✅ Restriction status updated - isPiggyCardsRestricted = \(isRestricted)")
+        DWLogger.log("GeoRestrictionService: \(normalizedCode) via \(source.rawValue), PiggyCards restricted: \(isRestricted)")
     }
 
     /// Force refresh the restriction check


### PR DESCRIPTION
## What

`GeoRestrictionService` no longer contacts `ip-api.com`. Country detection now uses only on-device sources: GPS → App Store storefront → device region.

This also fixes a latent bug that made the App Store branch dead code, and stops the check from re-running on every foreground.

## Why

This came out of a community question in the Russian Telegram group asking whether analytics/tracking are enabled in the new iOS build. There is **no analytics SDK** in the iOS app — no FirebaseAnalytics, GoogleAppMeasurement, Crashlytics, Mixpanel, Amplitude, Sentry or AppsFlyer is linked, there are zero `logEvent`/`trackEvent` call sites, and there is no IDFA/ATT surface. But the audit did turn up outbound calls, and this was the most significant one.

`ExploreDashObjcWrapper.checkGeoRestriction` is invoked from `applicationDidBecomeActive` (`DashWallet/AppDelegate.m`), and `checkRestriction()` unconditionally issued:

```
GET https://ip-api.com/json/?fields=countryCode
```

That disclosed the user's real IP address, plus an app-open timestamp, to a third-party geolocation service **every time the wallet was foregrounded**. `PIGGYCARDS_ENABLED` is set in the Release and Testflight configurations, so this shipped.

Three things made it worse than it needed to be:

1. **No throttle.** `hasCheckedRestriction` was assigned in `updateRestrictionStatus` but never read, so nothing gated re-entry — every foreground repeated the request.
2. **Fired even when unnecessary.** `gpsCountry`, `ipCountry` and `appStoreCountry` were all awaited *before* the priority check, so the IP request went out even when GPS had already resolved the country and would win.
3. **The purpose was minor.** The only consumer is deciding whether to hide the PiggyCards gift-card provider.

## The latent alpha-2 / alpha-3 bug

Worth calling out separately, because this PR promotes the App Store storefront from third choice to second.

`restrictedCountryCodes` held `["RU", "CU"]` — ISO 3166-1 **alpha-2**. But StoreKit's `Storefront.countryCode` returns **alpha-3**; the SDK's own initialiser is `init(iso3ACountryCode:id:locale:)` and `SKStorefront.h` documents it as "The three letter country code for the current storefront". So the App Store branch could never match: a user in Russia with location permission denied got `"RUS"`, which was not in the set, and was silently treated as unrestricted.

CoreLocation's `isoCountryCode` and `Locale.Region.identifier` are alpha-2. Rather than convert, the set now lists both forms and documents why:

```swift
private let restrictedCountryCodes: Set<String> = ["RU", "RUS", "CU", "CUB"]
```

## Behaviour change

| | before | after |
|---|---|---|
| Priority | GPS → IP → App Store | GPS → App Store → device region |
| Network calls | one per foreground | none |
| Frequency | every foreground | once per launch, until resolved |
| `"RUS"` / `"CUB"` storefront | not matched | matched |

Device region (`Locale.current.region`) replaces IP as the last resort so a signal still exists when GPS is unauthorised and StoreKit returns nothing. If nothing resolves, the behaviour is unchanged — unrestricted — and `hasCheckedRestriction` is deliberately left `false` so a later call retries.

Live GPS updates still refresh the status through `setupLocationObserver`, and `refreshRestriction()` still forces a re-check.

The `DetectionSource.ipGeolocation` case is removed since nothing can produce it. A previously persisted `"IP Geolocation"` string now decodes to `nil`; that property is diagnostic only and has no consumers outside this file.

## Also removed

The `🌍`-prefixed debug logging (roughly 15 lines per invocation, per foreground), replaced with one line stating the outcome — per the "no debug residue in commits" guardrail in `CLAUDE.md`. Two stale comments at the call sites that described the old log-every-foreground behaviour are updated.

## Verification

`GeoRestrictionService.swift` and `ExploreDash.swift` compile clean.

Full disclosure on the build: `xcodebuild -scheme dashpay` does **not** currently reach a successful link in my environment, but the failure is pre-existing on `develop` and unrelated to this change. It is four errors in `EvonodeStatusViewModel.swift` (`value of type 'SDK' has no member 'getEvonodeStatus'`, `cannot find type 'EvonodeStatus' in scope`, `'PlatformMasternode' has no member 'platformDAPIAddress'`) caused by the local `../platform` SwiftDashSDK checkout sitting on an unrelated feature branch that predates that API. I confirmed this by stashing this PR's changes and rebuilding untouched `develop`, which produces the identical four errors. No error references any file this PR touches.

## Related

Two companion PRs address the other outbound channels found in the same audit: #1053 disables the Firebase diagnostics heartbeat, and a third removes the unused Firebase Dynamic Links SDK, which fingerprints the device on first launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved location and country detection for geo-restricted features using GPS, App Store storefront information, and device region settings.
  * Added support for both two-letter and three-letter country codes.
  * Reduced repeated checks during an app launch while allowing retries when a country cannot be resolved.
  * Removed remote IP-based geolocation.
  * GPS-based updates remain available for more accurate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->