### PR TITLE
fix(ui): restore the third currency option and rename the DEX entry

### DIFF
--- a/DashWallet/Sources/UI/Buy Sell/Model/BuySellPortalModel.swift
+++ b/DashWallet/Sources/UI/Buy Sell/Model/BuySellPortalModel.swift
@@ -43,7 +43,10 @@ extension Service {
         case .uphold: return NSLocalizedString("Uphold", comment: "Dash Portal")
         case .topper: return NSLocalizedString("Topper", comment: "Dash Portal")
         case .maya: return NSLocalizedString("Maya", comment: "Dash Portal")
-        case .swapKit: return NSLocalizedString("SwapKit", comment: "Dash Portal")
+        // The product's name, not the provider's. "Dash DEX" is what the Home
+        // shortcut and the portal's own title already call it; SwapKit is the
+        // service behind it and stays in `SwapKitSwapProvider.displayName`.
+        case .swapKit: return NSLocalizedString("Dash DEX", comment: "Dash Portal")
         }
     }
 

--- a/DashWallet/Sources/UI/Swap/Buy/EnterAmount/BuyEnterAmountView.swift
+++ b/DashWallet/Sources/UI/Swap/Buy/EnterAmount/BuyEnterAmountView.swift
@@ -82,7 +82,7 @@ struct BuyEnterAmountView: View {
                 selectedCurrency: $viewModel.selectedCurrency,
                 options: viewModel.currencyOptions,
                 onCurrencyTap: { showLocalCurrency = true },
-                hidesSelectedOption: true
+                hidesSelectedOption: false
             )
             .frame(height: 70)
 

--- a/DashWallet/Sources/UI/Swap/Convert/SwapConvertView.swift
+++ b/DashWallet/Sources/UI/Swap/Convert/SwapConvertView.swift
@@ -79,7 +79,7 @@ struct SwapConvertView: View {
                 options: viewModel.currencyOptions,
                 onMax: { viewModel.setMax() },
                 onCurrencyTap: { showLocalCurrency = true },
-                hidesSelectedOption: true
+                hidesSelectedOption: false
             )
             .frame(height: 70)
             conversionCard


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two reports from the Dash DEX screens.

The currency column beside the amount on **Enter amount** listed two entries where there are three. The one missing was always the currency you were entering in, so the picker looked like it offered less than it did and there was no way to see what the current unit was.

The **Buy & Sell** portal listed the entry as "SwapKit" — the provider's name — while every other surface calls the product Dash DEX.

## What was done?

**Third option restored.** Both screens passed `hidesSelectedOption: true`, and `EnterAmountView` filters the selected currency out of the list when that is set. Removing it is the whole change: the view models already return the full set (fiat, Dash, coin), and `DashPickerView` already marks the selected entry with `primaryText` and a tinted pill — so "three options, one highlighted" needed no new styling and no DashUIKit change.

- `SwapConvertView.swift`
- `BuyEnterAmountView.swift`

**Renamed the portal card** to Dash DEX, reusing the string the Home shortcut and the portal's own title already use, so no locale gains work.

Scoped deliberately: `SwapKitSwapProvider.displayName` stays "SwapKit". That is the service behind the product and it names error domains rather than anything the user reads as a feature. Say the word if SwapKit should disappear from the interface entirely and I will sweep the rest.

## How Has This Been Tested?

Clean `dashpay` build (iOS Simulator, `ARCHS=arm64`) against `platform` `v4.2-dev`.

Not yet exercised on device: both screens should be opened once each — Buy & Sell → Dash DEX → Buy (Enter Amount) and → Convert (Enter amount) — to confirm the column shows all three and the active one is the highlighted one, and that tapping a row still switches the input currency.

The unit-test target is currently broken repo-wide, so no tests were added.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the SwapKit service label to display as “Dash DEX.”
  - Selected currency options now remain visible while entering amounts for Buy and Convert transactions.
  - Improved clarity by keeping the chosen currency visible throughout amount entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->