### PR TITLE
refactor(send): move route fee estimation out of the SwiftUI view layer

### DIFF
--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -416,6 +416,8 @@ struct ExternalSendAmountScreen: View {
                     dashDuffs: viewModel.dashDuffs,
                     creditsAmount: viewModel.creditsPreview,
                     fiatText: viewModel.fiatAmountString,
+                    networkFeeCredits: viewModel.confirmNetworkFeeCredits,
+                    totalDuffs: viewModel.confirmTotalDuffs,
                     withdrawalFeeCredits: viewModel.withdrawalPreflight?.estimatedFee,
                     isFullPlatformWithdrawal: viewModel.isFullPlatformWithdrawal,
                     isFullShieldedSweep: viewModel.isFullShieldedSweep,
@@ -716,6 +718,13 @@ struct SendConfirmSheet: View {
     let dashDuffs: Int64
     let creditsAmount: UInt64
     let fiatText: String
+    /// Route fee estimate (credits) for the Network fee row, computed by
+    /// `SendViewModel.confirmNetworkFeeCredits`. `nil` → the row shows "—".
+    let networkFeeCredits: UInt64?
+    /// What actually leaves the source balance (duffs) for the Total row,
+    /// computed by `SendViewModel.confirmTotalDuffs`. `nil` → the row
+    /// shows "—".
+    let totalDuffs: Int64?
     /// Preflighted withdrawal fee — only meaningful for `.platformToCore`.
     var withdrawalFeeCredits: UInt64? = nil
     var isFullPlatformWithdrawal: Bool = false
@@ -925,60 +934,19 @@ struct SendConfirmSheet: View {
     /// Platform credits per DASH (1e11).
     private static let creditsPerDash: Decimal = 100_000_000_000
 
-    /// Flat fee estimate (credits) for the active route — same estimators as
-    /// the internal transfer's confirm sheet. `nil` → the row shows "—".
-    private var networkFeeCredits: UInt64? {
-        switch route {
-        case .coreToShielded:
-            // The lock charges the fee rounded UP to a whole duff — display
-            // that, so Amount + Network fee equals Total exactly.
-            return CoreToShieldedAmountPolicy.currentPoolFeeDuffs.map { $0 * 1000 }
-        case .platformToPlatform:
-            // Credit transfer: the metered transition fee. The executor
-            // states ~0.001 DASH as the conservative max.
-            return 100_000_000
-        case .platformToCore:
-            return withdrawalFeeCredits
-        case .platformToShielded:
-            // The Type 15 shield is an output-only bundle padded to exactly
-            // 2 actions, charged the flat base fee — same number the Rust
-            // side reserves on input 0.
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
-        case .shieldedToCore:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 2)
-        case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)
-        case .shieldedToShielded:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
-        case .coreToCore:
-            // Never presented here — the L1 processor shows the real fee.
-            return nil
-        }
-    }
-
+    /// The view-model-computed fee estimate as fiat (e.g. "~ $0.08"), or "—"
+    /// if unavailable.
     private var networkFeeString: String {
         guard let credits = networkFeeCredits else { return "—" }
         let dash = Decimal(credits) / Self.creditsPerDash
         return "~ " + CurrencyExchanger.shared.fiatAmountString(for: dash)
     }
 
-    /// What actually leaves the source balance. Core→Shielded charges the
-    /// pool fee on top of the amount (the executed lock value); every other
-    /// route's total is the amount itself. "—" when the fee estimate is
-    /// unavailable — `canContinue` fails closed before that can be confirmed,
-    /// but the row must never show the un-inflated number.
+    /// The view-model-computed total as DASH, or "—" when the fee estimate
+    /// backing it is unavailable.
     private var totalString: String {
-        guard route == .coreToShielded else {
-            return dashDuffs.formattedDashAmount
-        }
-        guard let amountDuffs = UInt64(exactly: dashDuffs),
-              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
-              let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
-                  forAmountDuffs: amountDuffs,
-                  poolFeeCredits: poolFeeCredits),
-              let signedLockDuffs = Int64(exactly: lockDuffs)
-        else { return "—" }
-        return signedLockDuffs.formattedDashAmount
+        guard let totalDuffs else { return "—" }
+        return totalDuffs.formattedDashAmount
     }
 
     // MARK: - Info card

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -819,6 +819,58 @@ final class SendViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Confirm sheet fee display
+
+    /// Flat network-fee estimate (credits) for the active route — feeds the
+    /// confirm sheet's Network fee row, same estimators as the internal
+    /// transfer's confirm sheet. `nil` → the row shows "—".
+    var confirmNetworkFeeCredits: UInt64? {
+        switch route {
+        case .coreToShielded:
+            // The lock charges the fee rounded UP to a whole duff — display
+            // that, so Amount + Network fee equals Total exactly.
+            return CoreToShieldedAmountPolicy.currentPoolFeeDuffs.map { $0 * 1000 }
+        case .platformToPlatform:
+            // Credit transfer: the metered transition fee. The executor
+            // states ~0.001 DASH as the conservative max.
+            return Self.platformTransferFeeReserveCredits
+        case .platformToCore:
+            // The exact transition fee the preflight nets out of the payout.
+            return withdrawalPreflight?.estimatedFee
+        case .platformToShielded:
+            // The Type 15 shield is an output-only bundle padded to exactly
+            // 2 actions, charged the flat base fee — same number the Rust
+            // side reserves on input 0.
+            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
+        case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
+            // Two-action estimate — the common bundle shape. Worst-case note
+            // selection stays `feeReserveCredits`'s concern.
+            guard let feeKind = shieldedFeeKind(for: route) else { return nil }
+            return try? PlatformWalletManager.estimateShieldedFee(kind: feeKind, numActions: 2)
+        case .coreToCore, nil:
+            // Never presented in the confirm sheet — Core → Core rides the L1
+            // payment processor, which shows the real fee.
+            return nil
+        }
+    }
+
+    /// What actually leaves the source balance (duffs) — feeds the confirm
+    /// sheet's Total row. Core → Shielded charges the pool fee on top of the
+    /// amount (the executed lock value); every other route's total is the
+    /// amount itself. `nil` when the fee estimate is unavailable —
+    /// `canContinue` fails closed before that can be confirmed, but the row
+    /// must never show the un-inflated number.
+    var confirmTotalDuffs: Int64? {
+        guard route == .coreToShielded else { return dashDuffs }
+        guard let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
+              let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
+                  forAmountDuffs: dashDuffsUnsigned,
+                  poolFeeCredits: poolFeeCredits),
+              let signedLockDuffs = Int64(exactly: lockDuffs)
+        else { return nil }
+        return signedLockDuffs
+    }
+
     // MARK: - Max
 
     /// Source-aware Max fill — same envelopes as the internal transfer.


### PR DESCRIPTION
## Issue being fixed or feature implemented

CodeRabbit [flagged on #1057](https://github.com/dashpay/dashwallet-ios/pull/1057#discussion_r3845392477) that `SendConfirmSheet.networkFeeCredits` calls `PlatformWalletManager.estimateShieldedFee` (FFI) and performs per-route fee calculations inside a SwiftUI `View` — a pattern the repo's SwiftUI-first guardrails ban from `View` structs. The pattern predates #1057 (that PR only added the `.platformToShielded` case following the existing convention), so the refactor was declined there as out of scope and split into this PR.

## What was done?

- `SendViewModel` now owns both confirm-sheet computations:
  - `confirmNetworkFeeCredits` — the per-route fee switch. The pool-spending routes reuse the existing `shieldedFeeKind(for:)` mapping instead of duplicated `estimateShieldedFee` calls, `.platformToPlatform` reuses the existing `platformTransferFeeReserveCredits` constant instead of a bare `100_000_000` literal, `.platformToCore` reads `withdrawalPreflight?.estimatedFee` directly, and `.platformToShielded` keeps #1057's flat 2-action estimate.
  - `confirmTotalDuffs` — the Total row's Core → Shielded lock-value derivation (`CoreToShieldedAmountPolicy` is FFI-backed too, so leaving it would have kept an FFI call in the view).
- `SendConfirmSheet` receives the two values as stored `let` properties and only formats them. `SendScreen.swift` is now free of `PlatformWalletManager` / `CoreToShieldedAmountPolicy` references.
- Behavior is identical route by route: same estimators, same values, same `—` fallbacks. Update timing is unchanged — the sheet's parameters were already re-evaluated through the observed view model (the same mechanism as the existing `withdrawalFeeCredits` parameter).

## How Has This Been Tested?

Clean `dashpay` scheme simulator build (`-sdk iphonesimulator`, arm64) on top of current `develop` (includes #1057). Pure code motion with no rendering change, verified by diff review of each route's estimator against the previous switch. The unit-test target is broken pre-existing on this branch lineage, so no new tests were added.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)