### PR TITLE
feat: core-to-platform send route for external platform addresses

### DIFF
--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -947,6 +947,7 @@
 		87AC92AAD9DF8CBF271609AC /* SwiftDashSDKSPVStatusScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90D495F8DF1E8EE8A84C8E8 /* SwiftDashSDKSPVStatusScreen.swift */; };
 		88436E7D9764791AC81AFFB0 /* AuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE3302C1C5DF898D1A0F915 /* AuthenticationService.swift */; };
 		89ED38B6205FE4EEEE8013B9 /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C9D64AB542D03FE3704D02 /* ShieldedWithdrawalStore.swift */; };
+		408DF23C9C7BBF7FD7C49B8D /* PlatformFundingRecipientStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F48F3043C3BB643CCB30499 /* PlatformFundingRecipientStore.swift */; };
 		8A7607606A594C6E99A2FAC7 /* DerivationPathKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC1F4DB87C442BEABDF0DB2 /* DerivationPathKeysView.swift */; };
 		8AF94168DE3494EAF0811D77 /* PaymentURIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E3F6CC617DA824F467AADC /* PaymentURIBuilder.swift */; };
 		8B8898971DC24152E171DABC /* PaymentsLandingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E735446F9E918618E97EDD38 /* PaymentsLandingScreen.swift */; };
@@ -980,6 +981,7 @@
 		9A1606353B5B4E5481AC5C6A /* NotificationsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B728BBE755AB93DD58FDA4EC /* NotificationsScreen.swift */; };
 		9A891339E42C1BE3AED09CBB /* WalletAccountDetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BFD41DDFE194362A163BC7 /* WalletAccountDetailScreen.swift */; };
 		9B40E576972DB41F7EF4D21E /* ShieldedWithdrawalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C9D64AB542D03FE3704D02 /* ShieldedWithdrawalStore.swift */; };
+		262DD1FC124BA3166DABB2E6 /* PlatformFundingRecipientStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F48F3043C3BB643CCB30499 /* PlatformFundingRecipientStore.swift */; };
 		9B54AF317E7728C18646F702 /* QRCodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52F6A39C711B1E955B7E3A /* QRCodeGenerator.swift */; };
 		9B627F0FCC93D887BAB3E9A9 /* BIP70PaymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D58056D713E4B50DAE0F24B /* BIP70PaymentService.swift */; };
 		9E39B6CDE39A9CA4E74ADF3B /* IdentitiesScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528594007157A56ABDEAD552 /* IdentitiesScreen.swift */; };
@@ -2882,6 +2884,7 @@
 		59C18FCF827D815007BAEF29 /* DWLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = DWLogger.m; sourceTree = "<group>"; };
 		59C18FCF827D815007BAEB01 /* MainThreadStallMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadStallMonitor.swift; sourceTree = "<group>"; };
 		59C9D64AB542D03FE3704D02 /* ShieldedWithdrawalStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShieldedWithdrawalStore.swift; sourceTree = "<group>"; };
+		4F48F3043C3BB643CCB30499 /* PlatformFundingRecipientStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformFundingRecipientStore.swift; sourceTree = "<group>"; };
 		5A1EC0FE2E29A10000000001 /* ShieldedActivityHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShieldedActivityHistory.swift; sourceTree = "<group>"; };
 		5A1EC0FE2E29A20000000011 /* PlatformAddressActivityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAddressActivityStore.swift; sourceTree = "<group>"; };
 		5A1EC0FE2E29A20000000014 /* PlatformAddressHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformAddressHistory.swift; sourceTree = "<group>"; };
@@ -3871,6 +3874,7 @@
 				05723F61BFF76C3BB9EF3CDC /* InternalTransferConfirmSheet.swift */,
 				0D2C8F8102C5C603DB63569F /* ShieldedTransferCoordinator.swift */,
 				59C9D64AB542D03FE3704D02 /* ShieldedWithdrawalStore.swift */,
+				4F48F3043C3BB643CCB30499 /* PlatformFundingRecipientStore.swift */,
 			);
 			path = InternalTransfer;
 			sourceTree = "<group>";
@@ -10333,6 +10337,7 @@
 				A15ED0B9E7AAF29C694E4E17 /* DWIdentityAuthorizer.swift in Sources */,
 				2A6B1257A51E609B8025BF3A /* ShieldedTransferCoordinator.swift in Sources */,
 				9B40E576972DB41F7EF4D21E /* ShieldedWithdrawalStore.swift in Sources */,
+				262DD1FC124BA3166DABB2E6 /* PlatformFundingRecipientStore.swift in Sources */,
 				06132521E7B4D21B4A1597E7 /* PlatformSendExecutor.swift in Sources */,
 				D3DA37D1924A7F5B089FE110 /* StorageExplorerView.swift in Sources */,
 				3B1ECCE5521BAB084D74B5ED /* StorageModelListViews.swift in Sources */,
@@ -11365,6 +11370,7 @@
 				E2D0F4AD56B92356C871F568 /* InternalTransferConfirmSheet.swift in Sources */,
 				17ED79A8B56522CD03A8CD5E /* ShieldedTransferCoordinator.swift in Sources */,
 				89ED38B6205FE4EEEE8013B9 /* ShieldedWithdrawalStore.swift in Sources */,
+				408DF23C9C7BBF7FD7C49B8D /* PlatformFundingRecipientStore.swift in Sources */,
 				4AC8F492DD74101C71A5EA5E /* PlatformSendExecutor.swift in Sources */,
 				983748715D558F311DF6BFCD /* StorageExplorerView.swift in Sources */,
 				02EDCC7635BCD84768554D9C /* StorageModelListViews.swift in Sources */,

--- a/DashWallet.xcodeproj/project.pbxproj
+++ b/DashWallet.xcodeproj/project.pbxproj
@@ -1181,6 +1181,7 @@
 		BD509A68B1A0B6E4599F9C7A /* DWProfileUpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82926C69F3BB675BEF1A1FFD /* DWProfileUpdateCoordinator.swift */; };
 		C05FA6CE3DDE2D0327D334E5 /* CoinJoinRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B478AD92C1F1C11D09645DF4 /* CoinJoinRecovery.swift */; };
 		C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */; };
+		451EFA427874A094F9B85545 /* CoreToPlatformSendRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43CBA1F437965D7BE80145C6 /* CoreToPlatformSendRouteTests.swift */; };
 		C124DF94278D4238FAE0975D /* OrderPreviewFeeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */; };
 		C1A0B2C3D4E5F60718293A02 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
 		C1A0B2C3D4E5F60718293A03 /* ShortcutsBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */; };
@@ -3227,6 +3228,7 @@
 		BCD0199D74601A6150ABC8D1 /* WalletAccountDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalletAccountDetailViewModel.swift; sourceTree = "<group>"; };
 		C0D1A08496F925D17031493E /* OrderPreviewFeeRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderPreviewFeeRow.swift; sourceTree = "<group>"; };
 		C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDashSDKCoreLifecycleTests.swift; sourceTree = "<group>"; };
+		43CBA1F437965D7BE80145C6 /* CoreToPlatformSendRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreToPlatformSendRouteTests.swift; sourceTree = "<group>"; };
 		C1A0B2C3D4E5F60718293A01 /* ShortcutsBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsBarView.swift; sourceTree = "<group>"; };
 		C1D2E3F4A5B6C7D8E9F01234 /* TransferAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferAmountView.swift; sourceTree = "<group>"; };
 		C3DAD266246AA6F10001624F /* DWScreenshotWarningViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DWScreenshotWarningViewController.h; sourceTree = "<group>"; };
@@ -7210,6 +7212,7 @@
 				A17EED0126C7000000000002 /* WalletWipeSerialExecutorTests.swift */,
 				B7C072AA26C7000000000002 /* DWContestedNameStatusServiceTests.swift */,
 				C0DE5A0126C7000000000002 /* SwiftDashSDKCoreLifecycleTests.swift */,
+				43CBA1F437965D7BE80145C6 /* CoreToPlatformSendRouteTests.swift */,
 				CB9000012FE1000000000001 /* CoinbaseTransactionMetadataTests.swift */,
 				CB9100012FE2000000000001 /* CoinbaseTransferAmountTests.swift */,
 				7A30000130A1000000000001 /* TransactionDirectionTests.swift */,
@@ -10415,6 +10418,7 @@
 				A17EED0126C7000000000001 /* WalletWipeSerialExecutorTests.swift in Sources */,
 				B7C072AA26C7000000000001 /* DWContestedNameStatusServiceTests.swift in Sources */,
 				C0DE5A0126C7000000000001 /* SwiftDashSDKCoreLifecycleTests.swift in Sources */,
+				451EFA427874A094F9B85545 /* CoreToPlatformSendRouteTests.swift in Sources */,
 				CB9000022FE1000000000002 /* CoinbaseTransactionMetadataTests.swift in Sources */,
 				CB9100022FE2000000000002 /* CoinbaseTransferAmountTests.swift in Sources */,
 				7A30000230A1000000000002 /* TransactionDirectionTests.swift in Sources */,

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/AssetLockRecoveryService.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/AssetLockRecoveryService.swift
@@ -78,6 +78,13 @@ struct AssetLockRecoveryService {
             // can't forget the check.
             let coordinator = ShieldedTransferCoordinator()
             if fundingTypeRaw == 4 {
+                // No recipient argument: `PlatformAddressSyncCoordinator
+                // .resumeFundFromCore` resolves the lock's persisted recipient
+                // from its outpoint, so a Core → Platform send that was paying
+                // a third party resumes to THAT party rather than to the
+                // sender's own next address. Locks with no recorded recipient
+                // (the internal transfer, and anything predating the field
+                // family) keep the own-address behavior.
                 await coordinator.resumeFundPlatform(outPointTxidWire: txidWire, outPointVout: vout)
             } else {
                 await coordinator.resumeAssetLock(outPointTxidWire: txidWire, outPointVout: vout)

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/PlatformAddressSyncCoordinator.swift
@@ -537,23 +537,46 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
         Task { await self.syncNow() }
     }
 
-    /// Fund the wallet's own Platform balance from the Core L1 balance via
-    /// an asset lock (funding type 4, `AssetLockAddressTopUp`). `amountDuffs`
-    /// is locked on L1; the credited amount is that value minus the fees the
-    /// Rust side carves from the single remainder recipient (the wallet's
-    /// own next unused Platform address).
-    public func fundFromCore(amountDuffs: UInt64) async throws {
-        let (addressWallet, container, recipient, accountIndex) = try resolveFundEnvironment()
+    /// Fund a Platform balance from the Core L1 balance via an asset lock
+    /// (funding type 4, `AssetLockAddressTopUp`). `amountDuffs` is locked on L1.
+    ///
+    /// `externalRecipient` nil = the INTERNAL transfer: a single remainder
+    /// recipient pointed at the wallet's own next unused Platform address, which
+    /// receives the locked value minus the fees Rust carves from it.
+    ///
+    /// Non-nil and `isExternal` = the EXTERNAL send: two outputs, the payee's
+    /// with an explicit credit amount and the wallet's own next address as the
+    /// remainder. The fee strategy reduces the remainder, so the payee is paid
+    /// EXACTLY `credits` and the sender's own change absorbs every fee. This
+    /// takes the `fundFromAssetLockExternal` entry point, which relaxes the
+    /// membership pre-flight for explicit-amount recipients only — the
+    /// remainder must still be an address this wallet owns.
+    public func fundFromCore(
+        amountDuffs: UInt64,
+        externalRecipient: PlatformFundingRecipient? = nil
+    ) async throws {
+        let (addressWallet, container, ownChange, accountIndex) = try resolveFundEnvironment()
         let signer = KeychainSigner(modelContainer: container, network: runningNetwork!)
 
-        Self.logger.info("🛰️ PLATFORM-FUND :: core → platform amount=\(amountDuffs) account=\(accountIndex)")
-
-        let updated = try await addressWallet.fundFromAssetLock(
-            amountDuffs: amountDuffs,
-            fundingAccountIndex: 0,
-            platformAccountIndex: accountIndex,
-            recipients: [recipient],
-            signer: signer)
+        let updated: [ManagedPlatformAddressWallet.UpdatedBalance]
+        if let payee = try Self.externalPayee(externalRecipient) {
+            Self.logger.info(
+                "🛰️ PLATFORM-FUND :: core → external platform lock=\(amountDuffs) payee=\(payee.credits ?? 0) account=\(accountIndex)")
+            updated = try await addressWallet.fundFromAssetLockExternal(
+                amountDuffs: amountDuffs,
+                fundingAccountIndex: 0,
+                platformAccountIndex: accountIndex,
+                recipients: [payee, ownChange],
+                signer: signer)
+        } else {
+            Self.logger.info("🛰️ PLATFORM-FUND :: core → platform amount=\(amountDuffs) account=\(accountIndex)")
+            updated = try await addressWallet.fundFromAssetLock(
+                amountDuffs: amountDuffs,
+                fundingAccountIndex: 0,
+                platformAccountIndex: accountIndex,
+                recipients: [ownChange],
+                signer: signer)
+        }
 
         applyUpdatedBalances(updated, context: container.mainContext)
         await ShieldedTxLookup.shared.refresh(reason: "platform-fund-completed")
@@ -566,32 +589,106 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
     /// the existing outpoint instead of building (and stranding) a second
     /// lock. See `ShieldedTransferCoordinator.resumeAssetLock` for the same
     /// pattern on the shielded route.
-    public func resumeFundFromCore(outPointTxid: Data, outPointVout: UInt32) async throws {
-        let (addressWallet, container, recipient, accountIndex) = try resolveFundEnvironment()
+    ///
+    /// This is the single choke point every resume surface funnels through
+    /// (tx-detail retry, the home screen's tap-to-finish, `AssetLockRecovery
+    /// Service`, and the confirm sheet's "Try again"), so the recipient is
+    /// resolved from durable storage HERE rather than at each call site — a
+    /// resume path added later cannot forget to do it.
+    ///
+    /// `externalRecipient` nil means "look it up": the lock's persisted
+    /// recipient is used when one was recorded, and a lock with NO recorded
+    /// recipient keeps the legacy own-next-address behavior so funding locks
+    /// that predate the field family still resume correctly.
+    public func resumeFundFromCore(
+        outPointTxid: Data,
+        outPointVout: UInt32,
+        externalRecipient: PlatformFundingRecipient? = nil
+    ) async throws {
+        let (addressWallet, container, ownChange, accountIndex) = try resolveFundEnvironment()
         let signer = KeychainSigner(modelContainer: container, network: runningNetwork!)
 
-        Self.logger.info("🛰️ PLATFORM-FUND :: resume core → platform vout=\(outPointVout)")
+        let resolved = externalRecipient
+            ?? resolvePersistedFundingRecipient(
+                outPointTxid: outPointTxid,
+                outPointVout: outPointVout,
+                container: container)
 
-        let updated = try await addressWallet.resumeFundFromAssetLock(
-            outPointTxid: outPointTxid,
-            outPointVout: outPointVout,
-            platformAccountIndex: accountIndex,
-            recipients: [recipient],
-            signer: signer)
+        let updated: [ManagedPlatformAddressWallet.UpdatedBalance]
+        if let payee = try Self.externalPayee(resolved) {
+            Self.logger.info(
+                "🛰️ PLATFORM-FUND :: resume core → external platform vout=\(outPointVout)")
+            updated = try await addressWallet.resumeFundFromAssetLockExternal(
+                outPointTxid: outPointTxid,
+                outPointVout: outPointVout,
+                platformAccountIndex: accountIndex,
+                recipients: [payee, ownChange],
+                signer: signer)
+        } else {
+            Self.logger.info("🛰️ PLATFORM-FUND :: resume core → platform vout=\(outPointVout)")
+            updated = try await addressWallet.resumeFundFromAssetLock(
+                outPointTxid: outPointTxid,
+                outPointVout: outPointVout,
+                platformAccountIndex: accountIndex,
+                recipients: [ownChange],
+                signer: signer)
+        }
 
         applyUpdatedBalances(updated, context: container.mainContext)
         await ShieldedTxLookup.shared.refresh(reason: "platform-fund-resume-completed")
         Task { await self.syncNow() }
     }
 
-    /// Shared readiness + recipient resolution for `fundFromCore` /
-    /// `resumeFundFromCore`: the single credits-nil recipient is the
-    /// remainder output (absorbs the locked value less fees), pointed at the
-    /// wallet's own next receive address.
+    /// The persisted recipient of a tracked type-4 lock, or `nil` when none was
+    /// recorded (legacy locks, and every lock the internal transfer builds).
+    private func resolvePersistedFundingRecipient(
+        outPointTxid: Data,
+        outPointVout: UInt32,
+        container: ModelContainer
+    ) -> PlatformFundingRecipient? {
+        guard let walletId = SwiftDashSDKHost.shared.wallet?.walletId,
+              let hex = PlatformFundingRecipientStore.outPointHex(
+                  txidWire: outPointTxid, vout: outPointVout)
+        else { return nil }
+        return PlatformFundingRecipientStore.resolve(
+            outPointHex: hex, walletId: walletId, container: container)
+    }
+
+    /// Map a durable recipient record onto the SDK's explicit-amount recipient,
+    /// or `nil` when the funding is an ordinary own-address top-up.
+    ///
+    /// Throws rather than silently degrading to the own-address path: a record
+    /// that says "external" but carries no amount, or a P2SH destination, is a
+    /// bug or a corrupted row, and quietly paying the sender's own address
+    /// instead is exactly the misdirection this whole field family exists to
+    /// prevent.
+    private static func externalPayee(
+        _ recipient: PlatformFundingRecipient?
+    ) throws -> ManagedPlatformAddressWallet.FundFromAssetLockRecipient? {
+        guard let recipient, recipient.isExternal else { return nil }
+        guard recipient.addressType == 0 else { throw SendError.p2shNotSupported }
+        guard let credits = recipient.credits, credits > 0, recipient.hash.count == 20 else {
+            throw SendError.invalidDestination
+        }
+        return ManagedPlatformAddressWallet.FundFromAssetLockRecipient(
+            addressType: recipient.addressType,
+            hash: recipient.hash,
+            credits: credits)
+    }
+
+    /// Shared readiness + own-address resolution for `fundFromCore` /
+    /// `resumeFundFromCore`.
+    ///
+    /// The wallet's own next receive address is ALWAYS resolved, on both the
+    /// internal and the external path — it is the single `credits == nil`
+    /// remainder recipient, which on an external send is the sender's change
+    /// output (and the one the fee strategy reduces). `fundFromAssetLockExternal`
+    /// requires the remainder to be an address this wallet owns, so this lookup
+    /// is not an internal-only concern.
     private func resolveFundEnvironment() throws -> (
         wallet: ManagedPlatformAddressWallet,
         container: ModelContainer,
-        recipient: ManagedPlatformAddressWallet.FundFromAssetLockRecipient,
+        ownChange: ManagedPlatformAddressWallet.FundFromAssetLockRecipient,
         accountIndex: UInt32
     ) {
         guard isRunning,
@@ -603,9 +700,9 @@ public final class PlatformAddressSyncCoordinator: NSObject, ObservableObject {
               let parsed = Self.parsePlatformRecipient(bech32m: target.address),
               parsed.ffiAddressType == 0
         else { throw SendError.noPlatformReceiveAddress }
-        let recipient = ManagedPlatformAddressWallet.FundFromAssetLockRecipient(
+        let ownChange = ManagedPlatformAddressWallet.FundFromAssetLockRecipient(
             addressType: 0, hash: parsed.hash, credits: nil)
-        return (addressWallet, container, recipient, target.accountIndex)
+        return (addressWallet, container, ownChange, target.accountIndex)
     }
 
     /// Full local wipe of the platform-address sync state — the Sync Info

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletWiper.swift
@@ -305,6 +305,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
         CoinJoinRecovery.shared.resetForWipe()
         CoinJoinWithdrawalStore.shared.resetForWipe()
         ShieldedWithdrawalStore.shared.resetForWipe()
+        PlatformFundingRecipientStore.shared.resetForWipe()
         SPVChainResyncMarker.resetForWipe()
         // Without this a contested submission outlived the wallet that made it:
         // reset mid-vote, create a new wallet, and the new wallet reported the
@@ -639,6 +640,7 @@ final class SwiftDashSDKWalletWiper: NSObject {
             CrowdNodeDefaults.shared.clearPerWalletKeys(forWalletIdHex: walletIdHex)
             CoinJoinWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
             ShieldedWithdrawalStore.shared.clearForWallet(walletIdHex: walletIdHex)
+            PlatformFundingRecipientStore.shared.clearForWallet(walletIdHex: walletIdHex)
         }
     }
 }

--- a/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
+++ b/DashWallet/Sources/Models/PlatformAddress/PlatformAddressActivityStore.swift
@@ -461,7 +461,13 @@ enum PlatformAddressActivityRecorder {
             })
         guard let rows = try? container.mainContext.fetch(descriptor) else { return false }
         return rows.contains { lock in
-            lock.recipientPlatformAddressHash == Data(addressHash)
+            // `recipientIsExternal == true` is an outgoing payment to a third
+            // party, whose hash will never match one of our addresses anyway —
+            // but excluding it explicitly keeps an external send from ever
+            // being reported as an incoming own top-up. `nil` predates the
+            // discriminator and can only have come from the own-address flow.
+            lock.recipientIsExternal != true
+                && lock.recipientPlatformAddressHash == Data(addressHash)
                 && deltaDuffs <= lock.amountDuffs
         }
     }

--- a/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
+++ b/DashWallet/Sources/Models/Transactions/Model/Transaction.swift
@@ -395,8 +395,8 @@ class Transaction: TransactionDataItem, Identifiable {
 
     /// Platform-funding sibling of `isPendingShieldedTransfer`: the type-4
     /// lock is committed but the address-funding transition hasn't consumed
-    /// it. Drives the home row's "Pending" pill (no tap-to-recover surface
-    /// yet — retry lives in the transfer confirm sheet).
+    /// it. Drives the home row's "Pending — tap to finish" affordance and the
+    /// `PlatformFundingRecoverySheet` behind it.
     var isPendingPlatformFunding: Bool {
         guard let status = platformFundingLockInfo?.statusRaw else { return false }
         return (1...3).contains(status)
@@ -408,6 +408,14 @@ class Transaction: TransactionDataItem, Identifiable {
     /// keying `ShieldedTxLookup`). `nil` for non-shielded-transfer txs.
     var shieldedOutPoint: (txidWire: Data, vout: UInt32)? {
         guard let info = shieldedLockInfo else { return nil }
+        return (txHashData, info.vout)
+    }
+
+    /// Type-4 twin of `shieldedOutPoint`: the outpoint of this transfer's
+    /// Core → Platform address-funding asset lock, for a recovery resume.
+    /// `nil` for every other kind of transaction.
+    var platformFundingOutPoint: (txidWire: Data, vout: UInt32)? {
+        guard let info = platformFundingLockInfo else { return nil }
         return (txHashData, info.vout)
     }
 

--- a/DashWallet/Sources/UI/Home/Views/HomeView.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeView.swift
@@ -229,6 +229,9 @@ struct HomeViewContent<Content: View>: View {
     @State private var navigateToDashPayFlow: Bool = false
     @State private var navigateToClaimInvitation: Bool = false
     @State private var pendingShieldedRecovery: Transaction? = nil
+    /// Type-4 twin of `pendingShieldedRecovery`: a Core → Platform funding
+    /// whose asset lock committed but whose funding ST never landed.
+    @State private var pendingPlatformFundingRecovery: Transaction? = nil
     /// Balance whose explainer sheet is up (tap on a breakdown row's body).
     @State private var balanceInfoNetwork: ChainNetwork? = nil
 
@@ -498,8 +501,13 @@ struct HomeViewContent<Content: View>: View {
         .sheet(item: $viewModel.giftCardTxId) { txId in
             GiftCardDetailsSheet(txId: txId)
         }
+        .sheet(item: $pendingPlatformFundingRecovery) { tx in
+            AssetLockRecoverySheet(kind: .platformFunding, transaction: tx) {
+                pendingPlatformFundingRecovery = nil
+            }
+        }
         .sheet(item: $pendingShieldedRecovery) { tx in
-            ShieldedRecoverySheet(transaction: tx) {
+            AssetLockRecoverySheet(kind: .shielded, transaction: tx) {
                 pendingShieldedRecovery = nil
             }
         }
@@ -828,9 +836,11 @@ struct HomeViewContent<Content: View>: View {
                     ? NSLocalizedString("Pending — tap to finish", comment: "InternalTransfer recovery")
                     : txItem.isPendingIdentityRegistration
                         ? NSLocalizedString("Pending — tap to finish", comment: "DashPay registration recovery")
-                    // A pending top-up has nothing to "finish" in another
-                    // flow — it recovers from the tx detail sheet.
-                    : txItem.isPendingIdentityFunding || txItem.isPendingPlatformFunding
+                    : txItem.isPendingPlatformFunding
+                        ? NSLocalizedString("Pending — tap to finish", comment: "InternalTransfer recovery")
+                    // A pending identity top-up has nothing to "finish" in
+                    // another flow — it recovers from the tx detail sheet.
+                    : txItem.isPendingIdentityFunding
                         ? NSLocalizedString("Pending", comment: "")
                         : (metadata?.details?.isEmpty == false
                             ? metadata?.details
@@ -849,6 +859,8 @@ struct HomeViewContent<Content: View>: View {
                 // instead of the read-only detail/gift-card sheets.
                 if txItem.isPendingShieldedTransfer {
                     self.pendingShieldedRecovery = txItem
+                } else if txItem.isPendingPlatformFunding {
+                    self.pendingPlatformFundingRecovery = txItem
                 } else if txItem.isPendingIdentityRegistration {
                     #if DASHPAY
                     delegate?.homeViewRequestUsername()

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift
@@ -529,19 +529,32 @@ struct InternalTransferConfirmSheet: View {
     }
 }
 
-/// Recovery sheet for a stuck "to Shielded" transfer (Core→Shielded). The
-/// transfer's L1 asset lock is committed on-chain but the shield state
-/// transition never landed, so the funds sit on an unconsumed
-/// `PersistentAssetLock` — recoverable, not lost. "Finish now" resumes that
-/// exact outpoint via `ShieldedTransferCoordinator.resumeAssetLock`
-/// (re-auth → Orchard proof → ShieldFromAssetLock ST → consume), rather than
-/// building a second lock.
+/// Recovery sheet for a stuck asset-lock-funded transfer. The transfer's L1
+/// asset lock is committed on-chain but its state transition never landed, so
+/// the funds sit on an unconsumed `PersistentAssetLock` — recoverable, not
+/// lost. "Finish now" resumes that exact outpoint rather than building a second
+/// lock.
 ///
 /// Presented from the home tx list when the user taps a row flagged
-/// `Transaction.isPendingShieldedTransfer`. Owns its own coordinator so it is
-/// independent of any live confirm-sheet flow.
-struct ShieldedRecoverySheet: View {
+/// `Transaction.isPendingShieldedTransfer` (`.shielded`) or
+/// `.isPendingPlatformFunding` (`.platformFunding`). Owns its own coordinator
+/// so it is independent of any live confirm-sheet flow.
+struct AssetLockRecoverySheet: View {
 
+    /// Which funding route's lock is being recovered. The two differ in the
+    /// resume call, the stages that remain, and the lookup used to detect a
+    /// lock a background sync already consumed.
+    enum Kind {
+        /// Type 5 — `resumeAssetLock`, rebuilds the Orchard proof.
+        case shielded
+        /// Type 4 — `resumeFundPlatform`; no proof, so the resume is short.
+        /// The recipient is resolved from durable storage inside
+        /// `PlatformAddressSyncCoordinator.resumeFundFromCore`, so a cold
+        /// launch still pays the third party the user originally confirmed.
+        case platformFunding
+    }
+
+    var kind: Kind = .shielded
     let transaction: Transaction
     var onDismiss: () -> Void
 
@@ -557,7 +570,7 @@ struct ShieldedRecoverySheet: View {
             dragHandle
                 .padding(.top, 8)
 
-            Text(NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery"))
+            Text(sheetTitle)
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundColor(.dash.primaryText)
@@ -580,6 +593,61 @@ struct ShieldedRecoverySheet: View {
         }
         .background(Color.dash.primaryBackground)
         .interactiveDismissDisabled(isInFlight)
+    }
+
+    private var sheetTitle: String {
+        switch kind {
+        case .shielded:
+            return NSLocalizedString("Finish shielded transfer", comment: "InternalTransfer recovery")
+        case .platformFunding:
+            return NSLocalizedString("Finish Platform transfer", comment: "InternalTransfer recovery")
+        }
+    }
+
+    private var infoIcon: String {
+        switch kind {
+        case .shielded: return "shield.fill"
+        case .platformFunding: return "arrow.left.arrow.right"
+        }
+    }
+
+    private var infoBodyText: String {
+        switch kind {
+        case .shielded:
+            return NSLocalizedString(
+                "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.",
+                comment: "InternalTransfer recovery")
+        case .platformFunding:
+            return NSLocalizedString(
+                "This transfer's funds were locked on-chain but the Platform transfer didn't finish. Tap Finish now to complete it.",
+                comment: "InternalTransfer recovery")
+        }
+    }
+
+    /// Stages that remain on a resume. Both skip `.locking` (the lock is
+    /// already on-chain); only the shielded route builds a proof.
+    private var resumeSteps: [ShieldedTransferStepList.Step] {
+        var steps: [ShieldedTransferStepList.Step] = [
+            .init(label: NSLocalizedString("Authorizing", comment: ""), phase: .signing)
+        ]
+        if kind == .shielded {
+            steps.append(.init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving))
+        }
+        steps.append(.init(label: NSLocalizedString("Broadcasting", comment: ""), phase: .broadcasting))
+        return steps
+    }
+
+    private var inFlightNote: String {
+        switch kind {
+        case .shielded:
+            return NSLocalizedString(
+                "Building the privacy proof can take up to a minute. Keep the app open.",
+                comment: "InternalTransfer recovery")
+        case .platformFunding:
+            return NSLocalizedString(
+                "Completing the transfer on Platform. Keep the app open.",
+                comment: "InternalTransfer recovery")
+        }
     }
 
     private var isInFlight: Bool {
@@ -632,20 +700,10 @@ struct ShieldedRecoverySheet: View {
     private var inFlightBody: some View {
         VStack(alignment: .leading, spacing: 16) {
             // Same stepped checklist as the original transfer so the user sees
-            // what's happening during the (~30s+) Orchard proof build. Resume
-            // skips `.locking` (the lock is already on-chain), so only
-            // Authorizing → Generating proof → Broadcasting are shown.
-            ShieldedTransferStepList(
-                currentPhase: coordinator.phase,
-                steps: [
-                    .init(label: NSLocalizedString("Authorizing", comment: ""), phase: .signing),
-                    .init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving),
-                    .init(label: NSLocalizedString("Broadcasting", comment: ""), phase: .broadcasting),
-                ])
+            // what's happening while the resume runs.
+            ShieldedTransferStepList(currentPhase: coordinator.phase, steps: resumeSteps)
 
-            Text(NSLocalizedString(
-                "Building the privacy proof can take up to a minute. Keep the app open.",
-                comment: "InternalTransfer recovery"))
+            Text(inFlightNote)
                 .font(.caption)
                 .foregroundColor(.dash.secondaryText)
                 .fixedSize(horizontal: false, vertical: true)
@@ -705,7 +763,7 @@ struct ShieldedRecoverySheet: View {
                 Circle()
                     .fill(Color.dash.blue)
                     .frame(width: 30, height: 30)
-                Image(systemName: "shield.fill")
+                Image(systemName: infoIcon)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Color.dash.whiteText)
             }
@@ -714,9 +772,7 @@ struct ShieldedRecoverySheet: View {
                 Text(NSLocalizedString("Your Dash is safe", comment: "InternalTransfer recovery"))
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(.dash.primaryText)
-                Text(NSLocalizedString(
-                    "This transfer's funds were locked on-chain but the private transfer didn't finish. Tap Finish now to complete it.",
-                    comment: "InternalTransfer recovery"))
+                Text(infoBodyText)
                     .font(.system(size: 13))
                     .foregroundColor(.dash.secondaryText)
                     .fixedSize(horizontal: false, vertical: true)
@@ -732,7 +788,10 @@ struct ShieldedRecoverySheet: View {
     // MARK: - Action
 
     private func finish() {
-        guard let op = transaction.shieldedOutPoint else {
+        let outPoint = kind == .shielded
+            ? transaction.shieldedOutPoint
+            : transaction.platformFundingOutPoint
+        guard let op = outPoint else {
             onDismiss()
             return
         }
@@ -744,7 +803,9 @@ struct ShieldedRecoverySheet: View {
             // this guard a just-completed transfer would dead-end after ~30s.
             await ShieldedTxLookup.shared.refresh(reason: "shield-transfer-recovery-preflight")
             let displayTxid = op.txidWire.reversed().map { String(format: "%02x", $0) }.joined()
-            let statusRaw = ShieldedTxLookup.shared.info(forTxidHex: displayTxid)?.statusRaw
+            let statusRaw = kind == .shielded
+                ? ShieldedTxLookup.shared.info(forTxidHex: displayTxid)?.statusRaw
+                : ShieldedTxLookup.shared.platformFundingInfo(forTxidHex: displayTxid)?.statusRaw
             if statusRaw == 4 {
                 // Already consumed by a background sync since the row snapshot was
                 // captured → it's done; show success without a doomed ~30s resume.
@@ -755,8 +816,14 @@ struct ShieldedRecoverySheet: View {
             // unknown), or nil/0 (status unavailable, e.g. a failed refresh):
             // attempt the resume. Both a local Consumed tombstone and a remote
             // already-consumed report map to unconfirmed rather than false success.
-            await coordinator.resumeAssetLock(outPointTxidWire: op.txidWire, outPointVout: op.vout)
-            // On success the shield ST consumed the lock; refresh the snapshot so
+            switch kind {
+            case .shielded:
+                await coordinator.resumeAssetLock(outPointTxidWire: op.txidWire, outPointVout: op.vout)
+            case .platformFunding:
+                await coordinator.resumeFundPlatform(
+                    outPointTxidWire: op.txidWire, outPointVout: op.vout)
+            }
+            // On success the ST consumed the lock; refresh the snapshot so
             // the history row flips pending → completed even before the next
             // scheduled shielded sync pass lands.
             if case .success = coordinator.phase {

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferViewModel.swift
@@ -43,6 +43,105 @@ enum InternalTransferRoute: Equatable {
     }
 }
 
+/// Protocol cost constants shared by every asset-lock-funded route, mirrored
+/// from the Rust version tables. They are versioned constants rather than
+/// anything the FFI exposes to the host, so they are duplicated here the way
+/// the wallet already duplicates the base processing cost — each one names the
+/// exact Rust field it mirrors so a version bump has a grep handle.
+enum AssetLockFundingCostPolicy {
+    /// Credits per duff (`CREDITS_PER_DUFF`).
+    static let creditsPerDuff: UInt64 = 1000
+
+    /// The balance an asset lock must carry before Platform will begin
+    /// processing an address funding. Mirrors Rust
+    /// `required_asset_lock_duff_balance_for_processing_start_for_address_funding`
+    /// (50_000 duffs) x `CREDITS_PER_DUFF`.
+    ///
+    /// It is the ADDRESS-FUNDING constant, not a shielded-specific one — the
+    /// Core -> Shielded pool fee folds the same number in, which is why both
+    /// routes read it from here.
+    static let baseProcessingCostCredits: UInt64 = 50_000_000
+
+    /// Per-output component of `AddressFundingFromAssetLockTransition`'s
+    /// minimum required fee. Mirrors Rust `state_transition_min_fees
+    /// .address_funds_transfer_output_cost`.
+    static let addressFundsTransferOutputCostCredits: UInt64 = 6_000_000
+
+    /// Smallest credit amount a transition output may carry. Mirrors Rust
+    /// `dpp.state_transitions.min_output_amount`.
+    static let minOutputAmountCredits: UInt64 = 500_000
+
+    /// Credits expressed in whole duffs, rounded UP so a duff-denominated lock
+    /// always covers the full credit-denominated requirement.
+    static func duffsRoundingUp(credits: UInt64) -> UInt64 {
+        credits / creditsPerDuff + (credits.isMultiple(of: creditsPerDuff) ? 0 : 1)
+    }
+}
+
+/// Amount boundary for the Core -> Platform EXTERNAL send (paying a third
+/// party's Platform address from the Core balance via an asset lock).
+///
+/// Deliberately different from the Core -> Platform INTERNAL transfer, which
+/// locks exactly what the user typed and lets Platform carve its fees out of
+/// the single remainder output. That is fine when the remainder is your own
+/// address; paying a third party that way would silently short the payee.
+///
+/// Here the transition carries TWO outputs: the payee's, with an explicit
+/// credit amount, and the sender's own change address as the remainder. The
+/// fee strategy reduces the remainder, so the payee receives EXACTLY the typed
+/// amount and the sender's change absorbs the fees. That costs headroom on top
+/// of the amount, which is what this policy sizes.
+enum CoreToPlatformAmountPolicy {
+    /// Outputs in an external funding transition: payee + own change.
+    private static let externalOutputCount: UInt64 = 2
+
+    /// Headroom (credits) the lock must carry ON TOP of the payee's amount.
+    ///
+    /// `calculate_min_required_fee` for `AddressFundingFromAssetLockTransition`
+    /// is `base + input_cost x inputs + output_cost x max(outputs, 1)`. An
+    /// asset-lock-funded address funding has no address inputs (the lock IS the
+    /// funding), so the input term is zero and only the two outputs are
+    /// charged. On top of the fee the change output must itself clear
+    /// `min_output_amount`, or the transition is invalid.
+    ///
+    /// This is the protocol MINIMUM. The metered fee Platform actually charges
+    /// can exceed it, and it too comes out of the change output — never out of
+    /// the payee's explicit amount. A lock too thin to cover the real fee is
+    /// rejected Rust-side with a typed error, which surfaces as a failed
+    /// transfer rather than as a short payment.
+    static let externalHeadroomCredits: UInt64 =
+        AssetLockFundingCostPolicy.baseProcessingCostCredits
+            + AssetLockFundingCostPolicy.addressFundsTransferOutputCostCredits * externalOutputCount
+            + AssetLockFundingCostPolicy.minOutputAmountCredits
+
+    /// `externalHeadroomCredits` in whole duffs, rounded up.
+    static var externalHeadroomDuffs: UInt64 {
+        AssetLockFundingCostPolicy.duffsRoundingUp(credits: externalHeadroomCredits)
+    }
+
+    /// Smallest payable amount: the payee's output must clear
+    /// `min_output_amount` like any other transition output.
+    static var minimumAmountDuffs: UInt64 {
+        AssetLockFundingCostPolicy.duffsRoundingUp(
+            credits: AssetLockFundingCostPolicy.minOutputAmountCredits)
+    }
+
+    /// L1 lock value that delivers exactly `amountDuffs` to the payee while
+    /// leaving the sender's own change output able to pay the fees. `nil` on
+    /// UInt64 overflow - callers fail closed.
+    static func externalLockValueDuffs(forAmountDuffs amountDuffs: UInt64) -> UInt64? {
+        let (total, overflow) = amountDuffs.addingReportingOverflow(externalHeadroomDuffs)
+        return overflow ? nil : total
+    }
+
+    /// Credit amount the payee's explicit output carries for `amountDuffs`.
+    static func payeeCredits(forAmountDuffs amountDuffs: UInt64) -> UInt64? {
+        let (credits, overflow) = amountDuffs.multipliedReportingOverflow(
+            by: AssetLockFundingCostPolicy.creditsPerDuff)
+        return overflow ? nil : credits
+    }
+}
+
 /// Shared Type-18 amount boundary for Core → Shielded transfers.
 ///
 /// The pool fee rides ON TOP of the typed amount: the app locks
@@ -53,11 +152,12 @@ enum InternalTransferRoute: Equatable {
 /// transfer confirmation screens.
 @MainActor
 enum CoreToShieldedAmountPolicy {
-    /// Asset-lock processing base cost folded into a ShieldFromAssetLock
-    /// pool fee on top of `compute_minimum_shielded_fee`. Mirrors Rust
-    /// `required_asset_lock_duff_balance_for_processing_start_for_address_funding`
-    /// (50_000 duffs) × 1000 credits/duff.
-    static let assetLockBaseCostCredits: UInt64 = 50_000_000
+    /// Asset-lock processing base cost folded into a ShieldFromAssetLock pool
+    /// fee on top of `compute_minimum_shielded_fee`. Reads the shared
+    /// address-funding constant - the number is not shielded-specific.
+    static var assetLockBaseCostCredits: UInt64 {
+        AssetLockFundingCostPolicy.baseProcessingCostCredits
+    }
 
     /// Cached: this is read from `amountValidationMessage` and `canContinue`,
     /// both of which a SwiftUI `body` evaluates — so an uncached property

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/PlatformFundingRecipientStore.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/PlatformFundingRecipientStore.swift
@@ -1,0 +1,333 @@
+//
+//  PlatformFundingRecipientStore.swift
+//  DashWallet
+//
+//  Durable record of WHO a Core → Platform asset-lock funding pays.
+//
+//  Rust never learns the destination of an address-funding asset lock — it
+//  tracks the L1 outpoint, its status and its proof, and nothing else. The
+//  recipient is a PARAMETER of both `fundFromAssetLockExternal` and
+//  `resumeFundFromAssetLockExternal`, so the host is solely responsible for
+//  round-tripping it across an app restart.
+//
+//  Without that round-trip a kill between lock broadcast and ST submit is a
+//  silent misdirection: every resume surface (tx-detail retry, the home
+//  screen's tap-to-finish, `AssetLockRecoveryService`) would resume with no
+//  recipient and pay the SENDER's own next address instead of the third party
+//  the user actually confirmed. The lock is a bearer input, not a commitment
+//  to a destination, so the resume would succeed — just to the wrong party.
+//
+//  Two records, because the outpoint is not known when the intent is formed:
+//
+//  1. INTENT — written immediately before the funding call, when all we know
+//     is the recipient. Survives a kill in the window where Rust has built and
+//     broadcast the lock but the app has not yet observed the row.
+//  2. STAMP — outpoint → recipient, written the moment the outpoint is
+//     observed (the 0.5 s asset-lock poll sees the row at Broadcast status,
+//     which is BEFORE the funding ST is submitted).
+//
+//  The canonical record is the SwiftData `PersistentAssetLock` row's type-4
+//  field family (`recipientPlatformAddressHash` / `recipientPlatformAddressType`
+//  / `recipientIsExternal`) — this store is the app-side mirror that covers the
+//  pre-stamp window and stays readable without a `ModelContainer`. Reads
+//  consult the row first; see `resolve(outPointHex:walletId:container:)`.
+//
+//  Mirrors `ShieldedWithdrawalStore`'s shape: per-wallet UserDefaults key,
+//  NSLock-guarded in-memory cache, and the same wipe/remove lifecycle hooks in
+//  `SwiftDashSDKWalletWiper`.
+//
+
+import Foundation
+import SwiftData
+import SwiftDashSDK
+
+/// The Platform destination of a Core → Platform asset-lock funding, in the
+/// shape both the SDK's `FundFromAssetLockRecipient` and `PersistentAssetLock`'s
+/// funding-type-4 field family speak.
+public struct PlatformFundingRecipient: Equatable, Codable, Sendable {
+    /// FFI address discriminant: 0 = P2PKH, 1 = P2SH. Only 0 is executable —
+    /// the SDK preflight and the Rust `TryFrom<PlatformAddressFFI>` both reject
+    /// P2SH, and `SendViewModel` rejects it at address-entry time.
+    public let addressType: UInt8
+    /// 20-byte address hash.
+    public let hash: Data
+    /// `true` when `hash` names a THIRD PARTY's address rather than one of this
+    /// wallet's own. Consumers read a populated recipient hash as "this lock
+    /// topped up an address of mine" — `PlatformAddressActivityStore
+    /// .matchesOwnAssetLockTopUp` does exactly that — so without the
+    /// discriminator an outgoing payment would render as an incoming credit.
+    public let isExternal: Bool
+    /// Explicit credit amount this recipient receives, or `nil` for the
+    /// remainder output. An external payee ALWAYS carries an explicit amount —
+    /// that is what makes the payee whole and pushes the fees onto the
+    /// sender's own change output.
+    public let credits: UInt64?
+
+    public init(addressType: UInt8, hash: Data, isExternal: Bool, credits: UInt64?) {
+        self.addressType = addressType
+        self.hash = hash
+        self.isExternal = isExternal
+        self.credits = credits
+    }
+}
+
+/// Per-wallet durable store for `PlatformFundingRecipient`s.
+///
+/// `static let shared` justification (Architecture Guardrail 4): this is a
+/// process-wide cache over a single `UserDefaults` domain, read from surfaces
+/// that have no dependency-injection seam and no `ModelContainer` — the home
+/// screen's background transaction-grouping queue and the tx-detail retry
+/// button among them — and written from the transfer coordinator. It carries no
+/// published state and no behavior beyond the read/write of that one domain,
+/// exactly like the `ShieldedWithdrawalStore` / `CoinJoinWithdrawalStore` pair
+/// it is modelled on. An injected instance per call site would fragment the
+/// cache without changing the shared UserDefaults backing.
+final class PlatformFundingRecipientStore {
+
+    static let shared = PlatformFundingRecipientStore()
+
+    private let defaults = UserDefaults.standard
+    private let lock = NSLock()
+
+    /// Per-wallet key prefixes; effective keys are `<prefix>_<walletIdHex>` so a
+    /// recipient recorded under wallet A is never served while wallet B is
+    /// active. `WalletEnvironment.activeWalletIdHex` reads only UserDefaults,
+    /// so it is safe from background queues.
+    private let stampPrefix = "platformFunding.v1.recipients"
+    private let intentPrefix = "platformFunding.v1.intent"
+
+    /// An intent older than this is not adopted for an unstamped lock. The
+    /// window bounds the misattribution risk of the timestamp heuristic: a
+    /// stale intent from a previous, abandoned attempt must not be applied to
+    /// an unrelated lock built much later.
+    private static let intentAdoptionWindow: TimeInterval = 60 * 60 * 24
+
+    /// Cache keyed by the resolved (per-wallet) stamp key, so a wallet switch
+    /// between accesses re-reads the new wallet's map.
+    private var cacheKey: String?
+    private var cache: [String: PlatformFundingRecipient]?
+
+    private init() {}
+
+    // MARK: - Key resolution
+
+    private func resolvedKey(_ prefix: String) -> String {
+        guard let walletIdHex = WalletEnvironment.activeWalletIdHex as String?,
+              !walletIdHex.isEmpty else {
+            return prefix
+        }
+        return "\(prefix)_\(walletIdHex)"
+    }
+
+    // MARK: - Outpoint formatting
+
+    /// `PersistentAssetLock.outPointHex` form: display-order txid hex + ":" +
+    /// vout. The SDK stores the txid in DISPLAY order (reversed wire bytes),
+    /// which is the inverse of `ShieldedTransferCoordinator.parseOutPoint`.
+    static func outPointHex(txidWire: Data, vout: UInt32) -> String? {
+        guard txidWire.count == 32 else { return nil }
+        let display = txidWire.reversed().map { String(format: "%02x", $0) }.joined()
+        return "\(display):\(vout)"
+    }
+
+    // MARK: - Intent (pre-outpoint)
+
+    /// Record the recipient the user confirmed, immediately before the funding
+    /// call. Overwrites any previous intent — only one funding is in flight at
+    /// a time (`ShieldedTransferCoordinator.beginTransfer` enforces that).
+    func recordIntent(_ recipient: PlatformFundingRecipient) {
+        lock.lock(); defer { lock.unlock() }
+        let payload = IntentPayload(recipient: recipient, createdAt: Date())
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: resolvedKey(intentPrefix))
+    }
+
+    /// Clear the pending intent once the funding reached a terminal state.
+    func clearIntent() {
+        lock.lock(); defer { lock.unlock() }
+        defaults.removeObject(forKey: resolvedKey(intentPrefix))
+    }
+
+    /// The pending intent, if one was recorded within `intentAdoptionWindow`.
+    func pendingIntent() -> PlatformFundingRecipient? {
+        lock.lock(); defer { lock.unlock() }
+        return loadedIntent()?.recipient
+    }
+
+    private func loadedIntent() -> IntentPayload? {
+        guard let data = defaults.data(forKey: resolvedKey(intentPrefix)),
+              let payload = try? JSONDecoder().decode(IntentPayload.self, from: data),
+              Date().timeIntervalSince(payload.createdAt) <= Self.intentAdoptionWindow
+        else { return nil }
+        return payload
+    }
+
+    private struct IntentPayload: Codable {
+        let recipient: PlatformFundingRecipient
+        let createdAt: Date
+    }
+
+    // MARK: - Stamp (outpoint known)
+
+    /// Persisted form of the outpoint → recipient map. A named wrapper rather
+    /// than a bare dictionary so the payload has somewhere to grow a version
+    /// field without invalidating what is already on disk.
+    private struct StampPayload: Codable {
+        var entries: [String: PlatformFundingRecipient]
+    }
+
+    private func loadedStamps() -> [String: PlatformFundingRecipient] {
+        let key = resolvedKey(stampPrefix)
+        if cacheKey == key, let cache { return cache }
+        var stored: [String: PlatformFundingRecipient] = [:]
+        if let data = defaults.data(forKey: key) {
+            let decoded = try? JSONDecoder().decode(StampPayload.self, from: data)
+            stored = decoded?.entries ?? [:]
+        }
+        cacheKey = key
+        cache = stored
+        return stored
+    }
+
+    /// Bind `recipient` to a now-known outpoint. Idempotent; the FIRST stamp
+    /// wins so a later resume that resolved a fallback can never overwrite the
+    /// recipient the user actually confirmed.
+    func stamp(outPointHex: String, recipient: PlatformFundingRecipient) {
+        guard !outPointHex.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        var map = loadedStamps()
+        guard map[outPointHex] == nil else { return }
+        map[outPointHex] = recipient
+        cache = map
+        guard let data = try? JSONEncoder().encode(StampPayload(entries: map)) else { return }
+        defaults.set(data, forKey: resolvedKey(stampPrefix))
+    }
+
+    /// Recipient bound to `outPointHex`, or the pending intent when the lock
+    /// was never stamped (killed between broadcast and the first poll tick).
+    /// `nil` means "no recorded recipient" — callers MUST fall back to legacy
+    /// own-address behavior, never to a guess.
+    func recipient(forOutPointHex outPointHex: String) -> PlatformFundingRecipient? {
+        lock.lock(); defer { lock.unlock() }
+        if let stamped = loadedStamps()[outPointHex] { return stamped }
+        return loadedIntent()?.recipient
+    }
+
+    // MARK: - Canonical resolution
+
+    /// Resolve the recipient of a tracked type-4 lock, preferring the canonical
+    /// `PersistentAssetLock` row over this store's mirror.
+    ///
+    /// A row carrying a hash but a `nil` `recipientIsExternal` predates the
+    /// discriminator and can only have come from the own-address flow, so it
+    /// resolves as `isExternal: false` — the same rule the SDK documents on the
+    /// property. `nil` overall means the lock has no recorded recipient at all
+    /// and the caller keeps legacy own-next-address behavior.
+    @MainActor
+    static func resolve(
+        outPointHex: String,
+        walletId: Data,
+        container: ModelContainer
+    ) -> PlatformFundingRecipient? {
+        let topUpType = 4 // AssetLockAddressTopUp
+        var descriptor = FetchDescriptor<PersistentAssetLock>(
+            predicate: #Predicate { row in
+                row.walletId == walletId
+                    && row.fundingTypeRaw == topUpType
+                    && row.outPointHex == outPointHex
+            })
+        descriptor.fetchLimit = 1
+        let mirrored = shared.recipient(forOutPointHex: outPointHex)
+        guard let row = try? container.mainContext.fetch(descriptor).first,
+              let hash = row.recipientPlatformAddressHash,
+              hash.count == 20
+        else { return mirrored }
+
+        let isExternal = row.recipientIsExternal ?? false
+        // The type-4 field family carries no credit amount, so prefer the
+        // mirror's when it agrees on the destination. If the mirror is gone
+        // (an explicit per-wallet clear), derive the payee amount back out of
+        // the recorded lock value, which was built as amount + headroom.
+        let credits: UInt64?
+        if let mirrored, mirrored.hash == hash {
+            credits = mirrored.credits
+        } else if isExternal {
+            let headroom = CoreToPlatformAmountPolicy.externalHeadroomDuffs
+            guard let lockDuffs = UInt64(exactly: row.amountDuffs), lockDuffs > headroom
+            else { return nil }
+            credits = CoreToPlatformAmountPolicy.payeeCredits(forAmountDuffs: lockDuffs - headroom)
+        } else {
+            credits = nil
+        }
+        return PlatformFundingRecipient(
+            addressType: row.recipientPlatformAddressType ?? 0,
+            hash: hash,
+            isExternal: isExternal,
+            credits: credits)
+    }
+
+    /// Write the recipient onto the canonical `PersistentAssetLock` row AND
+    /// mirror it into this store. Called as soon as the outpoint is observed,
+    /// which the 0.5 s poll makes happen at Broadcast status — before the
+    /// funding ST is submitted.
+    ///
+    /// First-write-wins on the row too: a row that already names a recipient is
+    /// left alone, so a resume can never rewrite the original destination.
+    @MainActor
+    static func persist(
+        recipient: PlatformFundingRecipient,
+        outPointHex: String,
+        walletId: Data,
+        container: ModelContainer
+    ) {
+        shared.stamp(outPointHex: outPointHex, recipient: recipient)
+
+        let topUpType = 4 // AssetLockAddressTopUp
+        var descriptor = FetchDescriptor<PersistentAssetLock>(
+            predicate: #Predicate { row in
+                row.walletId == walletId
+                    && row.fundingTypeRaw == topUpType
+                    && row.outPointHex == outPointHex
+            })
+        descriptor.fetchLimit = 1
+        let context = container.mainContext
+        guard let row = try? context.fetch(descriptor).first,
+              row.recipientPlatformAddressHash == nil
+        else { return }
+        row.recipientPlatformAddressHash = recipient.hash
+        row.recipientPlatformAddressType = recipient.addressType
+        row.recipientIsExternal = recipient.isExternal
+        row.updatedAt = Date()
+        try? context.save()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Clear a SINGLE wallet's records (per-wallet Remove flow — the removed
+    /// wallet may not be the active one).
+    func clearForWallet(walletIdHex: String) {
+        guard !walletIdHex.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        let key = "\(stampPrefix)_\(walletIdHex)"
+        defaults.removeObject(forKey: key)
+        defaults.removeObject(forKey: "\(intentPrefix)_\(walletIdHex)")
+        if cacheKey == key {
+            cacheKey = nil
+            cache = nil
+        }
+    }
+
+    /// Clear ALL records on a full wallet wipe (walletIds are gone by wipe
+    /// time, so enumerate by prefix).
+    func resetForWipe() {
+        lock.lock(); defer { lock.unlock() }
+        for key in defaults.dictionaryRepresentation().keys {
+            if key == stampPrefix || key.hasPrefix("\(stampPrefix)_")
+                || key == intentPrefix || key.hasPrefix("\(intentPrefix)_") {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        cacheKey = nil
+        cache = nil
+    }
+}

--- a/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
+++ b/DashWallet/Sources/UI/Payments/InternalTransfer/ShieldedTransferCoordinator.swift
@@ -250,6 +250,13 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// cleared on `reset()` and at the start of a fresh `performAssetLock`.
     private(set) var lastAssetLockOutPoint: (txidWire: Data, vout: UInt32)?
 
+    /// Destination of the Core → Platform funding currently in flight, held
+    /// only long enough to stamp it onto the `PersistentAssetLock` row once the
+    /// outpoint is observed. Durability lives in `PlatformFundingRecipientStore`
+    /// and on the row itself — never in this property, which dies with the
+    /// process.
+    private var inFlightFundingRecipient: PlatformFundingRecipient?
+
     // MARK: - Errors
 
     enum CoordinatorError: LocalizedError {
@@ -702,6 +709,11 @@ final class ShieldedTransferCoordinator: ObservableObject {
         if let row = try? modelContainer.mainContext.fetch(descriptor).first,
            let outPoint = Self.parseOutPoint(row.outPointHex) {
             lastAssetLockOutPoint = outPoint
+            stampFundingRecipientIfNeeded(
+                outPointHex: row.outPointHex,
+                walletId: walletId,
+                modelContainer: modelContainer,
+                fundingType: fundingType)
         }
     }
 
@@ -1015,10 +1027,22 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// (IS/CL-locked) before the funding ST lands. On failure after the lock
     /// committed, `lastAssetLockOutPoint` is captured so "Try again" resumes
     /// that lock via `resumeFundPlatform` instead of stranding it.
-    func performFundPlatform(amountDuffs: UInt64) async {
+    func performFundPlatform(
+        amountDuffs: UInt64,
+        externalRecipient: PlatformFundingRecipient? = nil
+    ) async {
         guard beginTransfer() else { return }
         lastAssetLockOutPoint = nil
-        Self.logger.info("🛡️ SHIELD-TX :: core→platform fund route amount=\(amountDuffs)")
+        inFlightFundingRecipient = externalRecipient
+        Self.logger.info(
+            "🛡️ SHIELD-TX :: core→platform fund route lock=\(amountDuffs) external=\(externalRecipient?.isExternal == true)")
+        // Record the confirmed destination BEFORE anything is broadcast, so a
+        // kill in the window between the lock landing on-chain and the funding
+        // ST being submitted cannot leave a resume surface guessing. The
+        // outpoint is not known yet; the poll below stamps it as soon as it is.
+        if let externalRecipient {
+            PlatformFundingRecipientStore.shared.recordIntent(externalRecipient)
+        }
 
         let env: BasicEnvironment
         do {
@@ -1044,7 +1068,9 @@ final class ShieldedTransferCoordinator: ObservableObject {
             fundingType: Self.addressAssetLockFundingType)
 
         do {
-            try await PlatformAddressSyncCoordinator.shared.fundFromCore(amountDuffs: amountDuffs)
+            try await PlatformAddressSyncCoordinator.shared.fundFromCore(
+                amountDuffs: amountDuffs,
+                externalRecipient: externalRecipient)
         } catch {
             stopAssetLockPolling()
             captureLatestAssetLockOutPoint(
@@ -1058,6 +1084,10 @@ final class ShieldedTransferCoordinator: ObservableObject {
 
         stopAssetLockPolling()
         Self.logger.info("🛡️ SHIELD-TX :: core→platform fund route completed")
+        // The funding ST landed and consumed the lock: no resume can follow, so
+        // the pre-submit intent has nothing left to protect.
+        PlatformFundingRecipientStore.shared.clearIntent()
+        inFlightFundingRecipient = nil
         phase = .broadcasting
         phase = .success
         schedulePlatformResync()
@@ -1066,7 +1096,18 @@ final class ShieldedTransferCoordinator: ObservableObject {
     /// Resume of route 5 after its asset lock committed but the address-
     /// funding ST never landed — drives the remaining stages on the SAME
     /// outpoint. Mirrors `resumeAssetLock` on the shielded route.
-    func resumeFundPlatform(outPointTxidWire: Data, outPointVout: UInt32) async {
+    ///
+    /// `externalRecipient` nil means "resolve it from durable storage": the
+    /// resolution happens in `PlatformAddressSyncCoordinator.resumeFundFromCore`,
+    /// the single choke point every resume surface funnels through, so a lock
+    /// that was recorded as an external send resumes to the SAME third party
+    /// even after a cold launch. Locks with no recorded recipient keep the
+    /// legacy own-next-address behavior.
+    func resumeFundPlatform(
+        outPointTxidWire: Data,
+        outPointVout: UInt32,
+        externalRecipient: PlatformFundingRecipient? = nil
+    ) async {
         guard beginTransfer() else { return }
         Self.logger.info("🛡️ SHIELD-TX :: resume core→platform fund vout=\(outPointVout)")
 
@@ -1090,13 +1131,15 @@ final class ShieldedTransferCoordinator: ObservableObject {
         do {
             try await PlatformAddressSyncCoordinator.shared.resumeFundFromCore(
                 outPointTxid: outPointTxidWire,
-                outPointVout: outPointVout)
+                outPointVout: outPointVout,
+                externalRecipient: externalRecipient)
         } catch {
             handleFailure(CoordinatorError.transferFailed(error))
             return
         }
 
         Self.logger.info("🛡️ SHIELD-TX :: resume core→platform fund completed")
+        PlatformFundingRecipientStore.shared.clearIntent()
         phase = .success
         schedulePlatformResync()
     }
@@ -1448,6 +1491,27 @@ final class ShieldedTransferCoordinator: ObservableObject {
         }
     }
 
+    /// Bind the in-flight funding recipient to the now-known outpoint, on the
+    /// canonical `PersistentAssetLock` row and in the app-side mirror. Called
+    /// from both outpoint-capture sites so the record exists no matter which
+    /// one observed the lock first. No-op unless a Core → Platform funding with
+    /// an explicit recipient is in flight.
+    private func stampFundingRecipientIfNeeded(
+        outPointHex: String,
+        walletId: Data,
+        modelContainer: ModelContainer,
+        fundingType: Int
+    ) {
+        guard fundingType == Self.addressAssetLockFundingType,
+              let recipient = inFlightFundingRecipient
+        else { return }
+        PlatformFundingRecipientStore.persist(
+            recipient: recipient,
+            outPointHex: outPointHex,
+            walletId: walletId,
+            container: modelContainer)
+    }
+
     private func stopAssetLockPolling() {
         assetLockPollingTask?.cancel()
         assetLockPollingTask = nil
@@ -1485,6 +1549,11 @@ final class ShieldedTransferCoordinator: ObservableObject {
             // building a second one. Display→wire reversal happens in parse.
             if row.statusRaw >= 1, let outPoint = Self.parseOutPoint(row.outPointHex) {
                 lastAssetLockOutPoint = outPoint
+                stampFundingRecipientIfNeeded(
+                    outPointHex: row.outPointHex,
+                    walletId: walletId,
+                    modelContainer: modelContainer,
+                    fundingType: fundingType)
             }
             advancePhaseForAssetLockStatus(row.statusRaw)
         } catch {

--- a/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendScreen.swift
@@ -160,6 +160,10 @@ struct SendScreen: View {
                 Text(NSLocalizedString("This is not a valid Dash address for this network", comment: "Send screen"))
                     .font(.caption)
                     .foregroundColor(.red)
+            } else if let unsupported = viewModel.unsupportedDestinationMessage {
+                Text(unsupported)
+                    .font(.caption)
+                    .foregroundColor(.red)
             } else if viewModel.pinnedSourceMismatch {
                 Text(String(
                     format: NSLocalizedString("This address can't be paid from your %@ balance", comment: "Send sheet source/destination mismatch"),
@@ -413,6 +417,8 @@ struct ExternalSendAmountScreen: View {
                     route: route,
                     destinationAddress: viewModel.trimmedAddress,
                     destinationRaw43: shieldedRecipientRaw43,
+                    platformFundingRecipient: viewModel.coreToPlatformRecipient,
+                    platformFundingLockDuffs: viewModel.coreToPlatformLockDuffs,
                     dashDuffs: viewModel.dashDuffs,
                     creditsAmount: viewModel.creditsPreview,
                     fiatText: viewModel.fiatAmountString,
@@ -713,6 +719,12 @@ struct SendConfirmSheet: View {
     /// shielded-destination routes (`.coreToShielded`,
     /// `.platformToShielded`, `.shieldedToShielded`), nil otherwise.
     let destinationRaw43: Data?
+    /// Payee + exact credit amount for `.coreToPlatform`, nil otherwise. Built
+    /// by the ViewModel so this View does no fee math.
+    var platformFundingRecipient: PlatformFundingRecipient? = nil
+    /// L1 lock value for `.coreToPlatform` (payee amount + change headroom),
+    /// nil otherwise.
+    var platformFundingLockDuffs: UInt64? = nil
     let dashDuffs: Int64
     let creditsAmount: UInt64
     let fiatText: String
@@ -894,7 +906,7 @@ struct SendConfirmSheet: View {
             return NSLocalizedString("Platform balance", comment: "The Dash Platform credits balance")
         case .shieldedToCore, .shieldedToPlatform, .shieldedToShielded:
             return NSLocalizedString("Shielded balance", comment: "")
-        case .coreToCore, .coreToShielded:
+        case .coreToCore, .coreToShielded, .coreToPlatform:
             return NSLocalizedString("Transparent balance", comment: "The transparent (Core) balance of the Dash Wallet")
         }
     }
@@ -933,6 +945,13 @@ struct SendConfirmSheet: View {
             // The lock charges the fee rounded UP to a whole duff — display
             // that, so Amount + Network fee equals Total exactly.
             return CoreToShieldedAmountPolicy.currentPoolFeeDuffs.map { $0 * 1000 }
+        case .coreToPlatform:
+            // Address-funding asset lock with two outputs: the protocol
+            // minimum required fee plus the change output's own minimum —
+            // exactly the headroom the lock is built with. The metered fee can
+            // exceed it, and the excess also comes out of the sender's change,
+            // never out of the payee's explicit amount.
+            return CoreToPlatformAmountPolicy.externalHeadroomCredits
         case .platformToPlatform:
             // Credit transfer: the metered transition fee. The executor
             // states ~0.001 DASH as the conservative max.
@@ -962,22 +981,26 @@ struct SendConfirmSheet: View {
         return "~ " + CurrencyExchanger.shared.fiatAmountString(for: dash)
     }
 
-    /// What actually leaves the source balance. Core→Shielded charges the
-    /// pool fee on top of the amount (the executed lock value); every other
-    /// route's total is the amount itself. "—" when the fee estimate is
-    /// unavailable — `canContinue` fails closed before that can be confirmed,
-    /// but the row must never show the un-inflated number.
+    /// What actually leaves the source balance. The two asset-lock routes
+    /// charge their fee on top of the amount, so their total is the executed
+    /// lock value; every other route's total is the amount itself. "—" when the
+    /// fee estimate is unavailable — `canContinue` fails closed before that can
+    /// be confirmed, but the row must never show the un-inflated number.
     private var totalString: String {
-        guard route == .coreToShielded else {
+        guard route == .coreToShielded || route == .coreToPlatform,
+              let amountDuffs = UInt64(exactly: dashDuffs)
+        else {
             return dashDuffs.formattedDashAmount
         }
-        guard let amountDuffs = UInt64(exactly: dashDuffs),
-              let poolFeeCredits = CoreToShieldedAmountPolicy.poolFeeCredits,
-              let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
-                  forAmountDuffs: amountDuffs,
-                  poolFeeCredits: poolFeeCredits),
-              let signedLockDuffs = Int64(exactly: lockDuffs)
-        else { return "—" }
+        let lockDuffs: UInt64?
+        if route == .coreToPlatform {
+            lockDuffs = CoreToPlatformAmountPolicy.externalLockValueDuffs(forAmountDuffs: amountDuffs)
+        } else {
+            lockDuffs = CoreToShieldedAmountPolicy.poolFeeCredits.flatMap {
+                CoreToShieldedAmountPolicy.lockValueDuffs(forAmountDuffs: amountDuffs, poolFeeCredits: $0)
+            }
+        }
+        guard let lockDuffs, let signedLockDuffs = Int64(exactly: lockDuffs) else { return "—" }
         return signedLockDuffs.formattedDashAmount
     }
 
@@ -1055,7 +1078,7 @@ struct SendConfirmSheet: View {
             .init(label: NSLocalizedString("Authorizing", comment: ""), phase: .signing)
         ]
         // Only the asset-lock route has the on-chain locking stage.
-        if route == .coreToShielded {
+        if route == .coreToShielded || route == .coreToPlatform {
             steps.append(.init(label: NSLocalizedString("Locking funds", comment: ""), phase: .locking))
         }
         // Only shielded legs build an Orchard proof.
@@ -1063,7 +1086,7 @@ struct SendConfirmSheet: View {
         case .coreToShielded, .platformToShielded, .shieldedToCore, .shieldedToPlatform,
              .shieldedToShielded:
             steps.append(.init(label: NSLocalizedString("Generating proof", comment: ""), phase: .proving))
-        case .platformToPlatform, .platformToCore, .coreToCore:
+        case .coreToPlatform, .platformToPlatform, .platformToCore, .coreToCore:
             break
         }
         steps.append(.init(label: NSLocalizedString("Broadcasting", comment: ""), phase: .broadcasting))
@@ -1083,6 +1106,16 @@ struct SendConfirmSheet: View {
                 await coordinator.performAssetLock(
                     recipientAmountDuffs: UInt64(dashDuffs),
                     recipientRaw43: destinationRaw43)
+            case .coreToPlatform:
+                // Fail closed rather than falling back to a remainder-only
+                // funding, which would pay the SENDER's own address.
+                guard let platformFundingRecipient, let platformFundingLockDuffs else {
+                    coordinator.reset()
+                    return
+                }
+                await coordinator.performFundPlatform(
+                    amountDuffs: platformFundingLockDuffs,
+                    externalRecipient: platformFundingRecipient)
             case .platformToPlatform:
                 await coordinator.performPlatformSend(
                     destination: destinationAddress,
@@ -1142,6 +1175,20 @@ struct SendConfirmSheet: View {
                     outPointTxidWire: op.txidWire,
                     outPointVout: op.vout,
                     recipientRaw43: destinationRaw43)
+            }
+            return
+        }
+        // Same rule for the Core → Platform funding lock: resume the committed
+        // outpoint with the SAME payee rather than building a second lock.
+        if route == .coreToPlatform,
+           let op = coordinator.lastAssetLockOutPoint,
+           let platformFundingRecipient {
+            coordinator.reset()
+            Task {
+                await coordinator.resumeFundPlatform(
+                    outPointTxidWire: op.txidWire,
+                    outPointVout: op.vout,
+                    externalRecipient: platformFundingRecipient)
             }
             return
         }

--- a/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
+++ b/DashWallet/Sources/UI/Payments/Pay/SendViewModel.swift
@@ -38,6 +38,11 @@ final class SendViewModel: ObservableObject {
         /// coordinator locks `amount + pool_fee`, so the recipient receives
         /// the full typed amount.
         case coreToShielded
+        /// BIP44 UTXOs → asset lock → an explicit-amount credit output on a
+        /// THIRD PARTY's Platform address, with the wallet's own next address
+        /// carrying the remainder. The payee receives EXACTLY the typed
+        /// amount; the sender's own change absorbs the Platform fees.
+        case coreToPlatform
         case platformToPlatform
         case platformToCore
         /// Platform Payment credits → Type 15 shield note assigned to the
@@ -248,6 +253,56 @@ final class SendViewModel: ObservableObject {
         destination == nil && trimmedAddress.count >= 20
     }
 
+    /// The entered Platform address decoded into its FFI discriminant + hash,
+    /// or `nil` when the destination is not a Platform address. Decoding here
+    /// keeps the confirm sheet from re-parsing bech32m and gives the durable
+    /// recipient record its bytes.
+    var platformRecipient: PlatformAddressSyncCoordinator.PlatformRecipient? {
+        guard destination == .platform else { return nil }
+        return PlatformAddressSyncCoordinator.parsePlatformRecipient(bech32m: trimmedAddress)
+    }
+
+    /// Durable recipient record for a `.coreToPlatform` send: the payee's
+    /// decoded address plus the EXACT credit amount their output carries.
+    /// `nil` for every other route, and for a P2SH destination (which
+    /// `unsupportedDestinationMessage` already blocks at the address step).
+    var coreToPlatformRecipient: PlatformFundingRecipient? {
+        guard route == .coreToPlatform,
+              let recipient = platformRecipient,
+              recipient.ffiAddressType == 0,
+              let credits = CoreToPlatformAmountPolicy.payeeCredits(forAmountDuffs: dashDuffsUnsigned)
+        else { return nil }
+        return PlatformFundingRecipient(
+            addressType: recipient.ffiAddressType,
+            hash: recipient.hash,
+            isExternal: true,
+            credits: credits)
+    }
+
+    /// L1 value the `.coreToPlatform` asset lock is built with — the payee's
+    /// amount plus the headroom the sender's own change output needs to pay
+    /// the Platform fees. `nil` for every other route, or on overflow.
+    var coreToPlatformLockDuffs: UInt64? {
+        guard route == .coreToPlatform else { return nil }
+        return CoreToPlatformAmountPolicy.externalLockValueDuffs(forAmountDuffs: dashDuffsUnsigned)
+    }
+
+    /// Why a decodable address still can't be paid, surfaced on the ADDRESS
+    /// step rather than at confirm time.
+    ///
+    /// `DashAddressClassifier` accepts both DIP-0018 wire types, but every
+    /// execution path rejects P2SH (`0x80`): the Rust
+    /// `TryFrom<PlatformAddressFFI>` is P2PKH-only, and so are the SDK's
+    /// funding and transfer pre-flights. Letting the user reach Confirm and
+    /// fail there is a stub-and-assert — name it while the address is still
+    /// being entered.
+    var unsupportedDestinationMessage: String? {
+        guard let recipient = platformRecipient, recipient.ffiAddressType != 0 else { return nil }
+        return NSLocalizedString(
+            "P2SH Platform addresses aren't supported yet. Ask for a P2PKH address.",
+            comment: "Send screen: P2SH platform destination rejected at input")
+    }
+
     private func destinationDidChange() {
         let sanitized = addressText.trimmingCharacters(in: .whitespacesAndNewlines)
         if sanitized != addressText {
@@ -314,33 +369,49 @@ final class SendViewModel: ObservableObject {
 
     // MARK: - Sources & route
 
-    /// Which balances can fund a send to the entered destination.
-    /// Core addresses can be paid from any bucket; Platform addresses from
-    /// Platform credits or the shielded pool (there is no external
-    /// core → platform funding); shielded addresses from any bucket — the
-    /// pool (`shieldedTransfer`), the Core balance (asset-lock shield), or
-    /// Platform credits (`shieldedShieldToRecipient`).
+    /// Which balances can fund a send to the entered destination. Ordered by
+    /// preference — the auto-pick takes the first entry with a balance.
+    ///
+    /// Every destination type can now be paid from any bucket. Core addresses
+    /// from any of the three; Platform addresses from Platform credits, the
+    /// shielded pool (`shieldedUnshieldToRecipient`), or the Core balance
+    /// (`coreToPlatform`, an asset lock paying the payee an explicit credit
+    /// amount); shielded addresses from the pool (`shieldedTransfer`), the Core
+    /// balance (asset-lock shield), or Platform credits
+    /// (`shieldedShieldToRecipient`).
     var validSources: [ChainNetwork] {
+        Self.validSources(for: destination)
+    }
+
+    /// Pure form of `validSources` — the routing table with no instance state,
+    /// so it can be exercised directly.
+    static func validSources(for destination: DestinationKind?) -> [ChainNetwork] {
         switch destination {
         case .core: return [.core, .platform, .shielded]
-        case .platform: return [.platform, .shielded]
+        case .platform: return [.platform, .shielded, .core]
         case .shielded: return [.shielded, .core, .platform]
         case nil: return []
         }
     }
 
     var route: Route? {
+        Self.route(source: source, destination: destination)
+    }
+
+    /// Pure form of `route` — same rationale as `validSources(for:)`. Every
+    /// pair `validSources` admits must resolve here, and nothing else may.
+    static func route(source: ChainNetwork, destination: DestinationKind?) -> Route? {
         guard let destination else { return nil }
         switch (source, destination) {
         case (.core, .core): return .coreToCore
         case (.core, .shielded): return .coreToShielded
+        case (.core, .platform): return .coreToPlatform
         case (.platform, .platform): return .platformToPlatform
         case (.platform, .core): return .platformToCore
         case (.platform, .shielded): return .platformToShielded
         case (.shielded, .core): return .shieldedToCore
         case (.shielded, .platform): return .shieldedToPlatform
         case (.shielded, .shielded): return .shieldedToShielded
-        default: return nil
         }
     }
 
@@ -555,7 +626,7 @@ final class SendViewModel: ObservableObject {
     /// amount. `nil` = requirement unavailable → callers fail closed.
     private var feeReserveCredits: UInt64? {
         switch route {
-        case .coreToCore, .coreToShielded, .platformToCore, .platformToShielded, nil:
+        case .coreToCore, .coreToShielded, .coreToPlatform, .platformToCore, .platformToShielded, nil:
             // L1 send fees are handled by the payment processor; the
             // asset-lock shield's pool fee is duff-denominated and enforced
             // in the route branches (`canContinue`, Max) directly, mirroring
@@ -618,7 +689,7 @@ final class SendViewModel: ObservableObject {
     var isBlockedBySync: Bool {
         guard let route else { return false }
         switch route {
-        case .coreToCore, .coreToShielded:
+        case .coreToCore, .coreToShielded, .coreToPlatform:
             return WalletSendService.isBlockedByInitialRestoreSync(
                 isResyncingWallet: DWGlobalOptions.sharedInstance().isResyncingWallet,
                 isChainSynced: isChainSynced)
@@ -639,6 +710,17 @@ final class SendViewModel: ObservableObject {
         if route == .coreToShielded,
            CoreToShieldedAmountPolicy.currentPoolFeeDuffs == nil {
             return Self.feeEstimateUnavailableMessage
+        }
+
+        // The payee's credit output must clear the protocol's minimum output
+        // amount like any other transition output.
+        if route == .coreToPlatform,
+           dashDuffsUnsigned < CoreToPlatformAmountPolicy.minimumAmountDuffs {
+            return String.localizedStringWithFormat(
+                NSLocalizedString(
+                    "The smallest amount you can send to a Platform address is %@.",
+                    comment: "Core → Platform send minimum"),
+                "\(CoreToPlatformAmountPolicy.minimumAmountDuffs.formattedDashAmountWithoutCurrencySymbol) DASH")
         }
 
         return insufficientBalanceMessage
@@ -671,6 +753,17 @@ final class SendViewModel: ObservableObject {
                 requestedDuffs: dashDuffsUnsigned,
                 spendableDuffs: spendableDuffs > feeDuffs
                     ? spendableDuffs - feeDuffs : 0)
+
+        case .coreToPlatform:
+            // Fee-on-top: the lock is amount + headroom so the payee's output
+            // carries the exact typed amount and the sender's own change
+            // absorbs the fees. Mirrors `canContinue`.
+            let headroom = CoreToPlatformAmountPolicy.externalHeadroomDuffs
+            let spendable = coreSpendableDuffs
+            return TransferSpendAmountPolicy.insufficientBalanceMessage(
+                balanceName: balanceName,
+                requestedDuffs: dashDuffsUnsigned,
+                spendableDuffs: spendable > headroom ? spendable - headroom : 0)
 
         case .platformToPlatform:
             guard let reserve = feeReserveCredits else {
@@ -770,7 +863,7 @@ final class SendViewModel: ObservableObject {
     /// The amount, balance, and sync checks live on the amount step
     /// (`canContinue`).
     var canAdvanceToAmount: Bool {
-        destination != nil && !pinnedSourceMismatch
+        destination != nil && !pinnedSourceMismatch && unsupportedDestinationMessage == nil
     }
 
     var canContinue: Bool {
@@ -790,6 +883,14 @@ final class SendViewModel: ObservableObject {
                   let lockDuffs = CoreToShieldedAmountPolicy.lockValueDuffs(
                       forAmountDuffs: dashDuffsUnsigned,
                       poolFeeCredits: poolFeeCredits)
+            else { return false }
+            return lockDuffs <= coreSpendableDuffs
+        case .coreToPlatform:
+            // Fee-on-top: the lock is amount + headroom, so the balance must
+            // cover both. Fails closed on overflow or a sub-minimum amount.
+            guard dashDuffsUnsigned >= CoreToPlatformAmountPolicy.minimumAmountDuffs,
+                  let lockDuffs = CoreToPlatformAmountPolicy.externalLockValueDuffs(
+                      forAmountDuffs: dashDuffsUnsigned)
             else { return false }
             return lockDuffs <= coreSpendableDuffs
         case .platformToPlatform:
@@ -842,6 +943,15 @@ final class SendViewModel: ObservableObject {
                 break
             }
             sourceDuffs = spendable > feeDuffs ? spendable - feeDuffs : 0
+            if spendable > 0, sourceDuffs == 0 {
+                shieldedMaxNotice = InternalTransferViewModel.feeReserveExceedsBalanceMessage(source)
+            }
+        case .coreToPlatform:
+            // Fee-on-top Max: the lock is amount + headroom, so the largest
+            // payable amount is the L1-fee-aware spendable minus that headroom.
+            let spendable = coreSpendableDuffs
+            let headroom = CoreToPlatformAmountPolicy.externalHeadroomDuffs
+            sourceDuffs = spendable > headroom ? spendable - headroom : 0
             if spendable > 0, sourceDuffs == 0 {
                 shieldedMaxNotice = InternalTransferViewModel.feeReserveExceedsBalanceMessage(source)
             }

--- a/DashWalletTests/CoreToPlatformSendRouteTests.swift
+++ b/DashWalletTests/CoreToPlatformSendRouteTests.swift
@@ -1,0 +1,260 @@
+//
+//  CoreToPlatformSendRouteTests.swift
+//  DashWalletTests
+//
+//  Coverage for the Core → Platform external send route: the source/destination
+//  routing table, the fee-on-top amount policy, P2SH recipient rejection, and
+//  the durable-recipient round trip that keeps a cold resume pointed at the
+//  third party the user actually confirmed.
+//
+
+import XCTest
+@testable import dashpay
+
+@MainActor
+final class CoreToPlatformSendRouteTests: XCTestCase {
+
+    // MARK: - Routing table
+
+    /// Every (source, destination) pair the Send screen admits, including the
+    /// newly-legal `.core → .platform`. Written as a table so a route added
+    /// later has to declare its source set here too.
+    func testValidSourcesAndRouteAgreeForEveryDestination() {
+        let expected: [(SendViewModel.DestinationKind, [ChainNetwork], [SendViewModel.Route])] = [
+            (.core, [.core, .platform, .shielded],
+             [.coreToCore, .platformToCore, .shieldedToCore]),
+            (.platform, [.platform, .shielded, .core],
+             [.platformToPlatform, .shieldedToPlatform, .coreToPlatform]),
+            (.shielded(raw43: Data(repeating: 7, count: 43)), [.shielded, .core, .platform],
+             [.shieldedToShielded, .coreToShielded, .platformToShielded]),
+        ]
+
+        for (destination, sources, routes) in expected {
+            XCTAssertEqual(
+                SendViewModel.validSources(for: destination), sources,
+                "validSources for \(destination)")
+
+            for (source, route) in zip(sources, routes) {
+                XCTAssertEqual(
+                    SendViewModel.route(source: source, destination: destination), route,
+                    "route for \(source) → \(destination)")
+            }
+        }
+    }
+
+    /// No destination means no sources and no route — the screen's initial
+    /// state must not resolve to a spendable route.
+    func testNilDestinationHasNoSourcesAndNoRoute() {
+        XCTAssertEqual(SendViewModel.validSources(for: nil), [])
+        for source in [ChainNetwork.core, .platform, .shielded] {
+            XCTAssertNil(SendViewModel.route(source: source, destination: nil))
+        }
+    }
+
+    /// The regression this route fixes: a Platform address pasted while the
+    /// Transparent balance row is pinned used to dead-end as a mismatch,
+    /// because `.core` was not a valid source for a `.platform` destination.
+    func testCoreSourceCanPayAPlatformDestination() {
+        XCTAssertTrue(SendViewModel.validSources(for: .platform).contains(.core))
+        XCTAssertEqual(
+            SendViewModel.route(source: .core, destination: .platform),
+            .coreToPlatform)
+    }
+
+    // MARK: - Amount policy
+
+    /// The headroom is the protocol floor for a two-output address funding:
+    /// the asset-lock base processing cost, both outputs' minimum fee, and the
+    /// change output's own minimum amount.
+    func testExternalHeadroomMatchesTheProtocolFloor() {
+        let expectedCredits =
+            AssetLockFundingCostPolicy.baseProcessingCostCredits            // 50_000_000
+                + AssetLockFundingCostPolicy.addressFundsTransferOutputCostCredits * 2 // 12_000_000
+                + AssetLockFundingCostPolicy.minOutputAmountCredits          //    500_000
+
+        XCTAssertEqual(CoreToPlatformAmountPolicy.externalHeadroomCredits, expectedCredits)
+        XCTAssertEqual(CoreToPlatformAmountPolicy.externalHeadroomCredits, 62_500_000)
+        XCTAssertEqual(CoreToPlatformAmountPolicy.externalHeadroomDuffs, 62_500)
+    }
+
+    /// The base processing cost is the ADDRESS-funding constant, so the
+    /// shielded policy must read the very same number rather than its own copy.
+    func testShieldedPolicyReadsTheSharedBaseProcessingCost() {
+        XCTAssertEqual(
+            CoreToShieldedAmountPolicy.assetLockBaseCostCredits,
+            AssetLockFundingCostPolicy.baseProcessingCostCredits)
+    }
+
+    /// Fee-on-top: the lock is amount + headroom, so the payee's explicit
+    /// output can carry exactly the typed amount.
+    func testExternalLockValueIsAmountPlusHeadroom() {
+        let amountDuffs: UInt64 = 1_000_000
+        XCTAssertEqual(
+            CoreToPlatformAmountPolicy.externalLockValueDuffs(forAmountDuffs: amountDuffs),
+            amountDuffs + CoreToPlatformAmountPolicy.externalHeadroomDuffs)
+    }
+
+    func testExternalLockValueFailsClosedOnOverflow() {
+        XCTAssertNil(CoreToPlatformAmountPolicy.externalLockValueDuffs(forAmountDuffs: UInt64.max))
+    }
+
+    /// The payee's output must clear the same `min_output_amount` every other
+    /// transition output does.
+    func testMinimumAmountMatchesTheMinimumOutputAmount() {
+        XCTAssertEqual(CoreToPlatformAmountPolicy.minimumAmountDuffs, 500)
+        XCTAssertEqual(
+            CoreToPlatformAmountPolicy.payeeCredits(forAmountDuffs: 500),
+            AssetLockFundingCostPolicy.minOutputAmountCredits)
+    }
+
+    func testPayeeCreditsFailsClosedOnOverflow() {
+        XCTAssertNil(CoreToPlatformAmountPolicy.payeeCredits(forAmountDuffs: UInt64.max))
+    }
+
+    /// Rounding is UP, so a duff-denominated lock never under-covers a
+    /// credit-denominated requirement.
+    func testCreditsToDuffsRoundsUp() {
+        XCTAssertEqual(AssetLockFundingCostPolicy.duffsRoundingUp(credits: 1000), 1)
+        XCTAssertEqual(AssetLockFundingCostPolicy.duffsRoundingUp(credits: 1001), 2)
+        XCTAssertEqual(AssetLockFundingCostPolicy.duffsRoundingUp(credits: 0), 0)
+    }
+
+    // MARK: - P2SH rejection
+
+    /// `parsePlatformRecipient` decodes both DIP-0018 wire types, so the P2SH
+    /// discriminant has to reach the caller intact — that is what lets the Send
+    /// screen reject it at input time instead of at confirm time.
+    func testParsePlatformRecipientSurfacesTheP2SHDiscriminant() throws {
+        let hash = Data((0..<20).map { UInt8($0) })
+
+        let p2pkh = try XCTUnwrap(encodePlatformAddress(wireType: 0xb0, hash: hash))
+        let decodedP2PKH = try XCTUnwrap(
+            PlatformAddressSyncCoordinator.parsePlatformRecipient(bech32m: p2pkh))
+        XCTAssertEqual(decodedP2PKH.ffiAddressType, 0)
+        XCTAssertEqual(decodedP2PKH.hash, hash)
+
+        let p2sh = try XCTUnwrap(encodePlatformAddress(wireType: 0x80, hash: hash))
+        let decodedP2SH = try XCTUnwrap(
+            PlatformAddressSyncCoordinator.parsePlatformRecipient(bech32m: p2sh))
+        XCTAssertEqual(decodedP2SH.ffiAddressType, 1, "P2SH must decode as type 1, not be silently accepted as P2PKH")
+    }
+
+    /// A P2SH destination is named on the ADDRESS step and blocks Continue,
+    /// rather than being confirmed and then failing in execution.
+    func testP2SHPlatformDestinationIsRejectedBeforeTheAmountStep() throws {
+        let hash = Data(repeating: 0xAB, count: 20)
+        let model = SendViewModel()
+
+        model.addressText = try XCTUnwrap(encodePlatformAddress(wireType: 0x80, hash: hash))
+        try XCTSkipIf(model.destination != .platform, "P2SH address did not classify on this network")
+
+        XCTAssertNotNil(model.unsupportedDestinationMessage)
+        XCTAssertFalse(model.canAdvanceToAmount)
+    }
+
+    func testP2PKHPlatformDestinationAdvances() throws {
+        let hash = Data(repeating: 0xCD, count: 20)
+        let model = SendViewModel()
+
+        model.addressText = try XCTUnwrap(encodePlatformAddress(wireType: 0xb0, hash: hash))
+        try XCTSkipIf(model.destination != .platform, "P2PKH address did not classify on this network")
+
+        XCTAssertNil(model.unsupportedDestinationMessage)
+        XCTAssertTrue(model.canAdvanceToAmount)
+    }
+
+    // MARK: - Durable recipient round trip
+
+    /// Write then read back: a resume must recover the SAME third party, not
+    /// the sender's own address.
+    func testRecipientRoundTripsThroughTheStore() {
+        let store = PlatformFundingRecipientStore.shared
+        store.resetForWipe()
+        defer { store.resetForWipe() }
+
+        let outPointHex = String(repeating: "ab", count: 32) + ":0"
+        let recipient = PlatformFundingRecipient(
+            addressType: 0,
+            hash: Data(repeating: 0x11, count: 20),
+            isExternal: true,
+            credits: 2_000_000_000)
+
+        store.stamp(outPointHex: outPointHex, recipient: recipient)
+
+        XCTAssertEqual(store.recipient(forOutPointHex: outPointHex), recipient)
+    }
+
+    /// The pre-submit intent covers the window where the lock is broadcast but
+    /// its outpoint has not been observed yet — a kill there must not lose the
+    /// destination.
+    func testPendingIntentIsServedForAnUnstampedOutPoint() {
+        let store = PlatformFundingRecipientStore.shared
+        store.resetForWipe()
+        defer { store.resetForWipe() }
+
+        let recipient = PlatformFundingRecipient(
+            addressType: 0,
+            hash: Data(repeating: 0x22, count: 20),
+            isExternal: true,
+            credits: 5_000_000)
+        store.recordIntent(recipient)
+
+        let unseenOutPoint = String(repeating: "cd", count: 32) + ":0"
+        XCTAssertEqual(store.recipient(forOutPointHex: unseenOutPoint), recipient)
+
+        store.clearIntent()
+        XCTAssertNil(store.recipient(forOutPointHex: unseenOutPoint))
+    }
+
+    /// The legacy fallback: a lock with NO recorded recipient must read back as
+    /// `nil` so the resume keeps own-next-address behavior. Returning anything
+    /// else here is exactly the misdirection the record exists to prevent.
+    func testMissingRecipientReadsBackAsNil() {
+        let store = PlatformFundingRecipientStore.shared
+        store.resetForWipe()
+        defer { store.resetForWipe() }
+
+        let outPointHex = String(repeating: "ef", count: 32) + ":0"
+        XCTAssertNil(store.recipient(forOutPointHex: outPointHex))
+    }
+
+    /// First stamp wins: a later resume can never rewrite the destination the
+    /// user originally confirmed.
+    func testStampIsFirstWriteWins() {
+        let store = PlatformFundingRecipientStore.shared
+        store.resetForWipe()
+        defer { store.resetForWipe() }
+
+        let outPointHex = String(repeating: "12", count: 32) + ":0"
+        let original = PlatformFundingRecipient(
+            addressType: 0, hash: Data(repeating: 0x33, count: 20), isExternal: true, credits: 100)
+        let usurper = PlatformFundingRecipient(
+            addressType: 0, hash: Data(repeating: 0x44, count: 20), isExternal: false, credits: nil)
+
+        store.stamp(outPointHex: outPointHex, recipient: original)
+        store.stamp(outPointHex: outPointHex, recipient: usurper)
+
+        XCTAssertEqual(store.recipient(forOutPointHex: outPointHex), original)
+    }
+
+    /// The outpoint key must be the SDK's display-order form, or nothing
+    /// written under it is ever found again.
+    func testOutPointHexIsDisplayOrder() {
+        var wire = Data(repeating: 0x00, count: 32)
+        wire[0] = 0xAA
+        wire[31] = 0xBB
+
+        let hex = PlatformFundingRecipientStore.outPointHex(txidWire: wire, vout: 3)
+        XCTAssertEqual(hex, "bb" + String(repeating: "00", count: 30) + "aa:3")
+        XCTAssertNil(PlatformFundingRecipientStore.outPointHex(txidWire: Data([0x01]), vout: 0))
+    }
+
+    // MARK: - Helpers
+
+    /// DIP-0018 display form for a Platform address on the CURRENT network:
+    /// bech32m over `[wireType] + 20-byte hash`.
+    private func encodePlatformAddress(wireType: UInt8, hash: Data) -> String? {
+        let hrp = Bech32m.platformHrp(mainnet: !WalletEnvironment.isTestnet)
+        return Bech32m.encode(hrp: hrp, data: Data([wireType]) + hash)
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **BLOCKED — do not merge yet.** This depends on **dashpay/platform#4501**
> (`feat/external-recipient-asset-lock-funding`), which is still open. It uses
> `ManagedPlatformAddressWallet.fundFromAssetLockExternal(...)`,
> `.resumeFundFromAssetLockExternal(...)` and
> `PersistentAssetLock.recipientIsExternal`, none of which exist on any merged
> platform branch. Merge order: platform#4501 first, then advance this repo's
> platform pin, then this PR.
>
> Advancing the pin has to be reconciled with the migration posture recorded in
> `CLAUDE.md` ("temporary local integration branches are development-only …
> make the final migration/release build consume platform `v4.2-dev` or an
> explicitly selected release SHA/tag"). The `../platform` checkout this branch
> was compiled against was the PR branch itself.

## Issue being fixed or feature implemented

The app can move Dash from the Core (L1) balance to a Platform balance, but
only to **its own** next Platform address — an internal top-up.
`SendViewModel.validSources` said so outright: *"there is no external
core → platform funding"*. Pasting a third party's Platform address while the
Transparent balance was selected produced no route, and from the balance-row
send sheet it dead-ended as a `pinnedSourceMismatch` with no way forward.

This adds the missing leg: **pay someone else's Platform address from your Core
balance**, via an asset lock with an explicit-amount output for the payee.

## What was done?

### 1. Exact amounts, with the sender's own change absorbing the fees

The existing `.coreToShielded` external route is the same mechanic for the
shielded pool, and it was the template here — but it is copied with two
deliberate divergences, because it is wrong in these two ways.

The shielded route passes `credits: nil` (a sole remainder recipient), so the
recipient gets `lock − fee`: you type X, the payee receives slightly less. The
type-4 transition supports multiple outputs, so this route builds
**two**: the payee's, carrying an explicit credit amount, and the wallet's own
next address as the remainder. The fee strategy reduces the remainder, so
**the payee is credited exactly the amount that was typed** and the sender's own
change output absorbs the Platform fees.

That costs headroom on top of the amount, sized by the new
`CoreToPlatformAmountPolicy` from the protocol's own constants:
`base_processing_cost + output_cost × 2 + min_output_amount`
= 62,500,000 credits = 62,500 duffs. The metered fee Platform actually charges
can exceed that floor — and it too comes out of the sender's change, never out
of the payee's explicit amount. A lock too thin to cover the real fee is
rejected Rust-side with a typed error, i.e. a failed transfer rather than a
short payment.

`CoreToShieldedAmountPolicy.assetLockBaseCostCredits` was never
shielded-specific — it mirrors the Rust *address-funding* constant
`required_asset_lock_duff_balance_for_processing_start_for_address_funding`. It
is now extracted into a shared `AssetLockFundingCostPolicy` that both routes
read, rather than duplicated.

### 2. Durable recipient — the cold-resume misdirection this route would otherwise ship with

Rust never learns the destination of an address-funding asset lock; it tracks
the outpoint, its status and its proof. The recipient is a **parameter** of both
`fundFromAssetLockExternal` and `resumeFundFromAssetLockExternal`, so the host
alone is responsible for round-tripping it.

Without that, a kill between lock broadcast and ST submit is a silent
misdirection: every resume surface would come back with no recipient and pay
**the sender's own next address** instead of the third party the user confirmed.
The lock is a bearer input, not a commitment to a destination, so the resume
would succeed — just to the wrong party.

So the recipient is persisted **before ST submit**:

- New `PlatformFundingRecipientStore` records a pre-submit **intent** (covering
  the window where the lock exists on-chain but the app has not yet seen its
  outpoint), then **stamps** `outpoint → recipient` the moment the outpoint is
  observed. The 0.5 s asset-lock poll sees the row at Broadcast status, which is
  before the funding ST is submitted.
- The canonical record is written onto the `PersistentAssetLock` row itself —
  `recipientPlatformAddressHash` / `recipientPlatformAddressType` /
  `recipientIsExternal`. **dashwallet-ios never wrote these fields before**;
  the only writer in either repo was the platform SwiftExampleApp.
- Both writes are first-write-wins, so a resume can never rewrite the
  destination the user originally confirmed.
- Resolution happens in `PlatformAddressSyncCoordinator.resumeFundFromCore`, the
  single choke point every resume surface funnels through (tx-detail retry, the
  home screen's tap-to-finish, `AssetLockRecoveryService`, and the confirm
  sheet's "Try again"). A resume path added later cannot forget to do it.
- **A missing recipient falls back to legacy own-address behavior**, so
  pre-existing locks and every internal transfer keep working unchanged.

Side benefit: writing those fields fixes
`PlatformAddressActivityStore.matchesOwnAssetLockTopUp`, which always returned
`false` because nothing ever populated the hash. It is now gated on
`recipientIsExternal != true`, so an outgoing external send is never
misclassified as an incoming own top-up.

### 3. UI route

- `Route.coreToPlatform`, and `.core` added to `validSources` for `.platform`
  destinations. The routing table is now a pure static seam
  (`validSources(for:)` / `route(source:destination:)`) so it can be tested
  directly, and `route`'s switch lost its `default:` so the compiler enforces
  the full 3×3 table.
- Every non-`default` switch the compiler flagged: fee reserve, sync gating
  (Core-funded, so it gates on `isChainSynced`), insufficient-balance copy,
  `canContinue`, Max, from-label, network fee, total, progress steps
  (`.locking` yes, `.proving` no).
- **P2SH Platform destinations are now rejected at input time.**
  `DashAddressClassifier` accepts `0x80`, but every execution path rejects it,
  so the user could previously confirm a send and only then be told it was
  unsupported — a confirm-then-fail that violates the repo's "no
  stub-and-assert" guardrail. It is now an inline error on the address step that
  blocks Continue. Relaxing this properly is a platform-side follow-up
  (`TryFrom<PlatformAddressFFI>` is P2PKH-only).
- Home-screen **tap-to-recover** for pending type-4 locks. These previously
  showed a plain "Pending" pill with no affordance while shielded transfers got
  "Pending — tap to finish". Rather than duplicating the sheet,
  `ShieldedRecoverySheet` was generalized to `AssetLockRecoverySheet` with a
  `Kind` (`.shielded` / `.platformFunding`) covering the differing resume call,
  remaining stages, and consumed-lock pre-check.
- `pinnedSourceMismatch` for "Transparent row → Platform address" resolves, as
  expected — covered by a test.

## How Has This Been Tested?

**Built, with real results:**

- `DashSDKFFI.xcframework` rebuilt from the platform PR branch
  (`build_ios.sh --target ios --target sim`); both `ios-arm64` and
  `ios-arm64-simulator` slices verified to export
  `platform_address_wallet_fund_from_asset_lock_external_signer` and
  `platform_address_wallet_resume_fund_from_asset_lock_external_signer`.
- Clean **`dashpay` scheme build** against that SDK:
  `xcodebuild -workspace DashWallet.xcworkspace -scheme dashpay -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' ARCHS=arm64 build`
  → **BUILD SUCCEEDED**.

**Not run:**

- **No testnet smoke of the flow.** Nothing here has been exercised against a
  live chain. The end-to-end behavior — that the payee is credited the exact
  amount, that the sender's change absorbs the fee, and that a resume after a
  cold start pays the same third party — is unverified on-device and should be
  smoke-tested before this leaves draft.
- **Unit tests were not executed.** The `DashWalletTests` target is broken
  pre-existing (documented in `CLAUDE.md`). `CoreToPlatformSendRouteTests` is
  added and registered in the target, covering the route/`validSources` table,
  the amount policy (minimum + headroom + overflow), P2SH rejection, and the
  recipient-persistence round trip including the missing-recipient legacy
  fallback — but it is compile-ready, not green, because the target cannot run.

## Breaking Changes

None. The internal Core → Platform transfer and every pre-existing asset lock
keep their current behavior; the external path is only taken when a recipient
was explicitly recorded.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

---

Out of scope, noted for a separate issue: the pre-existing `.coreToShielded`
external route has the **same** cold-resume misdirection — its recipient lives
only in view/coordinator memory, so every recovery surface resumes with
`recipientOverride = nil` and silently shields to the sender's own address.
Deliberately not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
