### PR TITLE
fix(wallet): adopt instance estimateShieldedFee from platform #4470

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -442,7 +442,7 @@ final class IdentityTopUpViewModel: ObservableObject {
     static func estimatedFeeCredits(source: FundingSource) -> UInt64 {
         let unshieldFee: UInt64
         if source == .shielded {
-            unshieldFee = (try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)) ?? 0
+            unshieldFee = (try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .unshield, numActions: 2)) ?? 0
         } else {
             unshieldFee = 0
         }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -223,11 +223,11 @@ struct InternalTransferConfirmSheet: View {
         case .platformToShielded:
             // Shield (Type 15): base shielded fee. Real metered storage is
             // extra and only knowable on-chain, so this is a lower bound.
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .transfer, numActions: 2)
         case .shieldedToCore:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .withdrawal, numActions: 2)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .unshield, numActions: 2)
         case .coreToPlatform:
             // Address-funding asset lock: the required processing balance
             // (the same 50k-duff base the Rust side reserves for address

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -60,7 +60,7 @@ enum CoreToShieldedAmountPolicy {
     static let assetLockBaseCostCredits: UInt64 = 50_000_000
 
     static var poolFeeCredits: UInt64? {
-        guard let shieldedFee = try? PlatformWalletManager.estimateShieldedFee(
+        guard let shieldedFee = try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
             kind: .transfer,
             numActions: 2)
         else { return nil }
@@ -886,11 +886,11 @@ final class InternalTransferViewModel: ObservableObject {
             // (`ShieldedActionBudget.maxActionsPerTransition`) so a fragmented
             // wallet can't pass the affordability check and then fail SDK note
             // selection.
-            return try? PlatformWalletManager.estimateShieldedFee(
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: .withdrawal,
                 numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: .unshield,
                 numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .platformToCore:

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -375,7 +375,7 @@ final class ShieldedTransferCoordinator: ObservableObject {
         guard allCredits != UInt64.max else { return .unavailable }
 
         let feeForActions: (Int) -> UInt64? = { actionCount in
-            try? PlatformWalletManager.estimateShieldedFee(
+            try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: feeKind,
                 numActions: actionCount)
         }

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -943,13 +943,13 @@ struct SendConfirmSheet: View {
             // The Type 15 shield is an output-only bundle padded to exactly
             // 2 actions, charged the flat base fee — same number the Rust
             // side reserves on input 0.
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .transfer, numActions: 2)
         case .shieldedToCore:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .withdrawal, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .withdrawal, numActions: 2)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .unshield, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .unshield, numActions: 2)
         case .shieldedToShielded:
-            return try? PlatformWalletManager.estimateShieldedFee(kind: .transfer, numActions: 2)
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(kind: .transfer, numActions: 2)
         case .coreToCore:
             // Never presented here — the L1 processor shows the real fee.
             return nil

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -569,15 +569,15 @@ final class SendViewModel: ObservableObject {
         case .shieldedToCore:
             // Worst-case note selection for a bundle the size limit actually
             // admits — same reasoning as the internal transfer's reserve.
-            return try? PlatformWalletManager.estimateShieldedFee(
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: .withdrawal,
                 numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToPlatform:
-            return try? PlatformWalletManager.estimateShieldedFee(
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: .unshield,
                 numActions: ShieldedActionBudget.maxActionsPerTransition)
         case .shieldedToShielded:
-            return try? PlatformWalletManager.estimateShieldedFee(
+            return try? SwiftDashSDKHost.shared.manager?.estimateShieldedFee(
                 kind: .transfer,
                 numActions: ShieldedActionBudget.maxActionsPerTransition)
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Prerequisite for #1062, split out per review there: platform `v4.2-dev` merged dashpay/platform#4470 (`bea4122858`), which turned `PlatformWalletManager.estimateShieldedFee` from a `static func` into an instance method computed at the manager's network-tracked platform version. The app still called it statically in six files, so no platform revision could satisfy both this API and the merged shutdown API from dashpay/platform#4469 (`1e26927c61`, whose ancestor #4470 is).

## What was done?

Migrated all 15 call sites (SendViewModel/SendScreen, InternalTransferViewModel/ConfirmSheet, ShieldedTransferCoordinator, SDKIdentityProfileSheet) from `PlatformWalletManager.estimateShieldedFee(...)` to `SwiftDashSDKHost.shared.manager?.estimateShieldedFee(...)` — the live host manager, same `try?` fallbacks as before. Mechanical; no behavior change beyond the fee now being computed at the connected network's active protocol version (the point of #4470).

## How Has This Been Tested?

- DashPay Debug build for a generic iOS Simulator against platform `v4.2-dev` @ `1e26927c61` (rebuilt `DashSDKFFI.xcframework`, both slices): BUILD SUCCEEDED.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)