### PR TITLE
refactor(ui): migrate protected sheets to DashUIKit

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -13413,8 +13413,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dashpay/DashUIKit";
 			requirement = {
-				kind = revision;
-				revision = e8d92434bfc28fbf933b896cd40a01dd61835b5f;
+				branch = master;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -13413,8 +13413,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dashpay/DashUIKit";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = e8d92434bfc28fbf933b896cd40a01dd61835b5f;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
-  "originHash" : "2b9d5280ec4645105debdfd588a911137d45333db7102b1ec79310afb20db9cc",
-  "pins" : [
+  "originHash": "2b9d5280ec4645105debdfd588a911137d45333db7102b1ec79310afb20db9cc",
+  "pins": [
     {
-      "identity" : "dashuikit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/dashpay/DashUIKit",
-      "state" : {
-        "revision" : "e8d92434bfc28fbf933b896cd40a01dd61835b5f"
+      "identity": "dashuikit",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/dashpay/DashUIKit",
+      "state": {
+        "branch": "master",
+        "revision": "83cf65a84834f6a7a1f0a82446ea1258ea86f37d"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DashWallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dashpay/DashUIKit",
       "state" : {
-        "branch" : "master",
-        "revision" : "5b373b141054438e94903af52b9ec324f1efbdb2"
+        "revision" : "e8d92434bfc28fbf933b896cd40a01dd61835b5f"
       }
     }
   ],

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -480,7 +480,10 @@ struct UsernameMarketplaceScreen: View {
         }
         .sheet(item: $registerCandidate) { candidate in
             if candidate.isContested {
-                DashUIKit.BottomSheet(showBackButton: .constant(false)) {
+                DashUIKit.BottomSheet(
+                    showBackButton: .constant(false),
+                    isDismissalEnabled: .constant(!viewModel.isPerformingAction)
+                ) {
                     RegisterNameSheet(
                         label: candidate.label,
                         isContested: candidate.isContested,
@@ -490,6 +493,7 @@ struct UsernameMarketplaceScreen: View {
             } else {
                 DashUIKit.BottomSheet.selfSizing(
                     showBackButton: .constant(false),
+                    isDismissalEnabled: .constant(!viewModel.isPerformingAction),
                     fallback: 340,
                     cornerRadius: 24
                 ) {
@@ -1842,7 +1846,6 @@ private struct RegisterNameSheet: View {
             }
         }
         .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(viewModel.isPerformingAction)
         .overlay {
             if let activity = viewModel.activityMessage {
                 MarketplaceActivityOverlay(message: activity)

--- a/DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift
+++ b/DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift
@@ -182,16 +182,12 @@ struct CoinJoinMoveFundsSheet: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            dragHandle
-                .padding(.top, 8)
-
-            Text(NSLocalizedString("Move your mixed coins", comment: "CoinJoin"))
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-                .padding(.top, 20)
-
+        DashUIKit.BottomSheet(
+            title: NSLocalizedString("Move your mixed coins", comment: "CoinJoin"),
+            showBackButton: .constant(false),
+            isDismissalEnabled: .constant(!viewModel.isInFlight),
+            onClose: onDismiss
+        ) {
             switch viewModel.stage {
             case .choice:
                 choiceBody
@@ -207,8 +203,6 @@ struct CoinJoinMoveFundsSheet: View {
                 failedBody(message: message, destination: destination)
             }
         }
-        .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(viewModel.isInFlight)
     }
 
     // MARK: Choice
@@ -421,10 +415,4 @@ struct CoinJoinMoveFundsSheet: View {
 
     // MARK: Pieces
 
-    private var dragHandle: some View {
-        Rectangle()
-            .fill(Color.dash.grabberFill)
-            .frame(width: 36, height: 5)
-            .cornerRadius(2.5)
-    }
 }

--- a/DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift
+++ b/DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift
@@ -186,6 +186,9 @@ struct CoinJoinMoveFundsSheet: View {
             title: NSLocalizedString("Move your mixed coins", comment: "CoinJoin"),
             showBackButton: .constant(false),
             isDismissalEnabled: .constant(!viewModel.isInFlight),
+            // Supplying `onClose` makes the close button live regardless of
+            // `isDismissalEnabled`, so the in-flight stages have to gate it here.
+            isCloseButtonEnabled: !viewModel.isInFlight,
             onClose: onDismiss
         ) {
             switch viewModel.stage {
@@ -209,41 +212,49 @@ struct CoinJoinMoveFundsSheet: View {
 
     private var choiceBody: some View {
         VStack(spacing: 0) {
-            DashAmount(
-                amount: Int64(viewModel.amountDuffs),
-                font: .largeTitle,
-                dashSymbolFactor: 0.7,
-                showDirection: false)
-                .padding(.top, 14)
+            // Scrollable: this is the only migrated sheet whose initial detent is
+            // `.medium`, and the BottomSheet chrome takes 82pt of it. Letting the
+            // choices scroll keeps "Later" — the only way out that records the
+            // deferral — reachable on a short screen or a long translation.
+            ScrollView {
+                VStack(spacing: 0) {
+                    DashAmount(
+                        amount: Int64(viewModel.amountDuffs),
+                        font: .largeTitle,
+                        dashSymbolFactor: 0.7,
+                        showDirection: false)
+                        .padding(.top, 14)
 
-            Text(NSLocalizedString(
-                "CoinJoin is no longer supported — choose where to move your mixed coins.",
-                comment: "CoinJoin"))
-                .font(.system(size: 14))
-                .foregroundColor(.dash.secondaryText)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 24)
-                .padding(.top, 12)
+                    Text(NSLocalizedString(
+                        "CoinJoin is no longer supported — choose where to move your mixed coins.",
+                        comment: "CoinJoin"))
+                        .font(.system(size: 14))
+                        .foregroundColor(.dash.secondaryText)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 24)
+                        .padding(.top, 12)
 
-            VStack(spacing: 10) {
-                destinationCard(
-                    icon: "wallet.pass.fill",
-                    title: NSLocalizedString("Dash Wallet balance", comment: "CoinJoin"),
-                    subtitle: NSLocalizedString(
-                        "Move to your regular spendable balance.", comment: "CoinJoin"),
-                    action: { Task { await viewModel.moveToWallet() } })
-                destinationCard(
-                    icon: "shield.fill",
-                    title: NSLocalizedString("Shielded balance", comment: "CoinJoin"),
-                    subtitle: NSLocalizedString(
-                        "Keep these coins private. Network and privacy fees apply.",
-                        comment: "CoinJoin"),
-                    action: { Task { await viewModel.moveToShielded() } })
+                    VStack(spacing: 10) {
+                        destinationCard(
+                            icon: "wallet.pass.fill",
+                            title: NSLocalizedString("Dash Wallet balance", comment: "CoinJoin"),
+                            subtitle: NSLocalizedString(
+                                "Move to your regular spendable balance.", comment: "CoinJoin"),
+                            action: { Task { await viewModel.moveToWallet() } })
+                        destinationCard(
+                            icon: "shield.fill",
+                            title: NSLocalizedString("Shielded balance", comment: "CoinJoin"),
+                            subtitle: NSLocalizedString(
+                                "Keep these coins private. Network and privacy fees apply.",
+                                comment: "CoinJoin"),
+                            action: { Task { await viewModel.moveToShielded() } })
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 20)
+                    .padding(.bottom, 12)
+                }
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 20)
-
-            Spacer(minLength: 12)
+            .scrollBounceBehavior(.basedOnSize)
 
             DashButton(
                 text: NSLocalizedString("Later", comment: "CoinJoin"),

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift
@@ -352,7 +352,10 @@ struct EvonodeWithdrawalConfirmSheet: View {
             title: NSLocalizedString("Confirm withdrawal", comment: "Evonode withdrawal"),
             showBackButton: .constant(false),
             isDismissalEnabled: .constant(!(isInFlight || isUnconfirmed)),
-            onClose: onCancel
+            // Supplying `onClose` makes the close button live regardless of
+            // `isDismissalEnabled`, so the protected phases have to gate it here.
+            isCloseButtonEnabled: !(isInFlight || isUnconfirmed),
+            onClose: closeAction
         ) {
             switch viewModel.phase {
             case let .success(remaining):
@@ -368,6 +371,21 @@ struct EvonodeWithdrawalConfirmSheet: View {
     private var isUnconfirmed: Bool {
         if case .submittedUnconfirmed = viewModel.phase { return true }
         return false
+    }
+
+    /// The close button has to do what the visible button of the current phase
+    /// does. `onCancel` only closes the sheet, so on success it would skip
+    /// `onWithdrawn(remaining)` and leave the withdrawal screen showing the
+    /// stale pre-withdrawal claimable balance.
+    private var closeAction: () -> Void {
+        switch viewModel.phase {
+        case let .success(remaining):
+            return { onCompleted(remaining) }
+        case .submittedUnconfirmed:
+            return onUnconfirmedAcknowledged
+        default:
+            return onCancel
+        }
     }
 
     private var isInFlight: Bool {

--- a/DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift
@@ -348,19 +348,12 @@ struct EvonodeWithdrawalConfirmSheet: View {
     let onUnconfirmedAcknowledged: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            Rectangle()
-                .fill(Color.dash.grabberFill)
-                .frame(width: 36, height: 5)
-                .cornerRadius(2.5)
-                .padding(.top, 8)
-
-            Text(NSLocalizedString("Confirm withdrawal", comment: "Evonode withdrawal"))
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-                .padding(.top, 20)
-
+        DashUIKit.BottomSheet(
+            title: NSLocalizedString("Confirm withdrawal", comment: "Evonode withdrawal"),
+            showBackButton: .constant(false),
+            isDismissalEnabled: .constant(!(isInFlight || isUnconfirmed)),
+            onClose: onCancel
+        ) {
             switch viewModel.phase {
             case let .success(remaining):
                 successBody(remainingCredits: remaining)
@@ -370,8 +363,6 @@ struct EvonodeWithdrawalConfirmSheet: View {
                 detailsBody
             }
         }
-        .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(isInFlight || isUnconfirmed)
     }
 
     private var isUnconfirmed: Bool {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -55,7 +55,10 @@ struct InternalTransferConfirmSheet: View {
             title: NSLocalizedString("Confirm", comment: ""),
             showBackButton: .constant(false),
             isDismissalEnabled: .constant(!isInFlight),
-            onClose: onCancel
+            // Supplying `onClose` makes the close button live regardless of
+            // `isDismissalEnabled`, so the protected phases have to gate it here.
+            isCloseButtonEnabled: !isInFlight,
+            onClose: closeAction
         ) {
             switch coordinator.phase {
             case .success:
@@ -77,6 +80,18 @@ struct InternalTransferConfirmSheet: View {
             return true
         default:
             return false
+        }
+    }
+
+    /// The close button has to do what the visible button of the current phase
+    /// does. In the terminal phases that is `onCompleted`, which tells the
+    /// transfer screen the transfer finished; `onCancel` only closes the sheet.
+    private var closeAction: () -> Void {
+        switch coordinator.phase {
+        case .success, .submittedUnconfirmed:
+            return onCompleted
+        default:
+            return onCancel
         }
     }
 
@@ -544,6 +559,9 @@ struct ShieldedRecoverySheet: View {
             title: NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery"),
             showBackButton: .constant(false),
             isDismissalEnabled: .constant(!isInFlight),
+            // Supplying `onClose` makes the close button live regardless of
+            // `isDismissalEnabled`, so the protected phases have to gate it here.
+            isCloseButtonEnabled: !isInFlight,
             onClose: onDismiss
         ) {
             switch coordinator.phase {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -12,7 +12,7 @@ import SwiftDashSDK
 /// `ShieldedTransferCoordinator.phase`:
 ///   - `.idle`           → summary card + Cancel/Confirm buttons.
 ///   - in-flight phases  → step checklist (Signing / Locking / Proving /
-///                         Broadcasting). Drag-dismiss is disabled.
+///                         Broadcasting). Sheet dismissal is disabled.
 ///   - `.success`        → green check + amount + Done.
 ///   - `.failed(msg)`    → summary card with red error + Try again / Close.
 ///
@@ -51,16 +51,12 @@ struct InternalTransferConfirmSheet: View {
     @State private var handledPlatformShieldCapacityChange = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            dragHandle
-                .padding(.top, 8)
-
-            Text(NSLocalizedString("Confirm", comment: ""))
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-                .padding(.top, 20)
-
+        DashUIKit.BottomSheet(
+            title: NSLocalizedString("Confirm", comment: ""),
+            showBackButton: .constant(false),
+            isDismissalEnabled: .constant(!isInFlight),
+            onClose: onCancel
+        ) {
             switch coordinator.phase {
             case .success:
                 successBody
@@ -70,8 +66,6 @@ struct InternalTransferConfirmSheet: View {
                 detailsBody
             }
         }
-        .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(isInFlight)
         .onChange(of: coordinator.phase) { phase in
             handlePlatformShieldCapacityChange(phase)
         }
@@ -191,13 +185,6 @@ struct InternalTransferConfirmSheet: View {
     }
 
     // MARK: - Pieces
-
-    private var dragHandle: some View {
-        Rectangle()
-            .fill(Color.dash.grabberFill)
-            .frame(width: 36, height: 5)
-            .cornerRadius(2.5)
-    }
 
     private var secondaryLine: some View {
         Text(fiatText)
@@ -553,16 +540,12 @@ struct ShieldedRecoverySheet: View {
     @State private var alreadyComplete = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            dragHandle
-                .padding(.top, 8)
-
-            Text(NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery"))
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-                .padding(.top, 20)
-
+        DashUIKit.BottomSheet(
+            title: NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery"),
+            showBackButton: .constant(false),
+            isDismissalEnabled: .constant(!isInFlight),
+            onClose: onDismiss
+        ) {
             switch coordinator.phase {
             case .success:
                 successBody
@@ -578,8 +561,6 @@ struct ShieldedRecoverySheet: View {
                 }
             }
         }
-        .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(isInFlight)
     }
 
     private var isInFlight: Bool {
@@ -691,13 +672,6 @@ struct ShieldedRecoverySheet: View {
     }
 
     // MARK: - Pieces
-
-    private var dragHandle: some View {
-        Rectangle()
-            .fill(Color.dash.grabberFill)
-            .frame(width: 36, height: 5)
-            .cornerRadius(2.5)
-    }
 
     private var infoCard: some View {
         HStack(alignment: .top, spacing: 12) {

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -726,16 +726,12 @@ struct SendConfirmSheet: View {
     @StateObject private var coordinator = ShieldedTransferCoordinator()
 
     var body: some View {
-        VStack(spacing: 0) {
-            dragHandle
-                .padding(.top, 8)
-
-            Text(NSLocalizedString("Confirm", comment: ""))
-                .font(.subheadline)
-                .fontWeight(.semibold)
-                .foregroundColor(.dash.primaryText)
-                .padding(.top, 20)
-
+        DashUIKit.BottomSheet(
+            title: NSLocalizedString("Confirm", comment: ""),
+            showBackButton: .constant(false),
+            isDismissalEnabled: .constant(!isInFlight),
+            onClose: onCancel
+        ) {
             switch coordinator.phase {
             case .success:
                 successBody
@@ -745,8 +741,6 @@ struct SendConfirmSheet: View {
                 detailsBody
             }
         }
-        .background(Color.dash.primaryBackground)
-        .interactiveDismissDisabled(isInFlight)
     }
 
     private var isInFlight: Bool {
@@ -849,13 +843,6 @@ struct SendConfirmSheet: View {
     }
 
     // MARK: - Pieces
-
-    private var dragHandle: some View {
-        Rectangle()
-            .fill(Color.dash.grabberFill)
-            .frame(width: 36, height: 5)
-            .cornerRadius(2.5)
-    }
 
     private var summaryCard: some View {
         VStack(spacing: 0) {

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -730,7 +730,10 @@ struct SendConfirmSheet: View {
             title: NSLocalizedString("Confirm", comment: ""),
             showBackButton: .constant(false),
             isDismissalEnabled: .constant(!isInFlight),
-            onClose: onCancel
+            // Supplying `onClose` makes the close button live regardless of
+            // `isDismissalEnabled`, so the protected phases have to gate it here.
+            isCloseButtonEnabled: !isInFlight,
+            onClose: closeAction
         ) {
             switch coordinator.phase {
             case .success:
@@ -740,6 +743,20 @@ struct SendConfirmSheet: View {
             default:
                 detailsBody
             }
+        }
+    }
+
+    /// The close button has to do what the visible button of the current phase
+    /// does. In the terminal phases that is `onCompleted`, which also unwinds
+    /// the send flow — `onCancel` only closes the sheet, so routing every phase
+    /// there would drop the user back on the amount screen with the amount
+    /// still entered, one tap away from sending it twice.
+    private var closeAction: () -> Void {
+        switch coordinator.phase {
+        case .success, .submittedUnconfirmed:
+            return onCompleted
+        default:
+            return onCancel
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #1073 and #1074, using the dismissal controls introduced by
dashpay/DashUIKit#14. Protected signing, locking, proving, and broadcast flows still owned
their grabber/title shell and used a content-level `interactiveDismissDisabled` workaround.
That prevented swipe dismissal but could not coordinate DashUIKit's close affordance for
sheets already using the shared component.

This pull request is intentionally stacked on `refactor/dashuikit-sheet-content`.

## What was done?

- Pinned DashUIKit to the exact API revision from dashpay/DashUIKit#14 while that dependency
  is under review.
- Migrated internal-transfer confirmation, shielded recovery, send confirmation, CoinJoin
  move-funds, and evonode withdrawal confirmation to `DashUIKit.BottomSheet`.
- Preserved each host's cancellation/completion callbacks and existing detents.
- Routed protected state through `isDismissalEnabled`, disabling swipe and the shared close
  control together during authorization, signing, locking, proving, submitting, and
  broadcasting as appropriate.
- Removed the migrated sheets' duplicate grabbers, titles, backgrounds, and local interactive
  dismissal modifiers.
- Updated username registration sheets to use DashUIKit dismissal controls, disabling swipe
  and the shared close control together during an active operation.
- Kept marketplace name detail, set-price, and transfer as native detented sheets with native
  interactive-dismissal protection.
- Left `SDKIdentityProfileSheet` and `WalletsScreen` on native SwiftUI sheets; their remaining
  `interactiveDismissDisabled` modifiers are intentional.

## How Has This Been Tested?

- `xcodebuild -resolvePackageDependencies -workspace DashWallet.xcworkspace -scheme dashpay`
- Full `dashpay` Debug builds for iPhone 17 Pro / iOS 26.5 Simulator at exact base
  `bb34895b65769d5849b97aea56adb39dcf3c6982` and exact head
  `9198db97fe6f58f69efcfa5d7062d59530800463`, using separate worktrees, separate DerivedData,
  normal Simulator signing, and the required local-only service plists.
- Both builds installed, launched, and remained alive as `org.dashfoundation.dash` on clones
  of the same shut-down wallet fixture.
- Exercised the internal transparent-to-shielded confirmation at idle and during the locking
  phase. Accessibility reported the head's close control as disabled while protected.
- Validated the package lock as JSON, confirmed DashUIKit resolved to
  `e8d92434bfc28fbf933b896cd40a01dd61835b5f`, and ran `git diff --check`.
- Simplification review found no safe consolidation with positive value; independent
  correctness, quality, architecture, and reliability passes approved the migration with no
  findings.
- The dependency PR separately passes 7 focused Swift tests and an iOS 14 Simulator build for
  the dismissal API.

Exact provenance, device identifiers, full-resolution originals, dimensions, and SHA-256
hashes: [visual evidence tree](https://github.com/dashpay/dashwallet-ios/tree/d46b0ce29618a3dcf1a501e322507c9e4ba11d28)

### Idle confirmation

| Before — exact base | After — full head |
| --- | --- |
| ![Before idle confirmation](https://raw.githubusercontent.com/dashpay/dashwallet-ios/d46b0ce29618a3dcf1a501e322507c9e4ba11d28/comparison/before/internal-transfer-idle.png) | ![After idle confirmation](https://raw.githubusercontent.com/dashpay/dashwallet-ios/d46b0ce29618a3dcf1a501e322507c9e4ba11d28/comparison/after/internal-transfer-idle.png) |

### Protected locking phase

| Before — exact base | After — full head |
| --- | --- |
| ![Before protected transfer](https://raw.githubusercontent.com/dashpay/dashwallet-ios/d46b0ce29618a3dcf1a501e322507c9e4ba11d28/comparison/before/internal-transfer-protected.png) | ![After protected transfer](https://raw.githubusercontent.com/dashpay/dashwallet-ios/d46b0ce29618a3dcf1a501e322507c9e4ba11d28/comparison/after/internal-transfer-protected.png) |

## Breaking Changes

None. This wallet change depends on dashpay/DashUIKit#14 landing first.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (host composition
  is validated in Simulator; the shared dismissal behavior has focused tests in DashUIKit)
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
