### PR TITLE
fix(l10n): ship Localizable.stringsdict for every locale the app bundles

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -2720,6 +2720,24 @@
 		47A5145F2848F75B005A8E3E /* TxDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailViewController.swift; sourceTree = "<group>"; };
 		47A514612848FEAD005A8E3E /* Tx.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Tx.storyboard; sourceTree = "<group>"; };
 		47A5146328491C60005A8E3E /* TxDetailCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxDetailCells.swift; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000000 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = fr; path = fr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000001 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000002 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000003 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000004 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000005 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000006 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = es; path = es.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000007 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = it; path = it.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000008 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = tr; path = tr.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000009 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pl; path = pl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000A /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ru; path = ru.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000B /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = el; path = el.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = pt; path = pt.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000D /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = bg; path = bg.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000E /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = vi; path = vi.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E00000F /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = th; path = th.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000010 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		51D1C700000D10CA1E000011 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = id; path = id.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		A1C0DE0000000000000BADA1 /* TxDetailContactViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TxDetailContactViews.swift; sourceTree = "<group>"; };
 		47AC8412297822E000BD1B49 /* SpecifyAmountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecifyAmountViewController.swift; sourceTree = "<group>"; };
 		47AE8B9428BFACA100490F5E /* ExploreDash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreDash.swift; sourceTree = "<group>"; };
@@ -11423,6 +11441,24 @@
 				2A8E79B9240676D400AA7C3D /* sk */,
 				2A8E79BD2406772900AA7C3D /* cs */,
 				477A963C292BA4B90013605B /* uk */,
+				51D1C700000D10CA1E000000 /* fr */,
+				51D1C700000D10CA1E000001 /* ja */,
+				51D1C700000D10CA1E000002 /* ko */,
+				51D1C700000D10CA1E000003 /* nl */,
+				51D1C700000D10CA1E000004 /* de */,
+				51D1C700000D10CA1E000005 /* zh-Hans */,
+				51D1C700000D10CA1E000006 /* es */,
+				51D1C700000D10CA1E000007 /* it */,
+				51D1C700000D10CA1E000008 /* tr */,
+				51D1C700000D10CA1E000009 /* pl */,
+				51D1C700000D10CA1E00000A /* ru */,
+				51D1C700000D10CA1E00000B /* el */,
+				51D1C700000D10CA1E00000C /* pt */,
+				51D1C700000D10CA1E00000D /* bg */,
+				51D1C700000D10CA1E00000E /* vi */,
+				51D1C700000D10CA1E00000F /* th */,
+				51D1C700000D10CA1E000010 /* zh-Hant-TW */,
+				51D1C700000D10CA1E000011 /* id */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";


### PR DESCRIPTION
## The bug

The `Localizable.stringsdict` `PBXVariantGroup` (`2ADC722723B5547000D9DD37`) had exactly **four** children — `en`, `sk`, `cs`, `uk` — so only those four plural catalogs were copied into the app:

```
$ find <builtapp> -name '*.stringsdict' | wc -l
4
```

All 43 `DashWallet/*.lproj/Localizable.stringsdict` files exist on disk and are actively maintained (#945 added 15 plural entries to all of them, #1076 added `%d words`), but the rest were never referenced by the project. **Every pluralised string silently fell back to English** in those locales.

`%d words` is the cleanest demonstration: it lives **only** in stringsdict and in **no** `.strings` catalog, so it can only come from a bundled stringsdict.

## The fix

Add the 18 remaining locales the app actually ships — `bg de el es fr id it ja ko nl pl pt ru th tr vi zh-Hans zh-Hant-TW` — as children of that variant group, each with its own `PBXFileReference` (`lastKnownFileType = text.plist.stringsdict`).

Both targets already reference the single shared variant group through build files `2ADC722923B5547000D9DD37` (dashwallet `Resources`) and `C9D2C91C2A320AA000D15901` (dashpay `Resources`), so **no build-phase change was needed** — adding children to the group fixes both targets at once.

Bundled stringsdict count: **4 → 22**, one for every shipping locale.

## Before / after

Same screen, same simulator, same fresh install — the **Дополнительно** disclosure on "Сохранить фразу восстановления", Russian device language.

| Before — `12 words / 24 words` | After — `12 слов / 24 слова` |
|---|---|
| <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/f5dd26336cae227456e156ceb67d12b1c9dfba97/stringsdict-locales/before-ru.png" width="330"> | <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/f5dd26336cae227456e156ceb67d12b1c9dfba97/stringsdict-locales/after-ru.png" width="330"> |

Note the body copy around the picker is already Russian in **both** shots — it comes from `.strings`, which was shipping fine. Only the stringsdict-backed segment labels were falling back.

### Slavic plural categories resolve correctly

Russian and Polish both select two *different* CLDR categories on this one screen — 12 → `many`, 24 → `few` — and both render correctly:

| Russian | Polish |
|---|---|
| `12 слов` (many) / `24 слова` (few) | `12 słów` (many) / `24 słowa` (few) |

<img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/f5dd26336cae227456e156ceb67d12b1c9dfba97/stringsdict-locales/after-pl.png" width="330">

## Verification

1. `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build` → **BUILD SUCCEEDED**
2. `find <builtapp> -name '*.stringsdict' | wc -l` → **22** (was 4); every `.lproj` in the bundle except `Base` now has one
3. Russian simulator, fresh keychain + onboarding → picker shows `12 слов / 24 слова`
4. Polish simulator, same flow → `12 słów / 24 słowa`

## Out of scope (found while verifying)

Two further localisation gaps, deliberately **not** touched here:

1. **21 locales ship nothing at all.** `ar ca da eo et fa fi fil hr hu mk ms nb ro sl sl_SI sq sr sv zh zh_TW` each have a complete, fully-translated 2081-key `Localizable.strings` on disk, but are absent from `knownRegions` *and* from the `Localizable.strings` variant group — they are `tx pull -a` output that was never wired into Xcode. Adding only their stringsdict would have produced a `.lproj` with plurals and no strings, making the app advertise those languages (RTL included, for `ar`/`fa`) with an otherwise-English UI — a regression, so they are excluded. Wiring them up properly is a product decision that also needs the `sl`/`sl_SI`, `zh`/`zh-Hans` and `zh_TW`/`zh-Hant-TW` duplicates resolved.
2. **Hardcoded English copy.** The two bullets on the backup screen ("Dash Core Group does NOT store this recovery phrase", "You will NOT be able to restore the wallet without a recovery phrase") are string literals in `BackupInfoViewController.swift:32` and `BackupInfoItemView.xib`, never passed through `NSLocalizedString` — they are in no catalog, not even `en`. Visible as English in every screenshot above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized content for French, Japanese, Korean, Dutch, German, Chinese, Spanish, Italian, Turkish, Polish, Russian, Greek, Portuguese, Bulgarian, Vietnamese, Thai, Taiwanese Chinese, and Indonesian.
  * Improved support for pluralized and localized text across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->