### PR TITLE
refactor(ui): standardize dismiss-safe sheets on DashUIKit

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
+++ b/DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift
@@ -305,13 +305,16 @@ struct ContactsScreen: View {
                     }
                 }
             ) {
-                EnableDashPaySuccessSheet(onSendFirstRequest: {
-                    pendingFirstContactRequest = true
-                    viewModel.showEnableSuccess = false
-                })
+                DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                    EnableDashPaySuccessSheet(onSendFirstRequest: {
+                        pendingFirstContactRequest = true
+                        viewModel.showEnableSuccess = false
+                    })
+                }
                 // .medium can clip at large Dynamic Type sizes; the sheet
                 // content scrolls and .large stays reachable.
                 .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.hidden)
             }
             .sheet(item: $selectedContact) { contact in
                 ContactProfileSheet(contact: contact)
@@ -341,10 +344,13 @@ struct ContactsScreen: View {
                 viewModel: viewModel,
                 showingEnableDashPay: $showingEnableDashPay)
                 .sheet(isPresented: $showingEnableDashPay) {
-                    EnableDashPayConfirmSheet(viewModel: viewModel)
+                    DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                        EnableDashPayConfirmSheet(viewModel: viewModel)
+                    }
                         // .medium can clip at large Dynamic Type sizes; the
                         // sheet content scrolls and .large stays reachable.
                         .presentationDetents([.medium, .large])
+                        .presentationDragIndicator(.hidden)
                 }
         } else {
             VStack(spacing: 0) {

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -981,6 +981,11 @@ private struct ContestedNameConfirmationSheet: View {
                         .padding(.top, 16)
                 }
             }
+            // The buttons below sit outside this ScrollView, and `BottomSheet`'s
+            // `edgesIgnoringSafeArea(.bottom)` swallows the keyboard region as well as the
+            // home indicator, so nothing moves when the keyboard appears. Let a drag put it
+            // away; the toolbar below gives an explicit way out too.
+            .scrollDismissesKeyboard(.interactively)
 
             DashButton(
                 text: NSLocalizedString("Submit both usernames", comment: "Usernames"),
@@ -1008,6 +1013,15 @@ private struct ContestedNameConfirmationSheet: View {
         }
         .padding(.horizontal, 20)
         .padding(.bottom, 20)
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button(NSLocalizedString("Done", comment: "")) {
+                    UIApplication.shared.sendAction(
+                        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                }
+            }
+        }
         .onAppear {
             temporaryField.seedSuggestion(from: viewModel.username)
         }

--- a/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
+++ b/DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift
@@ -347,13 +347,20 @@ struct CreateUsernameView: View {
             syncFundingSourceToViableSource()
         }
         .sheet(isPresented: $showContestedConfirmation) {
-            ContestedNameConfirmationSheet(
-                viewModel: viewModel,
-                temporaryField: viewModel.temporaryField,
-                onSubmit: { temporaryUsername in
-                    confirmContestedSubmission(temporaryUsername: temporaryUsername)
-                },
-                onCancel: { showContestedConfirmation = false })
+            DashUIKit.BottomSheet(
+                title: NSLocalizedString("Contested name", comment: "Usernames"),
+                showBackButton: .constant(false)
+            ) {
+                ContestedNameConfirmationSheet(
+                    viewModel: viewModel,
+                    temporaryField: viewModel.temporaryField,
+                    onSubmit: { temporaryUsername in
+                        confirmContestedSubmission(temporaryUsername: temporaryUsername)
+                    },
+                    onCancel: { showContestedConfirmation = false })
+            }
+            .presentationDetents([.large])
+            .presentationDragIndicator(.hidden)
         }
         .alert(
             NSLocalizedString("Buy username", comment: "Usernames"),
@@ -950,15 +957,11 @@ private struct ContestedNameConfirmationSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(NSLocalizedString("Contested name", comment: "Usernames"))
-                        .foregroundColor(.dash.primaryText)
-                        .font(.title2.bold())
-                        .padding(.top, 24)
                     Text(voteMessage)
                         .foregroundColor(.dash.secondaryText)
                         .font(.subheadline)
                         .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, 8)
+                        .padding(.top, 24)
 
                     Text(NSLocalizedString("Add a temporary username", comment: "Usernames"))
                         .foregroundColor(.dash.primaryText)
@@ -1005,7 +1008,6 @@ private struct ContestedNameConfirmationSheet: View {
         }
         .padding(.horizontal, 20)
         .padding(.bottom, 20)
-        .presentationDetents([.large])
         .onAppear {
             temporaryField.seedSuggestion(from: viewModel.username)
         }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -20,6 +20,12 @@ import DashUIKit
 import SDWebImageSwiftUI
 
 struct DashSpendConfirmationDialog: View {
+    /// Detent used before `selfSizingSheet` has measured the sheet, so it doesn't
+    /// present short and then jump. Covers this dialog's own natural height plus
+    /// `DashUIKit.BottomSheet`'s chrome — an 18pt grabber and a 64pt navigation bar.
+    /// Both presenters share this value; keep it here so they can't drift apart.
+    static let sheetFallbackHeight: CGFloat = 582
+
     let merchantName: String
     let merchantIconUrl: String
     let originalPrice: Decimal
@@ -195,7 +201,7 @@ private struct DashSpendConfirmationDialogPreview: View {
             DashUIKit.BottomSheet.selfSizing(
                 title: NSLocalizedString("Confirm", comment: "DashSpend"),
                 showBackButton: .constant(false),
-                fallback: 500,
+                fallback: DashSpendConfirmationDialog.sheetFallbackHeight,
                 cornerRadius: 32
             ) {
                 DashSpendConfirmationDialog(

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift
@@ -54,17 +54,6 @@ struct DashSpendConfirmationDialog: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Capsule()
-                .fill(Color.dash.grabberFill)
-                .frame(width: 36, height: 5)
-                .padding(.top, 6)
-                .padding(.bottom, 13)
-
-            Text(NSLocalizedString("Confirm", comment: "DashSpend"))
-                .font(.calloutMedium)
-                .foregroundColor(.dash.primaryText)
-                .frame(height: 44)
-
             VStack(spacing: 20) {
                 DashSpendAmountView(
                     currencySymbol: fiatFormatter.currencySymbol,
@@ -203,28 +192,21 @@ private struct DashSpendConfirmationDialogPreview: View {
                 .onTapGesture { isPresented = true }
         }
         .sheet(isPresented: $isPresented) {
-            let content = DashSpendConfirmationDialog(
-                merchantName: "Amazon",
-                merchantIconUrl: "",
-                originalPrice: 75.70,
-                discount: 0.10,
-                quantities: [50: 1, 25: 2],
-                onConfirm: {},
-                onCancel: {}
-            )
-
-            if #available(iOS 16.4, *) {
-                content
-                    .presentationBackground(Color.dash.primaryBackground)
-                    .selfSizingSheet()
-                    .presentationCornerRadius(32)
-                    .presentationDragIndicator(.hidden)
-            } else if #available(iOS 16.0, *) {
-                content
-                    .selfSizingSheet()
-                    .presentationDragIndicator(.hidden)
-            } else {
-                content
+            DashUIKit.BottomSheet.selfSizing(
+                title: NSLocalizedString("Confirm", comment: "DashSpend"),
+                showBackButton: .constant(false),
+                fallback: 500,
+                cornerRadius: 32
+            ) {
+                DashSpendConfirmationDialog(
+                    merchantName: "Amazon",
+                    merchantIconUrl: "",
+                    originalPrice: 75.70,
+                    discount: 0.10,
+                    quantities: [50: 1, 25: 2],
+                    onConfirm: {},
+                    onCancel: {}
+                )
             }
         }
     }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
@@ -268,28 +268,21 @@ private struct DashSpendPayConfirmationSheet: View {
     
     @ViewBuilder
     var body: some View {
-        let dialog = DashSpendConfirmationDialog(
-            merchantName: merchantName,
-            merchantIconUrl: merchantIconUrl,
-            originalPrice: originalPrice,
-            discount: discount,
-            quantities: quantities,
-            onConfirm: onConfirm,
-            onCancel: onCancel
-        )
-
-        if #available(iOS 16.4, *) {
-            dialog
-                .presentationBackground(Color.dash.primaryBackground)
-                .selfSizingSheet(fallback: 500)
-                .presentationCornerRadius(32)
-                .presentationDragIndicator(.hidden)
-        } else if #available(iOS 16.0, *) {
-            dialog
-                .selfSizingSheet(fallback: 500)
-                .presentationDragIndicator(.hidden)
-        } else {
-            dialog
+        DashUIKit.BottomSheet.selfSizing(
+            title: NSLocalizedString("Confirm", comment: "DashSpend"),
+            showBackButton: .constant(false),
+            fallback: 500,
+            cornerRadius: 32
+        ) {
+            DashSpendConfirmationDialog(
+                merchantName: merchantName,
+                merchantIconUrl: merchantIconUrl,
+                originalPrice: originalPrice,
+                discount: discount,
+                quantities: quantities,
+                onConfirm: onConfirm,
+                onCancel: onCancel
+            )
         }
     }
 }

--- a/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendPayScreen.swift
@@ -271,7 +271,7 @@ private struct DashSpendPayConfirmationSheet: View {
         DashUIKit.BottomSheet.selfSizing(
             title: NSLocalizedString("Confirm", comment: "DashSpend"),
             showBackButton: .constant(false),
-            fallback: 500,
+            fallback: DashSpendConfirmationDialog.sheetFallbackHeight,
             cornerRadius: 32
         ) {
             DashSpendConfirmationDialog(

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -305,11 +305,13 @@ struct HomeViewContent<Content: View>: View {
                     .padding(.top, 5)
                     .padding(.bottom, -12)
                     .sheet(item: $balanceInfoNetwork) { network in
-                        BalanceInfoSheet(network: network) {
-                            balanceInfoNetwork = nil
+                        DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                            BalanceInfoSheet(network: network) {
+                                balanceInfoNetwork = nil
+                            }
                         }
                         .presentationDetents([.medium, .large])
-                        .presentationDragIndicator(.visible)
+                        .presentationDragIndicator(.hidden)
                     }
 
                     VStack(spacing: 0) {

--- a/DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift
@@ -22,23 +22,10 @@ import DashUIKit
 
 struct CSVExportSheet: View {
     @Environment(\.presentationMode) private var presentationMode
-    @Environment(\.colorScheme) private var colorScheme
     let onExport: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
-            // Grabber
-            Capsule()
-                .fill(colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.gray300Alpha50)
-                .frame(width: 36, height: 5)
-                .padding(.top, 6)
-                .padding(.bottom, 6)
-
-            // Close button
-            NavBarClose {
-                presentationMode.wrappedValue.dismiss()
-            }
-
             // Content
             VStack(spacing: 0) {
                 // Icon
@@ -89,7 +76,6 @@ struct CSVExportSheet: View {
             .padding(.top, 20)
             .padding(.bottom, 20)
         }
-        .background(Color.dash.secondaryBackground)
     }
 }
 

--- a/DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift
@@ -73,7 +73,6 @@ private struct ShareSheet: UIViewControllerRepresentable {
 
 struct ExtendedPublicKeySheet: View {
     @StateObject private var viewModel = ExtendedPublicKeySheetViewModel()
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var isCopied = false
@@ -81,19 +80,6 @@ struct ExtendedPublicKeySheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Grabber
-            VStack {
-                RoundedRectangle(cornerRadius: 5, style: .continuous)
-                    .fill(Color.dash.gray300.opacity(0.5))
-                    .frame(width: 36, height: 5)
-            }
-            .frame(maxWidth: .infinity, minHeight: 18)
-
-            // Close button
-            NavBarClose {
-                dismiss()
-            }
-
             // QR code
             Group {
                 if let qrImage = viewModel.qrImage {
@@ -162,7 +148,6 @@ struct ExtendedPublicKeySheet: View {
             .padding(.horizontal, 60)
             .padding(.bottom, 20)
         }
-        .background(Color.dash.secondaryBackground)
         .sheet(isPresented: $showShareSheet) {
             if !viewModel.keyValue.isEmpty {
                 ShareSheet(items: [viewModel.keyValue])

--- a/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift
@@ -103,14 +103,16 @@ struct ToolsMenuScreen: View {
         }
         .sheet(isPresented: $showCSVExportSheet) {
             if #available(iOS 16.4, *) {
-                CSVExportSheet(onExport: handleCSVExport)
+                csvExportSheet
                     .presentationDetents([.large])
                     .presentationCornerRadius(32)
+                    .presentationDragIndicator(.hidden)
             } else if #available(iOS 16.0, *) {
-                CSVExportSheet(onExport: handleCSVExport)
+                csvExportSheet
                     .presentationDetents([.large])
+                    .presentationDragIndicator(.hidden)
             } else {
-                CSVExportSheet(onExport: handleCSVExport)
+                csvExportSheet
             }
         }
         .alert(NSLocalizedString("Move CoinJoin Funds", comment: "CoinJoin"), isPresented: $viewModel.showCoinJoinSweepConfirmation) {
@@ -167,27 +169,49 @@ struct ToolsMenuScreen: View {
             }
         }) {
             if #available(iOS 16.4, *) {
-                ZenLedgerInfoSheet(safariLink: $viewModel.safariLink)
+                zenLedgerSheet
                     .presentationDetents([.large])
                     .presentationCornerRadius(32)
+                    .presentationDragIndicator(.hidden)
             } else if #available(iOS 16.0, *) {
-                ZenLedgerInfoSheet(safariLink: $viewModel.safariLink)
+                zenLedgerSheet
                     .presentationDetents([.large])
+                    .presentationDragIndicator(.hidden)
             } else {
-                ZenLedgerInfoSheet(safariLink: $viewModel.safariLink)
+                zenLedgerSheet
             }
         }
         .sheet(isPresented: $showExtendedPublicKeySheet) {
             if #available(iOS 16.4, *) {
-                ExtendedPublicKeySheet()
+                extendedPublicKeySheet
                     .presentationDetents([.height(640)])
                     .presentationCornerRadius(32)
+                    .presentationDragIndicator(.hidden)
             } else if #available(iOS 16.0, *) {
-                ExtendedPublicKeySheet()
+                extendedPublicKeySheet
                     .presentationDetents([.height(640)])
+                    .presentationDragIndicator(.hidden)
             } else {
-                ExtendedPublicKeySheet()
+                extendedPublicKeySheet
             }
+        }
+    }
+
+    private var csvExportSheet: some View {
+        DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+            CSVExportSheet(onExport: handleCSVExport)
+        }
+    }
+
+    private var zenLedgerSheet: some View {
+        DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+            ZenLedgerInfoSheet(safariLink: $viewModel.safariLink)
+        }
+    }
+
+    private var extendedPublicKeySheet: some View {
+        DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+            ExtendedPublicKeySheet()
         }
     }
     

--- a/DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift
@@ -24,24 +24,11 @@ struct ZenLedgerInfoSheet: View {
     @State private var errorAlert: Bool = false
     @State private var inProgress: Bool = false
     @Environment(\.presentationMode) private var presentationMode
-    @Environment(\.colorScheme) private var colorScheme
 
     @Binding var safariLink: String?
 
     var body: some View {
         VStack(spacing: 0) {
-            // Grabber
-            Capsule()
-                .fill(colorScheme == .dark ? Color.dash.whiteAlpha20 : Color.dash.gray300Alpha50)
-                .frame(width: 36, height: 5)
-                .padding(.top, 6)
-                .padding(.bottom, 6)
-
-            // Close button
-            NavBarClose {
-                presentationMode.wrappedValue.dismiss()
-            }
-
             // Content
             VStack(spacing: 0) {
                 // Icon
@@ -101,7 +88,6 @@ struct ZenLedgerInfoSheet: View {
             .padding(.top, 20)
             .padding(.bottom, 20)
         }
-        .background(Color.dash.secondaryBackground)
         .alert(isPresented: $showAlert) {
             resolveAlert()
         }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift
@@ -257,14 +257,25 @@ struct InternalTransferScreen: View {
             }
         }
         .sheet(item: $endpointPicker) { group in
-            endpointPickerSheet(for: group)
+            DashUIKit.BottomSheet(
+                title: endpointPickerTitle(for: group),
+                showBackButton: .constant(false)
+            ) {
+                endpointPickerSheet(for: group)
+            }
                 .presentationDetents([.height(400)])
-                .presentationDragIndicator(.visible)
+                .presentationDragIndicator(.hidden)
         }
     }
 
     private func presentEndpointPicker(_ group: EndpointGroup) {
         endpointPicker = group
+    }
+
+    private func endpointPickerTitle(for group: EndpointGroup) -> String {
+        group == .from
+            ? NSLocalizedString("Transfer from", comment: "Internal transfer source picker title")
+            : NSLocalizedString("Transfer to", comment: "Internal transfer destination picker title")
     }
 
     /// Bottom-sheet balance picker for one endpoint, sized to slide over
@@ -274,12 +285,6 @@ struct InternalTransferScreen: View {
     private func endpointPickerSheet(for group: EndpointGroup) -> some View {
         let isFrom = group == .from
         return VStack(alignment: .leading, spacing: 16) {
-            Text(isFrom
-                ? NSLocalizedString("Transfer from", comment: "Internal transfer source picker title")
-                : NSLocalizedString("Transfer to", comment: "Internal transfer destination picker title"))
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundColor(.dash.primaryText)
-
             selectionGroup(
                 caption: isFrom
                     ? NSLocalizedString("From", comment: "")
@@ -298,7 +303,7 @@ struct InternalTransferScreen: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 20)
-        .padding(.top, 24)
+        .padding(.top, 16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.dash.primaryBackground)
     }

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
@@ -11,27 +11,36 @@ struct TransferTimingSheet: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
-            Text(NSLocalizedString("Transfers take different times", comment: ""))
-                .font(.system(size: 24, weight: .bold))
-                .foregroundColor(.dash.primaryText)
-                .multilineTextAlignment(.leading)
-                .fixedSize(horizontal: false, vertical: true)
+            // Scrollable: the sheet is presented in a fixed `.medium()` detent and the
+            // `BottomSheet` chrome takes part of it, so on a short screen or with a long
+            // translation the text no longer fits. Letting it scroll keeps the CTA — the
+            // only thing that records the acknowledgement — reachable at any height.
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    Text(NSLocalizedString("Transfers take different times", comment: ""))
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.dash.primaryText)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
 
-            VStack(alignment: .leading, spacing: 18) {
-                timingRow(
-                    iconSystemName: "bolt.fill",
-                    iconColor: .orange,
-                    title: NSLocalizedString("From Dash Wallet to Shielded balance", comment: ""),
-                    subtitle: NSLocalizedString("The transfer is instant", comment: ""))
+                    VStack(alignment: .leading, spacing: 18) {
+                        timingRow(
+                            iconSystemName: "bolt.fill",
+                            iconColor: .orange,
+                            title: NSLocalizedString("From Dash Wallet to Shielded balance", comment: ""),
+                            subtitle: NSLocalizedString("The transfer is instant", comment: ""))
 
-                timingRow(
-                    iconSystemName: "clock.fill",
-                    iconColor: .blue,
-                    title: NSLocalizedString("From Shielded balance to Dash Wallet", comment: ""),
-                    subtitle: NSLocalizedString("The transfer could take up to 10 minutes", comment: ""))
+                        timingRow(
+                            iconSystemName: "clock.fill",
+                            iconColor: .blue,
+                            title: NSLocalizedString("From Shielded balance to Dash Wallet", comment: ""),
+                            subtitle: NSLocalizedString("The transfer could take up to 10 minutes", comment: ""))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 8)
             }
-
-            Spacer(minLength: 8)
+            .scrollBounceBehavior(.basedOnSize)
 
             DashButton(
                 text: NSLocalizedString("I got it", comment: ""),

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift
@@ -7,23 +7,10 @@ import SwiftUI
 import DashUIKit
 
 struct TransferTimingSheet: View {
-    @Environment(\.dismiss) private var dismiss
-
     var onConfirm: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
-            HStack {
-                Spacer()
-                Button(action: { dismiss() }) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 16, weight: .medium))
-                        .foregroundColor(.dash.primaryText)
-                        .frame(width: 36, height: 36)
-                        .overlay(Circle().stroke(Color.dash.gray300.opacity(0.3), lineWidth: 1))
-                }
-            }
-
             Text(NSLocalizedString("Transfers take different times", comment: ""))
                 .font(.system(size: 24, weight: .bold))
                 .foregroundColor(.dash.primaryText)
@@ -55,7 +42,7 @@ struct TransferTimingSheet: View {
                 })
         }
         .padding(.horizontal, 24)
-        .padding(.top, 14)
+        .padding(.top, 24)
         .padding(.bottom, 24)
         .background(Color.dash.primaryBackground)
     }

--- a/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
+++ b/DashWallet/Sources/UI/Payments/Landing/PaymentsLandingHostingController.swift
@@ -4,6 +4,7 @@
 //
 
 import Combine
+import DashUIKit
 import SwiftUI
 import UIKit
 
@@ -262,15 +263,17 @@ final class PaymentsLandingHostingController: DWBasePayViewController {
         else { return }
         viewModel.setReceiptWatchingObscured(true)
         let host = UIHostingController(
-            rootView: TransferTimingSheet(onConfirm: { [weak self] in
-                UserDefaults.standard.set(true, forKey: Self.shieldedBalanceTimingShownKey)
-                self?.dismiss(animated: true) {
-                    self?.viewModel.setReceiptWatchingObscured(false)
-                }
-            }))
+            rootView: DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                TransferTimingSheet(onConfirm: { [weak self] in
+                    UserDefaults.standard.set(true, forKey: Self.shieldedBalanceTimingShownKey)
+                    self?.dismiss(animated: true) {
+                        self?.viewModel.setReceiptWatchingObscured(false)
+                    }
+                })
+            })
         if let sheet = host.sheetPresentationController {
             sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
+            sheet.prefersGrabberVisible = false
         }
         present(host, animated: true) { [weak self, weak host] in
             host?.presentationController?.delegate = self


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #1073. Several dismiss-safe sheets still drew their own grabber/close chrome or relied on bare system sheets, so the wallet did not consistently use the shared `DashUIKit.BottomSheet` component.

This is intentionally stacked on `refactor/dashuikit-bottom-sheet-foundation`. Protected signing, proving, and broadcast flows remain deferred until DashUIKit exposes dynamic dismissal control.

## What was done?

- Wrapped CSV export, ZenLedger, extended public key, balance info, transfer timing, and the internal-transfer endpoint picker in `DashUIKit.BottomSheet`.
- Wrapped DashPay enable confirmation/success and contested-username confirmation sheets.
- Moved DashSpend purchase confirmation onto `DashUIKit.BottomSheet.selfSizing`.
- Removed duplicate grabbers, close controls, titles, backgrounds, and system drag indicators now owned by DashUIKit.
- Preserved native activity/share sheets and existing detents, callbacks, and acknowledgement semantics.

## How Has This Been Tested?

- `xcodebuild -list -workspace DashWallet.xcworkspace`
- Full `dashpay` Debug build for iPhone 17 Pro / iOS 26.5 Simulator at exact head `bb34895b65769d5849b97aea56adb39dcf3c6982`
- Installed, launched, and verified the process remained alive (`org.dashfoundation.dash`)
- Runtime navigation through CSV export, extended public key, ZenLedger, balance info, transfer timing, and endpoint-picker flows
- `git diff --check`
- Code simplification and independent four-pass review gates: approved with no findings

The separate `dashwallet` scheme retains unrelated baseline target-membership failures for `TxDetailContactAvatar` and `TxDetailContactRow`; this PR does not touch those files or target entries.

## Before / after screenshots

Exact-revision provenance, SHA-256 hashes, and full-resolution originals: [visual evidence tree](https://github.com/dashpay/dashwallet-ios/tree/0ab8e2660f9129194bda41c71c668e4d94a63156)

### Balance info

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before balance info](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/balance-info.png) | ![After balance info](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/balance-info.png) |

### CSV export

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before CSV export](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/csv-export.png) | ![After CSV export](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/csv-export.png) |

### Extended public key

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before extended public key](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/extended-public-key.png) | ![After extended public key](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/extended-public-key.png) |

### ZenLedger

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before ZenLedger](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/zenledger.png) | ![After ZenLedger](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/zenledger.png) |

### Transfer timing

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before transfer timing](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/transfer-timing.png) | ![After transfer timing](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/transfer-timing.png) |

### Transfer endpoint picker

| Before (`ab5661897`) | After (`bb34895b6`) |
| --- | --- |
| ![Before endpoint picker](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/before/endpoint-picker.png) | ![After endpoint picker](https://raw.githubusercontent.com/dashpay/dashwallet-ios/0ab8e2660f9129194bda41c71c668e4d94a63156/comparison/after/endpoint-picker.png) |

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (UI composition only; validated by exact-revision simulator runs)
- [x] I have made corresponding changes to the documentation (exact-revision visual evidence)

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized bottom sheets across contacts, payments, DashSpend, home, and tools screens.
  * Hidden drag indicators and removed redundant grabbers, close buttons, and in-content titles.
  * Improved sheet titles, spacing, sizing, and corner-radius presentation.

* **Bug Fixes**
  * Improved sheet behavior and appearance across supported iOS versions.
  * Preserved existing export, transfer, confirmation, and navigation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->