### PR TITLE
feat(wallet): pay external shielded addresses from the Platform balance

### DIFF
--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -1385,11 +1385,13 @@ final class InternalTransferViewModel: ObservableObject {
         return feeReserveExceedsBalanceMessage(.core)
     }
 
-    private static let platformShieldPreflightLoadingMessage = NSLocalizedString(
+    // Shared with `SendViewModel`'s Platform → external Shielded route,
+    // which runs the same preflight — hence `internal`, not `private`.
+    static let platformShieldPreflightLoadingMessage = NSLocalizedString(
         "Checking how much of your Platform balance can be moved…",
         comment: "Platform to Shielded preflight in progress")
 
-    private static let platformShieldPreflightUnavailableMessage = NSLocalizedString(
+    static let platformShieldPreflightUnavailableMessage = NSLocalizedString(
         "Could not check the available Platform balance. Sync and try again.",
         comment: "Platform to Shielded preflight failed")
 
@@ -1401,7 +1403,8 @@ final class InternalTransferViewModel: ObservableObject {
         "Refreshing your Platform balance before checking the new maximum…",
         comment: "Platform Shield manual resync in progress")
 
-    private static let platformShieldHeadroomUnavailableMessage = NSLocalizedString(
+    // Shared with `SendViewModel` — see the note above.
+    static let platformShieldHeadroomUnavailableMessage = NSLocalizedString(
         "Your Platform balance cannot currently cover the Shield transfer selection headroom.",
         comment: "Platform balance cannot fund shield selection headroom")
 

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -709,9 +709,15 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// Stages: `.signing → .proving → .broadcasting → .success`. No
     /// intermediate signals from the FFI — `.proving` covers the whole opaque
     /// ~30 s call; on return we jump to `.success`.
-    func performShield(amountCredits: UInt64) async {
+    ///
+    /// `recipientRaw43` nil = the wallet's own pool (the internal
+    /// transfer); an external Send passes the recipient's raw 43-byte
+    /// Orchard address and the note funds THAT wallet's pool instead
+    /// (`shieldedShieldToRecipient`). Capacity preflight and fees are
+    /// identical — the recipient does not change input selection.
+    func performShield(amountCredits: UInt64, recipientRaw43: Data? = nil) async {
         guard beginTransfer() else { return }
-        Self.logger.info("🛡️ SHIELD-TX :: shield route amount=\(amountCredits) credits")
+        Self.logger.info("🛡️ SHIELD-TX :: shield route amount=\(amountCredits) credits external=\(recipientRaw43 != nil)")
 
         let env: Environment
         do {
@@ -755,12 +761,22 @@ final class ShieldedTransferCoordinator: ObservableObject {
             network: env.network)
 
         do {
-            try await env.manager.shieldedShield(
-                walletId: env.walletId,
-                shieldedAccount: 0,
-                paymentAccount: 0,
-                amount: amountCredits,
-                addressSigner: signer)
+            if let recipientRaw43 {
+                try await env.manager.shieldedShieldToRecipient(
+                    walletId: env.walletId,
+                    shieldedAccount: 0,
+                    paymentAccount: 0,
+                    recipientRaw43: recipientRaw43,
+                    amount: amountCredits,
+                    addressSigner: signer)
+            } else {
+                try await env.manager.shieldedShield(
+                    walletId: env.walletId,
+                    shieldedAccount: 0,
+                    paymentAccount: 0,
+                    amount: amountCredits,
+                    addressSigner: signer)
+            }
         } catch {
             if case PlatformWalletError.shieldedInsufficientBalance = error {
                 handleFailure(CoordinatorError.platformShieldCapacityChanged(

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -709,8 +709,9 @@ struct SendConfirmSheet: View {
 
     let route: SendViewModel.Route
     let destinationAddress: String
-    /// The recipient's raw 43-byte Orchard payload — required for
-    /// `.shieldedToShielded`, nil otherwise.
+    /// The recipient's raw 43-byte Orchard payload — required for the
+    /// shielded-destination routes (`.coreToShielded`,
+    /// `.platformToShielded`, `.shieldedToShielded`), nil otherwise.
     let destinationRaw43: Data?
     let dashDuffs: Int64
     let creditsAmount: UInt64
@@ -889,7 +890,7 @@ struct SendConfirmSheet: View {
 
     private var fromLabel: String {
         switch route {
-        case .platformToPlatform, .platformToCore:
+        case .platformToPlatform, .platformToCore, .platformToShielded:
             return NSLocalizedString("Platform balance", comment: "The Dash Platform credits balance")
         case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
             return NSLocalizedString("Shielded balance", comment: "")
@@ -938,6 +939,11 @@ struct SendConfirmSheet: View {
             return 100_000_000
         case .platformToCore:
             return withdrawalFeeCredits
+        case .platformToShielded:
+            // The Type 15 shield is an output-only bundle padded to exactly
+            // 2 actions, charged the flat base fee — same number the Rust
+            // side reserves on input 0.
+            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
         case .shieldedToCore:
             return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 2)
         case .shieldedToPlatform:
@@ -1054,7 +1060,8 @@ struct SendConfirmSheet: View {
         }
         // Only shielded legs build an Orchard proof.
         switch route {
-        case .coreToShielded, .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
+        case .coreToShielded, .platformToShielded, .shieldedToCore, .shieldedToPlatform,
+             .shieldedToShielded:
             steps.append(.init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving))
         case .platformToPlatform, .platformToCore, .coreToCore:
             break
@@ -1080,6 +1087,14 @@ struct SendConfirmSheet: View {
                 await coordinator.performPlatformSend(
                     destination: destinationAddress,
                     amountCredits: creditsAmount)
+            case .platformToShielded:
+                guard let destinationRaw43 else {
+                    coordinator.reset()
+                    return
+                }
+                await coordinator.performShield(
+                    amountCredits: creditsAmount,
+                    recipientRaw43: destinationRaw43)
             case .platformToCore:
                 await coordinator.performPlatformWithdraw(
                     amountCredits: creditsAmount,

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -183,8 +183,14 @@ final class SendViewModel: ObservableObject {
         PlatformAddressSyncCoordinator.shared.$platformBalance
             .receive(on: RunLoop.main)
             .sink { [weak self] credits in
-                self?.platformCredits = credits
-                self?.restartShieldPreflightOnBalanceChange()
+                guard let self else { return }
+                // Only a CHANGED balance restarts the shield preflight —
+                // the publisher re-emits on every sync pass, and a restart
+                // clears the capacity (fails closed), which would flicker
+                // and could starve the preflight of time to resolve.
+                let changed = self.platformCredits != credits
+                self.platformCredits = credits
+                if changed { self.restartShieldPreflightOnBalanceChange() }
             }
             .store(in: &cancellables)
 
@@ -370,18 +376,40 @@ final class SendViewModel: ObservableObject {
             return
         }
         guard shieldPreflightTask == nil else { return }
+        // Fail closed while resolving: a preflight only starts when the
+        // cached capacity is suspect (route entry, balance change, Max
+        // retry), so clear it rather than let `canContinue` accept a stale
+        // ceiling — the same contract as the internal-transfer sibling.
+        platformShieldCapacity = nil
+        shieldPreflightFailed = false
         shieldPreflightTask = Task { [weak self] in
             let result = try? await PlatformAddressSyncCoordinator.shared.preflightShield()
             guard let self, !Task.isCancelled else { return }
             self.platformShieldCapacity = result.map(PlatformShieldCapacity.init)
             self.shieldPreflightFailed = result == nil
             self.shieldPreflightTask = nil
+            // A Max tapped mid-flight parked a preflight notice; resolve it
+            // rather than leave a "checking…" (or stale failure) up after
+            // the outcome is known. The user re-taps Max for the fresh
+            // ceiling — the amount is never auto-filled from a background
+            // completion.
+            let preflightNotices = [
+                InternalTransferViewModel.platformShieldPreflightLoadingMessage,
+                InternalTransferViewModel.platformShieldPreflightUnavailableMessage,
+            ]
+            if let notice = self.shieldedMaxNotice, preflightNotices.contains(notice) {
+                self.shieldedMaxNotice = result == nil
+                    ? InternalTransferViewModel.platformShieldPreflightUnavailableMessage
+                    : nil
+            }
         }
     }
 
     /// A fresh Platform balance can change shield capacity — re-run the
-    /// preflight so validation and Max track it. (The coordinator
-    /// revalidates against a live preflight at confirm time regardless.)
+    /// preflight (clearing the cached capacity, so validation fails closed
+    /// until the new ceiling lands) so validation and Max track it. (The
+    /// coordinator revalidates against a live preflight at confirm time
+    /// regardless.)
     private func restartShieldPreflightOnBalanceChange() {
         guard route == .platformToShielded else { return }
         shieldPreflightTask?.cancel()
@@ -824,7 +852,14 @@ final class SendViewModel: ObservableObject {
             // whole duffs (never round a credit ceiling up to an amount the
             // transition cannot select).
             guard let capacity = platformShieldCapacity else {
-                shieldedMaxNotice = InternalTransferViewModel.platformShieldPreflightLoadingMessage
+                // Name a FAILED check instead of a perpetual "checking…",
+                // and kick a fresh preflight either way — nothing else
+                // retries until the route or balance changes. Compute the
+                // notice first: the refresh clears `shieldPreflightFailed`.
+                shieldedMaxNotice = shieldPreflightFailed
+                    ? InternalTransferViewModel.platformShieldPreflightUnavailableMessage
+                    : InternalTransferViewModel.platformShieldPreflightLoadingMessage
+                refreshShieldPreflight()
                 sourceDuffs = 0
                 break
             }

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -40,6 +40,11 @@ final class SendViewModel: ObservableObject {
         case coreToShielded
         case platformToPlatform
         case platformToCore
+        /// Platform Payment credits → Type 15 shield note assigned to the
+        /// recipient's Orchard address (`shieldedShieldToRecipient`). Same
+        /// input selection and flat fee as the internal shield; the note
+        /// funds the RECIPIENT's pool.
+        case platformToShielded
         case shieldedToCore
         case shieldedToPlatform
         case shieldedToShielded
@@ -118,6 +123,17 @@ final class SendViewModel: ObservableObject {
     @Published private(set) var withdrawalPreflight: ManagedPlatformAddressWallet.WithdrawalPreflight?
     private var preflightTask: Task<Void, Never>?
 
+    /// Live result of `preflightShield()` for the Platform → Shielded route —
+    /// the SDK's account/address-aware capacity (the aggregate Platform
+    /// balance is NOT the authority). `nil` while unknown; affordability
+    /// fails closed.
+    @Published private(set) var platformShieldCapacity: PlatformShieldCapacity?
+    /// True when the last shield preflight ATTEMPT failed (threw), as
+    /// opposed to still resolving — distinguishes "checking…" (quiet)
+    /// from "could not check" (explained inline).
+    @Published private(set) var shieldPreflightFailed = false
+    private var shieldPreflightTask: Task<Void, Never>?
+
     /// Drives the one-time restore gate reactively. A normal catch-up may set
     /// this to false, but it only blocks while the recovery marker is active.
     @Published private(set) var isChainSynced = SyncingActivityMonitor.shared.state == .syncDone
@@ -168,6 +184,7 @@ final class SendViewModel: ObservableObject {
             .receive(on: RunLoop.main)
             .sink { [weak self] credits in
                 self?.platformCredits = credits
+                self?.restartShieldPreflightOnBalanceChange()
             }
             .store(in: &cancellables)
 
@@ -294,15 +311,14 @@ final class SendViewModel: ObservableObject {
     /// Which balances can fund a send to the entered destination.
     /// Core addresses can be paid from any bucket; Platform addresses from
     /// Platform credits or the shielded pool (there is no external
-    /// core → platform funding); shielded addresses from the pool or the
-    /// Core balance (asset-lock shield — `shieldedShield` has no recipient
-    /// parameter, so Platform credits can't pay an external shielded
-    /// address).
+    /// core → platform funding); shielded addresses from any bucket — the
+    /// pool (`shieldedTransfer`), the Core balance (asset-lock shield), or
+    /// Platform credits (`shieldedShieldToRecipient`).
     var validSources: [ChainNetwork] {
         switch destination {
         case .core: return [.core, .platform, .shielded]
         case .platform: return [.platform, .shielded]
-        case .shielded: return [.shielded, .core]
+        case .shielded: return [.shielded, .core, .platform]
         case nil: return []
         }
     }
@@ -314,6 +330,7 @@ final class SendViewModel: ObservableObject {
         case (.core, .shielded): return .coreToShielded
         case (.platform, .platform): return .platformToPlatform
         case (.platform, .core): return .platformToCore
+        case (.platform, .shielded): return .platformToShielded
         case (.shielded, .core): return .shieldedToCore
         case (.shielded, .platform): return .shieldedToPlatform
         case (.shielded, .shielded): return .shieldedToShielded
@@ -322,10 +339,16 @@ final class SendViewModel: ObservableObject {
     }
 
     /// Refreshes route-dependent async state — the Platform → Core route
-    /// needs the withdrawal preflight (fee headroom + full-balance payout).
+    /// needs the withdrawal preflight (fee headroom + full-balance payout),
+    /// Platform → Shielded the shield-capacity preflight.
     private func routeDidChange() {
         clearShieldedMaxSelection()
         refreshShieldedSpendCeiling()
+        refreshWithdrawalPreflight()
+        refreshShieldPreflight()
+    }
+
+    private func refreshWithdrawalPreflight() {
         guard route == .platformToCore else {
             preflightTask?.cancel()
             preflightTask = nil
@@ -338,6 +361,32 @@ final class SendViewModel: ObservableObject {
             self.withdrawalPreflight = result
             self.preflightTask = nil
         }
+    }
+
+    private func refreshShieldPreflight() {
+        guard route == .platformToShielded else {
+            shieldPreflightTask?.cancel()
+            shieldPreflightTask = nil
+            return
+        }
+        guard shieldPreflightTask == nil else { return }
+        shieldPreflightTask = Task { [weak self] in
+            let result = try? await PlatformAddressSyncCoordinator.shared.preflightShield()
+            guard let self, !Task.isCancelled else { return }
+            self.platformShieldCapacity = result.map(PlatformShieldCapacity.init)
+            self.shieldPreflightFailed = result == nil
+            self.shieldPreflightTask = nil
+        }
+    }
+
+    /// A fresh Platform balance can change shield capacity — re-run the
+    /// preflight so validation and Max track it. (The coordinator
+    /// revalidates against a live preflight at confirm time regardless.)
+    private func restartShieldPreflightOnBalanceChange() {
+        guard route == .platformToShielded else { return }
+        shieldPreflightTask?.cancel()
+        shieldPreflightTask = nil
+        refreshShieldPreflight()
     }
 
     // MARK: - Clipboard
@@ -478,12 +527,14 @@ final class SendViewModel: ObservableObject {
     /// amount. `nil` = requirement unavailable → callers fail closed.
     private var feeReserveCredits: UInt64? {
         switch route {
-        case .coreToCore, .coreToShielded, .platformToCore, nil:
+        case .coreToCore, .coreToShielded, .platformToCore, .platformToShielded, nil:
             // L1 send fees are handled by the payment processor; the
             // asset-lock shield's pool fee is duff-denominated and enforced
             // in the route branches (`canContinue`, Max) directly, mirroring
             // the internal transfer; the full-balance platform withdrawal
-            // nets its fee out of the preflighted payout.
+            // nets its fee out of the preflighted payout; the platform
+            // shield's headroom is governed by the SDK preflight
+            // (`platformShieldCapacity`) in its route branches.
             return 0
         case .platformToPlatform:
             return Self.platformTransferFeeReserveCredits
@@ -603,6 +654,24 @@ final class SendViewModel: ObservableObject {
                 balanceCredits: platformCredits,
                 feeReserveCredits: reserve)
 
+        case .platformToShielded:
+            // Stay quiet while the preflight is still resolving: Continue is
+            // disabled, but the amount is not yet known to be unaffordable.
+            // A FAILED preflight is named — never an unexplained dead button.
+            guard let capacity = platformShieldCapacity else {
+                return shieldPreflightFailed
+                    ? InternalTransferViewModel.platformShieldPreflightUnavailableMessage
+                    : nil
+            }
+            guard capacity.canShield else {
+                return InternalTransferViewModel.platformShieldHeadroomUnavailableMessage
+            }
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedCredits: creditsPreview,
+                balanceCredits: capacity.maxShieldableCredits,
+                feeReserveCredits: 0)
+
         case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
             // A Max sweep is planned against the real note set rather than the
             // amount+reserve envelope, so it is affordable by construction.
@@ -699,6 +768,12 @@ final class SendViewModel: ObservableObject {
             guard let reserve = feeReserveCredits else { return false }
             return platformCredits >= reserve
                 && creditsPreview <= platformCredits - reserve
+        case .platformToShielded:
+            // The SDK preflight is the sole affordability authority (the
+            // aggregate Platform balance is not); nil capacity fails closed.
+            return PlatformShieldAmountPolicy.canSubmit(
+                requestedCredits: creditsPreview,
+                capacity: platformShieldCapacity)
         case .platformToCore:
             guard withdrawalPreflight?.canWithdraw == true else { return false }
             if isFullPlatformWithdrawal { return true }
@@ -744,6 +819,20 @@ final class SendViewModel: ObservableObject {
             }
         case .platformToPlatform:
             sourceDuffs = creditsMinusFeeReserve(platformCredits) / 1000
+        case .platformToShielded:
+            // Max = the SDK preflight's executable capacity, floored to
+            // whole duffs (never round a credit ceiling up to an amount the
+            // transition cannot select).
+            guard let capacity = platformShieldCapacity else {
+                shieldedMaxNotice = InternalTransferViewModel.platformShieldPreflightLoadingMessage
+                sourceDuffs = 0
+                break
+            }
+            sourceDuffs = PlatformShieldAmountPolicy.maximumDuffs(capacity: capacity)
+            if sourceDuffs == 0 {
+                shieldedMaxNotice =
+                    InternalTransferViewModel.platformShieldHeadroomUnavailableMessage
+            }
         case .platformToCore:
             sourceDuffs = platformWithdrawableDuffs ?? 0
         case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Entering a shielded address on the **Platform balance-row Send sheet** dead-ended in *"This address can't be paid from your Platform balance"*. The pinned-source mismatch guard was correct at the time — the SDK's only Platform-credits shield operation (`shieldedShield`) had no recipient parameter, so Platform credits could only shield into the wallet's own pool.

## What was done?
dashpay/platform#4472 adds `shieldedShieldToRecipient` (the Type 15 shield with the note assigned to a third-party Orchard address — no consensus change, the transition already carried an arbitrary recipient inside the opaque Orchard action). This PR wires the missing route into the Send flow:

- **SendViewModel**: new `.platformToShielded` route; shielded destinations accept `.platform` as a source (`validSources`). Affordability is governed solely by the SDK shield-capacity preflight — the same `PlatformShieldAmountPolicy` authority the internal transfer uses: `nil` capacity fails closed (quiet while resolving, a *failed* preflight is named inline), Max fills the preflight's executable ceiling floored to whole duffs, and a Platform balance publication re-runs the preflight.
- **SendConfirmSheet**: From reads "Platform balance", the fee row shows the flat 2-action shield fee, the progress checklist gains the "Generating proof" step, and confirm dispatches the new coordinator leg.
- **ShieldedTransferCoordinator**: `performShield(amountCredits:recipientRaw43:)` — nil keeps the internal shield-to-self exactly; an external recipient routes to `shieldedShieldToRecipient`. The confirm-time capacity revalidation is unchanged (the recipient does not affect input selection).
- The three platform-shield preflight message strings are promoted from `private` to `internal` on `InternalTransferViewModel` for reuse (no copies).

**Depends on dashpay/platform#4472** — build against a swift-sdk checkout containing it (rebuild `DashSDKFFI.xcframework`).

## How Has This Been Tested?
- Clean `dashpay` scheme build (arm64 sim) against the platform branch.
- On-sim smoke of the exact repro path: Platform balance-row send arrow → paste shielded address → **no mismatch error**, destination badge + Continue enabled → source step shows the pinned Platform card → amount step runs the live shield preflight and fails closed with the inline headroom message on a zero-balance wallet (screenshots below).
- SDK-side round-trip test proves the recipient can decrypt the note, the sender cannot, and the sender's OVK recovers it as sent history (activity/restore parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
| Address step (Platform-pinned) | Source step | Amount validation (fail-closed) |
|---|---|---|
| ![address step](https://raw.githubusercontent.com/dashpay/dashwallet-ios/62f2c23442d2059b1fabc2a3784f54cde8094101/1057/1-address-step-platform-pinned.png) | ![source step](https://raw.githubusercontent.com/dashpay/dashwallet-ios/62f2c23442d2059b1fabc2a3784f54cde8094101/1057/2-source-step-platform.png) | ![amount validation](https://raw.githubusercontent.com/dashpay/dashwallet-ios/62f2c23442d2059b1fabc2a3784f54cde8094101/1057/3-amount-validation-failclosed.png) |

*A shielded address on the Platform balance-row Send sheet: previously an instant "This address can't be paid from your Platform balance" dead end; now the route advances, and affordability is governed by the live SDK shield preflight (shown failing closed on a zero-balance wallet).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending Platform balance directly to shielded recipients.
  - Added shielded recipient handling for external transfers.
  - Added preflight checks to determine shieldable capacity and available headroom.
  - Updated balance validation, Max amount selection, fees, progress steps, and confirmation flow for the new route.
  - Added clearer loading, failure, and unavailable-capacity messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->