### PR TITLE
fix(explore-dash): fit username registration sheet to content

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -478,8 +478,13 @@ struct UsernameMarketplaceScreen: View {
                 .presentationDetents([.medium, .large])
         }
         .sheet(item: $registerCandidate) { candidate in
-            RegisterNameSheet(label: candidate.label, viewModel: viewModel)
-                .presentationDetents([.medium, .large])
+            if UsernameMarketplaceService.isContested(candidate.label) {
+                RegisterNameSheet(label: candidate.label, viewModel: viewModel)
+                    .presentationDetents([.medium, .large])
+            } else {
+                RegisterNameSheet(label: candidate.label, viewModel: viewModel)
+                    .presentationDetents([.height(340)])
+            }
         }
         .overlay {
             // Blocking activity overlay while a trade transition is in

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -479,11 +479,24 @@ struct UsernameMarketplaceScreen: View {
         }
         .sheet(item: $registerCandidate) { candidate in
             if candidate.isContested {
-                RegisterNameSheet(label: candidate.label, viewModel: viewModel)
+                DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                    RegisterNameSheet(
+                        label: candidate.label,
+                        isContested: candidate.isContested,
+                        viewModel: viewModel)
+                }
                     .presentationDetents([.medium, .large])
             } else {
-                RegisterNameSheet(label: candidate.label, viewModel: viewModel)
-                    .presentationDetents([.height(340)])
+                DashUIKit.BottomSheet.selfSizing(
+                    showBackButton: .constant(false),
+                    fallback: 340,
+                    cornerRadius: 24
+                ) {
+                    RegisterNameSheet(
+                        label: candidate.label,
+                        isContested: candidate.isContested,
+                        viewModel: viewModel)
+                }
             }
         }
         .overlay {
@@ -1662,6 +1675,7 @@ private struct TransferNameSheet: View {
 
 private struct RegisterNameSheet: View {
     let label: String
+    let isContested: Bool
     @ObservedObject var viewModel: UsernameMarketplaceViewModel
     @Environment(\.dismiss) private var dismiss
 
@@ -1670,10 +1684,6 @@ private struct RegisterNameSheet: View {
     /// Live vote tallies for an active contest on this label (yours or
     /// anyone's); nil while loading, unavailable, or no contest exists.
     @State private var voteState: ContestVoteState?
-
-    private var isContested: Bool {
-        UsernameMarketplaceService.isContested(label)
-    }
 
     /// This identity already has a request in for this label — the vote
     /// is in progress and a second submission would just fail.

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -478,7 +478,7 @@ struct UsernameMarketplaceScreen: View {
                 .presentationDetents([.medium, .large])
         }
         .sheet(item: $registerCandidate) { candidate in
-            if UsernameMarketplaceService.isContested(candidate.label) {
+            if candidate.isContested {
                 RegisterNameSheet(label: candidate.label, viewModel: viewModel)
                     .presentationDetents([.medium, .large])
             } else {
@@ -946,7 +946,7 @@ struct UsernameMarketplaceScreen: View {
             subtitle = NSLocalizedString("Available — register it on your identity", comment: "Username marketplace: unregistered name row")
         }
         return Button {
-            registerCandidate = RegisterCandidate(label: label)
+            registerCandidate = RegisterCandidate(label: label, isContested: contested)
         } label: {
             HStack(spacing: 10) {
                 Image(systemName: icon)
@@ -1009,6 +1009,7 @@ struct SelectedMarketplaceLabel: Identifiable {
 
 struct RegisterCandidate: Identifiable {
     let label: String
+    let isContested: Bool
     var id: String { label }
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The standard username registration sheet always used the medium presentation detent, leaving a large unused area below its short confirmation content.

## What was done?

- Use DashUIKit's autosizing `BottomSheet` for standard username registration so the sheet follows its intrinsic content height.
- Preserve the medium and large detents for contested usernames, whose auction flow contains substantially more content.
- Pass the prepared contest state into the registration sheet instead of classifying the username again.

## Screenshots

Exact-base and full-head builds using clones of the same configured wallet fixture and the same `helloworld12354` registration flow:

| Before — exact base `53bb20d70` | After — full PR head `69590547a` |
| --- | --- |
| <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/be271e23bb2af78feab0628a70068d84a5d4e19f/comparison/before/username-registration-sheet.png" width="420" alt="Before: standard username registration sheet with excess empty space"> | <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/be271e23bb2af78feab0628a70068d84a5d4e19f/comparison/after/username-registration-sheet.png" width="420" alt="After: DashUIKit autosizing standard username registration sheet"> |

[Before — full resolution](https://raw.githubusercontent.com/dashpay/dashwallet-ios/be271e23bb2af78feab0628a70068d84a5d4e19f/comparison/before/username-registration-sheet.png) · [After — full resolution](https://raw.githubusercontent.com/dashpay/dashwallet-ios/be271e23bb2af78feab0628a70068d84a5d4e19f/comparison/after/username-registration-sheet.png) · [Evidence provenance and hashes](https://github.com/dashpay/dashwallet-ios/tree/be271e23bb2af78feab0628a70068d84a5d4e19f)

## How Has This Been Tested?

- Built, signed, installed, and launched the `dashpay` Debug scheme on an iPhone 17 Pro simulator running iOS 26.5.
- Verified the process remained live after launch.
- Compared the same `helloworld12354` registration flow using clones of the same configured wallet fixture:
  - Before: exact `develop` base `53bb20d70f53e981bd0eba27a3185982b7318e33`
  - After: full PR head `69590547a4777750bb2fa23451d3ea0df720b67e`
- Confirmed the standard DashUIKit sheet autosizes to its content without clipping or excess bottom space, while contested registration retains its medium/large detents.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
