### PR TITLE
fix(ui): localize the four recovery-phrase backup warnings

### DIFF
--- a/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
+++ b/DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift
@@ -29,15 +29,23 @@ private enum BackupInfoItem {
 extension BackupInfoItem {
     var title: String {
         switch self {
-        case .notStoredByDash: return "Dash Core Group does NOT store this recovery phrase"
-        case .unableToRestore: return "You will NOT be able to restore the wallet without a recovery phrase"
+        case .notStoredByDash:
+            return NSLocalizedString("Dash Core Group does NOT store this recovery phrase",
+                                     comment: "Recovery phrase backup: security warning title — Dash Core Group does not store the phrase")
+        case .unableToRestore:
+            return NSLocalizedString("You will NOT be able to restore the wallet without a recovery phrase",
+                                     comment: "Recovery phrase backup: security warning title — the phrase is required to restore the wallet")
         }
     }
 
     var description: String {
         switch self {
-        case .notStoredByDash: return "Anyone that has your recovery phrase can access your funds."
-        case .unableToRestore: return "Write it in a safe place and don’t show it to anyone."
+        case .notStoredByDash:
+            return NSLocalizedString("Anyone that has your recovery phrase can access your funds.",
+                                     comment: "Recovery phrase backup: security warning body — anyone with the phrase can spend the funds")
+        case .unableToRestore:
+            return NSLocalizedString("Write it in a safe place and don’t show it to anyone.",
+                                     comment: "Recovery phrase backup: security warning body — keep the phrase written down and private")
         }
     }
 

--- a/DashWallet/ar.lproj/Localizable.strings
+++ b/DashWallet/ar.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "أي شخص يملك عبارة الاسترداد الخاصة بك يمكنه الوصول إلى أموالك.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "أي شخص يعرف عنوانًا يمكنه الاطلاع على سجله";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "رصيد داش على Uphold ";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "لا تحتفظ Dash Core Group بعبارة الاسترداد هذه";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "اكتبها في مكان آمن ولا تُظهرها لأي شخص.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "ستحتاج إلى عبارة الاسترداد هذه للوصول إلى أموالك في حالة فقد هذا الجهاز أو تلفه.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "لن تتمكن من استعادة المحفظة بدون عبارة الاسترداد";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/bg.lproj/Localizable.strings
+++ b/DashWallet/bg.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Всеки, който има вашата фраза за възстановяване, може да получи достъп до средствата ви.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Всеки, който знае даден адрес, може да види историята му";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group НЕ съхранява тази фраза за възстановяване";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Запишете я на сигурно място и не я показвайте на никого.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "НЯМА да можете да възстановите портфейла без фраза за възстановяване";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ca.lproj/Localizable.strings
+++ b/DashWallet/ca.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Qualsevol que tingui la teva frase de recuperació pot accedir als teus fons.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Qualsevol que conegui una adreça en pot veure l'historial";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NO desa aquesta frase de recuperació";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Anota-la en un lloc segur i no la mostris a ningú.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "NO podràs restaurar la cartera sense una frase de recuperació";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/cs.lproj/Localizable.strings
+++ b/DashWallet/cs.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kdokoli, kdo má vaši frázi pro obnovení, může získat přístup k vašim prostředkům.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Kdokoli, kdo zná adresu, si může prohlédnout její historii";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group tuto frázi pro obnovení NEUKLÁDÁ";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapište si ji na bezpečné místo a nikomu ji neukazujte.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bez fráze pro obnovení NEBUDETE moci peněženku obnovit";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/da.lproj/Localizable.strings
+++ b/DashWallet/da.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Enhver, der har din gendannelsessætning, kan få adgang til dine midler.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Alle, der kender en adresse, kan se dens historik";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group gemmer IKKE denne gendannelsessætning";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Skriv den ned et sikkert sted, og vis den ikke til nogen.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Du vil IKKE kunne gendanne tegnebogen uden en gendannelsessætning";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/de.lproj/Localizable.strings
+++ b/DashWallet/de.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Jeder Nutzername, der die Nummern 2-9 beinhaltet, länger als 20 Zeichen ist oder einen Bindestrich beinhaltet, wird automatisch genehmigt.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Wer deine Wiederherstellungs-Wortfolge hat, kann auf dein Guthaben zugreifen.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Jeder, der eine Adresse kennt, kann ihren Verlauf einsehen";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash Guthaben auf Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group speichert diese Wiederherstellungs-Wortfolge NICHT";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Schreibe sie an einem sicheren Ort auf und zeige sie niemandem.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Du benötigst diese Wiederherstellungsphrase, um auf dein Guthaben zuzugreifen, wenn dieses Gerät verloren geht, beschädigt wird oder die Wallet von diesem Gerät deinstalliert wird.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Ohne Wiederherstellungs-Wortfolge kannst du die Wallet NICHT wiederherstellen";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/el.lproj/Localizable.strings
+++ b/DashWallet/el.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Οποιοδήποτε όνομα χρήστη που έχει αριθμό 2-9 ή είναι μεγαλύτερο από 20 χαρακτήρες ή που έχει παύλα θα εγκριθεί αυτόματα.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Όποιος έχει τη φράση ανάκτησής σας μπορεί να αποκτήσει πρόσβαση στα κεφάλαιά σας.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Όποιος γνωρίζει μια διεύθυνση μπορεί να δει το ιστορικό της";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Υπόλοιπο Dash στο Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Η Dash Core Group ΔΕΝ αποθηκεύει αυτή τη φράση ανάκτησης";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Γράψτε την σε ασφαλές μέρος και μην την δείξετε σε κανέναν.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Θα χρειαστείτε αυτή τη φράση ανάκτησης για να αποκτήσετε πρόσβαση στα χρήματά σας εάν αυτή η συσκευή χαθεί, καταστραφεί ή εάν το Πορτοφόλι Dash απεγκατασταθει τυχαία από αυτήν τη συσκευή.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "ΔΕΝ θα μπορέσετε να ανακτήσετε το πορτοφόλι χωρίς φράση ανάκτησης";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -378,6 +378,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Anyone that has your recovery phrase can access your funds.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Anyone who knows an address can view its history";
 
@@ -1271,6 +1274,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group does NOT store this recovery phrase";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5139,6 +5145,9 @@
 /* Wallets */
 "Write down these %d words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these %d words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Write it in a safe place and don’t show it to anyone.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5300,6 +5309,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "You will NOT be able to restore the wallet without a recovery phrase";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Iu ajn, kiu havas vian reakiran frazon, povas aliri viajn rimedojn.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Iu ajn kiu konas adreson povas vidi ĝian historion";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NE konservas ĉi tiun reakiran frazon";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Skribu ĝin en sekura loko kaj ne montru ĝin al iu ajn.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Vi NE povos reakiri la monujon sen reakira frazo";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/eo.lproj/Localizable.strings
+++ b/DashWallet/eo.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
 /* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
-"Anyone that has your recovery phrase can access your funds." = "Iu ajn, kiu havas vian reakiran frazon, povas aliri viajn rimedojn.";
+"Anyone that has your recovery phrase can access your funds." = "Iu ajn, kiu havas vian reakiran frazon, povas aliri viajn monrimedojn.";
 
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Iu ajn kiu konas adreson povas vidi ĝian historion";

--- a/DashWallet/es.lproj/Localizable.strings
+++ b/DashWallet/es.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Cualquier nombre de usuario que contenga un número del 2-9, o tenga más de 20 caracteres de largo, o que contenga un guion, será automáticamente aprobado";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Cualquiera que tenga tu frase de recuperación puede acceder a tus fondos.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Cualquiera que conozca una dirección puede ver su historial";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Saldo de Dash en Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NO almacena esta frase de recuperación";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Anótala en un lugar seguro y no se la muestres a nadie.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Necesitarás esta frase de recuperación para acceder a tus fondos si este dispositivo se pierde, se daña o si la billetera de Dash se desinstala de este dispositivo.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "NO podrás restaurar la cartera sin una frase de recuperación";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/et.lproj/Localizable.strings
+++ b/DashWallet/et.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Igaüks, kellel on sinu taastefraas, pääseb ligi sinu vahenditele.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Igaüks, kes aadressi teab, saab vaadata selle ajalugu";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group EI salvesta seda taastefraasi";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Kirjuta see turvalisse kohta üles ja ära näita seda kellelegi.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Ilma taastefraasita EI saa sa rahakotti taastada";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/fa.lproj/Localizable.strings
+++ b/DashWallet/fa.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "هر کسی که عبارت بازیابی شما را داشته باشد می‌تواند به دارایی شما دسترسی پیدا کند.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "هر کسی که یک نشانی را بداند می‌تواند تاریخچه‌اش را ببیند";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "موجودی دش در آپهولد";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "این عبارت بازیابی نزد Dash Core Group ذخیره نمی‌شود";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "آن را جایی امن بنویسید و به هیچ‌کس نشان ندهید.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "اگر دستگاه‌تان گم شود یا آسیب ببیند یا دش والت از روی دستگاه‌تان پاک شود، برای دسترسی به موجودی‌تان به این عبارت بازیابی نیاز خواهید داشت. ";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "بدون عبارت بازیابی نمی‌توانید کیف پول را بازیابی کنید";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/fi.lproj/Localizable.strings
+++ b/DashWallet/fi.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kuka tahansa, jolla on palautuslauseesi, pääsee käsiksi varoihisi.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Kuka tahansa osoitteen tunteva voi katsoa sen historian";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group EI säilytä tätä palautuslausetta";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Kirjoita se ylös turvalliseen paikkaan äläkä näytä sitä kenellekään.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Lompakkoa EI voi palauttaa ilman palautuslausetta";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/fil.lproj/Localizable.strings
+++ b/DashWallet/fil.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Awtomatikong maaaprubahan ang anumang username na mayroong numero 2-9, higit sa 20 character o may gitling.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Sinumang may hawak ng iyong recovery phrase ay maaaring ma-access ang iyong pondo.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Makikita ninuman ang kasaysayan ng isang address kung alam niya ito";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balanse sa Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "HINDI iniimbak ng Dash Core Group ang recovery phrase na ito";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Isulat ito sa isang ligtas na lugar at huwag itong ipakita kaninuman.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Kakailanganin mo ang recovery phrase na ito upang ma-access ang iyong mga pondo kung ang device na ito ay nawala, nasira o kung na-uninstall ang Dash Wallet mula sa device na ito.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "HINDI mo maibabalik ang wallet nang walang recovery phrase";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/fr.lproj/Localizable.strings
+++ b/DashWallet/fr.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Tout nom d'utilisateur sera automatiquement approuvé s'il contient au moins un chiffre entre 2 et 9, ou s'il a plus de 20 caractères, ou s'il contient un trait d'union.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Quiconque possède votre phrase de récupération peut accéder à vos fonds.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Quiconque connaît une adresse peut consulter son historique";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Solde Dash sur Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NE conserve PAS cette phrase de récupération";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Notez-la en lieu sûr et ne la montrez à personne.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Vous aurez besoin de cette phrase de récupération pour accéder à vos fonds si cet appareil est perdu ou endommagé, ou si Dash Wallet en est désinstallé.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Vous NE pourrez PAS restaurer le portefeuille sans phrase de récupération";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/hr.lproj/Localizable.strings
+++ b/DashWallet/hr.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Svatko tko ima vašu frazu za oporavak može pristupiti vašim sredstvima.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Svatko tko zna adresu može pogledati njezinu povijest";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NE pohranjuje ovu frazu za oporavak";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapišite je na sigurno mjesto i nemojte je nikome pokazivati.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bez fraze za oporavak NEĆETE moći obnoviti novčanik";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -5807,7 +5807,7 @@
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
 /* Recovery phrase backup: security warning body — keep the phrase written down and private */
-"Write it in a safe place and don’t show it to anyone." = "Írd le egy biztonságos helyre, és ne mutasd meg senkinek.";
+"Write it in a safe place and don’t show it to anyone." = "Írd le, tartsd biztonságos helyen, és ne mutasd meg senkinek.";
 
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";

--- a/DashWallet/hu.lproj/Localizable.strings
+++ b/DashWallet/hu.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Bárki, akinek megvan a helyreállítási kifejezésed, hozzáférhet a pénzedhez.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Bárki, aki ismer egy címet, megnézheti annak előzményeit";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "A Dash Core Group NEM tárolja ezt a helyreállítási kifejezést";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Írd le egy biztonságos helyre, és ne mutasd meg senkinek.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Helyreállítási kifejezés nélkül NEM tudod visszaállítani a tárcát";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/id.lproj/Localizable.strings
+++ b/DashWallet/id.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Nama pengguna apa pun yang memiliki angka 2-9, lebih dari 20 karakter atau yang memiliki tanda hubung akan disetujui secara otomatis";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Siapa pun yang memiliki frasa pemulihan Anda dapat mengakses dana Anda.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Siapa pun yang mengetahui suatu alamat dapat melihat riwayatnya";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Saldo Dash di Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group TIDAK menyimpan frasa pemulihan ini";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Tulis di tempat yang aman dan jangan tunjukkan kepada siapa pun.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Anda memerlukan frasa pemulihan ini untuk mengakses dana Anda jika perangkat ini hilang, rusak, atau jika Dash Wallet dihapus dari perangkat ini.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Anda TIDAK akan bisa memulihkan dompet tanpa frasa pemulihan";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/it.lproj/Localizable.strings
+++ b/DashWallet/it.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Qualsiasi nome utente che contenga un numero compreso tra 2 e 9, che abbia più di 20 caratteri o che contenga un trattino verrà automaticamente approvato";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Chiunque abbia la tua frase di recupero può accedere ai tuoi fondi.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Chiunque conosca un indirizzo può vederne la cronologia";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Bilancia del saldo su Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NON conserva questa frase di recupero";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Annotala in un posto sicuro e non mostrarla a nessuno.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Avrai bisogno di questa frase di recupero per accedere ai tuoi fondi se questo dispositivo viene smarrito, danneggiato o se il Portafoglio Dash viene disinstallato da questo dispositivo.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "NON potrai recuperare il portafoglio senza una frase di recupero";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ja.lproj/Localizable.strings
+++ b/DashWallet/ja.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "ユーザー名は2〜9の数字を含み、20文字を超えるもので、ハイフンを含むものが自動的に承認されます。";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "復元フレーズを持っている人は誰でもあなたの資金にアクセスできます。";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "アドレスを知っている人は誰でもその履歴を閲覧できます";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Uphold上のDash残高";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group はこの復元フレーズを保存しません";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "安全な場所に書き留め、誰にも見せないでください。";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "このデバイスを紛失したり破損した場合、またはDash Walletがこのデバイスからアンインストールされた場合は、資金にアクセスするためにこのリカバリーフレーズが必要です。";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "復元フレーズがなければウォレットを復元できません";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -1087,7 +1087,7 @@
 "Dash balance on Uphold" = "업홀드 내 대시 잔고";
 
 /* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
-"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group는 이 복구 문구를 저장하지 않습니다";
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group은 이 복구 문구를 저장하지 않습니다";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */

--- a/DashWallet/ko.lproj/Localizable.strings
+++ b/DashWallet/ko.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "2-9사이의 숫자가 포함되고, 20글자 이상이거나 하이픈 기호를 포함한 사용자 이름은 자동으로 승인됩니다";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "복구 문구를 가진 사람은 누구나 회원님의 자금에 접근할 수 있습니다.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "주소를 아는 사람은 누구나 그 내역을 볼 수 있습니다";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "업홀드 내 대시 잔고";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group는 이 복구 문구를 저장하지 않습니다";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "안전한 곳에 적어 두고 누구에게도 보여주지 마세요.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "이 기기가 분실되거나 망가지는 경우, 혹은 이 기기에서 대시 월렛이 삭제 되는 경우 자금에 접근하기 위해서는 이 복구 문구가 필요합니다.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "복구 문구가 없으면 지갑을 복원할 수 없습니다";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/mk.lproj/Localizable.strings
+++ b/DashWallet/mk.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Секој што ја има вашата фраза за обновување може да пристапи до вашите средства.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Секој што знае адреса може да ја види нејзината историја";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group НЕ ја чува оваа фраза за обновување";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Запишете ја на безбедно место и не покажувајте ја никому.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "НЕМА да можете да го обновите паричникот без фраза за обновување";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ms.lproj/Localizable.strings
+++ b/DashWallet/ms.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Sesiapa yang memiliki frasa pemulihan anda boleh mengakses dana anda.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Sesiapa yang mengetahui sesuatu alamat boleh melihat sejarahnya";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group TIDAK menyimpan frasa pemulihan ini";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Tulis di tempat yang selamat dan jangan tunjukkan kepada sesiapa.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Anda TIDAK akan dapat memulihkan dompet tanpa frasa pemulihan";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/nb.lproj/Localizable.strings
+++ b/DashWallet/nb.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Alle som har gjenopprettingsfrasen din, kan få tilgang til midlene dine.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Alle som kjenner en adresse, kan se historikken til den";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group lagrer IKKE denne gjenopprettingsfrasen";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Skriv den ned på et trygt sted, og ikke vis den til noen.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Du vil IKKE kunne gjenopprette lommeboken uten en gjenopprettingsfrase";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/nl.lproj/Localizable.strings
+++ b/DashWallet/nl.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Elke gebruikersnaam met een cijfer 2-9, meer dan 20 tekens of met een koppelteken wordt automatisch goedgekeurd";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Iedereen die je herstelzin heeft, heeft toegang tot je tegoed.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Iedereen die een adres kent, kan de geschiedenis ervan bekijken";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash saldo bij Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group bewaart deze herstelzin NIET";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Schrijf hem op een veilige plek op en laat hem aan niemand zien.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Je hebt deze herstelzin nodig om toegang te krijgen tot je saldo als dit apparaat is verloren of beschadigd, of als de Dash Portemonnee app van dit apparaat is verwijderd.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Zonder herstelzin kun je de wallet NIET herstellen";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/pl.lproj/Localizable.strings
+++ b/DashWallet/pl.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Każda nazwa użytkownika, która zawiera cyfrę od 2-9, ma więcej niż 20 znaków lub zawiera myślnik, zostanie automatycznie zatwierdzona.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Każdy, kto ma Twoją frazę odzyskiwania, może uzyskać dostęp do Twoich środków.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Każdy, kto zna adres, może zobaczyć jego historię";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Saldo Dash na Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NIE przechowuje tej frazy odzyskiwania";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapisz ją w bezpiecznym miejscu i nikomu jej nie pokazuj.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Szyk słów do odzysku portfela będzie potrzebny aby mieć dostęp do funduszy w wypadku uszkodzenia, utraty tego urządzenia lub jeśli Dash Wallet zostanie przypadkowo odinstalowany. ";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bez frazy odzyskiwania NIE odzyskasz portfela";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/pt.lproj/Localizable.strings
+++ b/DashWallet/pt.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Qualquer nome de usuário que contenha um número de 2 a 9, tenha mais de 20 caracteres ou que possua um hífen será automaticamente aprovado";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Qualquer pessoa que tenha a sua frase de recuperação pode acessar seus fundos.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Qualquer pessoa que saiba um endereço pode ver seu histórico";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Saldo Dash na Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "A Dash Core Group NÃO armazena esta frase de recuperação";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Anote-a em um lugar seguro e não a mostre a ninguém.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Você precisará desta frase de recuperação para acessar seus fundos caso este dispositivo seja perdido, danificado ou se a Carteira Dash for desinstalada deste dispositivo.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Você NÃO conseguirá recuperar a carteira sem uma frase de recuperação";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ro.lproj/Localizable.strings
+++ b/DashWallet/ro.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Oricine are fraza ta de recuperare îți poate accesa fondurile.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Oricine cunoaște o adresă îi poate vedea istoricul";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NU stochează această frază de recuperare";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Notează-o într-un loc sigur și nu o arăta nimănui.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "NU vei putea recupera portofelul fără o frază de recuperare";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/ru.lproj/Localizable.strings
+++ b/DashWallet/ru.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Любое имя пользователя, содержащее цифры от 2-9, больше 20 символов или дефис, будет автоматически одобрено";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Любой, у кого есть ваша фраза восстановления, может получить доступ к вашим средствам.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Любой, кто знает адрес, может посмотреть его историю";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Баланс Dash на Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group НЕ хранит эту фразу восстановления";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Запишите её в надёжном месте и никому не показывайте.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Вам понадобится эта фраза восстановления для доступа к Вашим средствам, если это устройство будет утеряно, повреждено или приложение Dash Wallet будет случайно удалено.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Без фразы восстановления вы НЕ сможете восстановить кошелёк";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sk.lproj/Localizable.strings
+++ b/DashWallet/sk.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Akékoľvek používateľské meno, ktoré má číslice 2-9, je dlhšie ako 20 znakov alebo obsahuje pomlčku, bude automaticky schválené.";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Ktokoľvek, kto má vašu frázu pre obnovenie, môže získať prístup k vašim prostriedkom.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Ktokoľvek, kto pozná adresu, si môže pozrieť jej históriu";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Zostatok Dash na Upholde";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group túto frázu pre obnovenie NEUCHOVÁVA";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapíšte si ju na bezpečné miesto a nikomu ju neukazujte.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Túto frázu pre obnovenie budete potrebovať na prístup k vašim finančným prostriedkom, ak dôjde k strate či poškodeniu zariadenia, alebo odinštalovaniu Dash Wallet zo zariadenia.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bez frázy pre obnovenie NEBUDETE môcť peňaženku obnoviť";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sl.lproj/Localizable.strings
+++ b/DashWallet/sl.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kdor koli ima vašo frazo za obnovitev, lahko dostopa do vaših sredstev.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Kdorkoli pozna naslov, si lahko ogleda njegovo zgodovino";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group te fraze za obnovitev NE shranjuje";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapišite jo na varno mesto in je nikomur ne pokažite.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Brez fraze za obnovitev denarnice NE boste mogli obnoviti";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sl_SI.lproj/Localizable.strings
+++ b/DashWallet/sl_SI.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kdor koli ima vašo frazo za obnovitev, lahko dostopa do vaših sredstev.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Kdorkoli pozna naslov, si lahko ogleda njegovo zgodovino";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group te fraze za obnovitev NE shranjuje";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapišite jo na varno mesto in je nikomur ne pokažite.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Brez fraze za obnovitev denarnice NE boste mogli obnoviti";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sq.lproj/Localizable.strings
+++ b/DashWallet/sq.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kushdo që ka frazën tënde të rikuperimit mund të hyjë te fondet e tua.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Kushdo që di një adresë mund të shohë historikun e saj";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NUK e ruan këtë frazë rikuperimi";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Shkruaje në një vend të sigurt dhe mos ia trego askujt.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "NUK do të mund ta rikuperosh portofolin pa një frazë rikuperimi";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sr.lproj/Localizable.strings
+++ b/DashWallet/sr.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Svako ko ima vašu frazu za oporavak može da pristupi vašim sredstvima.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Svako ko zna adresu može pogledati njenu istoriju";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group NE čuva ovu frazu za oporavak";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Zapišite je na bezbedno mesto i nemojte je nikome pokazivati.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bez fraze za oporavak NEĆETE moći da povratite novčanik";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/sv.lproj/Localizable.strings
+++ b/DashWallet/sv.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Vem som helst som har din återställningsfras kan komma åt dina medel.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Alla som känner till en adress kan se dess historik";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group lagrar INTE den här återställningsfrasen";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Skriv ner den på ett säkert ställe och visa den inte för någon.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Du kommer INTE att kunna återställa plånboken utan en återställningsfras";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/th.lproj/Localizable.strings
+++ b/DashWallet/th.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "ใครก็ตามที่มีวลีกู้คืนของคุณสามารถเข้าถึงเงินของคุณได้";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "ใครก็ตามที่รู้ที่อยู่ย่อมดูประวัติของที่อยู่นั้นได้";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "ยอด Dash คงเหลือใน Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group ไม่ได้เก็บวลีกู้คืนนี้ไว้";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "จดไว้ในที่ปลอดภัยและอย่าแสดงให้ใครเห็น";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "คุณจะต้องใช้วลีการกู้คืนนี้เพื่อเข้าถึงเงินของคุณ หากอุปกรณ์นี้สูญหาย เสียหาย หรือหากถอนการติดตั้ง Dash Wallet จากอุปกรณ์นี้";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "คุณจะไม่สามารถกู้คืนกระเป๋าเงินได้หากไม่มีวลีกู้คืน";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/tr.lproj/Localizable.strings
+++ b/DashWallet/tr.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Kurtarma sözcük grubunuza sahip olan herkes paranıza erişebilir.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Bir adresi bilen herkes onun geçmişini görüntüleyebilir";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Uphold’daki Dash bakiyeniz";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group bu kurtarma sözcük grubunu SAKLAMAZ";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Güvenli bir yere yazın ve kimseye göstermeyin.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Bu cihaz kaybolursa, hasar görürse veya Dash Cüzdan'ı bu cihazdan kaldırılırsa paranıza erişmek için bu kurtarma ifadesine ihtiyacınız olacaktır.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Kurtarma sözcük grubu olmadan cüzdanı geri YÜKLEYEMEZSİNİZ";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/uk.lproj/Localizable.strings
+++ b/DashWallet/uk.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Будь-яке ім’я користувача, яке містить цифру від 2-9, має понад 20 символів або містить дефіс, буде автоматично схвалене";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Будь-хто, у кого є ваша фраза відновлення, може отримати доступ до ваших коштів.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Будь-хто, хто знає адресу, може переглянути її історію";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Баланс Dash на Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group НЕ зберігає цю фразу відновлення";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Запишіть її в надійному місці й нікому не показуйте.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "Вам знадобиться ця фраза відновлення, щоб отримати доступ до своїх коштів, якщо цей пристрій буде втрачено, пошкоджено або якщо Dash Wallet буде видалено з цього пристрою.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Без фрази відновлення ви НЕ зможете відновити гаманець";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "Bất kỳ ai có cụm từ phục hồi của bạn đều có thể truy cập tiền của bạn.";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "Bất cứ ai biết một địa chỉ đều có thể xem lịch sử của địa chỉ đó";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group KHÔNG lưu cụm từ phục hồi này";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "Hãy ghi vào nơi an toàn và đừng cho ai xem.";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "Bạn sẽ KHÔNG thể khôi phục ví nếu không có cụm từ phục hồi";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/vi.lproj/Localizable.strings
+++ b/DashWallet/vi.lproj/Localizable.strings
@@ -5807,7 +5807,7 @@
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
 /* Recovery phrase backup: security warning body — keep the phrase written down and private */
-"Write it in a safe place and don’t show it to anyone." = "Hãy ghi vào nơi an toàn và đừng cho ai xem.";
+"Write it in a safe place and don’t show it to anyone." = "Hãy ghi lại và cất ở nơi an toàn, đừng cho ai xem.";
 
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
 /* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
-"Anyone that has your recovery phrase can access your funds." = "任何拥有你助记词的人都能访问你的资金。";
+"Anyone that has your recovery phrase can access your funds." = "任何拥有你的助记词的人都能访问你的资金。";
 
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";

--- a/DashWallet/zh-Hans.lproj/Localizable.strings
+++ b/DashWallet/zh-Hans.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "任何拥有你助记词的人都能访问你的资金。";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group 不会存储此助记词";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "把它写在安全的地方，不要给任何人看。";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "没有助记词，你将无法恢复此钱包";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "任何擁有你助記詞的人都能存取你的資金。";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Dash balance on Uphold";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group 不會儲存此助記詞";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5800,6 +5806,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "把它寫在安全的地方，不要給任何人看。";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5963,6 +5972,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "沒有助記詞，你將無法復原此錢包";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/zh-Hant-TW.lproj/Localizable.strings
+++ b/DashWallet/zh-Hant-TW.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved";
 
 /* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
-"Anyone that has your recovery phrase can access your funds." = "任何擁有你助記詞的人都能存取你的資金。";
+"Anyone that has your recovery phrase can access your funds." = "任何擁有你的助記詞的人都能存取你的資金。";
 
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超过20个字符且包含数字2-9, 或含有连字符的用户名将被自动批准";
 
 /* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
-"Anyone that has your recovery phrase can access your funds." = "任何拥有你助记词的人都能访问你的资金。";
+"Anyone that has your recovery phrase can access your funds." = "任何拥有你的助记词的人都能访问你的资金。";
 
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";

--- a/DashWallet/zh.lproj/Localizable.strings
+++ b/DashWallet/zh.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超过20个字符且包含数字2-9, 或含有连字符的用户名将被自动批准";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "任何拥有你助记词的人都能访问你的资金。";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道地址的人都可以查看它的历史记录";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Uphold 上的Dash余额";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group 不会存储此助记词";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "把它写在安全的地方，不要给任何人看。";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "如果此设备丢失, 或Dash钱包从此设备被卸载, 则需要此助记词来找回您的资金.";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "没有助记词，你将无法恢复此钱包";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -384,6 +384,9 @@
 /* Usernames */
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超20個字符或包含2-9個數字，或含有連字符的用戶名稱，將會自動批准";
 
+/* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
+"Anyone that has your recovery phrase can access your funds." = "任何擁有你恢復詞組的人都能存取你的資金。";
+
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";
 
@@ -1082,6 +1085,9 @@
 
 /* Uphold Entry Point */
 "Dash balance on Uphold" = "Uphold 上的達世幣結餘";
+
+/* Recovery phrase backup: security warning title — Dash Core Group does not store the phrase */
+"Dash Core Group does NOT store this recovery phrase" = "Dash Core Group 不會儲存此恢復詞組";
 
 /* Dash DEX Portal
    Translate it as short as possible! (24 symbols max) */
@@ -5798,6 +5804,9 @@
 /* Wallets */
 "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds." = "Write down these 12 words in order and keep them somewhere safe. They are the ONLY way to recover this wallet. Anyone with them can spend your funds.";
 
+/* Recovery phrase backup: security warning body — keep the phrase written down and private */
+"Write it in a safe place and don’t show it to anyone." = "把它寫在安全的地方，不要給任何人看。";
+
 /* No comment provided by engineer. */
 "XpEBa5... or BIP21 URI" = "XpEBa5... or BIP21 URI";
 
@@ -5961,6 +5970,9 @@
 
 /* Back up wallet */
 "You will need this recovery phrase to access your funds if this device is lost, damaged or if Dash Wallet is uninstalled from this device." = "如果此設備丟失、損壞或從該設備上卸載達世幣錢包，您將需要此恢復詞組來找回您的資金。";
+
+/* Recovery phrase backup: security warning title — the phrase is required to restore the wallet */
+"You will NOT be able to restore the wallet without a recovery phrase" = "沒有恢復詞組，你將無法復原此錢包";
 
 /* Coinbase */
 "You will receive" = "You will receive";

--- a/DashWallet/zh_TW.lproj/Localizable.strings
+++ b/DashWallet/zh_TW.lproj/Localizable.strings
@@ -385,7 +385,7 @@
 "Any username that has a number 2-9, is more than 20 characters or that has a hyphen will be automatically approved" = "任何超20個字符或包含2-9個數字，或含有連字符的用戶名稱，將會自動批准";
 
 /* Recovery phrase backup: security warning body — anyone with the phrase can spend the funds */
-"Anyone that has your recovery phrase can access your funds." = "任何擁有你恢復詞組的人都能存取你的資金。";
+"Anyone that has your recovery phrase can access your funds." = "任何擁有你的恢復詞組的人都能存取你的資金。";
 
 /* Balance info sheet */
 "Anyone who knows an address can view its history" = "任何知道位址的人都可以查看它的歷史紀錄";


### PR DESCRIPTION
The two bullet blocks on the recovery-phrase backup screen — arguably the most security-critical screen in the app — were plain Swift string literals in `BackupInfoItem`. They were never localization keys at all, so no catalog could override them and they rendered in English in all 42 languages, even while the screen's own title and body were translated.

| Before (ru) | After (ru) |
|---|---|
| <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/2f5ea350fc68ee6ee58d3d7225f983ae1a3c15c6/backup-info-l10n/ru-before.png" width="300"> | <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/2f5ea350fc68ee6ee58d3d7225f983ae1a3c15c6/backup-info-l10n/ru-after.png" width="300"> |

## What changed

- Wrapped all four strings in `NSLocalizedString` with context comments ([BackupInfoViewController.swift:29](DashWallet/Sources/UI/Setup/SecureWallet/BackupInfo/BackupInfoViewController.swift#L29)).
- Added the four keys to `en.lproj/Localizable.strings` (the Transifex source) in sorted position.
- Translated them into all 42 locales, taking terminology from each catalog's existing entries — in particular the wording each locale already uses for "recovery phrase" (de `Wiederherstellungs-Wortfolge`, ru `фраза восстановления`, fr `phrase de récupération`, …). "Dash Core Group" stays untranslated. Where the locale's script has case, the emphasis on **NOT** is carried over the way the existing `Write down these %d words … ONLY way` string does.

`BackupInfoItemView.xib` still carries two of the strings as design-time `text=` placeholders. Those are overwritten at runtime by `itemView(from:)`, so the XIB is untouched. (`SetPin.storyboard` has the same kind of stale placeholder — it even still says "everytime" while the live localized key says "every time" — also left alone.)

## Verification

- `plutil -lint` passes on all 43 touched `.strings` files; all remain UTF-8 without BOM.
- Parsed every catalog before and after: **no pre-existing key changed value or position**, and exactly 4 entries were added per catalog (89480 → 89652 = 43 × 4). The catalog diff is insert-only — zero deletion lines.
- Clean `dashpay` build for the simulator.
- Ran on a Russian simulator (fresh keychain, PIN 1234) — both bullet blocks now render in Russian, no layout overflow. The "before" image above is the same build with the four keys stripped from the bundled `ru.lproj`, which reproduces the reported behaviour exactly.

## Scope note

I also swept the rest of the onboarding/backup flow (`Sources/UI/Setup`, `Sources/UI/Onboarding`, and the backup reminder) for other bare user-visible literals with a comment-aware scanner. These four were the only ones — everything else that surfaces to a user is already wrapped; the remaining literals are `NSAssert` messages, `os_log`/`NSLog` strings, `#import`s, and internal sentinels like `DW_WIPE_STRONG`.

Independent of #1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery phrase backup security warnings explaining access risks, safe storage, and wallet restoration requirements.
* **Localization**
  * Added translations for these warnings across the app’s supported languages.
  * Backup information text now supports localization, improving accessibility for multilingual users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->