### PR TITLE
fix(explore-dash): stop stranding the merchant sheet over the amount screen

### DIFF
--- a/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/POIDetailsViewController.swift
+++ b/DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/POIDetailsViewController.swift
@@ -235,6 +235,14 @@ extension POIDetailsViewController {
 
     private func presentDetailsSheetIfNeeded() {
         guard pointOfUse.showMap, !didPresentDetailsSheet, presentedViewController == nil else { return }
+        // Only while this really is the visible screen. The gift-card flow pops
+        // back to here and pushes the amount screen in the same turn, and the
+        // push runs first — `performAfterDismissingDetailsSheetIfNeeded` finds
+        // no sheet to dismiss, so it calls straight through. `viewDidAppear`
+        // then arrives after the push, and without this guard it would strand
+        // the details sheet on top of the amount screen, where
+        // `isModalInPresentation` leaves no way to swipe it away.
+        if let navigationController, navigationController.topViewController !== self { return }
         guard let detailsView = makeDetailsView() else { return }
 
         let sheetViewController = UIHostingController(rootView: detailsView)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Buying a gift card from a physical merchant that requires a DashSpend login leaves the merchant details sheet stranded on top of the Enter Amount screen. It sets `isModalInPresentation = true`, so it cannot be swiped away — leaving the flow and re-entering is the only way out.

Reported from manual testing on an iOS 26.5 simulator.

The cause is ordering, not the sheet itself:

1. `showDashSpendAuth` goes through `performAfterDismissingDetailsSheetIfNeeded`, which dismisses the details sheet and resets `didPresentDetailsSheet = false` — deliberately, so the sheet returns when the user comes back.
2. On success the flow pops back to `POIDetailsViewController` and calls `showDashSpendPayScreen` in the same turn.
3. The push wins the race: by then `detailsSheetViewController` is `nil`, so `performAfterDismissingDetailsSheetIfNeeded` finds nothing to dismiss and calls its action straight through, pushing the amount screen.
4. `viewDidAppear` — from the pop in step 2 — arrives *after* that push, sees the reset flag and presents the details sheet on top of the screen that was just pushed.

## What was done?

Gate the presentation on this controller actually being the top of its navigation stack:

```swift
if let navigationController, navigationController.topViewController !== self { return }
```

Returning to the details screen still re-presents the sheet, because at that point the controller *is* the top. The modal-presentation case (no navigation controller) is unaffected.

## How Has This Been Tested?

- Clean `dashpay` build for the arm64 iOS Simulator.

The failure is a navigation race that needs the DashSpend login path with a physical merchant to reproduce, so it is worth exercising on a device: buy a gift card from a physical merchant while logged out, complete the login, and confirm the Enter Amount screen comes up clean.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented merchant and ATM details from reopening over gift-card payment screens after navigating away.
  * Details sheets now appear only when the relevant details screen is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->