### PR TITLE
fix(dashpay): keep username voting responsive

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/Voting/ContestedNamesService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/Voting/ContestedNamesService.swift
@@ -80,7 +80,7 @@ final class ContestedNamesService {
     /// reported end time sort last.
     func activeContests() async throws -> [DPNSContest] {
         let sdk = try requireSDK()
-        let contests = try sdk.dpnsActiveContests(limit: Self.activeContestLimit)
+        let contests = try await sdk.dpnsActiveContests(limit: Self.activeContestLimit)
 
         if contests.count >= Int(Self.activeContestLimit) {
             Self.logger.warning(


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Username voting screen can freeze indefinitely while loading active contests. The screen's main-actor refresh path called a synchronous Swift SDK wrapper that blocked inside Rust FFI while querying Platform.

Depends on dashpay/platform#4485, which makes the active-contest SDK query asynchronous, adds bounded concurrency, and enforces an overall timeout.

## What was done?

Await the asynchronous `dpnsActiveContests` SDK query so the Username voting refresh no longer blocks the main actor.

## How Has This Been Tested?

- Built the simulator XCFramework from dashpay/platform#4485
- Full `dashpay` Debug build, install, and launch on an iOS 26.5 simulator
- Reproduced the Username voting path with no masternode keys
- Verified loading completes with the “No open contests” state
- Verified Back responds immediately during loading
- Sampled the process during loading and confirmed the main thread remains in the UIKit run loop rather than Rust `block_on`

Simulator: iPhone 17 Pro, iOS 26.5 (`Username Voting Loading Fix Clean`)

## Breaking Changes

None in DashWallet. The required SDK source change is documented in dashpay/platform#4485.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval of active contested names by using asynchronous loading, while preserving existing sorting, limits, and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->