### PR TITLE
feat(dashpay): improve username marketplace access

### DIFF
--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -90,20 +90,27 @@ struct SDKIdentityProfileSheet: View {
                         .transition(.opacity)
                 }
             }
-            .onAppear {
-                loadIdentityId()
-                dpnsNames = DWCurrentUserIdentityInfo.shared.usernames
-                hasIdentity = DWCurrentUserIdentityInfo.shared.hasIdentity
-                pendingContestedName = DWContestedNameStatusService.shared.pendingLabel
-                pendingVotingEndTime = DWContestedNameStatusService.shared.pendingVotingEndTime
-                avatarURL = DWCurrentUserIdentityInfo.shared.avatarURL
-            }
+            .onAppear(perform: reloadIdentitySnapshot)
         }
-        .fullScreenCover(isPresented: $showingUsernameMarketplace) {
+        // `onDismiss` rather than relying on the `onAppear` above: SwiftUI does
+        // not re-run it for the presenting view when a `fullScreenCover` closes,
+        // and a name registered or bought in the marketplace changes both
+        // `dpnsNames` and `hasIdentity`.
+        .fullScreenCover(isPresented: $showingUsernameMarketplace,
+                         onDismiss: reloadIdentitySnapshot) {
             UsernameMarketplaceScreen {
                 showingUsernameMarketplace = false
             }
         }
+    }
+
+    private func reloadIdentitySnapshot() {
+        loadIdentityId()
+        dpnsNames = DWCurrentUserIdentityInfo.shared.usernames
+        hasIdentity = DWCurrentUserIdentityInfo.shared.hasIdentity
+        pendingContestedName = DWContestedNameStatusService.shared.pendingLabel
+        pendingVotingEndTime = DWContestedNameStatusService.shared.pendingVotingEndTime
+        avatarURL = DWCurrentUserIdentityInfo.shared.avatarURL
     }
 
     // MARK: - Edit button

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -291,8 +291,8 @@ struct SDKIdentityProfileSheet: View {
                             .foregroundColor(.dash.blue)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(dpnsNames.isEmpty
-                                ? NSLocalizedString("Add a username", comment: "Username marketplace: profile entry point")
-                                : NSLocalizedString("Add another username", comment: "Username marketplace: profile entry point"))
+                                ? NSLocalizedString("Get a username", comment: "Username marketplace: profile entry point")
+                                : NSLocalizedString("Get another username", comment: "Username marketplace: profile entry point"))
                                 .font(.system(size: 15, weight: .semibold))
                                 .foregroundColor(.dash.blue)
                             Text(NSLocalizedString(

--- a/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
+++ b/DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift
@@ -37,6 +37,7 @@ struct SDKIdentityProfileSheet: View {
     @State private var identityIdData: Data?
     @State private var showingBalanceInfo = false
     @State private var showingTopUp = false
+    @State private var showingUsernameMarketplace = false
 
     /// Callback invoked when the user taps Edit. Owner (HomeViewController)
     /// dismisses the sheet and pushes `RootEditProfileViewController`.
@@ -51,7 +52,7 @@ struct SDKIdentityProfileSheet: View {
                     header
                     Divider()
                     infoSection
-                    if !dpnsNames.isEmpty {
+                    if hasIdentity {
                         namesSection
                     }
                     // Edit Profile gated on hasIdentity: the editor's
@@ -96,6 +97,11 @@ struct SDKIdentityProfileSheet: View {
                 pendingContestedName = DWContestedNameStatusService.shared.pendingLabel
                 pendingVotingEndTime = DWContestedNameStatusService.shared.pendingVotingEndTime
                 avatarURL = DWCurrentUserIdentityInfo.shared.avatarURL
+            }
+        }
+        .fullScreenCover(isPresented: $showingUsernameMarketplace) {
+            UsernameMarketplaceScreen {
+                showingUsernameMarketplace = false
             }
         }
     }
@@ -273,6 +279,37 @@ struct SDKIdentityProfileSheet: View {
                         Divider()
                     }
                 }
+                if !dpnsNames.isEmpty {
+                    Divider()
+                }
+                Button {
+                    showingUsernameMarketplace = true
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundColor(.dash.blue)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(dpnsNames.isEmpty
+                                ? NSLocalizedString("Add a username", comment: "Username marketplace: profile entry point")
+                                : NSLocalizedString("Add another username", comment: "Username marketplace: profile entry point"))
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundColor(.dash.blue)
+                            Text(NSLocalizedString(
+                                "Buy a listed name or register an available one",
+                                comment: "Username marketplace: profile entry point subtitle"))
+                                .font(.caption)
+                                .foregroundColor(.dash.secondaryText)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal, 12)
             .background(Color.dash.secondaryBackground)

--- a/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift
@@ -426,21 +426,27 @@ final class UsernameMarketplaceViewModel: ObservableObject {
 // MARK: - UsernameMarketplaceScreen
 
 struct UsernameMarketplaceScreen: View {
-    private let vc: UINavigationController
+    private let onBack: () -> Void
 
     @StateObject private var viewModel = UsernameMarketplaceViewModel()
     @State private var selectedLabel: SelectedMarketplaceLabel?
     @State private var registerCandidate: RegisterCandidate?
 
     init(vc: UINavigationController) {
-        self.vc = vc
+        onBack = { [weak vc] in
+            vc?.popViewController(animated: true)
+        }
+    }
+
+    /// Standalone presentation path used by My Profile, which is itself
+    /// presented as a sheet and therefore has no UIKit navigation controller.
+    init(onBack: @escaping () -> Void) {
+        self.onBack = onBack
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            NavBarBack {
-                vc.popViewController(animated: true)
-            }
+            NavBarBack(onBack: onBack)
 
             TopIntro(
                 title: NSLocalizedString("Username Marketplace", comment: "Username marketplace"),

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -384,6 +384,12 @@ struct IdentityDetailScreen: View {
             }
         }
         .navigationBarHidden(true)
+        // Re-read on every appearance, not just the first: the username
+        // marketplace is pushed onto the same stack, and a name registered or
+        // bought there changes `currentRow`. Doing it here rather than in the
+        // marketplace's back action also covers the UIKit bar button and the
+        // swipe-back gesture.
+        .onAppear { viewModel.reload() }
         .alert(
             NSLocalizedString("Set as Main Identity", comment: "Identities"),
             isPresented: $confirmSetMain

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -632,8 +632,8 @@ struct IdentityDetailScreen: View {
                             .foregroundColor(.dash.blue)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(currentRow.dpnsNames.isEmpty
-                                ? NSLocalizedString("Add a username", comment: "Username marketplace: identity entry point")
-                                : NSLocalizedString("Add another username", comment: "Username marketplace: identity entry point"))
+                                ? NSLocalizedString("Get a username", comment: "Username marketplace: identity entry point")
+                                : NSLocalizedString("Get another username", comment: "Username marketplace: identity entry point"))
                                 .font(.system(size: 15, weight: .semibold))
                                 .foregroundColor(.dash.blue)
                             Text(NSLocalizedString(

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift
@@ -374,7 +374,7 @@ struct IdentityDetailScreen: View {
                         if row.pendingContestedName != nil {
                             pendingNameCard
                         }
-                        if !currentRow.dpnsNames.isEmpty {
+                        if !currentRow.dpnsNames.isEmpty || isMain {
                             namesCard
                         }
                         mainIdentityCard
@@ -623,11 +623,47 @@ struct IdentityDetailScreen: View {
                     .font(.caption)
                     .foregroundColor(.dash.secondaryText)
             }
+            if isMain {
+                Divider()
+                Button(action: showUsernameMarketplace) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundColor(.dash.blue)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(currentRow.dpnsNames.isEmpty
+                                ? NSLocalizedString("Add a username", comment: "Username marketplace: identity entry point")
+                                : NSLocalizedString("Add another username", comment: "Username marketplace: identity entry point"))
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundColor(.dash.blue)
+                            Text(NSLocalizedString(
+                                "Buy a listed name or register an available one",
+                                comment: "Username marketplace: identity entry point subtitle"))
+                                .font(.caption)
+                                .foregroundColor(.dash.secondaryText)
+                        }
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.dash.secondaryText)
+                    }
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .background(Color.dash.secondaryBackground)
         .cornerRadius(12)
+    }
+
+    private func showUsernameMarketplace() {
+        let controller = UIHostingController(
+            rootView: UsernameMarketplaceScreen(vc: vc))
+        controller.hidesBottomBarWhenPushed = true
+        vc.pushViewController(controller, animated: true)
     }
 
     private var pendingNameCard: some View {

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -584,6 +584,9 @@
 /* Buy a Gift Card */
 "Buy a Gift Card" = "Buy a Gift Card";
 
+/* Username marketplace: profile entry point subtitle */
+"Buy a listed name or register an available one" = "Buy a listed name or register an available one";
+
 /* Dash Service Overview */
 "Buy and convert Dash with another crypto" = "Buy and convert Dash with another crypto";
 
@@ -751,6 +754,12 @@
 
 /* Identity top-up sheet — linkability warning for transparent-side sources */
 "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance." = "Funding from a transparent balance publicly links those coins to your identity on the Dash chain. For privacy, pay from your Shielded balance.";
+
+/* Username marketplace: profile entry point */
+"Get a username" = "Get a username";
+
+/* Username marketplace: profile entry point */
+"Get another username" = "Get another username";
 
 /* DashPay FAQ */
 "How does this compare to Bitcoin in terms of privacy?" = "How does this compare to Bitcoin in terms of privacy?";


### PR DESCRIPTION
## Issue being fixed or feature implemented

Buying or registering another username was discoverable only from the Username Marketplace's Find Names search. This adds direct marketplace entry points where users already manage their identity and profile.

## What was done?

- add an "Add a username" / "Add another username" action to My Profile
- add the same action to the main Identity detail page
- open Username Marketplace on Find Names from both entry points
- support closing the marketplace when it is presented directly from SwiftUI while preserving the existing navigation-controller flow

## How Has This Been Tested?

- built the exact commit for iOS Simulator with `xcodebuild`
- installed and launched the resulting app on an iPhone simulator
- ran an XCUITest against an identity owning two DPNS names to verify both entry points and their Find Names destinations
- inspected the resulting full-resolution screenshots

## Screenshots

Captured from exact app commit `1056d73ef345e343e69b9a3e039cb8471d6422ef`
with the same identity fixture (`helloworld6789`, also owning `Helloworld1234`).

| My Profile | Main Identity |
| --- | --- |
| <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/9aea6da5bf7e1705720ec0d36c89aa383e4abfb5/my-profile-username-entry.png" width="390" alt="Add another username entry on My Profile"> | <img src="https://raw.githubusercontent.com/dashpay/dashwallet-ios/9aea6da5bf7e1705720ec0d36c89aa383e4abfb5/main-identity-username-entry.png" width="390" alt="Add another username entry on the main Identity detail page"> |

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the username marketplace from identity profiles.
  - Profile pages now display the usernames section even when no usernames are currently available.
  - Added options to get a username or purchase another username.
  - Added full-screen marketplace presentation from profile views.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->