### PR TITLE
fix(security): stop reporting every Mac as jailbroken, drop wipe from the alert

### DIFF
--- a/DashWallet/Sources/Categories/UIApplication+DashWallet.swift
+++ b/DashWallet/Sources/Categories/UIApplication+DashWallet.swift
@@ -17,11 +17,23 @@
 
 import Darwin
 import MachO.dyld
+import UIKit
 
 @objc
 extension UIApplication {
+    /// Advisory only: it runs in-process on the device it judges, so anything
+    /// able to read the keychain can also make it return `false`.
     @objc
     static var isJailbroken: Bool {
+        // macOS lets a sandboxed app stat system paths, so the probe below flags
+        // every Mac; "Designed for iPad" is neither simulator nor macCatalyst
+        #if targetEnvironment(simulator) || targetEnvironment(macCatalyst)
+        return false
+        #else
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return false
+        }
+
         var s = stat()
         let jailbroken = stat("/bin/sh", &s) == 0 // if we can see /bin/sh, the app isn't sandboxed
 
@@ -33,9 +45,6 @@ extension UIApplication {
             }
         }
 
-        #if targetEnvironment(simulator)
-        return false
-        #else
         return jailbroken
         #endif
     }

--- a/DashWallet/Sources/UI/Home/HomeViewController+JailbreakCheck.swift
+++ b/DashWallet/Sources/UI/Home/HomeViewController+JailbreakCheck.swift
@@ -17,21 +17,20 @@
 
 import UIKit
 
-extension HomeViewController: DWRecoverViewControllerDelegate {
+extension HomeViewController {
+    /// The jailbreak signal is a heuristic, so this only informs — wiping stays
+    /// behind Security → Reset Wallet, which gates it on the recovery phrase.
     func performJailbreakCheck() {
         guard UIApplication.isJailbroken else {
             return
         }
 
         let title = NSLocalizedString("WARNING", comment: "")
-        var message: String?
+        let message: String
         var mainAction: UIAlertAction?
 
         if !model.isWalletEmpty {
-            message = NSLocalizedString("DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.", comment: "")
-            mainAction = UIAlertAction(title: NSLocalizedString("Wipe", comment: ""), style: .destructive) { [weak self] action in
-                self?.wipeWallet()
-            }
+            message = NSLocalizedString("DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Move your funds to a wallet on a secure device, then reset this wallet using Reset Wallet in the Security menu.", comment: "")
         } else {
             message = NSLocalizedString("DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash).", comment: "")
             mainAction = UIAlertAction(title: NSLocalizedString("Close App", comment: ""), style: .default) { action in
@@ -40,41 +39,13 @@ extension HomeViewController: DWRecoverViewControllerDelegate {
         }
 
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let ignoreAction = UIAlertAction(title: NSLocalizedString("Ignore", comment: ""), style: .cancel, handler: nil)
-        
         if let mainAction = mainAction {
             alert.addAction(mainAction)
+            alert.addAction(UIAlertAction(title: NSLocalizedString("Ignore", comment: ""), style: .cancel, handler: nil))
+        } else {
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel, handler: nil))
         }
-        alert.addAction(ignoreAction)
-        
+
         present(alert, animated: true, completion: nil)
-    }
-
-    func wipeWallet() {
-        let controller = DWRecoverViewController()
-        controller.action = .wipe
-        controller.delegate = self
-        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(recoverCancelButtonAction(_:)))
-        controller.navigationItem.leftBarButtonItem = cancelButton
-
-        let navigationController = BaseNavigationController(rootViewController: controller)
-        present(navigationController, animated: true, completion: nil)
-    }
-
-    // MARK: - DWRecoverViewControllerDelegate
-
-    func recoverViewControllerDidRecoverWallet(_ controller: DWRecoverViewController, recover recoverCommand: DWRecoverWalletCommand) {
-        assertionFailure("Inconsistent state")
-        dismiss(animated: true, completion: nil)
-    }
-
-    func recoverViewControllerDidWipe(_ controller: DWRecoverViewController) {
-        dismiss(animated: true) { [weak self] in
-            self?.delegate?.didWipeWallet()
-        }
-    }
-
-    @objc func recoverCancelButtonAction(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
     }
 }

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -1371,7 +1371,7 @@
 "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash)." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash).";
 
 /* No comment provided by engineer. */
-"DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Wipe this wallet immediately and restore on a secure device.";
+"DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Move your funds to a wallet on a secure device, then reset this wallet using Reset Wallet in the Security menu." = "DEVICE SECURITY COMPROMISED\nAny 'jailbreak' app can access any other app's keychain data (and steal your Dash). Move your funds to a wallet on a secure device, then reset this wallet using Reset Wallet in the Security menu.";
 
 /* Identities: this identity key was disabled on Platform */
 "Disabled" = "Disabled";


### PR DESCRIPTION
## Problem

`UIApplication.isJailbroken` infers "this app is not sandboxed" from `stat("/bin/sh") == 0`:

```swift
let jailbroken = stat("/bin/sh", &s) == 0 // if we can see /bin/sh, the app isn't sandboxed
```

The macOS runtimes let a sandboxed app stat the host's system paths, so that probe is true on **every Mac**. The only guard was `#if targetEnvironment(simulator)`, which does not cover it: the app builds `TARGETED_DEVICE_FAMILY = "1,2"` with no Catalyst opt-out, so it is installable on Apple Silicon Macs as "Designed for iPad" — where `targetEnvironment` reports neither `simulator` nor `macCatalyst`, and only `ProcessInfo.processInfo.isiOSAppOnMac` distinguishes the case.

The false positive was not cosmetic. On such a Mac, a user **with a non-empty wallet** was shown "DEVICE SECURITY COMPROMISED" with a `.destructive` **Wipe** action as the first button, which pushed `DWRecoverViewController` in `.wipe` mode. Wrong signal paired with the most irreversible remedy in the app.

## Changes

**1. Guard the Mac runtimes** (`UIApplication+DashWallet.swift`)

`macCatalyst` at compile time, `isiOSAppOnMac` at runtime. The whole probe now sits in the `#else` branch, so the device path is byte-for-byte the same logic as before.

This also fixes a latent ordering quirk: previously the MobileSubstrate `_dyld` loop ran *before* the simulator early-return, so a simulator build could still `return true` from the loop. It now returns `false` immediately.

**2. The alert informs, it does not wipe** (`HomeViewController+JailbreakCheck.swift`)

`isJailbroken` is a heuristic that can be wrong in both directions, so it should not offer an irreversible action. The non-empty-wallet alert is now informational (single OK) and points the user at **Security → Reset Wallet**, the existing deliberate route — which gates the wipe behind entering the recovery phrase. The empty-wallet "Close App" path is unchanged.

This removes the now-unused `wipeWallet()`, the `DWRecoverViewControllerDelegate` conformance, and its delegate methods from the extension. Verified nothing else referenced them; `HomeViewController.delegate` is typed `(HomeViewControllerDelegate & DWWipeDelegate)?` independently of the removed conformance.

**3. Localization** — swapped the now-unreferenced source string for the new one in `en.lproj` (the Transifex source). Sort order preserved, UTF-8 no BOM, `plutil -lint` clean.

## Not in scope

This does **not** modernize the detection itself. The `MobileSubstrate` probe is Cydia Substrate era and no longer matches current tweak loaders (`ellekit`, `libhooker`, `substitute`), and any in-process check is defeatable by the very compromise it looks for. Treat `isJailbroken` as an advisory nudge, not a security boundary — the added doc comment says so. Deleting the check outright is a reasonable follow-up discussion; this PR only stops it from being actively harmful.

## Verification

- `swiftc -typecheck` of `UIApplication+DashWallet.swift` passes for **both** `arm64-apple-ios18.0-simulator` and `arm64-apple-ios18.0` (device) — i.e. both sides of the new `#if`.
- `HomeViewController+JailbreakCheck.swift` compiles clean in the `dashpay` scheme build.
- Traced the alert's advice to a real route: More → `MainMenuViewModel` "Security" → `SecurityMenuViewModel` "Reset Wallet" → `DWResetWalletInfoViewController` → recovery-phrase gate. Distinct from the sibling "Settings" item, so the copy is unambiguous.

> [!NOTE]
> The `dashpay` scheme does not currently build to completion in my environment, for reasons unrelated to this change: 5 errors in `EvonodeStatusViewModel.swift` referencing SwiftDashSDK symbols (`getEvonodeStatus`, `EvonodeStatus`, `platformDAPIAddress`) absent from the pinned `../platform` checkout. I confirmed this is pre-existing by building clean `HEAD` with my changes removed — **byte-identical error set**, and neither of my files appears in the failed-command list in either build. Runtime behavior on an actual jailbroken device and on a real Mac install is unverified; the `isiOSAppOnMac` guard is reasoned from the sandbox profile, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device security checks to avoid incorrectly flagging Mac-based runtimes as jailbroken.
  * Updated compromised-device warnings to prevent immediate wallet wiping.
  * Non-empty wallets now direct users to move funds and reset the wallet through Security settings.
  * Empty wallets retain the option to close the app.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->