### PR TITLE
feat(wallet): show the lifecycle overlay from the first moment of Add Wallet

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/WalletLifecycleTransitionState.swift
@@ -37,6 +37,11 @@ final class WalletLifecycleTransitionState: ObservableObject {
         case switchingWallet(targetName: String?)
         /// Per-wallet removal in flight (`deleteLogicalWallet`).
         case removingWallet
+        /// Add-wallet provisioning in flight (`SwiftDashSDKHost.addWallet` —
+        /// blocking wallet creation on the current network plus the other
+        /// network's mirror). `isImport` picks the card copy
+        /// (Creating/Importing wallet…).
+        case addingWallet(isImport: Bool)
         /// The wallet switch failed. The previous wallet is NOT guaranteed
         /// active afterwards (the registry is repointed before the rebuild
         /// and the host may have bound a fallback wallet), so the card
@@ -64,6 +69,7 @@ final class WalletLifecycleTransitionState: ObservableObject {
             case .failedNetworkSwitch(_, let target, _): return "failedNetworkSwitch(\(target))"
             case .switchingWallet: return "switchingWallet"
             case .removingWallet: return "removingWallet"
+            case .addingWallet: return "addingWallet"
             case .failedWalletSwitch: return "failedWalletSwitch"
             case .failedWalletRemoval: return "failedWalletRemoval"
             case .wiping: return "wiping"
@@ -91,9 +97,16 @@ final class WalletLifecycleTransitionState: ObservableObject {
         case (.idle, .switchingNetwork),
              (.idle, .switchingWallet),
              (.idle, .removingWallet),
+             (.idle, .addingWallet),
              (.idle, .wiping),
              (.failedNetworkSwitch, .switchingNetwork),
              (.failedWalletSwitch, .switchingWallet),
+             // Composite add → switch: the add flow's own continuation into
+             // its post-add switch, without dropping the window through idle.
+             // Deliberately not owner-scoped — in practice only the add flow
+             // can reach it, because the blocking overlay window covers every
+             // other interactive entry point for `.addingWallet`'s lifetime.
+             (.addingWallet, .switchingWallet),
              // The wipe/reset route stays reachable from EVERY failure card:
              // without this, a persistently failing switch (destination
              // network down) would block the whole app behind the overlay

--- a/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
+++ b/DashWallet/Sources/UI/Main/WalletLifecycleOverlay.swift
@@ -56,7 +56,7 @@ final class WalletLifecycleOverlayPresenter {
             overlayWindow?.isHidden = true
             overlayWindow = nil
         case .switchingNetwork, .failedNetworkSwitch,
-             .switchingWallet, .removingWallet,
+             .switchingWallet, .removingWallet, .addingWallet,
              .failedWalletSwitch, .failedWalletRemoval,
              .wiping:
             presentIfNeeded()
@@ -189,6 +189,14 @@ struct WalletLifecycleOverlayView: View {
                 progressCard(
                     title: NSLocalizedString("Removing wallet…", comment: "Wallets"),
                     subtitle: nil)
+            case let .addingWallet(isImport):
+                progressCard(
+                    title: isImport
+                        ? NSLocalizedString("Importing wallet…", comment: "Wallets")
+                        : NSLocalizedString("Creating wallet…", comment: "Wallets"),
+                    subtitle: NSLocalizedString(
+                        "Preparing your wallet. This may take a few seconds.",
+                        comment: "Wallets"))
             case let .wiping(title):
                 // Falls back to the Delete All copy — the same key the root
                 // controller's HUD used, so translations carry over.

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -265,28 +265,66 @@ final class WalletsViewModel: ObservableObject {
         addInProgress = true
         defer { addInProgress = false }
 
+        // Blocking overlay from the FIRST moment: provisioning is seconds of
+        // blocking MainActor work (wallet creation FFI on both networks, plus
+        // the other network's SDK build), and without this phase the app
+        // looked frozen until the post-add switch finally raised the window.
+        WalletLifecycleOverlayPresenter.shared.ensureActive()
+        let state = WalletLifecycleTransitionState.shared
+        guard state.tryBegin(.addingWallet(isImport: isImported)) else {
+            errorMessage = SwiftDashSDKWalletRuntime.SwitchError.switchInProgress.localizedDescription
+            return nil
+        }
+        // Give UIKit one runloop turn to commit the overlay window before the
+        // blocking provisioning starts (the Obj-C wipe's 0.1 s dispatch_after
+        // trick): the phase-apply Task was already enqueued by the sink, and
+        // both it and the CoreAnimation commit run while this sleeps.
+        try? await Task.sleep(for: .milliseconds(100))
+
+        let opID = String(UUID().uuidString.prefix(8))
+        let started = CFAbsoluteTimeGetCurrent()
+        DWLogger.log("🔁 WALLETOP [\(opID)] add begin import=\(isImported)")
+
         let result: SwiftDashSDKHost.AddWalletResult
         do {
             result = try await SwiftDashSDKHost.shared.addWallet(
                 mnemonic: normalized,
                 isImported: isImported)
         } catch {
+            // The ONE exit where a forgotten finish() would strand the
+            // blocking overlay with no owner.
+            state.finish()
+            let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
+            DWLogger.log("🔁 WALLETOP [\(opID)] add FAILED after \(ms)ms: \(error.localizedDescription)")
             Self.logger.error("addWallet failed: \(String(describing: error), privacy: .public)")
             errorMessage = error.localizedDescription
             return nil
         }
+        let ms = Int((CFAbsoluteTimeGetCurrent() - started) * 1000)
+        DWLogger.log("🔁 WALLETOP [\(opID)] add done in \(ms)ms")
 
         switch result {
         case .alreadyExists(let walletId):
+            state.finish()
             return .alreadyOnDevice(walletId: walletId)
         case .added(let walletId):
             switchInProgress = true
             do {
+                // Admitted from `.addingWallet` by the composite rule — the
+                // window advances Creating → Switching without dropping
+                // through idle; from here the helper owns finish/fail.
                 try await Self.gatedSwitchWallet(
                     targetId: walletId,
                     targetName: Self.displayName(for: walletId))
             } catch {
                 switchInProgress = false
+                // Defense in depth: a rejected admission (throws BEFORE any
+                // fail-phase is set) must not strand `.addingWallet`; a real
+                // switch failure has already moved to `.failedWalletSwitch`,
+                // which this deliberately leaves alone.
+                if case .addingWallet = state.phase {
+                    state.finish()
+                }
                 Self.logger.error("post-add switch failed: \(String(describing: error), privacy: .public)")
                 // The wallet was added but the switch failed; leave it on
                 // device — the overlay's blocking card owns recovery (Retry /

--- a/DashWalletTests/WalletLifecycleTransitionStateTests.swift
+++ b/DashWalletTests/WalletLifecycleTransitionStateTests.swift
@@ -23,6 +23,7 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         ("switchingNetwork", .switchingNetwork(from: .mainnet, to: .testnet)),
         ("switchingWallet", .switchingWallet(targetName: "A")),
         ("removingWallet", .removingWallet),
+        ("addingWallet", .addingWallet(isImport: false)),
         ("wiping", .wiping(title: nil)),
     ]
 
@@ -56,16 +57,26 @@ final class WalletLifecycleTransitionStateTests: XCTestCase {
         }
     }
 
-    /// No begin is admitted while any operation is busy.
+    /// No begin is admitted while any operation is busy — except the add
+    /// flow's own composite continuation into its post-add switch.
     func testBusyPhasesRejectEveryBegin() {
         for (busyLabel, busy) in Self.begins {
             for (nextLabel, next) in Self.begins {
                 let state = makeState(in: busy)
-                XCTAssertFalse(
-                    state.tryBegin(next),
-                    "\(nextLabel) must be rejected while \(busyLabel) is in flight")
+                let expected = busyLabel == "addingWallet" && nextLabel == "switchingWallet"
+                XCTAssertEqual(
+                    state.tryBegin(next), expected,
+                    "\(busyLabel) → \(nextLabel): expected admitted=\(expected)")
             }
         }
+    }
+
+    /// The add flow's window advances Creating → Switching without dropping
+    /// through idle.
+    func testAddFlowCompositeAdvancesToSwitch() {
+        let state = makeState(in: .addingWallet(isImport: false))
+        XCTAssertTrue(state.tryBegin(.switchingWallet(targetName: "A")))
+        XCTAssertEqual(state.phase, .switchingWallet(targetName: "A"))
     }
 
     /// Failure phases admit exactly their own retry — and a wipe.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Stacked on #1062 (review it first). Wallets → Add Wallet → Create/Import blocked the MainActor for ~5 s before any indicator appeared: ~2.2 s of wallet-creation FFI on the current network, then ~2.9 s for the other network's mirror (SDK build ~1.6 s + creation + temp-manager shutdown) — all before the post-add switch finally raised the overlay. Simulator logs: tap at 14:48:20.206, overlay only at 14:48:25.331.

## What was done?

- New phase `.addingWallet(isImport:)` with a "Creating wallet…" / "Importing wallet…" card ("Preparing your wallet. This may take a few seconds."). Admitted from idle; the composite pair `.addingWallet → .switchingWallet` lets the existing gated switch advance the window Creating → Switching without dropping through idle. The pair is deliberately not owner-scoped — the blocking overlay window covers every other interactive entry point for the phase's lifetime (noted in the matrix).
- `WalletsViewModel.addWallet` begins the phase before provisioning and sleeps 100 ms so UIKit commits the overlay window before the blocking work starts (the same trick as the Obj-C wipe's `dispatch_after`; the ordering is provable — the phase-apply Task is enqueued synchronously by the `@Published` sink before the sleep's continuation exists). Every exit pairs the begin: provisioning error and `.alreadyExists` → `finish()`; `.added` hands the phase to `gatedSwitchWallet` (whose `previousId` correctly captures the pre-add wallet — `host.addWallet` is additive and never publishes); a rejected post-add admission defensively finishes only when the phase is still `.addingWallet`.
- `🔁 WALLETOP add begin/done/FAILED` telemetry with duration.
- Admission-matrix table test gains the `.addingWallet` rows and the composite-continuation case.

**Scope note:** this is the cosmetic stage — the MainActor still blocks under the overlay (the SwiftUI spinner may pause; the card and copy stay visible). The real fix (an async off-main `createWallet` variant in the Swift SDK mirroring the #4469 `destroyQueue` pattern, plus lifecycle-queue serialization of the add) follows as a separate platform + app PR pair.

## How Has This Been Tested?

- DashPay Debug build for a generic iOS Simulator (platform `v4.2-dev` @ `1e26927c61`): BUILD SUCCEEDED.
- Simulator smoke (testnet): Create New Wallet — overlay card up immediately after the tap, advancing Creating → Switching over the still-presented sheet without an idle flicker, landing on Home with the new wallet active.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear progress feedback while creating or importing a wallet.
  * Wallet creation and import can now transition directly into wallet switching for a smoother experience.

* **Bug Fixes**
  * Improved lifecycle handling when wallet provisioning fails or a duplicate wallet is detected.
  * Prevented unnecessary intermediate states during wallet setup and switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->