### PR TITLE
chore: raise the dashpay Testnet deployment target to 18.0

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -12424,7 +12424,7 @@
 				);
 				INFOPLIST_FILE = "DashPay/dashpay-info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = DashPay;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `Testnet` configuration of the `dashpay` target is the only one in the project still on
`IPHONEOS_DEPLOYMENT_TARGET = 17.0`; the other 23 configurations are 18.0, and the Podfile has
declared `platform :ios, '18.0'` for a while, so the pods it links are already built against 18.

It matters now because DashUIKit is raising its own floor to iOS 18 to match this app
(dashpay/DashUIKit#15). `dashpay` links that package, so this configuration would be the single
one that fails to build against it — "compiled for iOS 18.0, but linking against target 17.0".

## What was done?

One line in `DashWallet.xcodeproj/project.pbxproj`: `17.0` → `18.0`. All 24 configurations now
agree.

## How Has This Been Tested?

Verified by inspection of the project file — after the change no `IPHONEOS_DEPLOYMENT_TARGET`
below 18.0 remains anywhere in it.

Not built locally: a clean checkout needs a full `pod install` first, and this change cannot
affect anything a 17.0-era build would have compiled differently — every dependency it links is
already built at 18. Worth a CI run on this branch before merging.

## Breaking Changes

None for anyone building the app: iOS 18 is already the project's effective minimum. It does
drop the ability to install this specific Testnet configuration on iOS 17 devices, which the
other configurations lost some time ago.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported iOS version to iOS 18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->