### PR TITLE
ci(ui): add a VoiceOver audit tool and an accessibility CI ratchet

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -7,9 +7,14 @@ name: "Accessibility"
 # control. New P2 findings (Dynamic Type) are reported as advisory and do not
 # fail the build.
 #
-# On a pull request the baseline is read from the BASE branch, not from the PR
-# checkout: otherwise a PR could add a regression and add its fingerprint to the
-# same file, and the check would pass.
+# On a pull request the baseline AND the config are read from the BASE branch,
+# not from the PR checkout. Otherwise a PR could add a regression and, in the
+# same commit, either baseline its fingerprint or disable the rule that catches
+# it — and the check would pass on its own weakened settings.
+#
+# Landing a deliberate config change therefore takes two steps: merge the config
+# change, then rely on it. Add the `a11y-config-change` label to a PR to have it
+# checked with its own config instead.
 #
 # No Xcode needed: the audit is static analysis, so it runs on a free Ubuntu
 # runner in about a second.
@@ -57,28 +62,39 @@ jobs:
 
       # Take the accepted debt from the base branch. A PR that both introduces
       # a finding and baselines it would otherwise pass its own check.
-      - name: Resolve the baseline to compare against
-        id: baseline
+      - name: Resolve the baseline and config to check against
+        id: settings
         env:
           BASE_REF: ${{ github.base_ref }}
+          ALLOW_PR_CONFIG: ${{ contains(github.event.pull_request.labels.*.name, 'a11y-config-change') }}
         run: |
           set -euo pipefail
           BASELINE_PATH="scripts/a11y_baseline.json"
+          CONFIG_PATH="scripts/a11y_config.json"
           if [ -n "${BASE_REF:-}" ]; then
             git fetch --depth=1 origin "$BASE_REF"
             if git cat-file -e "origin/${BASE_REF}:scripts/a11y_baseline.json" 2>/dev/null; then
               git show "origin/${BASE_REF}:scripts/a11y_baseline.json" > /tmp/base_baseline.json
               BASELINE_PATH="/tmp/base_baseline.json"
-              echo "Comparing against the baseline on origin/${BASE_REF}."
+              echo "Baseline: origin/${BASE_REF}."
             else
-              echo "origin/${BASE_REF} has no baseline yet — using the one in this PR."
+              echo "Baseline: origin/${BASE_REF} has none yet — using this PR's."
+            fi
+            if [ "${ALLOW_PR_CONFIG}" = "true" ]; then
+              echo "Config: this PR's (a11y-config-change label present)."
+            elif git cat-file -e "origin/${BASE_REF}:scripts/a11y_config.json" 2>/dev/null; then
+              git show "origin/${BASE_REF}:scripts/a11y_config.json" > /tmp/base_config.json
+              CONFIG_PATH="/tmp/base_config.json"
+              echo "Config: origin/${BASE_REF}."
+            else
+              echo "Config: origin/${BASE_REF} has none yet — using this PR's."
             fi
           fi
-          echo "path=${BASELINE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "baseline=${BASELINE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "config=${CONFIG_PATH}" >> "$GITHUB_OUTPUT"
 
-      # Flag a weakened config for the reviewer. This does not fail the build:
-      # relaxing the config can only ever reduce findings, so it cannot smuggle
-      # a regression past the ratchet — but it must not pass unnoticed either.
+      # Surface a config change for the reviewer. The blocking check above
+      # already runs with the base config, so this is informational.
       - name: Note config changes
         if: github.base_ref != ''
         env:
@@ -106,13 +122,15 @@ jobs:
           # Passed through the environment rather than interpolated into the
           # script body, so a dispatch input cannot inject shell.
           FAIL_ON: ${{ github.event.inputs.fail_on || 'P0,P1' }}
-          BASELINE_PATH: ${{ steps.baseline.outputs.path }}
+          BASELINE_PATH: ${{ steps.settings.outputs.baseline }}
+          CONFIG_PATH: ${{ steps.settings.outputs.config }}
         run: |
           set -euo pipefail
           python3 scripts/a11y_audit.py \
             --check \
             --github \
             --baseline "$BASELINE_PATH" \
+            --config "$CONFIG_PATH" \
             --fail-on "$FAIL_ON"
 
       - name: Current debt summary
@@ -127,7 +145,8 @@ jobs:
             python3 scripts/a11y_audit.py --summary
             echo '```'
             echo
-            echo "Fails only on findings absent from the base branch's \`scripts/a11y_baseline.json\`."
+            echo "Checked against the base branch's baseline and config, so a PR cannot"
+            echo "weaken its own gate. Label \`a11y-config-change\` to use this PR's config."
             echo "Deliberate exception: \`// a11y-ignore: <RULE> <why>\` on the line."
             echo "Fixed something? \`scripts/a11y_audit.py --write-baseline\` banks it."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,76 @@
+name: "Accessibility"
+
+# Static VoiceOver / Dynamic Type audit (scripts/a11y_audit.py).
+#
+# The job fails only on findings that are NOT in scripts/a11y_baseline.json, so
+# the existing debt never blocks unrelated work — but a PR cannot add a new
+# unlabeled control. New P2 findings (Dynamic Type) are reported as advisory and
+# do not fail the build.
+#
+# No Xcode needed: the audit is static analysis, so it runs on a free Ubuntu
+# runner in about a second.
+
+on:
+  pull_request:
+    paths:
+      - "DashWallet/**"
+      - "TodayExtension/**"
+      - "WatchApp/**"
+      - "WatchApp Extension/**"
+      - "scripts/a11y_audit.py"
+      - "scripts/a11y_baseline.json"
+      - ".github/workflows/accessibility.yml"
+  push:
+    branches:
+      - develop
+      - master
+  workflow_dispatch:
+    inputs:
+      fail_on:
+        description: "Severities that fail the run (P0,P1 | all)"
+        required: false
+        default: "P0,P1"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: VoiceOver / Dynamic Type audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # If the rules themselves regress, every later result is meaningless —
+      # so the fixtures run before the audit.
+      - name: Rule self-test
+        run: python3 scripts/a11y_audit.py --self-test
+
+      - name: Audit changed code against the baseline
+        id: audit
+        run: |
+          python3 scripts/a11y_audit.py \
+            --check \
+            --github \
+            --fail-on "${{ github.event.inputs.fail_on || 'P0,P1' }}"
+
+      - name: Current debt summary
+        # Runs even when the check above fails, so the PR always shows where
+        # the app stands overall.
+        if: always()
+        run: |
+          {
+            echo "### Accessibility debt"
+            echo
+            echo '```'
+            python3 scripts/a11y_audit.py --summary
+            echo '```'
+            echo
+            echo "Fails only on findings absent from \`scripts/a11y_baseline.json\`."
+            echo "Deliberate exception: \`// a11y-ignore: <RULE> <why>\` on the line."
+            echo "Fixed something? \`scripts/a11y_audit.py --write-baseline\` banks it."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -2,10 +2,14 @@ name: "Accessibility"
 
 # Static VoiceOver / Dynamic Type audit (scripts/a11y_audit.py).
 #
-# The job fails only on findings that are NOT in scripts/a11y_baseline.json, so
-# the existing debt never blocks unrelated work — but a PR cannot add a new
-# unlabeled control. New P2 findings (Dynamic Type) are reported as advisory and
-# do not fail the build.
+# The job fails only on findings that are NOT in the baseline, so the existing
+# debt never blocks unrelated work — but a PR cannot add a new unlabeled
+# control. New P2 findings (Dynamic Type) are reported as advisory and do not
+# fail the build.
+#
+# On a pull request the baseline is read from the BASE branch, not from the PR
+# checkout: otherwise a PR could add a regression and add its fingerprint to the
+# same file, and the check would pass.
 #
 # No Xcode needed: the audit is static analysis, so it runs on a free Ubuntu
 # runner in about a second.
@@ -19,6 +23,7 @@ on:
       - "WatchApp Extension/**"
       - "scripts/a11y_audit.py"
       - "scripts/a11y_baseline.json"
+      - "scripts/a11y_config.json"
       - ".github/workflows/accessibility.yml"
   push:
     branches:
@@ -50,13 +55,65 @@ jobs:
       - name: Rule self-test
         run: python3 scripts/a11y_audit.py --self-test
 
-      - name: Audit changed code against the baseline
-        id: audit
+      # Take the accepted debt from the base branch. A PR that both introduces
+      # a finding and baselines it would otherwise pass its own check.
+      - name: Resolve the baseline to compare against
+        id: baseline
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
+          set -euo pipefail
+          BASELINE_PATH="scripts/a11y_baseline.json"
+          if [ -n "${BASE_REF:-}" ]; then
+            git fetch --depth=1 origin "$BASE_REF"
+            if git cat-file -e "origin/${BASE_REF}:scripts/a11y_baseline.json" 2>/dev/null; then
+              git show "origin/${BASE_REF}:scripts/a11y_baseline.json" > /tmp/base_baseline.json
+              BASELINE_PATH="/tmp/base_baseline.json"
+              echo "Comparing against the baseline on origin/${BASE_REF}."
+            else
+              echo "origin/${BASE_REF} has no baseline yet — using the one in this PR."
+            fi
+          fi
+          echo "path=${BASELINE_PATH}" >> "$GITHUB_OUTPUT"
+
+      # Flag a weakened config for the reviewer. This does not fail the build:
+      # relaxing the config can only ever reduce findings, so it cannot smuggle
+      # a regression past the ratchet — but it must not pass unnoticed either.
+      - name: Note config changes
+        if: github.base_ref != ''
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if ! git cat-file -e "origin/${BASE_REF}:scripts/a11y_config.json" 2>/dev/null; then
+            exit 0
+          fi
+          git show "origin/${BASE_REF}:scripts/a11y_config.json" > /tmp/base_config.json
+          if ! diff -q /tmp/base_config.json scripts/a11y_config.json >/dev/null; then
+            {
+              echo "### ⚠️ Accessibility config changed"
+              echo
+              echo "Review the rule scope before merging:"
+              echo
+              echo '```diff'
+              diff -u /tmp/base_config.json scripts/a11y_config.json || true
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Audit changed code against the baseline
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script body, so a dispatch input cannot inject shell.
+          FAIL_ON: ${{ github.event.inputs.fail_on || 'P0,P1' }}
+          BASELINE_PATH: ${{ steps.baseline.outputs.path }}
+        run: |
+          set -euo pipefail
           python3 scripts/a11y_audit.py \
             --check \
             --github \
-            --fail-on "${{ github.event.inputs.fail_on || 'P0,P1' }}"
+            --baseline "$BASELINE_PATH" \
+            --fail-on "$FAIL_ON"
 
       - name: Current debt summary
         # Runs even when the check above fails, so the PR always shows where
@@ -70,7 +127,7 @@ jobs:
             python3 scripts/a11y_audit.py --summary
             echo '```'
             echo
-            echo "Fails only on findings absent from \`scripts/a11y_baseline.json\`."
+            echo "Fails only on findings absent from the base branch's \`scripts/a11y_baseline.json\`."
             echo "Deliberate exception: \`// a11y-ignore: <RULE> <why>\` on the line."
             echo "Fixed something? \`scripts/a11y_audit.py --write-baseline\` banks it."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -44,6 +44,11 @@ scripts/a11y_audit.py --path "DashWallet/Sources/UI/Payments"
 | A11Y011 | P1 | Image-only control in a xib/storyboard with no label |
 | A11Y012 | P1 | `.onTapGesture` on a view with no accessibility treatment |
 
+All three SwiftUI button forms are inspected — the trailing-closure
+`Button(action:) { … }`, the two-closure `Button { … } label: { … }`, and
+`Button(action:label:)` — so an icon-only label cannot hide in the form it was
+written with.
+
 What it does **not** check — these still need a human with VoiceOver on a device:
 
 - whether a label reads *well* (an accurate label can still be a bad one)
@@ -66,10 +71,16 @@ It fails **only on findings that are not in `scripts/a11y_baseline.json`.** The
 existing debt is recorded there, so the check can be adopted today without
 fixing everything first — but a PR cannot add a new unlabeled control.
 
-On a pull request the baseline is read from the **base branch**, not from the PR
-checkout. Otherwise a PR could introduce a regression and add its fingerprint to
-the same file in the same commit, and the check would pass on its own weakened
-baseline.
+On a pull request both the baseline **and `a11y_config.json`** are read from the
+**base branch**, not from the PR checkout. Otherwise a PR could introduce a
+regression and, in the same commit, either baseline its fingerprint or disable
+the rule that catches it — and the check would pass on its own weakened gate.
+
+A consequence worth knowing: a config change takes effect only once it is
+merged. If a PR genuinely needs its own config to pass — say it adds a wrapper
+component and lists it in `labeled_wrappers` — either land the config change
+first, or add the `a11y-config-change` label to have the PR checked with its own
+config.
 
 New **P2** findings (Dynamic Type) are printed as advisory and do not fail the
 build. Change that with `--fail-on all` once the P2 debt is paid down.

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,166 @@
+# Accessibility
+
+How to check whether the app is usable with VoiceOver, and how the CI ratchet
+keeps it from getting worse.
+
+Background: ticket 32072 — *"Please add support for screenreaders. The tabs at
+the bottom, as well as buttons, need to be labeled so that screenreaders can
+read them."*
+
+## The tool
+
+`scripts/a11y_audit.py` is a static audit. Python 3.8+, stdlib only, no Xcode,
+runs in about a second over the whole repo.
+
+```bash
+scripts/a11y_audit.py                  # full report
+scripts/a11y_audit.py --summary        # counts per rule
+scripts/a11y_audit.py --rule A11Y004   # one rule (repeatable)
+scripts/a11y_audit.py --list-rules     # what it checks and how to fix each
+scripts/a11y_audit.py --json out.json  # machine-readable
+scripts/a11y_audit.py --self-test      # verify the rules themselves still work
+```
+
+Scope it while you work on one screen:
+
+```bash
+scripts/a11y_audit.py --path "DashWallet/Sources/UI/Payments"
+```
+
+## What it checks
+
+| Rule | Sev | What it catches |
+|---|---|---|
+| A11Y001 | P0 | `UITabBarItem(title: nil)` with no `accessibilityLabel` |
+| A11Y002 | P1 | Icon-only `UIBarButtonItem` with no label |
+| A11Y003 | P1 | `UIButton` that only ever gets `setImage`, no title, no label |
+| A11Y004 | P1 | SwiftUI `Button` whose label is only an image/shape |
+| A11Y005 | P1 | `Toggle` with an empty label |
+| A11Y006 | P1 | Custom back button replacing UIKit's automatically labeled one |
+| A11Y007 | P2 | `.system(size:)` with no `relativeTo:` — ignores Dynamic Type |
+| A11Y008 | P0 | `extension Font` shadowing an Apple text style |
+| A11Y009 | P1 | `accessibilityLabel` with a bare, unlocalized string |
+| A11Y010 | P1 | `accessibilityLabel` key missing from `en.lproj` |
+| A11Y011 | P1 | Image-only control in a xib/storyboard with no label |
+| A11Y012 | P1 | `.onTapGesture` on a view with no accessibility treatment |
+
+What it does **not** check — these still need a human with VoiceOver on a device:
+
+- whether a label reads *well* (an accurate label can still be a bad one)
+- reading order, focus movement, and whether a modal traps focus
+- whether state changes are announced (`UIAccessibility.post`) — the app has
+  **zero** such announcements today, so nothing tells a blind user that a copy
+  succeeded, a PIN was wrong, or a payment went through
+- custom controls that need an `.adjustable` trait (sliders, steppers)
+- anything that only exists at runtime
+
+A quick VoiceOver spot-check can also mislead you: an unlabeled button does not
+go silent, it announces the image asset name — *"icon copy outline"*,
+*"diagonal-up-down"*. It sounds like something is there.
+
+## The CI ratchet
+
+`.github/workflows/accessibility.yml` runs on every PR that touches app code.
+
+It fails **only on findings that are not in `scripts/a11y_baseline.json`.** The
+existing debt is recorded there, so the check can be adopted today without
+fixing everything first — but a PR cannot add a new unlabeled control.
+
+New **P2** findings (Dynamic Type) are printed as advisory and do not fail the
+build. Change that with `--fail-on all` once the P2 debt is paid down.
+
+Baseline entries are keyed by a hash of the code snippet, not by line number, so
+moving code around or reindenting a file does not create false failures.
+
+### When CI fails on your PR
+
+1. **Fix it.** Almost always one line — `--list-rules` prints the fix for each
+   rule.
+2. **Or suppress it deliberately**, on the offending line or the one above:
+
+   ```swift
+   // a11y-ignore: A11Y004 decorative chevron, the row itself carries the label
+   ```
+
+   The rule id and a reason are both required.
+
+3. **Never regenerate the baseline to silence a new finding.** That is what the
+   baseline is for, and it is the one thing that makes the ratchet useless.
+
+### Tuning it to our design system
+
+`scripts/a11y_config.json` exists so the rules bend to the codebase rather than
+the other way round. Every field is optional:
+
+| Field | Use it for |
+|---|---|
+| `labeled_wrappers` | our own components that set an accessibility label internally — a view built from one counts as already announced |
+| `speaks_for_itself` | components whose API requires a title, so they always read |
+| `disabled_rules` | a rule that does not apply to this project at all |
+| `advisory_rules` | a rule that should report but never fail CI |
+| `exclude_paths` | path prefixes to skip (generated code, debug-only screens) |
+| `allowed_font_shadows` | Font tokens we knowingly keep despite shadowing an Apple text style |
+
+Prefer this over scattering `a11y-ignore` comments: a wrapper listed once covers
+every call site, and the claim is reviewable in one place. `DashStepper` and
+`SegmentedControl` are listed today because both genuinely set their own labels.
+
+**Note on custom fonts and icons.** The audit does not flag either. There are no
+bundled font files in the repo and no `Font.custom` / `UIFont(name:)` call sites
+— our "custom fonts" are tokens over the system face, and the 159 `dw_font`
+helper calls are never flagged because `dw_font(forTextStyle:)` scales
+correctly. Custom icons are only ever reported when they are the *entire* label
+of a tappable control, which is exactly the case a screen reader cannot resolve.
+A11Y008 is not about having our own tokens either: it fires only where a token's
+name collides with one of Apple's, and `allowed_font_shadows` turns it off.
+
+### After you fix something
+
+```bash
+scripts/a11y_audit.py --write-baseline
+```
+
+This banks the progress so the fixed entry can never come back unnoticed. The
+`--check` output tells you when there is progress worth banking.
+
+## Where the debt actually is
+
+From the full audit (see ticket 32072), the defects concentrate in a handful of
+shared components rather than being spread across screens. Fixing these repairs
+an estimated 60–70 screens:
+
+| Component | Defect |
+|---|---|
+| `UI/Views/Navigation/BaseNavigationController.swift` | replaces UIKit's automatically labeled system Back button with an unlabeled image button |
+| `UI/SwiftUI Components/NavigationBar.swift` | back/close/plus/info built from a bare `Icon` — the DashUIKit original *does* set the label; this copy dropped it |
+| `UI/SwiftUI Components/MenuItem.swift` | `Toggle(isOn:) { }` with an empty label — every settings switch |
+| `UI/SwiftUI Components/DashAmount.swift` | currency symbol is an image, so amounts never say "Dash" |
+| `UI/Views/SharedViews/Keyboard/NumberKeyboardButton.swift` | keys are plain `UIView`s with no button trait; the delete key is an image attachment |
+
+`UI/SwiftUI Components/Font+DWStyle.swift` is the Dynamic Type root cause: it
+declares an `extension Font` whose members shadow Apple's `body`, `headline`,
+`largeTitle`, `title2`, `title3`, `callout`, `footnote` and `caption2`. It
+compiles silently and wins inside the app module, so `.font(.body)` — which
+looks entirely correct — stops scaling. Any Dynamic Type work starts there.
+
+## Writing accessible UI here
+
+`UI/SwiftUI Components/DashStepper.swift` is the reference: it sets a label, a
+value, a hint, and custom actions. Copy its shape.
+
+```swift
+Button(action: onClose) {
+    Icon(name: .custom("icon_close"))
+}
+.accessibilityLabel(Text(NSLocalizedString("Close", comment: "Accessibility")))
+```
+
+- A control with visible text needs nothing — VoiceOver reads the title.
+- An icon-only control always needs `.accessibilityLabel`.
+- `accessibilityIdentifier` is for XCUITest and is **never** spoken. It is not a
+  substitute for a label.
+- A composite row (icon + title + value + chevron) should be one element:
+  `.accessibilityElement(children: .combine)`, or `.ignore` plus an explicit
+  label.
+- Every label is a user-visible string: wrap it in `NSLocalizedString` and let it
+  reach Transifex, or it ships English-only across 43 locales.

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -66,11 +66,18 @@ It fails **only on findings that are not in `scripts/a11y_baseline.json`.** The
 existing debt is recorded there, so the check can be adopted today without
 fixing everything first — but a PR cannot add a new unlabeled control.
 
+On a pull request the baseline is read from the **base branch**, not from the PR
+checkout. Otherwise a PR could introduce a regression and add its fingerprint to
+the same file in the same commit, and the check would pass on its own weakened
+baseline.
+
 New **P2** findings (Dynamic Type) are printed as advisory and do not fail the
 build. Change that with `--fail-on all` once the P2 debt is paid down.
 
 Baseline entries are keyed by a hash of the code snippet, not by line number, so
-moving code around or reindenting a file does not create false failures.
+moving code around or reindenting a file does not create false failures. They are
+matched as a **multiset**: two identical unlabeled buttons in one file share a
+fingerprint, so the baseline records the count and a third copy still fails.
 
 ### When CI fails on your PR
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,19 @@ All new UI MUST be built in SwiftUI with a ViewModel. Do **not** add new Storybo
 - When integrating with existing UIKit navigation, use a thin `UIHostingController` wrapper only.
 - Maintain existing UIKit code but don't extend it; migrate a screen to SwiftUI when substantially reworking it.
 
+## Accessibility
+
+Icon-only controls must carry an `accessibilityLabel` — see `ACCESSIBILITY.md`.
+Check your work before committing:
+
+```bash
+scripts/a11y_audit.py --check          # what CI runs; fails only on NEW findings
+scripts/a11y_audit.py --path "DashWallet/Sources/UI/Payments"   # one screen
+```
+
+`accessibilityIdentifier` is an XCUITest id and is never spoken — it does not
+count as a label. `.github/workflows/accessibility.yml` enforces this on every PR.
+
 ## Architecture Guardrails (check before every commit)
 
 Distilled from the 2026-07 branch review (`ARCH_REVIEW_2026-07-03.md`) — each rule exists because we shipped its violation:

--- a/scripts/a11y_audit.py
+++ b/scripts/a11y_audit.py
@@ -1,0 +1,1153 @@
+#!/usr/bin/env python3
+"""
+Accessibility (VoiceOver / Dynamic Type) static audit for dashwallet-ios.
+
+Finds interactive controls that a screen reader cannot announce, and text that
+ignores the user's Dynamic Type setting. Written for ticket 32072.
+
+No third-party dependencies — stdlib only, Python 3.8+.
+
+Usage
+-----
+  scripts/a11y_audit.py                       # human-readable report
+  scripts/a11y_audit.py --summary             # counts only
+  scripts/a11y_audit.py --rule A11Y001        # one rule (repeatable)
+  scripts/a11y_audit.py --json report.json    # machine-readable
+  scripts/a11y_audit.py --github              # GitHub Actions annotations
+  scripts/a11y_audit.py --write-baseline      # record today's debt as accepted
+  scripts/a11y_audit.py --check               # fail only on NEW findings
+
+`--check` is the CI mode: it compares against scripts/a11y_baseline.json and
+exits non-zero only when a finding appears that is not in the baseline. Existing
+debt never fails the build, so the ratchet can be adopted without fixing
+everything first.
+
+Suppressing a finding
+---------------------
+Put a comment on the offending line or the line above it:
+
+    // a11y-ignore: A11Y004 decorative chevron, row itself is labeled
+
+The rule id is required; the reason is required and must be non-empty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from typing import Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+SCAN_ROOTS = ["DashWallet", "TodayExtension", "WatchApp", "WatchApp Extension"]
+
+EXCLUDED_DIR_NAMES = {
+    "Pods", "build", "DerivedData", ".build", ".git", "Carthage",
+    "fastlane", "vendor", "node_modules",
+}
+
+SWIFT_EXT = ".swift"
+OBJC_EXTS = (".m", ".mm")
+IB_EXTS = (".xib", ".storyboard")
+
+BASELINE_PATH = os.path.join("scripts", "a11y_baseline.json")
+
+# Apple's own SwiftUI Font text styles. Redeclaring any of these in an
+# app-module `extension Font` silently shadows the scaling system font.
+SYSTEM_FONT_STYLES = {
+    "largeTitle", "title", "title2", "title3", "headline", "subheadline",
+    "body", "callout", "footnote", "caption", "caption2",
+}
+
+# Things that make a SwiftUI view announce itself without an explicit label.
+SPEAKS_FOR_ITSELF = (
+    "Text(", "Label(", "TextField(", "SecureField(", "Link(",
+    "LocalizedStringKey", "NSLocalizedString", "verbatim:",
+)
+
+ACCESSIBILITY_ESCAPES = (
+    ".accessibilityLabel", ".accessibilityElement", ".accessibilityHidden",
+    ".accessibilityRepresentation", ".accessibilityValue", ".labelsHidden",
+    ".accessibility(label:", "accessibilityLabel =",
+)
+
+SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2}
+
+CONFIG_PATH = os.path.join("scripts", "a11y_config.json")
+
+
+class Config:
+    """Project-specific tuning, so a design system does not fight the rules.
+
+    Loaded from scripts/a11y_config.json when present; every field is optional.
+    """
+
+    def __init__(self, data: Optional[Dict[str, object]] = None) -> None:
+        data = data or {}
+        # Rules that never run at all.
+        self.disabled_rules: Set[str] = set(data.get("disabled_rules") or [])
+        # Rules that report but never fail --check, whatever their severity.
+        self.advisory_rules: Set[str] = set(data.get("advisory_rules") or [])
+        # Path prefixes skipped entirely (debug screens, generated code).
+        self.exclude_paths: List[str] = list(data.get("exclude_paths") or [])
+        # Wrapper components that guarantee a label themselves. A view built
+        # from one of these is treated as already announced.
+        self.labeled_wrappers: List[str] = list(data.get("labeled_wrappers") or [])
+        # Extra tokens that mean "this view speaks for itself" — e.g. a custom
+        # component whose API requires a title.
+        self.speaks_for_itself: List[str] = list(data.get("speaks_for_itself") or [])
+        # Font token names the project deliberately keeps despite shadowing
+        # an Apple text style.
+        self.allowed_font_shadows: Set[str] = set(
+            data.get("allowed_font_shadows") or [])
+
+    def speaks_tokens(self) -> Tuple[str, ...]:
+        return SPEAKS_FOR_ITSELF + tuple(self.speaks_for_itself) \
+            + tuple(self.labeled_wrappers)
+
+    def escape_tokens(self) -> Tuple[str, ...]:
+        return ACCESSIBILITY_ESCAPES + tuple(self.labeled_wrappers)
+
+    def excluded(self, rel_path: str) -> bool:
+        normalized = rel_path.replace(os.sep, "/")
+        return any(normalized.startswith(prefix.rstrip("/") )
+                   for prefix in self.exclude_paths)
+
+
+CONFIG = Config()
+
+
+def load_config(repo_root: str, path: str) -> Config:
+    abs_path = os.path.join(repo_root, path)
+    if not os.path.exists(abs_path):
+        return Config()
+    with open(abs_path, "r", encoding="utf-8") as handle:
+        return Config(json.load(handle))
+
+
+def has_real_title(args: str) -> bool:
+    """True when a `title:` argument is present and is not nil.
+
+    Written as an explicit value match rather than a negative lookahead: with
+    `title\\s*:\\s*(?!nil)` the `\\s*` backtracks to zero width and the lookahead
+    then passes on the space, so `title: nil` reads as a real title.
+    """
+    match = re.search(r"title\s*:\s*(\S+)", args)
+    if not match:
+        return False
+    return match.group(1).rstrip(",)") != "nil"
+
+
+class Rule:
+    def __init__(self, rid: str, severity: str, title: str, fix: str) -> None:
+        self.id = rid
+        self.severity = severity
+        self.title = title
+        self.fix = fix
+
+
+RULES: Dict[str, Rule] = {
+    r.id: r
+    for r in [
+        Rule("A11Y001", "P0", "Tab bar item with no accessibility label",
+             "Set item.accessibilityLabel to a localized name."),
+        Rule("A11Y002", "P1", "Icon-only UIBarButtonItem with no label",
+             "Set .accessibilityLabel on the bar button item."),
+        Rule("A11Y003", "P1", "Icon-only UIButton with no label",
+             "Set .accessibilityLabel, or give the button a title."),
+        Rule("A11Y004", "P1", "Icon-only SwiftUI Button with no label",
+             "Add .accessibilityLabel(Text(NSLocalizedString(...)))."),
+        Rule("A11Y005", "P1", "Toggle with an empty label",
+             "Give the Toggle a label, or set .accessibilityLabel on it."),
+        Rule("A11Y006", "P1", "Custom back button replaces the labeled system one",
+             "Set .accessibilityLabel on the custom back button."),
+        Rule("A11Y007", "P2", "Fixed font size ignores Dynamic Type",
+             "Use .system(size:..., relativeTo: .body) or a text style."),
+        Rule("A11Y008", "P0", "extension Font shadows an Apple text style",
+             "Rename the token; a shadowed style silently stops scaling."),
+        Rule("A11Y009", "P1", "accessibilityLabel is not localized",
+             "Wrap the string in NSLocalizedString."),
+        Rule("A11Y010", "P1", "accessibilityLabel key missing from en.lproj",
+             "Add the key to DashWallet/en.lproj/Localizable.strings."),
+        Rule("A11Y011", "P1", "Image-only control in a xib/storyboard with no label",
+             "Add an <accessibility> node with a label in Interface Builder."),
+        Rule("A11Y012", "P1", "Tap gesture on a view with no accessibility",
+             "Use a Button, or add .accessibilityElement + label + .isButton trait."),
+    ]
+}
+
+
+class Finding:
+    __slots__ = ("rule_id", "path", "line", "snippet", "detail")
+
+    def __init__(self, rule_id: str, path: str, line: int, snippet: str,
+                 detail: str = "") -> None:
+        self.rule_id = rule_id
+        self.path = path
+        self.line = line
+        self.snippet = snippet.strip()[:160]
+        self.detail = detail
+
+    @property
+    def severity(self) -> str:
+        return RULES[self.rule_id].severity
+
+    def fingerprint(self) -> str:
+        """Stable across line moves and reindentation, unlike a line number."""
+        normalized = re.sub(r"\s+", "", self.snippet)
+        payload = "{}|{}|{}".format(self.rule_id, self.path, normalized)
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
+    def key(self) -> Tuple[str, str, str]:
+        return (self.rule_id, self.path, self.fingerprint())
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "rule": self.rule_id,
+            "severity": self.severity,
+            "title": RULES[self.rule_id].title,
+            "path": self.path,
+            "line": self.line,
+            "snippet": self.snippet,
+            "detail": self.detail,
+            "fingerprint": self.fingerprint(),
+        }
+
+
+# --------------------------------------------------------------------------
+# Source helpers
+# --------------------------------------------------------------------------
+
+def iter_files(repo_root: str, roots: Sequence[str],
+               extensions: Tuple[str, ...]) -> Iterable[str]:
+    for root in roots:
+        abs_root = os.path.join(repo_root, root)
+        if not os.path.isdir(abs_root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(abs_root):
+            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIR_NAMES]
+            for name in sorted(filenames):
+                if name.endswith(extensions):
+                    abs_path = os.path.join(dirpath, name)
+                    yield os.path.relpath(abs_path, repo_root)
+
+
+def read(repo_root: str, rel_path: str) -> str:
+    abs_path = os.path.join(repo_root, rel_path)
+    if not os.path.exists(abs_path):
+        return ""
+    for encoding in ("utf-8", "utf-16", "latin-1"):
+        try:
+            with open(abs_path, "r", encoding=encoding) as handle:
+                return handle.read()
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+    return ""
+
+
+def strip_comments(text: str) -> str:
+    """Blank out comments and string bodies, preserving offsets and newlines.
+
+    Keeping length identical means every offset computed on the stripped text
+    still points at the right place in the original.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if ch == "/" and nxt == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+        elif ch == "/" and nxt == "*":
+            depth = 1
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i < n and depth:
+                if text[i] == "/" and i + 1 < n and text[i + 1] == "*":
+                    depth += 1
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    continue
+                if text[i] == "*" and i + 1 < n and text[i + 1] == "/":
+                    depth -= 1
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    continue
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+        elif ch == '"':
+            # Leave the quotes, blank the body: rules that look for string
+            # literals still see "" and can tell an empty label from a real one.
+            i += 1
+            while i < n and text[i] != '"':
+                if text[i] == "\\" and i + 1 < n:
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    continue
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            i += 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def line_text(text: str, line_no: int) -> str:
+    lines = text.splitlines()
+    if 1 <= line_no <= len(lines):
+        return lines[line_no - 1]
+    return ""
+
+
+def balanced_block(text: str, open_pos: int) -> Optional[int]:
+    """Given the offset of a '{', return the offset just past its '}'."""
+    if open_pos >= len(text) or text[open_pos] != "{":
+        return None
+    depth = 0
+    for i in range(open_pos, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
+
+
+def balanced_parens(text: str, open_pos: int) -> Optional[int]:
+    if open_pos >= len(text) or text[open_pos] != "(":
+        return None
+    depth = 0
+    for i in range(open_pos, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
+
+
+def modifier_tail(text: str, end_pos: int, max_chars: int = 700) -> str:
+    """The chained modifiers that follow a view expression."""
+    return text[end_pos:end_pos + max_chars]
+
+
+def suppressed(original: str, line_no: int, rule_id: str) -> bool:
+    """`// a11y-ignore: RULEID reason` on this line or the one above."""
+    for candidate in (line_no, line_no - 1):
+        raw = line_text(original, candidate)
+        match = re.search(r"a11y-ignore:\s*([A-Z0-9]+)\s+(\S.*)$", raw)
+        if match and match.group(1) == rule_id and match.group(2).strip():
+            return True
+    return False
+
+
+def add(findings: List[Finding], original: str, rule_id: str, path: str,
+        offset_or_line, snippet: str, detail: str = "",
+        text_for_offsets: Optional[str] = None) -> None:
+    if isinstance(offset_or_line, int) and text_for_offsets is not None:
+        line_no = line_of(text_for_offsets, offset_or_line)
+    else:
+        line_no = int(offset_or_line)
+    if suppressed(original, line_no, rule_id):
+        return
+    findings.append(Finding(rule_id, path, line_no, snippet, detail))
+
+
+# --------------------------------------------------------------------------
+# Rules — UIKit
+# --------------------------------------------------------------------------
+
+def _receiver_of_assignment(line: str) -> Optional[str]:
+    """`var item = UITabBarItem(...)` -> 'item'."""
+    match = re.search(r"(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=", line)
+    if match:
+        return match.group(1)
+    match = re.search(r"^\s*(?:self\.)?([A-Za-z_][A-Za-z0-9_]*)\s*=", line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _labeled_nearby(code: str, start: int, receiver: Optional[str],
+                    window: int = 1200) -> bool:
+    region = code[start:start + window]
+    if receiver:
+        if re.search(re.escape(receiver) + r"\s*\.\s*accessibilityLabel\s*=", region):
+            return True
+        # `item.accessibilityLabel = ...` may also be written via a helper
+        if re.search(re.escape(receiver) + r"\s*\.\s*isAccessibilityElement", region):
+            return True
+    return False
+
+
+def rule_tabbar(code: str, original: str, path: str,
+                findings: List[Finding]) -> None:
+    for match in re.finditer(r"UITabBarItem\s*\(", code):
+        open_paren = match.end() - 1
+        close = balanced_parens(code, open_paren)
+        if close is None:
+            continue
+        args = code[open_paren:close]
+        # A tab with a real title announces itself.
+        if has_real_title(args):
+            continue
+        line_no = line_of(code, match.start())
+        receiver = _receiver_of_assignment(line_text(original, line_no))
+        if _labeled_nearby(code, close, receiver):
+            continue
+        add(findings, original, "A11Y001", path, line_no,
+            line_text(original, line_no),
+            "title: nil and no accessibilityLabel — VoiceOver falls back to the "
+            "image asset name")
+
+
+def rule_barbuttonitem(code: str, original: str, path: str,
+                       findings: List[Finding]) -> None:
+    for match in re.finditer(r"UIBarButtonItem\s*\(", code):
+        open_paren = match.end() - 1
+        close = balanced_parens(code, open_paren)
+        if close is None:
+            continue
+        args = code[open_paren:close]
+        if "image" not in args and "customView" not in args:
+            continue
+        if has_real_title(args):
+            continue
+        if re.search(r"barButtonSystemItem\s*:", args):
+            continue  # system items are labeled by UIKit
+        line_no = line_of(code, match.start())
+        receiver = _receiver_of_assignment(line_text(original, line_no))
+        if _labeled_nearby(code, close, receiver):
+            continue
+        add(findings, original, "A11Y002", path, line_no,
+            line_text(original, line_no),
+            "image-only bar button with no accessibilityLabel")
+
+
+def rule_uibutton(code: str, original: str, path: str,
+                  findings: List[Finding]) -> None:
+    """UIButton that only ever gets an image, never a title or a label."""
+    for match in re.finditer(r"(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+                             r"UIButton\s*\(", code):
+        name = match.group(1)
+        region = code[match.end():match.end() + 1500]
+        sets_image = re.search(re.escape(name) + r"\s*\.\s*setImage\s*\(", region)
+        if not sets_image:
+            continue
+        sets_title = re.search(
+            re.escape(name) + r"\s*\.\s*(setTitle|setAttributedTitle)\s*\(", region)
+        if sets_title:
+            continue
+        if re.search(re.escape(name) + r"\s*\.\s*accessibilityLabel\s*=", region):
+            continue
+        line_no = line_of(code, match.start())
+        is_back = "back" in name.lower()
+        rule_id = "A11Y006" if is_back else "A11Y003"
+        detail = ("custom back button replaces UIKit's automatically labeled "
+                  "system back button" if is_back
+                  else "setImage without setTitle and without accessibilityLabel")
+        add(findings, original, rule_id, path, line_no,
+            line_text(original, line_no), detail)
+
+
+# --------------------------------------------------------------------------
+# Rules — SwiftUI
+# --------------------------------------------------------------------------
+
+def _block_speaks(block: str) -> bool:
+    return any(token in block for token in CONFIG.speaks_tokens())
+
+
+def _block_has_visual(block: str) -> bool:
+    return bool(re.search(r"\bImage\s*\(|\bIcon\s*\(|systemName\s*:|"
+                          r"\bCircle\s*\(|\bRoundedRectangle\s*\(", block))
+
+
+def _tail_escapes(tail: str) -> bool:
+    return any(token in tail for token in CONFIG.escape_tokens())
+
+
+def rule_swiftui_button(code: str, original: str, path: str,
+                        findings: List[Finding]) -> None:
+    for match in re.finditer(r"\bButton\s*(\(|\{)", code):
+        opener = match.end() - 1
+        if code[opener] == "(":
+            close_paren = balanced_parens(code, opener)
+            if close_paren is None:
+                continue
+            args = code[opener:close_paren]
+            # Button("Title", action:) announces its title.
+            if _block_speaks(args):
+                continue
+            brace = code.find("{", close_paren)
+            if brace == -1 or brace - close_paren > 4:
+                # No trailing closure: Button(action:) with no label body.
+                continue
+        else:
+            brace = opener
+        block_end = balanced_block(code, brace)
+        if block_end is None:
+            continue
+        block = code[brace:block_end]
+        if _block_speaks(block):
+            continue
+        if not _block_has_visual(block):
+            continue
+        tail = modifier_tail(code, block_end)
+        if _tail_escapes(tail):
+            continue
+        if _tail_escapes(block):
+            continue
+        line_no = line_of(code, match.start())
+        add(findings, original, "A11Y004", path, line_no,
+            line_text(original, line_no),
+            "button label is an image/shape with no text and no "
+            ".accessibilityLabel")
+
+
+def rule_toggle(code: str, original: str, path: str,
+                findings: List[Finding]) -> None:
+    for match in re.finditer(r"\bToggle\s*\(", code):
+        open_paren = match.end() - 1
+        close = balanced_parens(code, open_paren)
+        if close is None:
+            continue
+        args = code[open_paren:close]
+        if _block_speaks(args):
+            continue
+        brace = code.find("{", close)
+        empty_label = False
+        end_of_toggle = close
+        if brace != -1 and brace - close <= 3:
+            block_end = balanced_block(code, brace)
+            if block_end is not None:
+                block = code[brace + 1:block_end - 1]
+                end_of_toggle = block_end
+                if not block.strip():
+                    empty_label = True
+                elif not _block_speaks(block):
+                    empty_label = True
+        else:
+            # Toggle(isOn:) with no label argument at all
+            empty_label = '""' in args or "isOn" in args and not _block_speaks(args)
+        if not empty_label:
+            continue
+        tail = modifier_tail(code, end_of_toggle)
+        if _tail_escapes(tail):
+            continue
+        line_no = line_of(code, match.start())
+        add(findings, original, "A11Y005", path, line_no,
+            line_text(original, line_no),
+            "switch is announced with no indication of what it controls")
+
+
+def rule_tap_gesture(code: str, original: str, path: str,
+                     findings: List[Finding]) -> None:
+    """`.onTapGesture` with no accessibility treatment anywhere near it."""
+    for match in re.finditer(r"\.onTapGesture\s*(\{|\()", code):
+        # Look both ways: the modifier chain around this view.
+        before = code[max(0, match.start() - 900):match.start()]
+        opener = match.end() - 1
+        block_end = (balanced_block(code, opener) if code[opener] == "{"
+                     else balanced_parens(code, opener))
+        after_start = block_end if block_end else match.end()
+        after = code[after_start:after_start + 600]
+        if _tail_escapes(before) or _tail_escapes(after):
+            continue
+        # A tap gesture attached to something that already reads as text is a
+        # smaller problem than a bare icon, but still unreachable by trait.
+        line_no = line_of(code, match.start())
+        add(findings, original, "A11Y012", path, line_no,
+            line_text(original, line_no),
+            "tap target is invisible to VoiceOver — no button trait, no label")
+
+
+# --------------------------------------------------------------------------
+# Rules — Dynamic Type
+# --------------------------------------------------------------------------
+
+def rule_font_shadowing(code: str, original: str, path: str,
+                        findings: List[Finding]) -> None:
+    for match in re.finditer(r"extension\s+Font\b", code):
+        brace = code.find("{", match.end())
+        if brace == -1:
+            continue
+        block_end = balanced_block(code, brace)
+        if block_end is None:
+            continue
+        block = code[brace:block_end]
+        for decl in re.finditer(
+                r"static\s+(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*:", block):
+            name = decl.group(1)
+            if name not in SYSTEM_FONT_STYLES:
+                continue
+            if name in CONFIG.allowed_font_shadows:
+                continue
+            line_no = line_of(code, brace + decl.start())
+            add(findings, original, "A11Y008", path, line_no,
+                line_text(original, line_no),
+                "shadows SwiftUI's Font.{} — every .font(.{}) call in this "
+                "module silently stops scaling".format(name, name))
+
+
+def rule_fixed_font_size(code: str, original: str, path: str,
+                         findings: List[Finding]) -> None:
+    for match in re.finditer(r"\.system\s*\(\s*size\s*:", code):
+        close = balanced_parens(code, code.rindex("(", 0, match.end()))
+        args = code[match.start():close] if close else code[match.start():match.end() + 120]
+        if "relativeTo" in args:
+            continue
+        line_no = line_of(code, match.start())
+        add(findings, original, "A11Y007", path, line_no,
+            line_text(original, line_no),
+            "fixed point size with no relativeTo: — ignores the user's text size")
+
+
+# --------------------------------------------------------------------------
+# Rules — localization of the labels that do exist
+# --------------------------------------------------------------------------
+
+def load_en_strings(repo_root: str) -> Set[str]:
+    keys: Set[str] = set()
+    for rel in ("DashWallet/en.lproj/Localizable.strings",
+                "DashWallet/Base.lproj/Localizable.strings"):
+        content = read(repo_root, rel)
+        for match in re.finditer(r'^\s*"((?:[^"\\]|\\.)*)"\s*=', content,
+                                 re.MULTILINE):
+            keys.add(match.group(1))
+    return keys
+
+
+def rule_label_localization(original: str, path: str, en_keys: Set[str],
+                            findings: List[Finding]) -> None:
+    """Runs on the ORIGINAL text — string bodies matter here."""
+    for match in re.finditer(r"\.accessibilityLabel\s*\(", original):
+        open_paren = match.end() - 1
+        close = balanced_parens(original, open_paren)
+        if close is None:
+            continue
+        args = original[open_paren:close]
+        line_no = line_of(original, match.start())
+        if "NSLocalizedString" in args or "LocalizedStringKey" in args:
+            key = re.search(r'NSLocalizedString\s*\(\s*"((?:[^"\\]|\\.)*)"', args)
+            if key and en_keys and key.group(1) not in en_keys:
+                add(findings, original, "A11Y010", path, line_no,
+                    line_text(original, line_no),
+                    'key "{}" is not in en.lproj/Localizable.strings — ships '
+                    "untranslated".format(key.group(1)))
+            continue
+        if "verbatim:" in args:
+            continue  # deliberate, e.g. a currency ticker
+        if re.search(r'"\s*(?:[^"\\]|\\.)+\s*"', args):
+            add(findings, original, "A11Y009", path, line_no,
+                line_text(original, line_no),
+                "bare string literal — this label ships in English only")
+
+
+# --------------------------------------------------------------------------
+# Rules — Interface Builder
+# --------------------------------------------------------------------------
+
+IB_INTERACTIVE = ("<button", "<barButtonItem", "<segmentedControl", "<slider",
+                  "<switch", "<textField", "<searchBar", "<tabBarItem")
+
+
+def rule_interface_builder(content: str, path: str,
+                           findings: List[Finding]) -> None:
+    lines = content.splitlines()
+    for index, raw in enumerate(lines):
+        stripped = raw.strip()
+        if not any(stripped.startswith(tag) for tag in IB_INTERACTIVE):
+            continue
+        # Self-closing elements carry no children, so no accessibility node.
+        element_lines = [raw]
+        if not stripped.endswith("/>"):
+            depth_probe = index + 1
+            while depth_probe < len(lines) and depth_probe < index + 40:
+                element_lines.append(lines[depth_probe])
+                if lines[depth_probe].strip().startswith("</"):
+                    break
+                depth_probe += 1
+        blob = "\n".join(element_lines)
+        if "<accessibility" in blob and "label=" in blob:
+            continue
+        has_title = re.search(r'\stitle="[^"]+"|<state[^>]+title="[^"]+"', blob)
+        if has_title:
+            continue
+        has_image = re.search(r'image="[^"]+"', blob)
+        if not has_image:
+            continue
+        if suppressed(content, index + 1, "A11Y011"):
+            continue
+        findings.append(Finding("A11Y011", path, index + 1, stripped,
+                                "image-only control with no accessibility label "
+                                "in Interface Builder"))
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+def analyze(repo_root: str, roots: Sequence[str],
+            enabled: Optional[Set[str]]) -> List[Finding]:
+    findings: List[Finding] = []
+    en_keys = load_en_strings(repo_root)
+
+    def on(rule_id: str) -> bool:
+        if rule_id in CONFIG.disabled_rules:
+            return False
+        return enabled is None or rule_id in enabled
+
+    for rel in iter_files(repo_root, roots, (SWIFT_EXT,) + OBJC_EXTS):
+        if CONFIG.excluded(rel):
+            continue
+        original = read(repo_root, rel)
+        if not original:
+            continue
+        code = strip_comments(original)
+        if on("A11Y001"):
+            rule_tabbar(code, original, rel, findings)
+        if on("A11Y002"):
+            rule_barbuttonitem(code, original, rel, findings)
+        if on("A11Y003") or on("A11Y006"):
+            rule_uibutton(code, original, rel, findings)
+        if rel.endswith(SWIFT_EXT):
+            if on("A11Y004"):
+                rule_swiftui_button(code, original, rel, findings)
+            if on("A11Y005"):
+                rule_toggle(code, original, rel, findings)
+            if on("A11Y012"):
+                rule_tap_gesture(code, original, rel, findings)
+            if on("A11Y008"):
+                rule_font_shadowing(code, original, rel, findings)
+            if on("A11Y007"):
+                rule_fixed_font_size(code, original, rel, findings)
+        if on("A11Y009") or on("A11Y010"):
+            rule_label_localization(original, rel, en_keys, findings)
+
+    if on("A11Y011"):
+        for rel in iter_files(repo_root, roots, IB_EXTS):
+            if CONFIG.excluded(rel):
+                continue
+            content = read(repo_root, rel)
+            if content:
+                rule_interface_builder(content, rel, findings)
+
+    findings = [f for f in findings if f.rule_id not in CONFIG.disabled_rules]
+    if enabled is not None:
+        findings = [f for f in findings if f.rule_id in enabled]
+
+    findings.sort(key=lambda f: (SEVERITY_ORDER[f.severity], f.rule_id,
+                                 f.path, f.line))
+    return findings
+
+
+def load_baseline(repo_root: str, path: str) -> Optional[Set[Tuple[str, str, str]]]:
+    abs_path = os.path.join(repo_root, path)
+    if not os.path.exists(abs_path):
+        return None
+    with open(abs_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    return {(item["rule"], item["path"], item["fingerprint"])
+            for item in data.get("findings", [])}
+
+
+def write_baseline(repo_root: str, path: str,
+                   findings: List[Finding]) -> None:
+    abs_path = os.path.join(repo_root, path)
+    os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+    payload = {
+        "_comment": [
+            "Accepted accessibility debt, recorded by scripts/a11y_audit.py.",
+            "CI fails only on findings that are NOT in this list, so the debt",
+            "can shrink over time without blocking unrelated work.",
+            "Regenerate with: scripts/a11y_audit.py --write-baseline",
+        ],
+        "counts": dict(Counter(f.rule_id for f in findings)),
+        "total": len(findings),
+        "findings": [
+            {"rule": f.rule_id, "path": f.path, "fingerprint": f.fingerprint(),
+             "line_when_recorded": f.line, "snippet": f.snippet}
+            for f in findings
+        ],
+    }
+    with open(abs_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+        handle.write("\n")
+
+
+def print_report(findings: List[Finding], summary_only: bool) -> None:
+    by_rule = defaultdict(list)
+    for f in findings:
+        by_rule[f.rule_id].append(f)
+
+    print("Accessibility audit — dashwallet-ios")
+    print("=" * 72)
+    if not findings:
+        print("No findings.")
+        return
+
+    by_sev = Counter(f.severity for f in findings)
+    print("{} findings   P0={}  P1={}  P2={}".format(
+        len(findings), by_sev["P0"], by_sev["P1"], by_sev["P2"]))
+    print()
+    print("{:<9} {:<4} {:>6}  {}".format("RULE", "SEV", "COUNT", "TITLE"))
+    print("-" * 72)
+    for rule_id in sorted(by_rule, key=lambda r: (SEVERITY_ORDER[RULES[r].severity], r)):
+        rule = RULES[rule_id]
+        print("{:<9} {:<4} {:>6}  {}".format(
+            rule_id, rule.severity, len(by_rule[rule_id]), rule.title))
+
+    if summary_only:
+        return
+
+    for rule_id in sorted(by_rule, key=lambda r: (SEVERITY_ORDER[RULES[r].severity], r)):
+        rule = RULES[rule_id]
+        items = by_rule[rule_id]
+        print()
+        print("-" * 72)
+        print("{} [{}] {}  ({} findings)".format(
+            rule_id, rule.severity, rule.title, len(items)))
+        print("Fix: {}".format(rule.fix))
+        print("-" * 72)
+        shown = items[:40]
+        for f in shown:
+            print("  {}:{}".format(f.path, f.line))
+            if f.snippet:
+                print("      {}".format(f.snippet))
+            if f.detail:
+                print("      -> {}".format(f.detail))
+        if len(items) > len(shown):
+            print("  ... and {} more".format(len(items) - len(shown)))
+
+
+def print_github(findings: List[Finding]) -> None:
+    for f in findings:
+        level = "error" if f.severity == "P0" else "warning"
+        message = "{}: {}".format(RULES[f.rule_id].title, f.detail or f.snippet)
+        message = message.replace("\n", " ").replace("::", ":")
+        print("::{} file={},line={},title={}::{}".format(
+            level, f.path, f.line, f.rule_id, message))
+
+
+# --------------------------------------------------------------------------
+# Self-test
+# --------------------------------------------------------------------------
+
+def _analyze_source(source: str, path: str = "Fixture.swift",
+                    en_keys: Optional[Set[str]] = None) -> List[Finding]:
+    findings: List[Finding] = []
+    code = strip_comments(source)
+    rule_tabbar(code, source, path, findings)
+    rule_barbuttonitem(code, source, path, findings)
+    rule_uibutton(code, source, path, findings)
+    rule_swiftui_button(code, source, path, findings)
+    rule_toggle(code, source, path, findings)
+    rule_tap_gesture(code, source, path, findings)
+    rule_font_shadowing(code, source, path, findings)
+    rule_fixed_font_size(code, source, path, findings)
+    rule_label_localization(source, path, en_keys or set(), findings)
+    return findings
+
+
+# (rule id, should the rule fire, source)
+FIXTURES: List[Tuple[str, bool, str]] = [
+    # A11Y001 — tab bar
+    ("A11Y001", True,
+     'let item = UITabBarItem(title: nil, image: icon, selectedImage: sel)\n'),
+    ("A11Y001", False,
+     'let item = UITabBarItem(title: nil, image: icon, selectedImage: sel)\n'
+     'item.accessibilityLabel = NSLocalizedString("Home", comment: "")\n'),
+    ("A11Y001", False,
+     'let item = UITabBarItem(title: "Home", image: icon, selectedImage: sel)\n'),
+
+    # A11Y002 — bar button item
+    ("A11Y002", True,
+     'let b = UIBarButtonItem(image: img, style: .plain, target: self, action: nil)\n'),
+    ("A11Y002", False,
+     'let b = UIBarButtonItem(image: img, style: .plain, target: self, action: nil)\n'
+     'b.accessibilityLabel = NSLocalizedString("Notifications", comment: "")\n'),
+    ("A11Y002", False,
+     'let b = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: nil)\n'),
+
+    # A11Y003 / A11Y006 — UIButton
+    ("A11Y003", True,
+     'let infoButton = UIButton(type: .custom)\n'
+     'infoButton.setImage(UIImage(named: "info"), for: .normal)\n'),
+    ("A11Y003", False,
+     'let infoButton = UIButton(type: .custom)\n'
+     'infoButton.setImage(UIImage(named: "info"), for: .normal)\n'
+     'infoButton.setTitle("Info", for: .normal)\n'),
+    ("A11Y006", True,
+     'let backButton = UIButton(type: .custom)\n'
+     'backButton.setImage(UIImage(systemName: "arrow.backward"), for: .normal)\n'),
+
+    # A11Y004 — SwiftUI button
+    ("A11Y004", True,
+     'Button(action: onClose) {\n    Image(systemName: "xmark")\n}\n'),
+    ("A11Y004", False,
+     'Button(action: onClose) {\n    Image(systemName: "xmark")\n}\n'
+     '.accessibilityLabel(Text("Close"))\n'),
+    ("A11Y004", False,
+     'Button(action: onClose) {\n    Text("Close")\n}\n'),
+    ("A11Y004", False,
+     'Button("Close", action: onClose)\n'),
+    ("A11Y004", False,
+     'Button(action: onClose) {\n    Image(systemName: "xmark")\n'
+     '        .accessibilityHidden(true)\n}\n'
+     '.accessibilityLabel(Text("Close"))\n'),
+
+    # A11Y005 — toggle
+    ("A11Y005", True, 'Toggle(isOn: $on) { }\n'),
+    ("A11Y005", False, 'Toggle(isOn: $on) { Text("Enable Face ID") }\n'),
+    ("A11Y005", False, 'Toggle(isOn: $on) { }\n.accessibilityLabel(Text("Face ID"))\n'),
+
+    # A11Y007 — Dynamic Type
+    ("A11Y007", True, 'Text(x).font(.system(size: 15, weight: .medium))\n'),
+    ("A11Y007", False,
+     'Text(x).font(.system(size: 15, weight: .medium, relativeTo: .body))\n'),
+
+    # A11Y008 — font shadowing
+    ("A11Y008", True,
+     'extension Font {\n    public static let body: Font = .system(size: 17)\n}\n'),
+    ("A11Y008", False,
+     'extension Font {\n    public static let subhead: Font = .system(size: 15)\n}\n'),
+
+    # A11Y009 — unlocalized label
+    ("A11Y009", True, 'Image(x).accessibilityLabel("Close")\n'),
+    ("A11Y009", False,
+     'Image(x).accessibilityLabel(NSLocalizedString("Close", comment: ""))\n'),
+    ("A11Y009", False, 'Image(x).accessibilityLabel(Text(verbatim: "Dash"))\n'),
+
+    # A11Y012 — tap gesture
+    ("A11Y012", True, 'HStack { Text(name) }\n.onTapGesture { select() }\n'),
+    ("A11Y012", False,
+     'HStack { Text(name) }\n.accessibilityElement(children: .combine)\n'
+     '.onTapGesture { select() }\n'),
+
+    # Suppression comment
+    ("A11Y004", False,
+     '// a11y-ignore: A11Y004 decorative, the row above carries the label\n'
+     'Button(action: onClose) {\n    Image(systemName: "xmark")\n}\n'),
+
+    # Comments and strings must not trigger rules
+    ("A11Y001", False,
+     '// let item = UITabBarItem(title: nil, image: icon)\n'),
+    ("A11Y004", False,
+     'let doc = "Button(action: x) { Image(systemName: y) }"\n'),
+]
+
+
+def _config_fixtures() -> List[Tuple[str, bool, str, Dict[str, object]]]:
+    """(rule, should_fire, source, config) — the tuning knobs must actually work."""
+    icon_button = 'Button(action: x) {\n    Icon(name: .custom("icon_close"))\n}\n'
+    font_ext = ('extension Font {\n'
+                '    public static let body: Font = .system(size: 17)\n}\n')
+    wrapper_use = 'DashStepper(count: $n, onChange: f)\n'
+    return [
+        # A component listed in labeled_wrappers is treated as announced.
+        ("A11Y004", True, icon_button, {}),
+        ("A11Y004", False,
+         'Button(action: x) {\n    DashStepper(count: $n)\n}\n',
+         {"labeled_wrappers": ["DashStepper"]}),
+        ("A11Y004", False, wrapper_use, {}),
+        # A deliberately kept shadow can be allowed by name.
+        ("A11Y008", True, font_ext, {}),
+        ("A11Y008", False, font_ext, {"allowed_font_shadows": ["body"]}),
+        # Disabling a rule silences it entirely.
+        ("A11Y004", False, icon_button, {"disabled_rules": ["A11Y004"]}),
+    ]
+
+
+def self_test() -> int:
+    global CONFIG
+    failures = 0
+
+    for index, (rule_id, should_fire, source, cfg) in enumerate(
+            _config_fixtures(), 1):
+        saved = CONFIG
+        CONFIG = Config(cfg)
+        try:
+            found = [f for f in _analyze_source(source)
+                     if f.rule_id == rule_id
+                     and f.rule_id not in CONFIG.disabled_rules]
+        finally:
+            CONFIG = saved
+        if bool(found) != should_fire:
+            failures += 1
+            print("FAIL config#{:<2} {} with {} expected {}, got {}".format(
+                index, rule_id, cfg or "{}",
+                "a finding" if should_fire else "no finding",
+                len(found)))
+
+    for index, (rule_id, should_fire, source) in enumerate(FIXTURES, 1):
+        found = [f for f in _analyze_source(source) if f.rule_id == rule_id]
+        fired = bool(found)
+        if fired != should_fire:
+            failures += 1
+            print("FAIL #{:<2} {} expected {}, got {}".format(
+                index, rule_id,
+                "a finding" if should_fire else "no finding",
+                "{} finding(s)".format(len(found)) if fired else "none"))
+            for line in source.strip().splitlines():
+                print("         | {}".format(line))
+    total = len(FIXTURES) + len(_config_fixtures())
+    if failures:
+        print("\n{}/{} fixtures failed".format(failures, total))
+        return 1
+    print("All {} rule and config fixtures pass".format(total))
+    return 0
+
+
+def main(argv: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Static VoiceOver / Dynamic Type audit for dashwallet-ios.")
+    parser.add_argument("--repo-root", default=None,
+                        help="defaults to the git root of this script")
+    parser.add_argument("--path", action="append", default=None,
+                        help="limit the scan to these paths (repeatable)")
+    parser.add_argument("--rule", action="append", default=None,
+                        help="only run these rules (repeatable)")
+    parser.add_argument("--summary", action="store_true",
+                        help="counts per rule, no individual findings")
+    parser.add_argument("--json", metavar="FILE",
+                        help="write the findings as JSON")
+    parser.add_argument("--github", action="store_true",
+                        help="emit GitHub Actions annotations")
+    parser.add_argument("--baseline", default=BASELINE_PATH)
+    parser.add_argument("--config", default=CONFIG_PATH,
+                        help="project tuning file (optional)")
+    parser.add_argument("--write-baseline", action="store_true",
+                        help="record the current findings as accepted debt")
+    parser.add_argument("--check", action="store_true",
+                        help="exit 1 if a finding is not in the baseline")
+    parser.add_argument("--fail-on", default="P0,P1",
+                        help="severities that fail --check (default: P0,P1). "
+                             "New P2 findings are reported but do not block.")
+    parser.add_argument("--list-rules", action="store_true")
+    parser.add_argument("--self-test", action="store_true",
+                        help="run the rule fixtures and exit")
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if args.list_rules:
+        for rule_id in sorted(RULES, key=lambda r: (SEVERITY_ORDER[RULES[r].severity], r)):
+            rule = RULES[rule_id]
+            print("{:<9} {:<4} {}".format(rule_id, rule.severity, rule.title))
+            print("{:>14} {}".format("fix:", rule.fix))
+        return 0
+
+    repo_root = args.repo_root
+    if repo_root is None:
+        here = os.path.dirname(os.path.abspath(__file__))
+        repo_root = os.path.dirname(here)
+    repo_root = os.path.abspath(repo_root)
+
+    roots = args.path if args.path else SCAN_ROOTS
+    enabled = set(args.rule) if args.rule else None
+    if enabled:
+        unknown = enabled - set(RULES)
+        if unknown:
+            print("Unknown rule(s): {}".format(", ".join(sorted(unknown))),
+                  file=sys.stderr)
+            return 2
+
+    global CONFIG
+    CONFIG = load_config(repo_root, args.config)
+
+    findings = analyze(repo_root, roots, enabled)
+
+    if args.write_baseline:
+        write_baseline(repo_root, args.baseline, findings)
+        print("Wrote {} findings to {}".format(len(findings), args.baseline))
+        return 0
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as handle:
+            json.dump({"total": len(findings),
+                       "counts": dict(Counter(f.rule_id for f in findings)),
+                       "findings": [f.to_dict() for f in findings]},
+                      handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+
+    if args.check:
+        baseline = load_baseline(repo_root, args.baseline)
+        if baseline is None:
+            print("No baseline at {} — run --write-baseline first."
+                  .format(args.baseline), file=sys.stderr)
+            return 2
+        new = [f for f in findings if f.key() not in baseline]
+        current_keys = {f.key() for f in findings}
+        fixed = len(baseline - current_keys)
+
+        blocking_severities = {s.strip().upper()
+                               for s in args.fail_on.split(",") if s.strip()}
+        if "ALL" in blocking_severities:
+            blocking_severities = set(SEVERITY_ORDER)
+        def blocks(f: "Finding") -> bool:
+            if f.rule_id in CONFIG.advisory_rules:
+                return False
+            return f.severity in blocking_severities
+
+        blocking = [f for f in new if blocks(f)]
+        advisory = [f for f in new if not blocks(f)]
+
+        if args.github:
+            print_github(new)
+
+        for label, group in (("BLOCKING", blocking), ("advisory", advisory)):
+            if not group:
+                continue
+            print("{} — {} new accessibility finding(s):".format(
+                label, len(group)))
+            for f in group:
+                print("  [{}] {} {}:{}".format(
+                    f.severity, f.rule_id, f.path, f.line))
+                if f.detail:
+                    print("        {}".format(f.detail))
+                print("        fix: {}".format(RULES[f.rule_id].fix))
+            print()
+
+        if blocking:
+            print("If a finding is a deliberate exception, annotate the line:")
+            print("  // a11y-ignore: <RULE> <why>")
+            print("Never regenerate the baseline to silence a new finding.")
+            return 1
+
+        message = "No new blocking accessibility findings ({} known)".format(
+            len(findings))
+        if fixed:
+            message += " — {} baseline entr{} fixed, run --write-baseline " \
+                       "to bank the progress".format(
+                           fixed, "y" if fixed == 1 else "ies")
+        print(message)
+        return 0
+
+    if args.github:
+        print_github(findings)
+    else:
+        print_report(findings, args.summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/a11y_audit.py
+++ b/scripts/a11y_audit.py
@@ -203,7 +203,7 @@ class Finding:
         """Stable across line moves and reindentation, unlike a line number."""
         normalized = re.sub(r"\s+", "", self.snippet)
         payload = "{}|{}|{}".format(self.rule_id, self.path, normalized)
-        return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
     def key(self) -> Tuple[str, str, str]:
         return (self.rule_id, self.path, self.fingerprint())
@@ -343,9 +343,66 @@ def balanced_parens(text: str, open_pos: int) -> Optional[int]:
     return None
 
 
-def modifier_tail(text: str, end_pos: int, max_chars: int = 700) -> str:
-    """The chained modifiers that follow a view expression."""
-    return text[end_pos:end_pos + max_chars]
+def modifier_tail(text: str, end_pos: int, max_chars: int = 2000) -> str:
+    """Only the modifiers chained onto THIS expression.
+
+    A fixed character window would also swallow the next sibling view, so an
+    unrelated `.accessibilityLabel` further down the body could mask a real
+    finding. This walks `.name(...)`/`.name { ... }` segments and stops at the
+    first token that is not part of the chain.
+    """
+    limit = min(len(text), end_pos + max_chars)
+    collected: List[str] = []
+    i = end_pos
+    while i < limit:
+        j = i
+        while j < limit and text[j] in " \t\r\n":
+            j += 1
+        if j >= limit or text[j] != ".":
+            break
+        k = j + 1
+        while k < limit and (text[k].isalnum() or text[k] == "_"):
+            k += 1
+        if k == j + 1:            # a lone dot, not a modifier
+            break
+        end = k
+        while end < limit:        # consume (...) and/or { ... }
+            m = end
+            while m < limit and text[m] in " \t":
+                m += 1
+            if m < limit and text[m] == "(":
+                close = balanced_parens(text, m)
+                if close is None:
+                    return "".join(collected)
+                end = close
+                continue
+            if m < limit and text[m] == "{":
+                close = balanced_block(text, m)
+                if close is None:
+                    return "".join(collected)
+                end = close
+                continue
+            break
+        collected.append(text[j:end])
+        i = end
+    return "".join(collected)
+
+
+def modifier_chain_before(code: str, offset: int) -> str:
+    """The part of this expression that precedes `offset`.
+
+    Walks back over lines that are continuation modifiers (`.foo(...)`) and
+    stops at the line that starts the expression, so a neighbouring view's
+    accessibility modifier cannot suppress a finding.
+    """
+    lines = code.splitlines()
+    index = line_of(code, offset) - 1
+    if index < 0 or index >= len(lines):
+        return ""
+    start = index
+    while start > 0 and lines[start].lstrip().startswith("."):
+        start -= 1
+    return "\n".join(lines[start:index + 1])
 
 
 def suppressed(original: str, line_no: int, rule_id: str) -> bool:
@@ -562,13 +619,13 @@ def rule_tap_gesture(code: str, original: str, path: str,
                      findings: List[Finding]) -> None:
     """`.onTapGesture` with no accessibility treatment anywhere near it."""
     for match in re.finditer(r"\.onTapGesture\s*(\{|\()", code):
-        # Look both ways: the modifier chain around this view.
-        before = code[max(0, match.start() - 900):match.start()]
+        # Look both ways along THIS expression's modifier chain only.
+        before = modifier_chain_before(code, match.start())
         opener = match.end() - 1
         block_end = (balanced_block(code, opener) if code[opener] == "{"
                      else balanced_parens(code, opener))
         after_start = block_end if block_end else match.end()
-        after = code[after_start:after_start + 600]
+        after = modifier_tail(code, after_start)
         if _tail_escapes(before) or _tail_escapes(after):
             continue
         # A tap gesture attached to something that already reads as text is a
@@ -759,14 +816,34 @@ def analyze(repo_root: str, roots: Sequence[str],
     return findings
 
 
-def load_baseline(repo_root: str, path: str) -> Optional[Set[Tuple[str, str, str]]]:
-    abs_path = os.path.join(repo_root, path)
-    if not os.path.exists(abs_path):
+def load_baseline(path: str) -> Optional["Counter"]:
+    """Accepted debt as a multiset.
+
+    Counting matters: two identical unlabeled buttons in one file share a
+    fingerprint, so a set would let a third copy in unnoticed. With counts, only
+    the excess over what was recorded is treated as new.
+    """
+    if not os.path.exists(path):
         return None
-    with open(abs_path, "r", encoding="utf-8") as handle:
+    with open(path, "r", encoding="utf-8") as handle:
         data = json.load(handle)
-    return {(item["rule"], item["path"], item["fingerprint"])
-            for item in data.get("findings", [])}
+    return Counter((item["rule"], item["path"], item["fingerprint"])
+                   for item in data.get("findings", []))
+
+
+def new_findings(findings: List[Finding],
+                 baseline: "Counter") -> Tuple[List[Finding], int]:
+    """Findings beyond the recorded count, plus how many entries were fixed."""
+    allowance = Counter(baseline)
+    new: List[Finding] = []
+    for finding in findings:
+        key = finding.key()
+        if allowance.get(key, 0) > 0:
+            allowance[key] -= 1
+        else:
+            new.append(finding)
+    fixed = sum(count for count in allowance.values() if count > 0)
+    return new, fixed
 
 
 def write_baseline(repo_root: str, path: str,
@@ -947,6 +1024,23 @@ FIXTURES: List[Tuple[str, bool, str]] = [
      '// a11y-ignore: A11Y004 decorative, the row above carries the label\n'
      'Button(action: onClose) {\n    Image(systemName: "xmark")\n}\n'),
 
+    # A sibling view's accessibility modifier must not suppress this one.
+    ("A11Y004", True,
+     'VStack {\n'
+     '    Button(action: a) { Image(systemName: "x") }\n'
+     '    Text("hi").accessibilityLabel(Text("y"))\n'
+     '}\n'),
+    ("A11Y012", True,
+     'VStack {\n'
+     '    Text("a").accessibilityElement(children: .combine)\n'
+     '    Text(name).onTapGesture { select() }\n'
+     '}\n'),
+    # ...but a modifier on the same chain still counts.
+    ("A11Y004", False,
+     'Button(action: a) { Image(systemName: "x") }\n'
+     '    .padding(4)\n'
+     '    .accessibilityLabel(Text("Close"))\n'),
+
     # Comments and strings must not trigger rules
     ("A11Y001", False,
      '// let item = UITabBarItem(title: nil, image: icon)\n'),
@@ -976,9 +1070,52 @@ def _config_fixtures() -> List[Tuple[str, bool, str, Dict[str, object]]]:
     ]
 
 
+def _baseline_fixtures() -> List[Tuple[str, int, int]]:
+    """(label, expected_new, expected_fixed) for the multiset matcher."""
+    return []
+
+
+def _run_baseline_fixtures() -> int:
+    """Two identical findings must not be covered by one baseline entry."""
+    failures = 0
+    source = ('VStack {\n'
+              '    Button(action: a) { Image(systemName: "x") }\n'
+              '    Button(action: a) { Image(systemName: "x") }\n'
+              '}\n')
+    findings = [f for f in _analyze_source(source) if f.rule_id == "A11Y004"]
+    if len(findings) != 2:
+        print("FAIL baseline#1 expected 2 identical findings, got {}"
+              .format(len(findings)))
+        return 1
+    if findings[0].key() != findings[1].key():
+        print("FAIL baseline#2 fixture no longer produces a shared key")
+        return 1
+
+    one_recorded = Counter([findings[0].key()])
+    new, fixed = new_findings(findings, one_recorded)
+    if len(new) != 1 or fixed != 0:
+        failures += 1
+        print("FAIL baseline#3 one baselined + one new: expected 1 new/0 fixed,"
+              " got {} new/{} fixed".format(len(new), fixed))
+
+    both_recorded = Counter([findings[0].key(), findings[1].key()])
+    new, fixed = new_findings(findings, both_recorded)
+    if new or fixed:
+        failures += 1
+        print("FAIL baseline#4 both baselined: expected 0 new/0 fixed, got "
+              "{} new/{} fixed".format(len(new), fixed))
+
+    new, fixed = new_findings([findings[0]], both_recorded)
+    if new or fixed != 1:
+        failures += 1
+        print("FAIL baseline#5 one fixed: expected 0 new/1 fixed, got "
+              "{} new/{} fixed".format(len(new), fixed))
+    return failures
+
+
 def self_test() -> int:
     global CONFIG
-    failures = 0
+    failures = _run_baseline_fixtures()
 
     for index, (rule_id, should_fire, source, cfg) in enumerate(
             _config_fixtures(), 1):
@@ -1008,11 +1145,11 @@ def self_test() -> int:
                 "{} finding(s)".format(len(found)) if fired else "none"))
             for line in source.strip().splitlines():
                 print("         | {}".format(line))
-    total = len(FIXTURES) + len(_config_fixtures())
+    total = len(FIXTURES) + len(_config_fixtures()) + 5
     if failures:
         print("\n{}/{} fixtures failed".format(failures, total))
         return 1
-    print("All {} rule and config fixtures pass".format(total))
+    print("All {} rule, config and baseline fixtures pass".format(total))
     return 0
 
 
@@ -1090,14 +1227,17 @@ def main(argv: Sequence[str]) -> int:
             handle.write("\n")
 
     if args.check:
-        baseline = load_baseline(repo_root, args.baseline)
+        baseline_path = args.baseline
+        if not os.path.isabs(baseline_path):
+            candidate = os.path.join(repo_root, baseline_path)
+            baseline_path = candidate if os.path.exists(candidate) \
+                else baseline_path
+        baseline = load_baseline(baseline_path)
         if baseline is None:
             print("No baseline at {} — run --write-baseline first."
                   .format(args.baseline), file=sys.stderr)
             return 2
-        new = [f for f in findings if f.key() not in baseline]
-        current_keys = {f.key() for f in findings}
-        fixed = len(baseline - current_keys)
+        new, fixed = new_findings(findings, baseline)
 
         blocking_severities = {s.strip().upper()
                                for s in args.fail_on.split(",") if s.strip()}

--- a/scripts/a11y_audit.py
+++ b/scripts/a11y_audit.py
@@ -602,6 +602,10 @@ def rule_swiftui_button(code: str, original: str, path: str,
             if "label" not in args and _block_speaks(args):
                 continue
 
+        # For `Button(action:, label: { ... })` the label block ends INSIDE the
+        # parens, so the modifier chain has to be scanned from the end of the
+        # whole expression — otherwise a chained .accessibilityLabel is missed.
+        expr_end = balanced_parens(code, opener) if code[opener] == "(" else None
         located = _label_block(code, opener)
         if located is None:
             continue
@@ -613,7 +617,8 @@ def rule_swiftui_button(code: str, original: str, path: str,
             continue
         if _tail_escapes(block):
             continue
-        if _tail_escapes(modifier_tail(code, block_end)):
+        tail_start = max(block_end, expr_end) if expr_end else block_end
+        if _tail_escapes(modifier_tail(code, tail_start)):
             continue
         line_no = line_of(code, match.start())
         add(findings, original, "A11Y004", path, line_no,
@@ -1082,6 +1087,16 @@ FIXTURES: List[Tuple[str, bool, str]] = [
     ("A11Y004", False,
      'Button { act() } label: {\n    Image(systemName: "xmark")\n}\n'
      '.accessibilityLabel(Text("Close"))\n'),
+
+    # A chained .accessibilityLabel must be seen on every form, including the
+    # one whose label block closes inside the parentheses.
+    ("A11Y004", False,
+     'Button(action: a, label: { Image(systemName: "x") })\n'
+     '.accessibilityLabel(Text("Close"))\n'),
+    ("A11Y004", False,
+     'Button(action: a, label: { Image(systemName: "x") })\n'
+     '    .padding(4)\n'
+     '    .accessibilityLabel(Text("Close"))\n'),
 
     # A label given as a plain string literal is a real label: masking string
     # bodies must not turn it into an empty one.

--- a/scripts/a11y_audit.py
+++ b/scripts/a11y_audit.py
@@ -286,16 +286,18 @@ def strip_comments(text: str) -> str:
                     out[i] = " "
                 i += 1
         elif ch == '"':
-            # Leave the quotes, blank the body: rules that look for string
-            # literals still see "" and can tell an empty label from a real one.
+            # Mask the body with 'x' rather than spaces, so a non-empty literal
+            # stays visibly non-empty: blanking turned Toggle("Wi-Fi", isOn:)
+            # into Toggle("", isOn:) and reported a correctly labeled control.
+            # Only a genuinely empty literal survives as "".
             i += 1
             while i < n and text[i] != '"':
                 if text[i] == "\\" and i + 1 < n:
-                    out[i] = out[i + 1] = " "
+                    out[i] = out[i + 1] = "x"
                     i += 2
                     continue
                 if text[i] != "\n":
-                    out[i] = " "
+                    out[i] = "x"
                 i += 1
             i += 1
         else:
@@ -541,6 +543,50 @@ def _tail_escapes(tail: str) -> bool:
     return any(token in tail for token in CONFIG.escape_tokens())
 
 
+def _has_string_title(args: str) -> bool:
+    """Button("Title", action:) — a leading non-empty string literal."""
+    return re.match(r'\(\s*"[^"]', args) is not None
+
+
+def _label_block(code: str, opener: int) -> Optional[Tuple[int, int]]:
+    """Locate the closure that provides a Button's LABEL, not its action.
+
+    Handles every form we use:
+      Button(action: x) { Image(...) }            trailing closure is the label
+      Button { x } label: { Image(...) }          second closure is the label
+      Button(action: x, label: { Image(...) })    label lives inside the parens
+    Returns (block_start, block_end) or None.
+    """
+    if code[opener] == "(":
+        close_paren = balanced_parens(code, opener)
+        if close_paren is None:
+            return None
+        args = code[opener:close_paren]
+        # label: { ... } passed as an argument
+        label_arg = re.search(r"\blabel\s*:\s*\{", args)
+        if label_arg:
+            brace = opener + label_arg.end() - 1
+            end = balanced_block(code, brace)
+            return (brace, end) if end else None
+        brace = code.find("{", close_paren)
+        if brace == -1 or brace - close_paren > 4:
+            return None
+        end = balanced_block(code, brace)
+        return (brace, end) if end else None
+
+    # Button { ... } — could be the label, or the action of a two-closure form.
+    first_end = balanced_block(code, opener)
+    if first_end is None:
+        return None
+    following = code[first_end:first_end + 40]
+    second = re.match(r"\s*label\s*:\s*\{", following)
+    if second:
+        brace = first_end + second.end() - 1
+        end = balanced_block(code, brace)
+        return (brace, end) if end else None
+    return (opener, first_end)
+
+
 def rule_swiftui_button(code: str, original: str, path: str,
                         findings: List[Finding]) -> None:
     for match in re.finditer(r"\bButton\s*(\(|\{)", code):
@@ -550,27 +596,24 @@ def rule_swiftui_button(code: str, original: str, path: str,
             if close_paren is None:
                 continue
             args = code[opener:close_paren]
-            # Button("Title", action:) announces its title.
-            if _block_speaks(args):
+            if _has_string_title(args):
                 continue
-            brace = code.find("{", close_paren)
-            if brace == -1 or brace - close_paren > 4:
-                # No trailing closure: Button(action:) with no label body.
+            # Button(action:) with a Text label inside the parens
+            if "label" not in args and _block_speaks(args):
                 continue
-        else:
-            brace = opener
-        block_end = balanced_block(code, brace)
-        if block_end is None:
+
+        located = _label_block(code, opener)
+        if located is None:
             continue
+        brace, block_end = located
         block = code[brace:block_end]
         if _block_speaks(block):
             continue
         if not _block_has_visual(block):
             continue
-        tail = modifier_tail(code, block_end)
-        if _tail_escapes(tail):
-            continue
         if _tail_escapes(block):
+            continue
+        if _tail_escapes(modifier_tail(code, block_end)):
             continue
         line_no = line_of(code, match.start())
         add(findings, original, "A11Y004", path, line_no,
@@ -587,27 +630,29 @@ def rule_toggle(code: str, original: str, path: str,
         if close is None:
             continue
         args = code[open_paren:close]
+
+        # Toggle("Wi-Fi", isOn:) — the title argument is the label.
+        if _has_string_title(args):
+            continue
         if _block_speaks(args):
             continue
-        brace = code.find("{", close)
-        empty_label = False
+
         end_of_toggle = close
+        brace = code.find("{", close)
         if brace != -1 and brace - close <= 3:
             block_end = balanced_block(code, brace)
-            if block_end is not None:
-                block = code[brace + 1:block_end - 1]
-                end_of_toggle = block_end
-                if not block.strip():
-                    empty_label = True
-                elif not _block_speaks(block):
-                    empty_label = True
-        else:
-            # Toggle(isOn:) with no label argument at all
-            empty_label = '""' in args or "isOn" in args and not _block_speaks(args)
-        if not empty_label:
+            if block_end is None:
+                continue
+            end_of_toggle = block_end
+            block = code[brace + 1:block_end - 1]
+            if block.strip() and _block_speaks(block):
+                continue
+            # An empty or purely visual label closure announces nothing.
+        elif not re.search(r"\bisOn\s*:", args):
+            # Not the labelled initialiser we care about.
             continue
-        tail = modifier_tail(code, end_of_toggle)
-        if _tail_escapes(tail):
+
+        if _tail_escapes(modifier_tail(code, end_of_toggle)):
             continue
         line_no = line_of(code, match.start())
         add(findings, original, "A11Y005", path, line_no,
@@ -1023,6 +1068,27 @@ FIXTURES: List[Tuple[str, bool, str]] = [
     ("A11Y004", False,
      '// a11y-ignore: A11Y004 decorative, the row above carries the label\n'
      'Button(action: onClose) {\n    Image(systemName: "xmark")\n}\n'),
+
+    # Every Button label-closure form must be inspected, not just the
+    # trailing-closure one.
+    ("A11Y004", True,
+     'Button { act() } label: {\n    Image(systemName: "xmark")\n}\n'),
+    ("A11Y004", False,
+     'Button { act() } label: {\n    Text("Close")\n}\n'),
+    ("A11Y004", True,
+     'Button(action: act, label: {\n    Image(systemName: "xmark")\n})\n'),
+    ("A11Y004", False,
+     'Button(action: act, label: {\n    Text("Close")\n})\n'),
+    ("A11Y004", False,
+     'Button { act() } label: {\n    Image(systemName: "xmark")\n}\n'
+     '.accessibilityLabel(Text("Close"))\n'),
+
+    # A label given as a plain string literal is a real label: masking string
+    # bodies must not turn it into an empty one.
+    ("A11Y005", False, 'Toggle("Wi-Fi", isOn: $enabled)\n'),
+    ("A11Y005", False, 'Toggle("Wi-Fi", isOn: $enabled) { }\n'),
+    ("A11Y005", True, 'Toggle("", isOn: $enabled)\n'),
+    ("A11Y004", False, 'Button("Close", action: act)\n'),
 
     # A sibling view's accessibility modifier must not suppress this one.
     ("A11Y004", True,

--- a/scripts/a11y_baseline.json
+++ b/scripts/a11y_baseline.json
@@ -9,4613 +9,4627 @@
     "A11Y008": 8,
     "A11Y002": 10,
     "A11Y003": 1,
-    "A11Y004": 30,
+    "A11Y004": 31,
     "A11Y005": 1,
     "A11Y006": 2,
     "A11Y009": 2,
     "A11Y010": 3,
     "A11Y011": 11,
-    "A11Y012": 30,
+    "A11Y012": 31,
     "A11Y007": 559
   },
-  "total": 657,
+  "total": 659,
   "findings": [
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "84144361824789ed",
+      "fingerprint": "55cddf6569c3f0fd",
       "line_when_recorded": 24,
       "snippet": "public static let largeTitle: Font = .system(size: 34, weight: .bold)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "809e21b4ebdef45d",
+      "fingerprint": "e3969c337298aa46",
       "line_when_recorded": 30,
       "snippet": "public static let title2: Font = .system(size: 22, weight: .bold)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "33631dcce2e417b2",
+      "fingerprint": "985e585d87ca1bbc",
       "line_when_recorded": 33,
       "snippet": "public static let title3: Font = .system(size: 20, weight: .bold)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "58e68dd11ff6fcd2",
+      "fingerprint": "7b05c3648c6a85a7",
       "line_when_recorded": 41,
       "snippet": "public static let headline: Font = .system(size: 17, weight: .bold)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "6aad66c68311c82d",
+      "fingerprint": "6e16fae6e849a20c",
       "line_when_recorded": 44,
       "snippet": "public static let body: Font = .system(size: 17, weight: .regular)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "25461bc4e19d3a67",
+      "fingerprint": "758d7acf9829e496",
       "line_when_recorded": 47,
       "snippet": "public static let callout: Font = .system(size: 16, weight: .regular)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "d78b42282c6327c1",
+      "fingerprint": "2f1df0cf86a647d9",
       "line_when_recorded": 59,
       "snippet": "public static let footnote: Font = .system(size: 13, weight: .regular)"
     },
     {
       "rule": "A11Y008",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "9399897f3ba8d951",
+      "fingerprint": "1671c5bcbd154fd8",
       "line_when_recorded": 68,
       "snippet": "public static let caption2: Font = .system(size: 11, weight: .regular)"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
-      "fingerprint": "d4e5d5705b3b7865",
+      "fingerprint": "3ed4ba51690bb49c",
       "line_when_recorded": 115,
       "snippet": "navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
-      "fingerprint": "d5fb2fe8cef6e430",
+      "fingerprint": "67615e7739843196",
       "line_when_recorded": 121,
       "snippet": "let button = UIBarButtonItem(image: buttonImage, style: UIBarButtonItem.Style.plain, target: self, action: #selector(infoButtonAction))"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
-      "fingerprint": "baade693e219e86b",
+      "fingerprint": "4bb2185ad4a0f040",
       "line_when_recorded": 405,
       "snippet": "let appliedFilters = UIBarButtonItem(customView: appliedFiltersStackView)"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
-      "fingerprint": "c7dd6b33b822fa89",
+      "fingerprint": "fcf8294f9f7cd1ba",
       "line_when_recorded": 406,
       "snippet": "let filter = UIBarButtonItem(image: .init(systemName: \"line.3.horizontal.decrease.circle.fill\"), style: .plain,"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
-      "fingerprint": "a39c4dd0b02ca581",
+      "fingerprint": "0bd82e6c5f6f1178",
       "line_when_recorded": 410,
       "snippet": "let fakeFilter = UIBarButtonItem(image: .init(systemName: \"line.3.horizontal.decrease.circle.fill\"), style: .plain,"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift",
-      "fingerprint": "7609009204e51cf1",
+      "fingerprint": "8bb40207ed9bd203",
       "line_when_recorded": 413,
       "snippet": "infoButton = UIBarButtonItem(image: infoImage, style: .plain, target: self, action: #selector(infoButtonAction))"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Home/HomeViewController.swift",
-      "fingerprint": "b5d8e9956bd12717",
+      "fingerprint": "b5cdaeaa9868e904",
       "line_when_recorded": 201,
       "snippet": "let notificationButton = UIBarButtonItem(image: notificationsImage, style: .plain, target: self, action: #selector(notificationAction))"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Home/HomeViewController.swift",
-      "fingerprint": "ebd65e8d9018fa1f",
+      "fingerprint": "318267e4fe1724b1",
       "line_when_recorded": 265,
       "snippet": "let avatarButton = UIBarButtonItem(customView: avatarView)"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Views/BaseController/ActionButtonViewController.swift",
-      "fingerprint": "6f9ea5c48f770b44",
+      "fingerprint": "64d20f1c746d8531",
       "line_when_recorded": 80,
       "snippet": "let barButtonItem = UIBarButtonItem(customView: activityIndicator)"
     },
     {
       "rule": "A11Y002",
       "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
-      "fingerprint": "7bfea68d64b4670a",
+      "fingerprint": "6ab921512e79bf0f",
       "line_when_recorded": 182,
       "snippet": "let item = UIBarButtonItem(customView: backButton)"
     },
     {
       "rule": "A11Y003",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift",
-      "fingerprint": "89ee65e07c6d997c",
+      "fingerprint": "3fa24af41dd6e897",
       "line_when_recorded": 355,
       "snippet": "let myLocationButton = UIButton(type: .custom)"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "009e4095a4d81052",
+      "fingerprint": "603d89e57095d24b",
       "line_when_recorded": 842,
       "snippet": "Button(action: action) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/VerifyIdentityScreen.swift",
-      "fingerprint": "ee77ca9025da8d06",
+      "fingerprint": "5a68fd8a1691e7da",
       "line_when_recorded": 63,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift",
-      "fingerprint": "84301d0300925c1f",
+      "fingerprint": "1335e56c9c9b970a",
       "line_when_recorded": 70,
       "snippet": "Button(action: onClose) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "5e7e3f2cb094defe",
+      "fingerprint": "2acbaa62dc8d8d70",
       "line_when_recorded": 210,
       "snippet": "Button(action: directionAction) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift",
-      "fingerprint": "900e00a721ab69b5",
+      "fingerprint": "85b6512ade71522c",
       "line_when_recorded": 123,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
-      "fingerprint": "42faa08080b47ad5",
+      "fingerprint": "51d843969884a0ec",
       "line_when_recorded": 37,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
-      "fingerprint": "74154c279d5c7aae",
+      "fingerprint": "a198e7d6657226d9",
       "line_when_recorded": 81,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsInfoCard.swift",
-      "fingerprint": "72248ae40da4edfa",
+      "fingerprint": "62e96f3514fcec54",
       "line_when_recorded": 209,
       "snippet": "Button(action: onCopy) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0defbdba85142afb",
+      "fingerprint": "6959c08ee2fb80f6",
       "line_when_recorded": 119,
       "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0defbdba85142afb",
+      "fingerprint": "6959c08ee2fb80f6",
       "line_when_recorded": 424,
       "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
-      "fingerprint": "9973c8027a37796c",
+      "fingerprint": "ad0dd1a56a19022f",
       "line_when_recorded": 95,
       "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
     },
     {
       "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "04a63d269b6275ba",
+      "line_when_recorded": 228,
+      "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
+    },
+    {
+      "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "e28ac9d78d9b4361",
+      "fingerprint": "918c29efd330abe2",
       "line_when_recorded": 144,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "141c4ce5af723be1",
+      "fingerprint": "718b3834df63f632",
       "line_when_recorded": 43,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "934f5ceac27db560",
+      "fingerprint": "1aec3b3f7825792d",
       "line_when_recorded": 195,
       "snippet": "Button(action: { UIPasteboard.general.string = addr.address }) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "aeecd142cce9e6b0",
+      "fingerprint": "ab8fcd8b4d695e3d",
       "line_when_recorded": 37,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "5dc99df382b60ffb",
+      "fingerprint": "560baec496958611",
       "line_when_recorded": 86,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "5dc99df382b60ffb",
+      "fingerprint": "560baec496958611",
       "line_when_recorded": 301,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift",
-      "fingerprint": "03e7e9f74095825b",
+      "fingerprint": "2cae16ec45fd2585",
       "line_when_recorded": 236,
       "snippet": "Button(action: popRoot) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift",
-      "fingerprint": "f84c69b86412d8e5",
+      "fingerprint": "29d05529e916004c",
       "line_when_recorded": 102,
       "snippet": "Button(action: { loadCounts() }) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift",
-      "fingerprint": "6c7e2ee173df03f8",
+      "fingerprint": "0bc340276de2bdfc",
       "line_when_recorded": 259,
       "snippet": "Button(action: popRoot) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift",
-      "fingerprint": "6c7e2ee173df03f8",
+      "fingerprint": "0bc340276de2bdfc",
       "line_when_recorded": 275,
       "snippet": "Button(action: popRoot) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "08b7fc2fb4037212",
+      "fingerprint": "2571406d144c14c4",
       "line_when_recorded": 109,
       "snippet": "Button(action: onClose) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "a1c9d3de8022efc3",
+      "fingerprint": "c8e2182d66463e6f",
       "line_when_recorded": 87,
       "snippet": "Button(action: onClose) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "3ddfd8b898b8480f",
+      "fingerprint": "d4fd4876589ed8d5",
       "line_when_recorded": 588,
       "snippet": "Button(action: onBack) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
-      "fingerprint": "0143fd4144df14a0",
+      "fingerprint": "098ae243c9f1f45c",
       "line_when_recorded": 61,
       "snippet": "Button(action: { torchOn.toggle() }) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "c2ea76f6cd01c31f",
+      "fingerprint": "099a421bad6a3019",
       "line_when_recorded": 152,
       "snippet": "Button(action: onBack) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "c2ea76f6cd01c31f",
+      "fingerprint": "099a421bad6a3019",
       "line_when_recorded": 211,
       "snippet": "Button(action: onBack) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "6833995482ae652e",
+      "fingerprint": "7690c023535454ae",
       "line_when_recorded": 233,
       "snippet": "Button(action: onAdd) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "a7dc9971f9cf05c0",
+      "fingerprint": "07fa3ed86b3e1f10",
       "line_when_recorded": 287,
       "snippet": "Button(action: onClose) {"
     },
     {
       "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift",
-      "fingerprint": "04a22d3697ea388b",
+      "fingerprint": "e5251255b9f564fd",
       "line_when_recorded": 69,
       "snippet": "Button(action: {"
     },
     {
       "rule": "A11Y005",
       "path": "DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift",
-      "fingerprint": "3ea1f401f0b12c36",
+      "fingerprint": "34bcf206edfe454d",
       "line_when_recorded": 232,
       "snippet": "Toggle(isOn: $isToggled) { }"
     },
     {
       "rule": "A11Y006",
       "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
-      "fingerprint": "67c208cbce08b390",
+      "fingerprint": "78003431c215cd98",
       "line_when_recorded": 109,
       "snippet": "let backButton = UIButton(type: .custom)"
     },
     {
       "rule": "A11Y006",
       "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
-      "fingerprint": "4423c686f217929f",
+      "fingerprint": "6ee73a8d95d7ac7f",
       "line_when_recorded": 177,
       "snippet": "let backButton = UIButton(type: .custom)"
     },
     {
       "rule": "A11Y009",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift",
-      "fingerprint": "5cd54c554ab5a556",
+      "fingerprint": "2541ada9449b0441",
       "line_when_recorded": 151,
       "snippet": ".accessibilityLabel(Text(\"Refresh from Platform\"))"
     },
     {
       "rule": "A11Y009",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
-      "fingerprint": "454683cec5a6c99c",
+      "fingerprint": "4d1e3547449ff9a1",
       "line_when_recorded": 116,
       "snippet": ".accessibilityLabel(Text(\"Refresh from Platform\"))"
     },
     {
       "rule": "A11Y010",
       "path": "DashWallet/Sources/UI/DashConnect/Components/ConnectionRow.swift",
-      "fingerprint": "02df12e2f7227b32",
+      "fingerprint": "45091151e31466bb",
       "line_when_recorded": 105,
       "snippet": ".accessibilityLabel(Text(NSLocalizedString(\"Disconnect\", comment: \"DashConnect\")))"
     },
     {
       "rule": "A11Y010",
       "path": "DashWallet/Sources/UI/Home/Views/HomeUsernameRow.swift",
-      "fingerprint": "fc20a8f3918a7567",
+      "fingerprint": "e09d553d2f272598",
       "line_when_recorded": 31,
       "snippet": ".accessibilityLabel(Text(String(format: NSLocalizedString(\"My profile, %@\", comment: \"Home — persistent username row accessibility label\"), username)))"
     },
     {
       "rule": "A11Y010",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "6050298251b9e842",
+      "fingerprint": "5bfbc9b927bdbd04",
       "line_when_recorded": 838,
       "snippet": ".accessibilityLabel(Text(NSLocalizedString(\"Refresh keys from Platform\", comment: \"Identities: re-fetch this identity's public keys\")))"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/Buy Sell/BuySellPortal.storyboard",
-      "fingerprint": "b09336b2b50985cf",
+      "fingerprint": "44a773501b7623af",
       "line_when_recorded": 315,
       "snippet": "<barButtonItem key=\"rightBarButtonItem\" id=\"hlH-Nb-mXz\">"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
-      "fingerprint": "e59764611405db5d",
+      "fingerprint": "81abf4b1bd1c52b0",
       "line_when_recorded": 380,
       "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" selected=\"YES\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncati"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
-      "fingerprint": "11cf4bf48799ba77",
+      "fingerprint": "b77babe630b242e9",
       "line_when_recorded": 449,
       "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncation\" translatesA"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
-      "fingerprint": "11cf4bf48799ba77",
+      "fingerprint": "b77babe630b242e9",
       "line_when_recorded": 502,
       "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncation\" translatesA"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 88,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 1335,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 1516,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 1573,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 1719,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
-      "fingerprint": "f8cdb0ea182d85bc",
+      "fingerprint": "04b35db4c19a8677",
       "line_when_recorded": 1776,
       "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
     },
     {
       "rule": "A11Y011",
       "path": "WatchApp/Base.lproj/Interface.storyboard",
-      "fingerprint": "5c416c3a871270f5",
+      "fingerprint": "a9c69e3fe7b991a7",
       "line_when_recorded": 192,
       "snippet": "<button width=\"1\" alignment=\"left\" id=\"DPm-5o-p0S\">"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "6f1e1bdcc4e3f2e4",
+      "fingerprint": "8111858237f22da0",
       "line_when_recorded": 315,
       "snippet": ".onTapGesture { previewTarget = candidate(result) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "d2959c4b0d5e37bf",
+      "fingerprint": "986474d0bf98356a",
       "line_when_recorded": 196,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "d2959c4b0d5e37bf",
+      "fingerprint": "986474d0bf98356a",
       "line_when_recorded": 665,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "2d2830c857230f01",
+      "fingerprint": "bbcb06b0a1e2c357",
       "line_when_recorded": 467,
       "snippet": ".onTapGesture { selectedContact = item }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "2d2830c857230f01",
+      "fingerprint": "bbcb06b0a1e2c357",
       "line_when_recorded": 479,
       "snippet": ".onTapGesture { selectedContact = item }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "2d2830c857230f01",
+      "fingerprint": "bbcb06b0a1e2c357",
       "line_when_recorded": 490,
       "snippet": ".onTapGesture { selectedContact = item }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "2d2830c857230f01",
+      "fingerprint": "bbcb06b0a1e2c357",
       "line_when_recorded": 503,
       "snippet": ".onTapGesture { selectedContact = item }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d472650a84c0a9f9",
+      "fingerprint": "fb6369e16ab6876a",
       "line_when_recorded": 557,
       "snippet": ".onTapGesture { openAddContact(query: result.fullName.withoutDashSuffix) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "9e40677581eede6f",
+      "fingerprint": "745557511c7647ef",
       "line_when_recorded": 262,
       "snippet": ".onTapGesture { selectedContact = event.item }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift",
-      "fingerprint": "c109fb9a8a3f5dee",
+      "fingerprint": "76fdb464e30fff02",
       "line_when_recorded": 190,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
-      "fingerprint": "2ebc5e2101a3d71d",
+      "fingerprint": "481e695a25ed37fb",
       "line_when_recorded": 298,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift",
-      "fingerprint": "36150e2a5946d5f7",
+      "fingerprint": "a5fb7524fd5533a9",
       "line_when_recorded": 198,
       "snippet": ".onTapGesture { isPresented = true }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
-      "fingerprint": "cd218d8662236d70",
+      "fingerprint": "462d91cfe98f5fac",
       "line_when_recorded": 102,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
-      "fingerprint": "fc42cdfce0dd86d8",
+      "fingerprint": "25c275dad6c8ddb4",
       "line_when_recorded": 133,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
+      "fingerprint": "b4a35a18537f7ccf",
+      "line_when_recorded": 295,
+      "snippet": ".onTapGesture { infoAction() }"
+    },
+    {
+      "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
-      "fingerprint": "99b0140a7827009d",
+      "fingerprint": "972a31ca77ddb3e5",
       "line_when_recorded": 763,
       "snippet": ".onTapGesture { self.selectedTxDataItem = txDataItem }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
-      "fingerprint": "99b0140a7827009d",
+      "fingerprint": "972a31ca77ddb3e5",
       "line_when_recorded": 777,
       "snippet": ".onTapGesture { self.selectedTxDataItem = txDataItem }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutsBarView.swift",
-      "fingerprint": "6fe03e4a2f2fd1fd",
+      "fingerprint": "0aaf98b25ec548ae",
       "line_when_recorded": 107,
       "snippet": ".onTapGesture { onSelect() }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0e2bbe238ad43f4b",
+      "fingerprint": "cc7fe89a6840de01",
       "line_when_recorded": 57,
       "snippet": ".onTapGesture { showDetail(row) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
-      "fingerprint": "a56aa329e1d56193",
+      "fingerprint": "4fffebf2f4af699b",
       "line_when_recorded": 252,
       "snippet": ".onTapGesture { copy(item.address) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
-      "fingerprint": "56c740b37bdf311f",
+      "fingerprint": "d1e1e11a48f50056",
       "line_when_recorded": 64,
       "snippet": ".onTapGesture { showDetail(row) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "96732b96cf9bc821",
+      "fingerprint": "504b81bc1ebe8da5",
       "line_when_recorded": 81,
       "snippet": ".onTapGesture { showAccounts(row) }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Settings/LocalCurrency/LocalCurrencyView.swift",
-      "fingerprint": "a76ed76dc8df1d8f",
+      "fingerprint": "4a0035037268b921",
       "line_when_recorded": 131,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
-      "fingerprint": "5e88a5e8846b28b1",
+      "fingerprint": "9220d5387590789b",
       "line_when_recorded": 29,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
-      "fingerprint": "5e88a5e8846b28b1",
+      "fingerprint": "9220d5387590789b",
       "line_when_recorded": 480,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
-      "fingerprint": "5e88a5e8846b28b1",
+      "fingerprint": "9220d5387590789b",
       "line_when_recorded": 675,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "76d131dd1c2c9c51",
+      "fingerprint": "3c01b8c6f512cc87",
       "line_when_recorded": 301,
       "snippet": ".onTapGesture { onCopyAddress() }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/Swap/OrderPreview/Components/OrderPreviewFeeRow.swift",
-      "fingerprint": "c0638eb367473ee1",
+      "fingerprint": "3327671dc452e19d",
       "line_when_recorded": 51,
       "snippet": ".onTapGesture { showInfoSheet = true }"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
-      "fingerprint": "a66835180ca20a96",
+      "fingerprint": "7dd9ff7c6143faa9",
       "line_when_recorded": 46,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
-      "fingerprint": "a66835180ca20a96",
+      "fingerprint": "7dd9ff7c6143faa9",
       "line_when_recorded": 88,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y012",
       "path": "DashWallet/Sources/UI/SwiftUI Components/TextInput.swift",
-      "fingerprint": "13ea5194fb6d6d2b",
+      "fingerprint": "258eec9fd0a07956",
       "line_when_recorded": 86,
       "snippet": ".onTapGesture {"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
-      "fingerprint": "323053bb1509331d",
+      "fingerprint": "9951a0930a3b57ce",
       "line_when_recorded": 229,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
-      "fingerprint": "b2d6137cba3ec4de",
+      "fingerprint": "0d18d2cf94bec62c",
       "line_when_recorded": 237,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
-      "fingerprint": "4466c2bfca075e99",
+      "fingerprint": "187ba3d2df2e2c69",
       "line_when_recorded": 244,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
-      "fingerprint": "67888c5050ef935a",
+      "fingerprint": "f0b8cde209c1a653",
       "line_when_recorded": 257,
       "snippet": ".font(.system(size: 17))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "0f9a19cb80a0725c",
+      "fingerprint": "3404c29d9bd1252c",
       "line_when_recorded": 205,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "b22a69b756b6da3a",
+      "fingerprint": "e3cb983e62b52499",
       "line_when_recorded": 216,
       "snippet": ".font(.system(size: 44))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "7ea3ef1c02ce67cc",
+      "fingerprint": "64ae36c7ab3d7f10",
       "line_when_recorded": 221,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "836e74fad9faf0fe",
+      "fingerprint": "98bc48e89206a680",
       "line_when_recorded": 261,
       "snippet": ".font(.system(size: 17, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "7ea3ef1c02ce67cc",
+      "fingerprint": "64ae36c7ab3d7f10",
       "line_when_recorded": 263,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "6f2085bcd59da200",
+      "fingerprint": "56b6eb3446fba946",
       "line_when_recorded": 279,
       "snippet": ".font(.system(size: 56, weight: .light))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "da71ac82e66f3517",
+      "fingerprint": "9f9e87fc6ec1fc25",
       "line_when_recorded": 283,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "b04ceca88a0d5e2d",
+      "fingerprint": "32ed9bc81a452d46",
       "line_when_recorded": 286,
       "snippet": ".font(.system(size: 16))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 300,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 305,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "49796c018dfde2e3",
+      "fingerprint": "aba14b7324bd1c5d",
       "line_when_recorded": 374,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "fa29be4afd46accf",
+      "fingerprint": "e4b5f04315c78692",
       "line_when_recorded": 379,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "66e268fee870c301",
+      "fingerprint": "ec2da8323c2d86cf",
       "line_when_recorded": 681,
       "snippet": ".font(.system(size: 22, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 687,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 696,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 703,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "7ea3ef1c02ce67cc",
+      "fingerprint": "64ae36c7ab3d7f10",
       "line_when_recorded": 772,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "6c93b028a3e48534",
+      "fingerprint": "7b3eac17e9a3c1fe",
       "line_when_recorded": 784,
       "snippet": "Text(title).font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "66e268fee870c301",
+      "fingerprint": "ec2da8323c2d86cf",
       "line_when_recorded": 812,
       "snippet": ".font(.system(size: 22, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 817,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
-      "fingerprint": "60cbb96f56f4a9d9",
+      "fingerprint": "14433a459008c54e",
       "line_when_recorded": 840,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "fe280c80eae046b6",
+      "fingerprint": "8f78e6f8fdf2672c",
       "line_when_recorded": 59,
       "snippet": ".font(.system(size: size * 0.5, weight: .regular))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "88a2623c1cc24cee",
+      "fingerprint": "48353e7bc740c80d",
       "line_when_recorded": 97,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "dd066f8455e8f8b2",
+      "fingerprint": "c3de862f478aadea",
       "line_when_recorded": 117,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "e499779a2ca3c48e",
+      "fingerprint": "b1e79350a6f3a897",
       "line_when_recorded": 142,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "7d9f0b7688ee54fc",
+      "fingerprint": "ce1f845059f732b0",
       "line_when_recorded": 233,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "eab76b81339485e0",
+      "fingerprint": "f161905a68dbf9ff",
       "line_when_recorded": 237,
       "snippet": ".font(.system(size: 12, design: .monospaced))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
-      "fingerprint": "735ef047a069cb5f",
+      "fingerprint": "e76f8981418d1c42",
       "line_when_recorded": 242,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ac62203b00dcf55a",
+      "fingerprint": "186d4a5cc49ca281",
       "line_when_recorded": 74,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "fe1c60df270e5cb6",
+      "fingerprint": "df2d2606a8cce479",
       "line_when_recorded": 154,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e5e97d453dd650a7",
+      "fingerprint": "58ebe1dc14e11eb0",
       "line_when_recorded": 173,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ac62203b00dcf55a",
+      "fingerprint": "186d4a5cc49ca281",
       "line_when_recorded": 182,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ce70d9f0492921e9",
+      "fingerprint": "d524ff1426f8203a",
       "line_when_recorded": 189,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "54902d031f2af9b5",
+      "fingerprint": "4922c8efa4e960f8",
       "line_when_recorded": 214,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "6ba1f1a70860a1e7",
+      "fingerprint": "7afaebdd14fc8fa2",
       "line_when_recorded": 225,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "6ba1f1a70860a1e7",
+      "fingerprint": "7afaebdd14fc8fa2",
       "line_when_recorded": 238,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 253,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "fe1c60df270e5cb6",
+      "fingerprint": "df2d2606a8cce479",
       "line_when_recorded": 255,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "6ba1f1a70860a1e7",
+      "fingerprint": "7afaebdd14fc8fa2",
       "line_when_recorded": 287,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "6ba1f1a70860a1e7",
+      "fingerprint": "7afaebdd14fc8fa2",
       "line_when_recorded": 309,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "3ce6513e8aa334e1",
+      "fingerprint": "822fa4b20b8b0b2a",
       "line_when_recorded": 328,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 331,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "5e11110294a7ae48",
+      "fingerprint": "e0bdf2e2767accf0",
       "line_when_recorded": 336,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "5e11110294a7ae48",
+      "fingerprint": "e0bdf2e2767accf0",
       "line_when_recorded": 347,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "d29484accb68087a",
+      "fingerprint": "def31fccaa58ca8d",
       "line_when_recorded": 360,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "6ba1f1a70860a1e7",
+      "fingerprint": "7afaebdd14fc8fa2",
       "line_when_recorded": 453,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "54902d031f2af9b5",
+      "fingerprint": "4922c8efa4e960f8",
       "line_when_recorded": 458,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "3ce6513e8aa334e1",
+      "fingerprint": "822fa4b20b8b0b2a",
       "line_when_recorded": 476,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 482,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ac62203b00dcf55a",
+      "fingerprint": "186d4a5cc49ca281",
       "line_when_recorded": 486,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ac62203b00dcf55a",
+      "fingerprint": "186d4a5cc49ca281",
       "line_when_recorded": 608,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "f544152b2c6d93a5",
+      "fingerprint": "57a7e7b4f6e54aad",
       "line_when_recorded": 612,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e4e958d0bea51213",
+      "fingerprint": "b8a09d3d9f4efe65",
       "line_when_recorded": 639,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 643,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 648,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 655,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ce70d9f0492921e9",
+      "fingerprint": "d524ff1426f8203a",
       "line_when_recorded": 659,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "54902d031f2af9b5",
+      "fingerprint": "4922c8efa4e960f8",
       "line_when_recorded": 795,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 799,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "fbbdcce9fb0250c6",
+      "fingerprint": "fd2dfd7fb88fe8e8",
       "line_when_recorded": 824,
       "snippet": ".font(.system(size: 48))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "32c2335d78579ddd",
+      "fingerprint": "4a130734b9f8724e",
       "line_when_recorded": 827,
       "snippet": ".font(.system(size: 17, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "ac62203b00dcf55a",
+      "fingerprint": "186d4a5cc49ca281",
       "line_when_recorded": 833,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
-      "fingerprint": "e1b808e60f9836c7",
+      "fingerprint": "d6d47176e11bfec4",
       "line_when_recorded": 839,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "080a73e06068bc5d",
+      "fingerprint": "8e61fd4d88cd3794",
       "line_when_recorded": 377,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9649d8f289bb5ae0",
+      "fingerprint": "dd1bdde9136d9098",
       "line_when_recorded": 384,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "e103ea14dc12259d",
+      "fingerprint": "30fd28fa88780913",
       "line_when_recorded": 405,
       "snippet": ".font(.system(size: 17, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "0f4b97b9c9241003",
+      "fingerprint": "87d40ba22e4e3918",
       "line_when_recorded": 410,
       "snippet": ".font(.system(size: 12.5))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "15f562ab39e631b7",
+      "fingerprint": "96ebfe284a0a1052",
       "line_when_recorded": 417,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "a6ee2efe281b9cce",
+      "fingerprint": "0377425f91b437e6",
       "line_when_recorded": 533,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d5a1550a1a6dad07",
+      "fingerprint": "a42a5d1026c1aaca",
       "line_when_recorded": 547,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "15f562ab39e631b7",
+      "fingerprint": "96ebfe284a0a1052",
       "line_when_recorded": 564,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9c9a3b3028571a8d",
+      "fingerprint": "9f2774b1103b97ca",
       "line_when_recorded": 582,
       "snippet": ".font(.system(size: size, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "5d2ecf94017c6456",
+      "fingerprint": "824dc9c1d1b67575",
       "line_when_recorded": 607,
       "snippet": ".font(.system(size: 72, weight: .light))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9b64c7030a55f3a9",
+      "fingerprint": "a4cb02185c80c4ec",
       "line_when_recorded": 611,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "f464f586bac2f1cf",
+      "fingerprint": "a0b0e2f6e794c276",
       "line_when_recorded": 614,
       "snippet": ".font(.system(size: 16))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "15f562ab39e631b7",
+      "fingerprint": "96ebfe284a0a1052",
       "line_when_recorded": 624,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "8b69a0b0e21a9403",
+      "fingerprint": "ee1785c634abec59",
       "line_when_recorded": 680,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "60abecb92956dfd3",
+      "fingerprint": "32d1e6e748d5fa17",
       "line_when_recorded": 687,
       "snippet": ".font(.system(size: 22, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "78afd492ec5a699f",
+      "fingerprint": "1527572283799484",
       "line_when_recorded": 695,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "1b88b7594122e91d",
+      "fingerprint": "97845fcea121cc10",
       "line_when_recorded": 727,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9649d8f289bb5ae0",
+      "fingerprint": "dd1bdde9136d9098",
       "line_when_recorded": 739,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "cc339ac2b6656df6",
+      "fingerprint": "fb8bca393ade0a66",
       "line_when_recorded": 758,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d544243993fcb6e2",
+      "fingerprint": "ed943641fbffb8be",
       "line_when_recorded": 764,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "a6ee2efe281b9cce",
+      "fingerprint": "0377425f91b437e6",
       "line_when_recorded": 767,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "6b1daee1747dce8e",
+      "fingerprint": "1d09261a42d306e0",
       "line_when_recorded": 856,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d544243993fcb6e2",
+      "fingerprint": "ed943641fbffb8be",
       "line_when_recorded": 863,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "8b69a0b0e21a9403",
+      "fingerprint": "ee1785c634abec59",
       "line_when_recorded": 911,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9b64c7030a55f3a9",
+      "fingerprint": "a4cb02185c80c4ec",
       "line_when_recorded": 918,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "6b1daee1747dce8e",
+      "fingerprint": "1d09261a42d306e0",
       "line_when_recorded": 925,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9649d8f289bb5ae0",
+      "fingerprint": "dd1bdde9136d9098",
       "line_when_recorded": 934,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "847e622e7693b715",
+      "fingerprint": "f9102e234b8c7ba3",
       "line_when_recorded": 948,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "1812ceaf135d9d10",
+      "fingerprint": "f929bd449f849062",
       "line_when_recorded": 982,
       "snippet": ".font(.system(size: 34))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9b64c7030a55f3a9",
+      "fingerprint": "a4cb02185c80c4ec",
       "line_when_recorded": 989,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "6b1daee1747dce8e",
+      "fingerprint": "1d09261a42d306e0",
       "line_when_recorded": 996,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d544243993fcb6e2",
+      "fingerprint": "ed943641fbffb8be",
       "line_when_recorded": 1008,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "178e5a7a411d6824",
+      "fingerprint": "7dcb20fc5a4dec91",
       "line_when_recorded": 1021,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "9649d8f289bb5ae0",
+      "fingerprint": "dd1bdde9136d9098",
       "line_when_recorded": 1030,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "847e622e7693b715",
+      "fingerprint": "f9102e234b8c7ba3",
       "line_when_recorded": 1045,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d5a1550a1a6dad07",
+      "fingerprint": "a42a5d1026c1aaca",
       "line_when_recorded": 1071,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "178e5a7a411d6824",
+      "fingerprint": "7dcb20fc5a4dec91",
       "line_when_recorded": 1076,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "47fba84d3f45c081",
+      "fingerprint": "ff98362d69776b8d",
       "line_when_recorded": 1084,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "d5a1550a1a6dad07",
+      "fingerprint": "a42a5d1026c1aaca",
       "line_when_recorded": 1117,
       "snippet": ".font(.system(size: 17, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "178e5a7a411d6824",
+      "fingerprint": "7dcb20fc5a4dec91",
       "line_when_recorded": 1122,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "178e5a7a411d6824",
+      "fingerprint": "7dcb20fc5a4dec91",
       "line_when_recorded": 1132,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
-      "fingerprint": "47fba84d3f45c081",
+      "fingerprint": "ff98362d69776b8d",
       "line_when_recorded": 1134,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "2e3f604750f072a2",
+      "fingerprint": "2a7cb2c99f7dbabf",
       "line_when_recorded": 121,
       "snippet": ".font(.system(size: 44, weight: .light))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "c3f300edf2ec435e",
+      "fingerprint": "8e15dfa6fdd119b1",
       "line_when_recorded": 124,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "4c7ba246e978fe19",
+      "fingerprint": "5fa55445838bef6e",
       "line_when_recorded": 148,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "65e7ddc350eb745a",
+      "fingerprint": "c6ddd24a3c55499b",
       "line_when_recorded": 183,
       "snippet": "Image(systemName: \"hourglass\").font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "87b4f7cdbb632539",
+      "fingerprint": "0993cad9f431c770",
       "line_when_recorded": 185,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "65e7ddc350eb745a",
+      "fingerprint": "c6ddd24a3c55499b",
       "line_when_recorded": 202,
       "snippet": "Image(systemName: \"hourglass\").font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "87b4f7cdbb632539",
+      "fingerprint": "0993cad9f431c770",
       "line_when_recorded": 204,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "d11fc63395ee4249",
+      "fingerprint": "7710edb36a2162b6",
       "line_when_recorded": 217,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "d11fc63395ee4249",
+      "fingerprint": "7710edb36a2162b6",
       "line_when_recorded": 228,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "c3f300edf2ec435e",
+      "fingerprint": "8e15dfa6fdd119b1",
       "line_when_recorded": 249,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
-      "fingerprint": "cfb4c2a4f794587a",
+      "fingerprint": "8bed7f81b3b40569",
       "line_when_recorded": 253,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
-      "fingerprint": "68ea53b83a769207",
+      "fingerprint": "2dd366f4d77fe7ab",
       "line_when_recorded": 226,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
-      "fingerprint": "24bf81a8a51a4021",
+      "fingerprint": "a3d7768cc1c29e3e",
       "line_when_recorded": 234,
       "snippet": ".font(.system(size: 14, design: .monospaced))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
-      "fingerprint": "3323fc854ec9bb4c",
+      "fingerprint": "0430236bce8a9812",
       "line_when_recorded": 305,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "e478b6ecbf1331aa",
+      "fingerprint": "d8b9e9697ed58eaf",
       "line_when_recorded": 221,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "fa0b4fdea47194cb",
+      "fingerprint": "048aa391e73ce850",
       "line_when_recorded": 297,
       "snippet": ".font(.system(size: 18))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "8d43d0f579f4ad59",
+      "fingerprint": "ed71c19cf0015a63",
       "line_when_recorded": 303,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "bf4b9dcb6cb8d4d4",
+      "fingerprint": "ae33459c91e0aa67",
       "line_when_recorded": 313,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "b26483c457254e8e",
+      "fingerprint": "c5c27a7e57e59899",
       "line_when_recorded": 645,
       "snippet": ".font(.system(size: 34))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "1a183cd9c5f0929a",
+      "fingerprint": "b0052305b8686d3c",
       "line_when_recorded": 652,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "209c6279f1284789",
+      "fingerprint": "9a44446cb4d9762b",
       "line_when_recorded": 659,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 680,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 688,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 692,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "8d43d0f579f4ad59",
+      "fingerprint": "ed71c19cf0015a63",
       "line_when_recorded": 708,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "b0c05be285841cf4",
+      "fingerprint": "362e65c5f75559c2",
       "line_when_recorded": 710,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "8d43d0f579f4ad59",
+      "fingerprint": "ed71c19cf0015a63",
       "line_when_recorded": 721,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "b0c05be285841cf4",
+      "fingerprint": "362e65c5f75559c2",
       "line_when_recorded": 723,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "aececc43bd4d247f",
+      "fingerprint": "21e8fc0413b26638",
       "line_when_recorded": 738,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 745,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 751,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "587f4d827726b4a4",
+      "fingerprint": "79693fa0a6f18d76",
       "line_when_recorded": 761,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "e478b6ecbf1331aa",
+      "fingerprint": "d8b9e9697ed58eaf",
       "line_when_recorded": 765,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 772,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "156032002835d55a",
+      "fingerprint": "784e58f4e959d7c0",
       "line_when_recorded": 787,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "aececc43bd4d247f",
+      "fingerprint": "21e8fc0413b26638",
       "line_when_recorded": 795,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
-      "fingerprint": "bcfabf7425d08697",
+      "fingerprint": "31f71d9085560378",
       "line_when_recorded": 812,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "755388e771ef6baa",
+      "fingerprint": "b095c56ef3170bd9",
       "line_when_recorded": 176,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "ccad05e4b7dc3661",
+      "fingerprint": "4a586f75fbda47ae",
       "line_when_recorded": 466,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "ccad05e4b7dc3661",
+      "fingerprint": "4a586f75fbda47ae",
       "line_when_recorded": 497,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "ccad05e4b7dc3661",
+      "fingerprint": "4a586f75fbda47ae",
       "line_when_recorded": 606,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "ccad05e4b7dc3661",
+      "fingerprint": "4a586f75fbda47ae",
       "line_when_recorded": 655,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
-      "fingerprint": "ccad05e4b7dc3661",
+      "fingerprint": "4a586f75fbda47ae",
       "line_when_recorded": 677,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "1c7f7ea6bbc75234",
+      "fingerprint": "50112953f7de2e59",
       "line_when_recorded": 67,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "24c9bb8dd99a19c3",
+      "fingerprint": "0b563969f3fdc9cb",
       "line_when_recorded": 86,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "6c7822476f64d8a9",
+      "fingerprint": "5a83dcc9d20b3924",
       "line_when_recorded": 244,
       "snippet": ".font(.system(size: 20, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "6046a4740c7c4ad1",
+      "fingerprint": "26ebd1aeff6060bc",
       "line_when_recorded": 250,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "9205079d05ff6487",
+      "fingerprint": "63c2a1197de66b1a",
       "line_when_recorded": 254,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
-      "fingerprint": "080948e71a2268bd",
+      "fingerprint": "14af6813ff6d4295",
       "line_when_recorded": 263,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Voting/BulkVoteSheet.swift",
-      "fingerprint": "dc1458ffa24dd205",
+      "fingerprint": "72f4df17cc41f548",
       "line_when_recorded": 378,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Voting/CastVoteSheet.swift",
-      "fingerprint": "c29bdb1de30d25da",
+      "fingerprint": "85e0207e74ca7e15",
       "line_when_recorded": 246,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift",
-      "fingerprint": "1f2a95a6321e9e34",
+      "fingerprint": "78c9791c017c6b59",
       "line_when_recorded": 384,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "6f1620a366e5ff77",
+      "fingerprint": "8adc48f1100781b2",
       "line_when_recorded": 143,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 148,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "b2b67d815b005022",
+      "fingerprint": "47eb4729d947b4fb",
       "line_when_recorded": 212,
       "snippet": ".font(.system(size: 22))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "d61e678894bb557a",
+      "fingerprint": "8f9ffea609831edd",
       "line_when_recorded": 271,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 277,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "d61e678894bb557a",
+      "fingerprint": "8f9ffea609831edd",
       "line_when_recorded": 316,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 322,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "d61e678894bb557a",
+      "fingerprint": "8f9ffea609831edd",
       "line_when_recorded": 333,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 384,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 414,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
-      "fingerprint": "26f388f658636abb",
+      "fingerprint": "8ba5a83f95ed8d55",
       "line_when_recorded": 425,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift",
-      "fingerprint": "51ffca9cf8b647ca",
+      "fingerprint": "b6b34c31f7f3a521",
       "line_when_recorded": 127,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift",
-      "fingerprint": "91ad4cbb0169cab8",
+      "fingerprint": "c11dc53fa7019721",
       "line_when_recorded": 132,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
-      "fingerprint": "9b84c97dfc9e294e",
+      "fingerprint": "778549d0b49d5009",
       "line_when_recorded": 230,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
-      "fingerprint": "9b84c97dfc9e294e",
+      "fingerprint": "778549d0b49d5009",
       "line_when_recorded": 237,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift",
-      "fingerprint": "8bc76e94170a5e55",
+      "fingerprint": "0ed1305df73db63b",
       "line_when_recorded": 127,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "e9cd1e0d3e625029",
+      "fingerprint": "e6926687311ff733",
       "line_when_recorded": 521,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 616,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "e9cd1e0d3e625029",
+      "fingerprint": "e6926687311ff733",
       "line_when_recorded": 626,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 677,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 681,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a4a32498cb62e978",
+      "fingerprint": "574cfd17ab0675c9",
       "line_when_recorded": 689,
       "snippet": ".font(.system(size: 10, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 692,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "7fb2ae8ff24fe9e8",
+      "fingerprint": "15b6d044a926e913",
       "line_when_recorded": 697,
       "snippet": ".font(.system(size: 10, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 701,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 761,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 768,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a4a32498cb62e978",
+      "fingerprint": "574cfd17ab0675c9",
       "line_when_recorded": 776,
       "snippet": ".font(.system(size: 10, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 779,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 784,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 818,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 822,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a4a32498cb62e978",
+      "fingerprint": "574cfd17ab0675c9",
       "line_when_recorded": 830,
       "snippet": ".font(.system(size: 10, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 833,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 838,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "97100287959b34b3",
+      "fingerprint": "3c5d2672b1c55180",
       "line_when_recorded": 903,
       "snippet": ".font(.system(size: 20, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 910,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "d523068a185b0211",
+      "fingerprint": "77a3563545fa6e83",
       "line_when_recorded": 915,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 921,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "eb57050f3f263917",
+      "fingerprint": "e37239e450f65376",
       "line_when_recorded": 977,
       "snippet": ".font(.system(size: 26))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 981,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 984,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 989,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1008,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1019,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "736ab3b0660ece46",
+      "fingerprint": "99da4d1c5705a102",
       "line_when_recorded": 1041,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "1c044349c188f0b9",
+      "fingerprint": "dc3d1be45098edc7",
       "line_when_recorded": 1119,
       "snippet": ".font(.system(size: 22, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1146,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 1201,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "e76b9efeadf7433b",
+      "fingerprint": "e773e4b8684c6728",
       "line_when_recorded": 1204,
       "snippet": ".font(.system(size: 18, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1207,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "d523068a185b0211",
+      "fingerprint": "77a3563545fa6e83",
       "line_when_recorded": 1215,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1226,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1230,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1271,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 1296,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1301,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 1306,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1452,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "fe46c5cd570a7fbc",
+      "fingerprint": "15b4b27bf044a7b2",
       "line_when_recorded": 1456,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 1461,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1471,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1475,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "637b6d9ae6cc9cb4",
+      "fingerprint": "94ff4ef37aef0dde",
       "line_when_recorded": 1486,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "6d823c326d86d556",
+      "fingerprint": "c54cdeea0a7a5469",
       "line_when_recorded": 1499,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c18fad49d81aeea6",
+      "fingerprint": "e3e7a5d8a42efb7b",
       "line_when_recorded": 1537,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "5b1131fa195c8c9d",
+      "fingerprint": "343a64bcb5c2d685",
       "line_when_recorded": 1544,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "f3a46846ccf1c319",
+      "fingerprint": "187c0514df3c6b4f",
       "line_when_recorded": 1557,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1564,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1572,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 1591,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c9f5433ac6d992a9",
+      "fingerprint": "1a103b53a68a8ee6",
       "line_when_recorded": 1608,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c18fad49d81aeea6",
+      "fingerprint": "e3e7a5d8a42efb7b",
       "line_when_recorded": 1647,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "5b1131fa195c8c9d",
+      "fingerprint": "343a64bcb5c2d685",
       "line_when_recorded": 1652,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "9fded2ec55ba0230",
+      "fingerprint": "52185e0ae704f6c7",
       "line_when_recorded": 1665,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 1672,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 1688,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c9f5433ac6d992a9",
+      "fingerprint": "1a103b53a68a8ee6",
       "line_when_recorded": 1706,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3d8148d5c6c30ac2",
+      "fingerprint": "b2a0b4b6f8d3d807",
       "line_when_recorded": 1801,
       "snippet": ".font(.system(size: 36))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c18fad49d81aeea6",
+      "fingerprint": "e3e7a5d8a42efb7b",
       "line_when_recorded": 1812,
       "snippet": ".font(.system(size: 20, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "5b1131fa195c8c9d",
+      "fingerprint": "343a64bcb5c2d685",
       "line_when_recorded": 1820,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "c9f5433ac6d992a9",
+      "fingerprint": "1a103b53a68a8ee6",
       "line_when_recorded": 1843,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "5b1131fa195c8c9d",
+      "fingerprint": "343a64bcb5c2d685",
       "line_when_recorded": 1875,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "5b1131fa195c8c9d",
+      "fingerprint": "343a64bcb5c2d685",
       "line_when_recorded": 1897,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1943,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1949,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 1956,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1960,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 1966,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "3a21eec1805f704b",
+      "fingerprint": "4aca3acba0fe4442",
       "line_when_recorded": 1974,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 1996,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 2003,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "d671bd8549c1c66e",
+      "fingerprint": "73e3c99aaca82a63",
       "line_when_recorded": 2043,
       "snippet": ".font(.system(size: 13, weight: emphasized ? .semibold : .regular))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 2049,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 2059,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "69fd6636b0c7aad8",
+      "fingerprint": "7829bd6bce53cf69",
       "line_when_recorded": 2063,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "017502583fd9b095",
+      "fingerprint": "87b8e7c628871dd3",
       "line_when_recorded": 2086,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "a785d656fb830563",
+      "fingerprint": "246c4e184803745b",
       "line_when_recorded": 2090,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
-      "fingerprint": "531fbb8e1cbd2681",
+      "fingerprint": "e6b3ace4d457ed8a",
       "line_when_recorded": 2105,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
-      "fingerprint": "6f391204f4b5c651",
+      "fingerprint": "f65d0916997d04ca",
       "line_when_recorded": 41,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
-      "fingerprint": "730e0942c14020bf",
+      "fingerprint": "88ae0e394d382d59",
       "line_when_recorded": 86,
       "snippet": ".font(.system(size: 14, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
-      "fingerprint": "6140482c89b529b8",
+      "fingerprint": "d64312ee97b09e8d",
       "line_when_recorded": 96,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
-      "fingerprint": "6f50b84020dd6612",
+      "fingerprint": "1257e5c4ef772db5",
       "line_when_recorded": 85,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
-      "fingerprint": "3a2cde81f0d2a6f4",
+      "fingerprint": "9bae222c8de91c6d",
       "line_when_recorded": 93,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
-      "fingerprint": "ea7e709ffd238c7c",
+      "fingerprint": "ec93c94f4404d9b9",
       "line_when_recorded": 111,
       "snippet": ".font(.system(size: 24, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
-      "fingerprint": "74599f252ce59c65",
+      "fingerprint": "86f4ce0f574b1077",
       "line_when_recorded": 115,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "3f25959907f25967",
+      "fingerprint": "a1c170c84f8112db",
       "line_when_recorded": 231,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "a256feb052596cfa",
+      "fingerprint": "05929c1e994de5ef",
       "line_when_recorded": 279,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "a256feb052596cfa",
+      "fingerprint": "05929c1e994de5ef",
       "line_when_recorded": 285,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "e85c9e5f462216f9",
+      "fingerprint": "9d49afa6c18e48e8",
       "line_when_recorded": 288,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "bf63ce438b1dda6f",
+      "fingerprint": "a16ac8882250ca63",
       "line_when_recorded": 297,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "3f25959907f25967",
+      "fingerprint": "a1c170c84f8112db",
       "line_when_recorded": 371,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
-      "fingerprint": "3f25959907f25967",
+      "fingerprint": "a1c170c84f8112db",
       "line_when_recorded": 398,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift",
-      "fingerprint": "ce1197cdc5e863f8",
+      "fingerprint": "9850f3195e247565",
       "line_when_recorded": 62,
       "snippet": ".font(.system(size: 26, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift",
-      "fingerprint": "219d4833ef88fe45",
+      "fingerprint": "1e5d097d5ddc1104",
       "line_when_recorded": 83,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
-      "fingerprint": "3412bd57595cab9a",
+      "fingerprint": "0620b7704fb2d670",
       "line_when_recorded": 238,
       "snippet": ".font(.system(size: 11, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
-      "fingerprint": "3027a019fe575207",
+      "fingerprint": "f2676e0908fa4758",
       "line_when_recorded": 266,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
-      "fingerprint": "ec3b61b85d2a17f4",
+      "fingerprint": "42b95eac5e6a60e7",
       "line_when_recorded": 314,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
-      "fingerprint": "01c63eecf3014b95",
+      "fingerprint": "f8741c7f4a0210f7",
       "line_when_recorded": 741,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift",
-      "fingerprint": "55cf453394cf8832",
+      "fingerprint": "7a205d04f109d0f6",
       "line_when_recorded": 84,
       "snippet": ".font(.system(size: 24, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift",
-      "fingerprint": "4016783cd171fd54",
+      "fingerprint": "2e2d32dc57d1c55b",
       "line_when_recorded": 89,
       "snippet": ".font(.system(size: 11, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift",
-      "fingerprint": "c34f9f9921fe57a8",
+      "fingerprint": "00e3f07a5308071e",
       "line_when_recorded": 329,
       "snippet": ".font(.system(size: 26, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift",
-      "fingerprint": "9c682b3d735256d6",
+      "fingerprint": "d883898f22aaa707",
       "line_when_recorded": 335,
       "snippet": ".font(.system(size: 11, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/NodesShortcutIcon.swift",
-      "fingerprint": "58a3591902c332b6",
+      "fingerprint": "dd61dc13510d3b59",
       "line_when_recorded": 86,
       "snippet": ".font(.system(size: 19, weight: .bold, design: .rounded))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/NodesShortcutIcon.swift",
-      "fingerprint": "9e02482ada2734cc",
+      "fingerprint": "8ecf394f0ae11fcd",
       "line_when_recorded": 92,
       "snippet": ".font(.system(size: 8.5, weight: .heavy, design: .rounded))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift",
-      "fingerprint": "008cc823c50cdebf",
+      "fingerprint": "dccdcbb5e0834f78",
       "line_when_recorded": 43,
       "snippet": ".font(.system(size: 10, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift",
-      "fingerprint": "58f88a00fdde9f45",
+      "fingerprint": "09b430bddfe39a6f",
       "line_when_recorded": 55,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
-      "fingerprint": "278c057f6580bf1e",
+      "fingerprint": "48d74fcf744f40ba",
       "line_when_recorded": 569,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
-      "fingerprint": "bc14db0c86fada64",
+      "fingerprint": "65dba795966cd9f2",
       "line_when_recorded": 573,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
-      "fingerprint": "f21de81f316aa8d6",
+      "fingerprint": "e8dd3c583f50b27f",
       "line_when_recorded": 580,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
-      "fingerprint": "be3828644272788c",
+      "fingerprint": "fcd3ed07e8cb7311",
       "line_when_recorded": 584,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "8388c880a9255221",
+      "fingerprint": "e48f1d6cc88ac42a",
       "line_when_recorded": 121,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "f57aa6cfb415640a",
+      "fingerprint": "2713de2919eb05af",
       "line_when_recorded": 136,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "f57aa6cfb415640a",
+      "fingerprint": "2713de2919eb05af",
       "line_when_recorded": 151,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "911a5928f5b444c0",
+      "fingerprint": "7aa570423b71772e",
       "line_when_recorded": 180,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "17120559b8005208",
+      "fingerprint": "a3b7051e93ac5731",
       "line_when_recorded": 206,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "f57aa6cfb415640a",
+      "fingerprint": "2713de2919eb05af",
       "line_when_recorded": 231,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d2f660dad68c399e",
+      "fingerprint": "9aba7959bc15e72b",
       "line_when_recorded": 248,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0f3f3d5e7d0f26a7",
+      "fingerprint": "73d167f2725d3ffa",
       "line_when_recorded": 263,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "8388c880a9255221",
+      "fingerprint": "e48f1d6cc88ac42a",
       "line_when_recorded": 426,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "7729fe1170cc468d",
+      "fingerprint": "95081a46471792dd",
       "line_when_recorded": 444,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d7a05632edfea3b8",
+      "fingerprint": "90c7d75ce580d391",
       "line_when_recorded": 465,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d2f660dad68c399e",
+      "fingerprint": "9aba7959bc15e72b",
       "line_when_recorded": 477,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "377befe798feee21",
+      "fingerprint": "c66cb59c1afb870a",
       "line_when_recorded": 485,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d2f660dad68c399e",
+      "fingerprint": "9aba7959bc15e72b",
       "line_when_recorded": 496,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "6b58a0a920c7a23c",
+      "fingerprint": "7da925d98f3367a4",
       "line_when_recorded": 523,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "085e67c41be3a9e4",
+      "fingerprint": "23d2eae64f8e1592",
       "line_when_recorded": 566,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0f3f3d5e7d0f26a7",
+      "fingerprint": "73d167f2725d3ffa",
       "line_when_recorded": 570,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "101c50e0aaa2d77b",
+      "fingerprint": "a9672bc341db5cff",
       "line_when_recorded": 573,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d7a05632edfea3b8",
+      "fingerprint": "90c7d75ce580d391",
       "line_when_recorded": 612,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "67fdf35bfbba02d0",
+      "fingerprint": "59163fe519877f76",
       "line_when_recorded": 616,
       "snippet": ".font(.system(size: 18))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "67fdf35bfbba02d0",
+      "fingerprint": "59163fe519877f76",
       "line_when_recorded": 637,
       "snippet": ".font(.system(size: 18))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "17120559b8005208",
+      "fingerprint": "a3b7051e93ac5731",
       "line_when_recorded": 643,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "101c50e0aaa2d77b",
+      "fingerprint": "a9672bc341db5cff",
       "line_when_recorded": 653,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "d7a05632edfea3b8",
+      "fingerprint": "90c7d75ce580d391",
       "line_when_recorded": 682,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "085e67c41be3a9e4",
+      "fingerprint": "23d2eae64f8e1592",
       "line_when_recorded": 719,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0f3f3d5e7d0f26a7",
+      "fingerprint": "73d167f2725d3ffa",
       "line_when_recorded": 723,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "8388c880a9255221",
+      "fingerprint": "e48f1d6cc88ac42a",
       "line_when_recorded": 815,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "f57aa6cfb415640a",
+      "fingerprint": "2713de2919eb05af",
       "line_when_recorded": 830,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "085e67c41be3a9e4",
+      "fingerprint": "23d2eae64f8e1592",
       "line_when_recorded": 852,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "17120559b8005208",
+      "fingerprint": "a3b7051e93ac5731",
       "line_when_recorded": 866,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "6b58a0a920c7a23c",
+      "fingerprint": "7da925d98f3367a4",
       "line_when_recorded": 911,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "085e67c41be3a9e4",
+      "fingerprint": "23d2eae64f8e1592",
       "line_when_recorded": 950,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
-      "fingerprint": "0f3f3d5e7d0f26a7",
+      "fingerprint": "73d167f2725d3ffa",
       "line_when_recorded": 954,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
-      "fingerprint": "d443bc75f57b0f2c",
+      "fingerprint": "e08d73970027134d",
       "line_when_recorded": 97,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
-      "fingerprint": "66836a2040815e08",
+      "fingerprint": "46790a3a2cf9b305",
       "line_when_recorded": 162,
       "snippet": ".font(.system(size: 15, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
-      "fingerprint": "9e02abea1b52bc80",
+      "fingerprint": "c87db9119649219a",
       "line_when_recorded": 293,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
-      "fingerprint": "dbcdc2c75d0a261a",
+      "fingerprint": "2a8f0614d2856d86",
       "line_when_recorded": 169,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
-      "fingerprint": "8d899caae8725242",
+      "fingerprint": "90e2e99a4fb9d6d7",
       "line_when_recorded": 183,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf45f673aec2a714",
+      "fingerprint": "bfed835b92398635",
       "line_when_recorded": 230,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf45f673aec2a714",
+      "fingerprint": "bfed835b92398635",
       "line_when_recorded": 238,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "47f065ae0d4cf9ee",
+      "fingerprint": "03c87366c2732cdd",
       "line_when_recorded": 335,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "b62949a6cebfb0e2",
+      "fingerprint": "fe421ee05575cdb2",
       "line_when_recorded": 340,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "b62949a6cebfb0e2",
+      "fingerprint": "fe421ee05575cdb2",
       "line_when_recorded": 346,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 354,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 391,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "2f77d94e68348492",
+      "fingerprint": "e0c35004b54310a9",
       "line_when_recorded": 397,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "58190b0931f2086c",
+      "fingerprint": "6f9425af4fb359dc",
       "line_when_recorded": 442,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 463,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "019d5ba8f88fb0d1",
+      "fingerprint": "8f6540fbfcde3a1e",
       "line_when_recorded": 595,
       "snippet": ".font(.system(size: 22))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 600,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "b62949a6cebfb0e2",
+      "fingerprint": "fe421ee05575cdb2",
       "line_when_recorded": 603,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "2f77d94e68348492",
+      "fingerprint": "e0c35004b54310a9",
       "line_when_recorded": 608,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "8da52739bf05fedd",
+      "fingerprint": "70dd8ee2022c161e",
       "line_when_recorded": 652,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 663,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "1542fabd64399bdb",
+      "fingerprint": "badd38b19e586b4d",
       "line_when_recorded": 698,
       "snippet": ".font(.system(size: 13, design: .monospaced))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "58190b0931f2086c",
+      "fingerprint": "6f9425af4fb359dc",
       "line_when_recorded": 702,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "900cf989191b7974",
+      "fingerprint": "3f5face4c3725ff1",
       "line_when_recorded": 770,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
-      "fingerprint": "bf2f6ca974f687ed",
+      "fingerprint": "0b013c674d0bf0b8",
       "line_when_recorded": 781,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "961c2d9707c8710d",
+      "fingerprint": "aac60fb4f843afff",
       "line_when_recorded": 148,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 201,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 206,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 212,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 218,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "2ab5dbbada58a3a5",
+      "fingerprint": "414310c56fb33a6b",
       "line_when_recorded": 224,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 237,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 252,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "04156343d109247d",
+      "fingerprint": "80769f9a753784c4",
       "line_when_recorded": 255,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "fef56d029b85cb59",
+      "fingerprint": "2ebb0cc02767507f",
       "line_when_recorded": 273,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "04156343d109247d",
+      "fingerprint": "80769f9a753784c4",
       "line_when_recorded": 292,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
-      "fingerprint": "efaf6753ca37d662",
+      "fingerprint": "5bead6853b816ab1",
       "line_when_recorded": 296,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "f958529e49f8b9d0",
+      "fingerprint": "400798f0c35c0af6",
       "line_when_recorded": 47,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 102,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 108,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 114,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "ba36857c726693a7",
+      "fingerprint": "12df86f87d660a7c",
       "line_when_recorded": 120,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 154,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d241cce6ddd5e328",
+      "fingerprint": "b588961444dec79d",
       "line_when_recorded": 160,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "f5d1960bf7113327",
+      "fingerprint": "9858f0b4728f6afe",
       "line_when_recorded": 223,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d241cce6ddd5e328",
+      "fingerprint": "b588961444dec79d",
       "line_when_recorded": 227,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d241cce6ddd5e328",
+      "fingerprint": "b588961444dec79d",
       "line_when_recorded": 230,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 244,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "ba36857c726693a7",
+      "fingerprint": "12df86f87d660a7c",
       "line_when_recorded": 248,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 266,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "f5d1960bf7113327",
+      "fingerprint": "9858f0b4728f6afe",
       "line_when_recorded": 269,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 288,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 304,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "d644d609ea265c74",
+      "fingerprint": "f17d7101ebe82066",
       "line_when_recorded": 317,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "f5d1960bf7113327",
+      "fingerprint": "9858f0b4728f6afe",
       "line_when_recorded": 333,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "e400cade6090ac20",
+      "fingerprint": "686eda21b7a5f95e",
       "line_when_recorded": 337,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "1959ddbc5273be14",
+      "fingerprint": "4f94bd3976a1caca",
       "line_when_recorded": 346,
       "snippet": ".font(.system(size: 16, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "e36db957a18fe033",
+      "fingerprint": "5f04f2d7334e0195",
       "line_when_recorded": 350,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
-      "fingerprint": "699689a3f05643ac",
+      "fingerprint": "b395142be36ea5be",
       "line_when_recorded": 354,
       "snippet": ".font(.system(size: 10))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "e8c2820754b61109",
+      "fingerprint": "87ba1e8dc2349b38",
       "line_when_recorded": 41,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 97,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 102,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 108,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 114,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 120,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "a425634931a4676c",
+      "fingerprint": "b6a4a78920ec0d71",
       "line_when_recorded": 126,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 153,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "a425634931a4676c",
+      "fingerprint": "b6a4a78920ec0d71",
       "line_when_recorded": 158,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 201,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "a425634931a4676c",
+      "fingerprint": "b6a4a78920ec0d71",
       "line_when_recorded": 205,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 222,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "991674adbaa847b2",
+      "fingerprint": "3d25e8a8b52c6a1f",
       "line_when_recorded": 225,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 244,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "2e082897e331c5ad",
+      "fingerprint": "941a8431f65f2430",
       "line_when_recorded": 257,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "991674adbaa847b2",
+      "fingerprint": "3d25e8a8b52c6a1f",
       "line_when_recorded": 276,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "07a6ab41f1475a4f",
+      "fingerprint": "01362c3466e97713",
       "line_when_recorded": 280,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "991674adbaa847b2",
+      "fingerprint": "3d25e8a8b52c6a1f",
       "line_when_recorded": 292,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "0a9de042f9860a93",
+      "fingerprint": "75fc3ba51b6f322f",
       "line_when_recorded": 299,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "0a9de042f9860a93",
+      "fingerprint": "75fc3ba51b6f322f",
       "line_when_recorded": 305,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "6dba5368218fd867",
+      "fingerprint": "a39b3039d5bd298c",
       "line_when_recorded": 319,
       "snippet": ".font(.system(size: 16, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
-      "fingerprint": "b661f0fad60620f0",
+      "fingerprint": "7a096a758ccc4bd8",
       "line_when_recorded": 323,
       "snippet": ".font(.system(size: 11, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c5a0f89015cb9e98",
+      "fingerprint": "35ab9b656bc38676",
       "line_when_recorded": 90,
       "snippet": ".font(.system(size: 18, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "aa0528c87ab928ca",
+      "fingerprint": "de214f57bb37f519",
       "line_when_recorded": 245,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 258,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 262,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 294,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "f5dcfeab0e3ba1f5",
+      "fingerprint": "d2617abe3c58e091",
       "line_when_recorded": 298,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "f5dcfeab0e3ba1f5",
+      "fingerprint": "d2617abe3c58e091",
       "line_when_recorded": 306,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 321,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 325,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 333,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 339,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "f050e6e33aace722",
+      "fingerprint": "69580b673766b7ac",
       "line_when_recorded": 356,
       "snippet": ".font(.system(size: 11, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 385,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 426,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 432,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 441,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 454,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 460,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 474,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 480,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 500,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 514,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "11f2745ef3ec8a06",
+      "fingerprint": "e28a99fca5eb03bf",
       "line_when_recorded": 520,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 534,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 537,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 553,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c647c06200e94414",
+      "fingerprint": "031bb34a6d0135f7",
       "line_when_recorded": 570,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 591,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "f5dcfeab0e3ba1f5",
+      "fingerprint": "d2617abe3c58e091",
       "line_when_recorded": 595,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "c6f5dbed95f97fea",
+      "fingerprint": "eb511563352dc35c",
       "line_when_recorded": 604,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
-      "fingerprint": "ef347edb5857ac0a",
+      "fingerprint": "ac8bbd785ecb9377",
       "line_when_recorded": 608,
       "snippet": ".font(.system(size: 12, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift",
-      "fingerprint": "ca93c49bda34a50b",
+      "fingerprint": "23e05032208d7cc8",
       "line_when_recorded": 42,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift",
-      "fingerprint": "94e85104b58b9f77",
+      "fingerprint": "453b110873960b65",
       "line_when_recorded": 48,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Evonode Status/EvonodeStatusScreen.swift",
-      "fingerprint": "ab920a5dc45ed110",
+      "fingerprint": "dba25efd9d363401",
       "line_when_recorded": 103,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift",
-      "fingerprint": "e132d6afc6832fb9",
+      "fingerprint": "50b59256b438e4c3",
       "line_when_recorded": 101,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift",
-      "fingerprint": "70b53f9218741ead",
+      "fingerprint": "7c8f830901ddbcd8",
       "line_when_recorded": 116,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/DerivationPathKeysView.swift",
-      "fingerprint": "6e6311d9ad5145b2",
+      "fingerprint": "64ec8899b1200aa2",
       "line_when_recorded": 76,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/KeysOverviewView.swift",
-      "fingerprint": "d0d17fb3d24847eb",
+      "fingerprint": "11d78540c475864d",
       "line_when_recorded": 40,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 137,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 143,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "d6cb6382fdb4553b",
+      "fingerprint": "287a0eee7c036293",
       "line_when_recorded": 191,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "01086ffda9dbda82",
+      "fingerprint": "8f14487cba416c76",
       "line_when_recorded": 211,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 219,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 226,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "9102314d2ad9060a",
+      "fingerprint": "2b3631d487fb0f6d",
       "line_when_recorded": 232,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "387c7e29955d5643",
+      "fingerprint": "88c46d8a9b0c5bcd",
       "line_when_recorded": 237,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 253,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "d6cb6382fdb4553b",
+      "fingerprint": "287a0eee7c036293",
       "line_when_recorded": 272,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "d6cb6382fdb4553b",
+      "fingerprint": "287a0eee7c036293",
       "line_when_recorded": 278,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 285,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "9102314d2ad9060a",
+      "fingerprint": "2b3631d487fb0f6d",
       "line_when_recorded": 325,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 328,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 418,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 427,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "9102314d2ad9060a",
+      "fingerprint": "2b3631d487fb0f6d",
       "line_when_recorded": 465,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 497,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "4caf2fbccf088fa2",
+      "fingerprint": "c908df908c1f437d",
       "line_when_recorded": 503,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "1b43a799b768bab6",
+      "fingerprint": "7f7437d49e9c0ce9",
       "line_when_recorded": 544,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "01086ffda9dbda82",
+      "fingerprint": "8f14487cba416c76",
       "line_when_recorded": 552,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "9102314d2ad9060a",
+      "fingerprint": "2b3631d487fb0f6d",
       "line_when_recorded": 608,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "21caa2de777ff76e",
+      "fingerprint": "4fc10f63e3531cbc",
       "line_when_recorded": 612,
       "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
-      "fingerprint": "21caa2de777ff76e",
+      "fingerprint": "4fc10f63e3531cbc",
       "line_when_recorded": 612,
       "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift",
-      "fingerprint": "34614d6f2f7cfc68",
+      "fingerprint": "62e8a2c01a86f102",
       "line_when_recorded": 257,
       "snippet": ".font(.system(size: 40))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
-      "fingerprint": "37d5823d5aec4b48",
+      "fingerprint": "cb9b6738fb8e2e0c",
       "line_when_recorded": 45,
       "snippet": ".font(.system(size: 28, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
-      "fingerprint": "ef9dbcca73150c14",
+      "fingerprint": "bd8a00364ed8b451",
       "line_when_recorded": 51,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
-      "fingerprint": "863c270cc1311c9c",
+      "fingerprint": "ce7bde1eb105455e",
       "line_when_recorded": 63,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "aaa69f0ca77a1543",
+      "fingerprint": "57aec64ddcf267cc",
       "line_when_recorded": 118,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "f0ec5adf85b65344",
+      "fingerprint": "945ec80201018837",
       "line_when_recorded": 327,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "7eb31d497e0d4efb",
+      "fingerprint": "93f1eb18278ff1cc",
       "line_when_recorded": 334,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "145d09dd36926d90",
+      "fingerprint": "d0be79d3e56c4465",
       "line_when_recorded": 359,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "145d09dd36926d90",
+      "fingerprint": "d0be79d3e56c4465",
       "line_when_recorded": 365,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "aaa69f0ca77a1543",
+      "fingerprint": "57aec64ddcf267cc",
       "line_when_recorded": 368,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "aaa69f0ca77a1543",
+      "fingerprint": "57aec64ddcf267cc",
       "line_when_recorded": 610,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "145d09dd36926d90",
+      "fingerprint": "d0be79d3e56c4465",
       "line_when_recorded": 701,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "145d09dd36926d90",
+      "fingerprint": "d0be79d3e56c4465",
       "line_when_recorded": 707,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "aaa69f0ca77a1543",
+      "fingerprint": "57aec64ddcf267cc",
       "line_when_recorded": 712,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "63119344afb5a628",
+      "fingerprint": "8d36f6386d2d68c0",
       "line_when_recorded": 846,
       "snippet": ".font(.system(size: 15, weight: state == .active ? .semibold : .regular))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
-      "fingerprint": "d9d7e44836bcc46f",
+      "fingerprint": "e3beb59f4e101aa9",
       "line_when_recorded": 879,
       "snippet": ".font(.system(size: 11, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "9aff53ae2e1cd596",
+      "fingerprint": "deb33032e96a2d9a",
       "line_when_recorded": 140,
       "snippet": ".font(.system(size: 24, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "220f45355e7593c5",
+      "fingerprint": "4d95a9d3bfdc3a0d",
       "line_when_recorded": 406,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "002e01927b833c30",
+      "fingerprint": "d04db211dc38db03",
       "line_when_recorded": 410,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "2d4ace0ba7c7fdcf",
+      "fingerprint": "bf9bb7ba6340a6b8",
       "line_when_recorded": 495,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "2d4ace0ba7c7fdcf",
+      "fingerprint": "bf9bb7ba6340a6b8",
       "line_when_recorded": 498,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "5f93ac9c90f5933e",
+      "fingerprint": "4736d3349939cc03",
       "line_when_recorded": 532,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "27f6cad051445d61",
+      "fingerprint": "17241a0c4ca297f7",
       "line_when_recorded": 545,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "17c9ddd4bee56a44",
+      "fingerprint": "60d210fddf289b19",
       "line_when_recorded": 553,
       "snippet": ".font(.system(size: 11))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "f6617e3c43b7cc62",
+      "fingerprint": "8982a1ba018182c6",
       "line_when_recorded": 556,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
-      "fingerprint": "002e01927b833c30",
+      "fingerprint": "d04db211dc38db03",
       "line_when_recorded": 568,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
-      "fingerprint": "35b1042b89979923",
+      "fingerprint": "80255c497f68929b",
       "line_when_recorded": 21,
       "snippet": ".font(.system(size: 24, weight: .bold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
-      "fingerprint": "8625ad2b42fc1368",
+      "fingerprint": "05f94612daea0e3b",
       "line_when_recorded": 67,
       "snippet": ".font(.system(size: 18, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
-      "fingerprint": "f3a10d3c3cee19aa",
+      "fingerprint": "12fb02bfa4ac8fbd",
       "line_when_recorded": 73,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
-      "fingerprint": "77ed87c75fca734a",
+      "fingerprint": "f0d3bd7e8dd4e717",
       "line_when_recorded": 77,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "4278181bb7b120dd",
+      "fingerprint": "175f7e878b315651",
       "line_when_recorded": 111,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "c02837d854577e0f",
+      "fingerprint": "87792b8ee8a0f84d",
       "line_when_recorded": 143,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "d7849b4571170958",
+      "fingerprint": "ec83d90cb720e7aa",
       "line_when_recorded": 145,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
-      "fingerprint": "f6efb32e79615515",
+      "fingerprint": "1153cf0bec3f9607",
       "line_when_recorded": 326,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "f13639e928f93e11",
+      "fingerprint": "bd29f22e5e943a08",
       "line_when_recorded": 89,
       "snippet": ".font(.system(size: 16, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "defb175bcd87b069",
+      "fingerprint": "c96a80c65308bf23",
       "line_when_recorded": 185,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "ebd3f98ef7d86a4b",
+      "fingerprint": "ece39b3a5eff36fb",
       "line_when_recorded": 199,
       "snippet": ".font(.system(size: 10, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "d441b14a3c1b5569",
+      "fingerprint": "257ce2dceea50384",
       "line_when_recorded": 263,
       "snippet": ".font(.system(size: 14, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "713c2b5de21dae45",
+      "fingerprint": "da831089d211b6a2",
       "line_when_recorded": 489,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "1a64618a96658ecc",
+      "fingerprint": "caac818020385744",
       "line_when_recorded": 497,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "defb175bcd87b069",
+      "fingerprint": "c96a80c65308bf23",
       "line_when_recorded": 502,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "2da3d12ad779cdcd",
+      "fingerprint": "7eb51f8bc7928673",
       "line_when_recorded": 590,
       "snippet": ".font(.system(size: 16, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "defb175bcd87b069",
+      "fingerprint": "c96a80c65308bf23",
       "line_when_recorded": 630,
       "snippet": ".font(.system(size: 13, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "ebd3f98ef7d86a4b",
+      "fingerprint": "ece39b3a5eff36fb",
       "line_when_recorded": 665,
       "snippet": ".font(.system(size: 10, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "2dfd1f0e28719bb2",
+      "fingerprint": "674c08b590e39ac9",
       "line_when_recorded": 794,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "1705709bc5d9460f",
+      "fingerprint": "448e62af25256544",
       "line_when_recorded": 872,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "1705709bc5d9460f",
+      "fingerprint": "448e62af25256544",
       "line_when_recorded": 909,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "713c2b5de21dae45",
+      "fingerprint": "da831089d211b6a2",
       "line_when_recorded": 913,
       "snippet": ".font(.system(size: 15, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "4e57d77e637e7001",
+      "fingerprint": "a0c510de6db1ba73",
       "line_when_recorded": 997,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "4e57d77e637e7001",
+      "fingerprint": "a0c510de6db1ba73",
       "line_when_recorded": 1003,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "2dfd1f0e28719bb2",
+      "fingerprint": "674c08b590e39ac9",
       "line_when_recorded": 1006,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
-      "fingerprint": "2dfd1f0e28719bb2",
+      "fingerprint": "674c08b590e39ac9",
       "line_when_recorded": 1163,
       "snippet": ".font(.system(size: 13))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
-      "fingerprint": "c3db04b29f8479b8",
+      "fingerprint": "85e4778de339089a",
       "line_when_recorded": 63,
       "snippet": ".font(.system(size: 13, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
-      "fingerprint": "c09ae9e746f06362",
+      "fingerprint": "7ed0b95fe03929fa",
       "line_when_recorded": 79,
       "snippet": ".font(.system(size: 12))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
-      "fingerprint": "a7c2bc997c0285e2",
+      "fingerprint": "d94d7741a747fbf8",
       "line_when_recorded": 119,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
-      "fingerprint": "107b2d1240aba61c",
+      "fingerprint": "c11b55453550b3c2",
       "line_when_recorded": 121,
       "snippet": ".font(.system(size: 11, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
-      "fingerprint": "64cf107eb1994bc2",
+      "fingerprint": "9daaff35c0ce1c0c",
       "line_when_recorded": 55,
       "snippet": ".font(.system(size: 17))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
-      "fingerprint": "dd16bf2a726147de",
+      "fingerprint": "8e95f1cafe3d1a38",
       "line_when_recorded": 64,
       "snippet": ".font(.system(size: 20))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
-      "fingerprint": "113223743ee6dd6b",
+      "fingerprint": "becbfc5e30de3548",
       "line_when_recorded": 79,
       "snippet": ".font(.system(size: 15, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
-      "fingerprint": "de937384b0f3a469",
+      "fingerprint": "68c796f94a711f4a",
       "line_when_recorded": 180,
       "snippet": ".font(.system(size: Layout.errorIconSize))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
-      "fingerprint": "2587f469a611a31b",
+      "fingerprint": "ba45fb8ec4db9206",
       "line_when_recorded": 184,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
-      "fingerprint": "6ae38dca76bc0270",
+      "fingerprint": "8784aaa908eb7ca2",
       "line_when_recorded": 200,
       "snippet": ".font(.system(size: 14, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
-      "fingerprint": "7fa5f3927cdfa4b5",
+      "fingerprint": "3f8dc5ef955300eb",
       "line_when_recorded": 60,
       "snippet": ".font(.system(size: iconSize))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
-      "fingerprint": "7fac7a7750d4c569",
+      "fingerprint": "6a3c6da8866c9aa7",
       "line_when_recorded": 71,
       "snippet": ".font(.system(size: fontSize))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
-      "fingerprint": "7fa5f3927cdfa4b5",
+      "fingerprint": "3f8dc5ef955300eb",
       "line_when_recorded": 80,
       "snippet": ".font(.system(size: iconSize))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
-      "fingerprint": "058bd28f8541a4c4",
+      "fingerprint": "f22f746d68e37bf4",
       "line_when_recorded": 43,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "14357cbe2e3055ff",
+      "fingerprint": "708734bce306b5d5",
       "line_when_recorded": 24,
       "snippet": "public static let largeTitle: Font = .system(size: 34, weight: .bold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "cd274d8249815587",
+      "fingerprint": "65f05631898ac788",
       "line_when_recorded": 27,
       "snippet": "public static let title1: Font = .system(size: 28, weight: .bold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "ca7b60a94d015c87",
+      "fingerprint": "508d4de1a784635c",
       "line_when_recorded": 30,
       "snippet": "public static let title2: Font = .system(size: 22, weight: .bold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "bbcb30070366d2ac",
+      "fingerprint": "892b2e5fd558cce5",
       "line_when_recorded": 33,
       "snippet": "public static let title3: Font = .system(size: 20, weight: .bold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "7bfd2d00c3c09a7f",
+      "fingerprint": "83769aa61668df67",
       "line_when_recorded": 36,
       "snippet": "public static let title3Medium: Font = .system(size: 20, weight: .medium)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "4a52b157b833580d",
+      "fingerprint": "bb06620b53de7fe8",
       "line_when_recorded": 41,
       "snippet": "public static let headline: Font = .system(size: 17, weight: .bold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "ac125a5b3d92d019",
+      "fingerprint": "c0c253b1d879bb81",
       "line_when_recorded": 44,
       "snippet": "public static let body: Font = .system(size: 17, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "260bb09e3fa03a62",
+      "fingerprint": "c0ede382db69d677",
       "line_when_recorded": 47,
       "snippet": "public static let callout: Font = .system(size: 16, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "4f637f6662db5365",
+      "fingerprint": "eff03ca024da95fe",
       "line_when_recorded": 50,
       "snippet": "public static let calloutMedium: Font = .system(size: 16, weight: .semibold)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "5af12a3d74fddb7f",
+      "fingerprint": "13598227bd05667c",
       "line_when_recorded": 53,
       "snippet": "public static let subhead: Font = .system(size: 15, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "88dc400851e7cea5",
+      "fingerprint": "336cc23823ba9aa3",
       "line_when_recorded": 56,
       "snippet": "public static let subheadMedium: Font = .system(size: 15, weight: .medium)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "26dfc40424b0fc32",
+      "fingerprint": "741a95af95e46190",
       "line_when_recorded": 59,
       "snippet": "public static let footnote: Font = .system(size: 13, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "a6f6056029aee936",
+      "fingerprint": "a9f3c8999f148cfa",
       "line_when_recorded": 62,
       "snippet": "public static let footnoteMedium: Font = .system(size: 13, weight: .medium)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "2d1dd468941d8ba4",
+      "fingerprint": "d2e0aa69a29fc90c",
       "line_when_recorded": 65,
       "snippet": "public static let caption1: Font = .system(size: 12, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
-      "fingerprint": "b6d3ddf369d8f379",
+      "fingerprint": "536706bce61b8b45",
       "line_when_recorded": 68,
       "snippet": "public static let caption2: Font = .system(size: 11, weight: .regular)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift",
-      "fingerprint": "031eb8c1a8edc249",
+      "fingerprint": "770bf1325e7e4a4e",
       "line_when_recorded": 61,
       "snippet": ".font(.system(size: side * 0.4, weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift",
-      "fingerprint": "5396ff5e123d80d4",
+      "fingerprint": "2d78666aa59d2909",
       "line_when_recorded": 64,
       "snippet": ".font(.system(size: fittedFontSize(side: side), weight: .semibold))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/NetworkUnavailableStateView.swift",
-      "fingerprint": "a57154fee613d125",
+      "fingerprint": "b8c4ad1caf7e99ce",
       "line_when_recorded": 81,
       "snippet": ".font(.system(size: 17, weight: .medium))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Toast.swift",
-      "fingerprint": "eb5e514029354099",
+      "fingerprint": "7aee9abc75840865",
       "line_when_recorded": 37,
       "snippet": ".font(.system(size: 15))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/SwiftUI Components/Toast.swift",
-      "fingerprint": "5409fc0923785110",
+      "fingerprint": "730b29044d085ed2",
       "line_when_recorded": 43,
       "snippet": ".font(.system(size: 14))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
-      "fingerprint": "0141b67693808b4d",
+      "fingerprint": "6896d2c60db2dbf1",
       "line_when_recorded": 90,
       "snippet": ".font(.system(size: 34))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
-      "fingerprint": "532e966c1eeaa156",
+      "fingerprint": "f432e149ed830f67",
       "line_when_recorded": 253,
       "snippet": ".font(.system(size: 11, design: .monospaced))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
-      "fingerprint": "492502273e8725c6",
+      "fingerprint": "60cd45103f5f3e2a",
       "line_when_recorded": 302,
       "snippet": ".font(.system(size: 10))"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
-      "fingerprint": "23fd7f1f1d3b17c5",
+      "fingerprint": "fc566b3c3d505a60",
       "line_when_recorded": 306,
       "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .footnote)"
     },
     {
       "rule": "A11Y007",
       "path": "DashWallet/Sources/UI/Tx/Details/Views/TxDetailContactViews.swift",
-      "fingerprint": "36bdd51d9aabe56d",
+      "fingerprint": "5b93c7a4fea96afe",
       "line_when_recorded": 92,
       "snippet": ".font(.system(size: 12, weight: .semibold))"
     }

--- a/scripts/a11y_baseline.json
+++ b/scripts/a11y_baseline.json
@@ -9,7 +9,7 @@
     "A11Y008": 8,
     "A11Y002": 10,
     "A11Y003": 1,
-    "A11Y004": 31,
+    "A11Y004": 37,
     "A11Y005": 1,
     "A11Y006": 2,
     "A11Y009": 2,
@@ -18,7 +18,7 @@
     "A11Y012": 31,
     "A11Y007": 559
   },
-  "total": 659,
+  "total": 665,
   "findings": [
     {
       "rule": "A11Y008",
@@ -155,6 +155,27 @@
     },
     {
       "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "d71909e411b8e790",
+      "line_when_recorded": 147,
+      "snippet": "Button {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "31b848249e2e75eb",
+      "line_when_recorded": 275,
+      "snippet": "Button {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "31b848249e2e75eb",
+      "line_when_recorded": 339,
+      "snippet": "Button {"
+    },
+    {
+      "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
       "fingerprint": "603d89e57095d24b",
       "line_when_recorded": 842,
@@ -222,6 +243,13 @@
       "fingerprint": "6959c08ee2fb80f6",
       "line_when_recorded": 424,
       "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "1a4bb9493c42e241",
+      "line_when_recorded": 811,
+      "snippet": "Button {"
     },
     {
       "rule": "A11Y004",
@@ -306,6 +334,20 @@
       "fingerprint": "0bc340276de2bdfc",
       "line_when_recorded": 275,
       "snippet": "Button(action: popRoot) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Tracked Masternodes/AddMasternodeScreen.swift",
+      "fingerprint": "18468fb6082a418f",
+      "line_when_recorded": 69,
+      "snippet": "Button {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Tracked Masternodes/AddMasternodeScreen.swift",
+      "fingerprint": "18468fb6082a418f",
+      "line_when_recorded": 79,
+      "snippet": "Button {"
     },
     {
       "rule": "A11Y004",

--- a/scripts/a11y_baseline.json
+++ b/scripts/a11y_baseline.json
@@ -1,0 +1,4623 @@
+{
+  "_comment": [
+    "Accepted accessibility debt, recorded by scripts/a11y_audit.py.",
+    "CI fails only on findings that are NOT in this list, so the debt",
+    "can shrink over time without blocking unrelated work.",
+    "Regenerate with: scripts/a11y_audit.py --write-baseline"
+  ],
+  "counts": {
+    "A11Y008": 8,
+    "A11Y002": 10,
+    "A11Y003": 1,
+    "A11Y004": 30,
+    "A11Y005": 1,
+    "A11Y006": 2,
+    "A11Y009": 2,
+    "A11Y010": 3,
+    "A11Y011": 11,
+    "A11Y012": 30,
+    "A11Y007": 559
+  },
+  "total": 657,
+  "findings": [
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "84144361824789ed",
+      "line_when_recorded": 24,
+      "snippet": "public static let largeTitle: Font = .system(size: 34, weight: .bold)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "809e21b4ebdef45d",
+      "line_when_recorded": 30,
+      "snippet": "public static let title2: Font = .system(size: 22, weight: .bold)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "33631dcce2e417b2",
+      "line_when_recorded": 33,
+      "snippet": "public static let title3: Font = .system(size: 20, weight: .bold)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "58e68dd11ff6fcd2",
+      "line_when_recorded": 41,
+      "snippet": "public static let headline: Font = .system(size: 17, weight: .bold)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "6aad66c68311c82d",
+      "line_when_recorded": 44,
+      "snippet": "public static let body: Font = .system(size: 17, weight: .regular)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "25461bc4e19d3a67",
+      "line_when_recorded": 47,
+      "snippet": "public static let callout: Font = .system(size: 16, weight: .regular)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "d78b42282c6327c1",
+      "line_when_recorded": 59,
+      "snippet": "public static let footnote: Font = .system(size: 13, weight: .regular)"
+    },
+    {
+      "rule": "A11Y008",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "9399897f3ba8d951",
+      "line_when_recorded": 68,
+      "snippet": "public static let caption2: Font = .system(size: 11, weight: .regular)"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
+      "fingerprint": "d4e5d5705b3b7865",
+      "line_when_recorded": 115,
+      "snippet": "navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
+      "fingerprint": "d5fb2fe8cef6e430",
+      "line_when_recorded": 121,
+      "snippet": "let button = UIBarButtonItem(image: buttonImage, style: UIBarButtonItem.Style.plain, target: self, action: #selector(infoButtonAction))"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
+      "fingerprint": "baade693e219e86b",
+      "line_when_recorded": 405,
+      "snippet": "let appliedFilters = UIBarButtonItem(customView: appliedFiltersStackView)"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
+      "fingerprint": "c7dd6b33b822fa89",
+      "line_when_recorded": 406,
+      "snippet": "let filter = UIBarButtonItem(image: .init(systemName: \"line.3.horizontal.decrease.circle.fill\"), style: .plain,"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/ExplorePointOfUseListViewController.swift",
+      "fingerprint": "a39c4dd0b02ca581",
+      "line_when_recorded": 410,
+      "snippet": "let fakeFilter = UIBarButtonItem(image: .init(systemName: \"line.3.horizontal.decrease.circle.fill\"), style: .plain,"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/MerchantListViewController.swift",
+      "fingerprint": "7609009204e51cf1",
+      "line_when_recorded": 413,
+      "snippet": "infoButton = UIBarButtonItem(image: infoImage, style: .plain, target: self, action: #selector(infoButtonAction))"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Home/HomeViewController.swift",
+      "fingerprint": "b5d8e9956bd12717",
+      "line_when_recorded": 201,
+      "snippet": "let notificationButton = UIBarButtonItem(image: notificationsImage, style: .plain, target: self, action: #selector(notificationAction))"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Home/HomeViewController.swift",
+      "fingerprint": "ebd65e8d9018fa1f",
+      "line_when_recorded": 265,
+      "snippet": "let avatarButton = UIBarButtonItem(customView: avatarView)"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Views/BaseController/ActionButtonViewController.swift",
+      "fingerprint": "6f9ea5c48f770b44",
+      "line_when_recorded": 80,
+      "snippet": "let barButtonItem = UIBarButtonItem(customView: activityIndicator)"
+    },
+    {
+      "rule": "A11Y002",
+      "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
+      "fingerprint": "7bfea68d64b4670a",
+      "line_when_recorded": 182,
+      "snippet": "let item = UIBarButtonItem(customView: backButton)"
+    },
+    {
+      "rule": "A11Y003",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Views/ExploreMapView.swift",
+      "fingerprint": "89ee65e07c6d997c",
+      "line_when_recorded": 355,
+      "snippet": "let myLocationButton = UIButton(type: .custom)"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "009e4095a4d81052",
+      "line_when_recorded": 842,
+      "snippet": "Button(action: action) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/VerifyIdentityScreen.swift",
+      "fingerprint": "ee77ca9025da8d06",
+      "line_when_recorded": 63,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift",
+      "fingerprint": "84301d0300925c1f",
+      "line_when_recorded": 70,
+      "snippet": "Button(action: onClose) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "5e7e3f2cb094defe",
+      "line_when_recorded": 210,
+      "snippet": "Button(action: directionAction) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift",
+      "fingerprint": "900e00a721ab69b5",
+      "line_when_recorded": 123,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
+      "fingerprint": "42faa08080b47ad5",
+      "line_when_recorded": 37,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
+      "fingerprint": "74154c279d5c7aae",
+      "line_when_recorded": 81,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/GiftCardDetails/Components/GiftCardDetailsInfoCard.swift",
+      "fingerprint": "72248ae40da4edfa",
+      "line_when_recorded": 209,
+      "snippet": "Button(action: onCopy) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0defbdba85142afb",
+      "line_when_recorded": 119,
+      "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0defbdba85142afb",
+      "line_when_recorded": 424,
+      "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
+      "fingerprint": "9973c8027a37796c",
+      "line_when_recorded": 95,
+      "snippet": "Button(action: { vc.popViewController(animated: true) }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "e28ac9d78d9b4361",
+      "line_when_recorded": 144,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "141c4ce5af723be1",
+      "line_when_recorded": 43,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "934f5ceac27db560",
+      "line_when_recorded": 195,
+      "snippet": "Button(action: { UIPasteboard.general.string = addr.address }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "aeecd142cce9e6b0",
+      "line_when_recorded": 37,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "5dc99df382b60ffb",
+      "line_when_recorded": 86,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "5dc99df382b60ffb",
+      "line_when_recorded": 301,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift",
+      "fingerprint": "03e7e9f74095825b",
+      "line_when_recorded": 236,
+      "snippet": "Button(action: popRoot) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageExplorerView.swift",
+      "fingerprint": "f84c69b86412d8e5",
+      "line_when_recorded": 102,
+      "snippet": "Button(action: { loadCounts() }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift",
+      "fingerprint": "6c7e2ee173df03f8",
+      "line_when_recorded": 259,
+      "snippet": "Button(action: popRoot) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ToolsMenuScreen.swift",
+      "fingerprint": "6c7e2ee173df03f8",
+      "line_when_recorded": 275,
+      "snippet": "Button(action: popRoot) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "08b7fc2fb4037212",
+      "line_when_recorded": 109,
+      "snippet": "Button(action: onClose) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "a1c9d3de8022efc3",
+      "line_when_recorded": 87,
+      "snippet": "Button(action: onClose) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "3ddfd8b898b8480f",
+      "line_when_recorded": 588,
+      "snippet": "Button(action: onBack) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
+      "fingerprint": "0143fd4144df14a0",
+      "line_when_recorded": 61,
+      "snippet": "Button(action: { torchOn.toggle() }) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
+      "fingerprint": "c2ea76f6cd01c31f",
+      "line_when_recorded": 152,
+      "snippet": "Button(action: onBack) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
+      "fingerprint": "c2ea76f6cd01c31f",
+      "line_when_recorded": 211,
+      "snippet": "Button(action: onBack) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
+      "fingerprint": "6833995482ae652e",
+      "line_when_recorded": 233,
+      "snippet": "Button(action: onAdd) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
+      "fingerprint": "a7dc9971f9cf05c0",
+      "line_when_recorded": 287,
+      "snippet": "Button(action: onClose) {"
+    },
+    {
+      "rule": "A11Y004",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift",
+      "fingerprint": "04a22d3697ea388b",
+      "line_when_recorded": 69,
+      "snippet": "Button(action: {"
+    },
+    {
+      "rule": "A11Y005",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift",
+      "fingerprint": "3ea1f401f0b12c36",
+      "line_when_recorded": 232,
+      "snippet": "Toggle(isOn: $isToggled) { }"
+    },
+    {
+      "rule": "A11Y006",
+      "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
+      "fingerprint": "67c208cbce08b390",
+      "line_when_recorded": 109,
+      "snippet": "let backButton = UIButton(type: .custom)"
+    },
+    {
+      "rule": "A11Y006",
+      "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
+      "fingerprint": "4423c686f217929f",
+      "line_when_recorded": 177,
+      "snippet": "let backButton = UIButton(type: .custom)"
+    },
+    {
+      "rule": "A11Y009",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageModelListViews.swift",
+      "fingerprint": "5cd54c554ab5a556",
+      "line_when_recorded": 151,
+      "snippet": ".accessibilityLabel(Text(\"Refresh from Platform\"))"
+    },
+    {
+      "rule": "A11Y009",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
+      "fingerprint": "454683cec5a6c99c",
+      "line_when_recorded": 116,
+      "snippet": ".accessibilityLabel(Text(\"Refresh from Platform\"))"
+    },
+    {
+      "rule": "A11Y010",
+      "path": "DashWallet/Sources/UI/DashConnect/Components/ConnectionRow.swift",
+      "fingerprint": "02df12e2f7227b32",
+      "line_when_recorded": 105,
+      "snippet": ".accessibilityLabel(Text(NSLocalizedString(\"Disconnect\", comment: \"DashConnect\")))"
+    },
+    {
+      "rule": "A11Y010",
+      "path": "DashWallet/Sources/UI/Home/Views/HomeUsernameRow.swift",
+      "fingerprint": "fc20a8f3918a7567",
+      "line_when_recorded": 31,
+      "snippet": ".accessibilityLabel(Text(String(format: NSLocalizedString(\"My profile, %@\", comment: \"Home — persistent username row accessibility label\"), username)))"
+    },
+    {
+      "rule": "A11Y010",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "6050298251b9e842",
+      "line_when_recorded": 838,
+      "snippet": ".accessibilityLabel(Text(NSLocalizedString(\"Refresh keys from Platform\", comment: \"Identities: re-fetch this identity's public keys\")))"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/Buy Sell/BuySellPortal.storyboard",
+      "fingerprint": "b09336b2b50985cf",
+      "line_when_recorded": 315,
+      "snippet": "<barButtonItem key=\"rightBarButtonItem\" id=\"hlH-Nb-mXz\">"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
+      "fingerprint": "e59764611405db5d",
+      "line_when_recorded": 380,
+      "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" selected=\"YES\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncati"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
+      "fingerprint": "11cf4bf48799ba77",
+      "line_when_recorded": 449,
+      "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncation\" translatesA"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/Coinbase/Base.lproj/Coinbase.storyboard",
+      "fingerprint": "11cf4bf48799ba77",
+      "line_when_recorded": 502,
+      "snippet": "<button opaque=\"NO\" contentMode=\"scaleToFill\" contentHorizontalAlignment=\"center\" contentVerticalAlignment=\"center\" lineBreakMode=\"middleTruncation\" translatesA"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 88,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 1335,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 1516,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 1573,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 1719,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "DashWallet/Sources/UI/CrowdNode/CrowdNode.storyboard",
+      "fingerprint": "f8cdb0ea182d85bc",
+      "line_when_recorded": 1776,
+      "snippet": "<buttonConfiguration key=\"configuration\" style=\"plain\" image=\"icon_copy_outline\"/>"
+    },
+    {
+      "rule": "A11Y011",
+      "path": "WatchApp/Base.lproj/Interface.storyboard",
+      "fingerprint": "5c416c3a871270f5",
+      "line_when_recorded": 192,
+      "snippet": "<button width=\"1\" alignment=\"left\" id=\"DPm-5o-p0S\">"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "6f1e1bdcc4e3f2e4",
+      "line_when_recorded": 315,
+      "snippet": ".onTapGesture { previewTarget = candidate(result) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "d2959c4b0d5e37bf",
+      "line_when_recorded": 196,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "d2959c4b0d5e37bf",
+      "line_when_recorded": 665,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "2d2830c857230f01",
+      "line_when_recorded": 467,
+      "snippet": ".onTapGesture { selectedContact = item }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "2d2830c857230f01",
+      "line_when_recorded": 479,
+      "snippet": ".onTapGesture { selectedContact = item }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "2d2830c857230f01",
+      "line_when_recorded": 490,
+      "snippet": ".onTapGesture { selectedContact = item }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "2d2830c857230f01",
+      "line_when_recorded": 503,
+      "snippet": ".onTapGesture { selectedContact = item }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d472650a84c0a9f9",
+      "line_when_recorded": 557,
+      "snippet": ".onTapGesture { openAddContact(query: result.fullName.withoutDashSuffix) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "9e40677581eede6f",
+      "line_when_recorded": 262,
+      "snippet": ".onTapGesture { selectedContact = event.item }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayView.swift",
+      "fingerprint": "c109fb9a8a3f5dee",
+      "line_when_recorded": 190,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
+      "fingerprint": "2ebc5e2101a3d71d",
+      "line_when_recorded": 298,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendConfirmationDialog.swift",
+      "fingerprint": "36150e2a5946d5f7",
+      "line_when_recorded": 198,
+      "snippet": ".onTapGesture { isPresented = true }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
+      "fingerprint": "cd218d8662236d70",
+      "line_when_recorded": 102,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
+      "fingerprint": "fc42cdfce0dd86d8",
+      "line_when_recorded": 133,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
+      "fingerprint": "99b0140a7827009d",
+      "line_when_recorded": 763,
+      "snippet": ".onTapGesture { self.selectedTxDataItem = txDataItem }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
+      "fingerprint": "99b0140a7827009d",
+      "line_when_recorded": 777,
+      "snippet": ".onTapGesture { self.selectedTxDataItem = txDataItem }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutsBarView.swift",
+      "fingerprint": "6fe03e4a2f2fd1fd",
+      "line_when_recorded": 107,
+      "snippet": ".onTapGesture { onSelect() }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0e2bbe238ad43f4b",
+      "line_when_recorded": 57,
+      "snippet": ".onTapGesture { showDetail(row) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
+      "fingerprint": "a56aa329e1d56193",
+      "line_when_recorded": 252,
+      "snippet": ".onTapGesture { copy(item.address) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
+      "fingerprint": "56c740b37bdf311f",
+      "line_when_recorded": 64,
+      "snippet": ".onTapGesture { showDetail(row) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "96732b96cf9bc821",
+      "line_when_recorded": 81,
+      "snippet": ".onTapGesture { showAccounts(row) }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Settings/LocalCurrency/LocalCurrencyView.swift",
+      "fingerprint": "a76ed76dc8df1d8f",
+      "line_when_recorded": 131,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
+      "fingerprint": "5e88a5e8846b28b1",
+      "line_when_recorded": 29,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
+      "fingerprint": "5e88a5e8846b28b1",
+      "line_when_recorded": 480,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Menu/Tools/StorageExplorer/StorageRecordDetailViews.swift",
+      "fingerprint": "5e88a5e8846b28b1",
+      "line_when_recorded": 675,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "76d131dd1c2c9c51",
+      "line_when_recorded": 301,
+      "snippet": ".onTapGesture { onCopyAddress() }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/Swap/OrderPreview/Components/OrderPreviewFeeRow.swift",
+      "fingerprint": "c0638eb367473ee1",
+      "line_when_recorded": 51,
+      "snippet": ".onTapGesture { showInfoSheet = true }"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
+      "fingerprint": "a66835180ca20a96",
+      "line_when_recorded": 46,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
+      "fingerprint": "a66835180ca20a96",
+      "line_when_recorded": 88,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y012",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/TextInput.swift",
+      "fingerprint": "13ea5194fb6d6d2b",
+      "line_when_recorded": 86,
+      "snippet": ".onTapGesture {"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
+      "fingerprint": "323053bb1509331d",
+      "line_when_recorded": 229,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
+      "fingerprint": "b2d6137cba3ec4de",
+      "line_when_recorded": 237,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
+      "fingerprint": "4466c2bfca075e99",
+      "line_when_recorded": 244,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Auth/PinPromptView.swift",
+      "fingerprint": "67888c5050ef935a",
+      "line_when_recorded": 257,
+      "snippet": ".font(.system(size: 17))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "0f9a19cb80a0725c",
+      "line_when_recorded": 205,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "b22a69b756b6da3a",
+      "line_when_recorded": 216,
+      "snippet": ".font(.system(size: 44))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "7ea3ef1c02ce67cc",
+      "line_when_recorded": 221,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "836e74fad9faf0fe",
+      "line_when_recorded": 261,
+      "snippet": ".font(.system(size: 17, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "7ea3ef1c02ce67cc",
+      "line_when_recorded": 263,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "6f2085bcd59da200",
+      "line_when_recorded": 279,
+      "snippet": ".font(.system(size: 56, weight: .light))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "da71ac82e66f3517",
+      "line_when_recorded": 283,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "b04ceca88a0d5e2d",
+      "line_when_recorded": 286,
+      "snippet": ".font(.system(size: 16))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 300,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 305,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "49796c018dfde2e3",
+      "line_when_recorded": 374,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "fa29be4afd46accf",
+      "line_when_recorded": 379,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "66e268fee870c301",
+      "line_when_recorded": 681,
+      "snippet": ".font(.system(size: 22, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 687,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 696,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 703,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "7ea3ef1c02ce67cc",
+      "line_when_recorded": 772,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "6c93b028a3e48534",
+      "line_when_recorded": 784,
+      "snippet": "Text(title).font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "66e268fee870c301",
+      "line_when_recorded": 812,
+      "snippet": ".font(.system(size: 22, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 817,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/AddContactScreen.swift",
+      "fingerprint": "60cbb96f56f4a9d9",
+      "line_when_recorded": 840,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "fe280c80eae046b6",
+      "line_when_recorded": 59,
+      "snippet": ".font(.system(size: size * 0.5, weight: .regular))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "88a2623c1cc24cee",
+      "line_when_recorded": 97,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "dd066f8455e8f8b2",
+      "line_when_recorded": 117,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "e499779a2ca3c48e",
+      "line_when_recorded": 142,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "7d9f0b7688ee54fc",
+      "line_when_recorded": 233,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "eab76b81339485e0",
+      "line_when_recorded": 237,
+      "snippet": ".font(.system(size: 12, design: .monospaced))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactAvatarView.swift",
+      "fingerprint": "735ef047a069cb5f",
+      "line_when_recorded": 242,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ac62203b00dcf55a",
+      "line_when_recorded": 74,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "fe1c60df270e5cb6",
+      "line_when_recorded": 154,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e5e97d453dd650a7",
+      "line_when_recorded": 173,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ac62203b00dcf55a",
+      "line_when_recorded": 182,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ce70d9f0492921e9",
+      "line_when_recorded": 189,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "54902d031f2af9b5",
+      "line_when_recorded": 214,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "6ba1f1a70860a1e7",
+      "line_when_recorded": 225,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "6ba1f1a70860a1e7",
+      "line_when_recorded": 238,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 253,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "fe1c60df270e5cb6",
+      "line_when_recorded": 255,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "6ba1f1a70860a1e7",
+      "line_when_recorded": 287,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "6ba1f1a70860a1e7",
+      "line_when_recorded": 309,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "3ce6513e8aa334e1",
+      "line_when_recorded": 328,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 331,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "5e11110294a7ae48",
+      "line_when_recorded": 336,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "5e11110294a7ae48",
+      "line_when_recorded": 347,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "d29484accb68087a",
+      "line_when_recorded": 360,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "6ba1f1a70860a1e7",
+      "line_when_recorded": 453,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "54902d031f2af9b5",
+      "line_when_recorded": 458,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "3ce6513e8aa334e1",
+      "line_when_recorded": 476,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 482,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ac62203b00dcf55a",
+      "line_when_recorded": 486,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ac62203b00dcf55a",
+      "line_when_recorded": 608,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "f544152b2c6d93a5",
+      "line_when_recorded": 612,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e4e958d0bea51213",
+      "line_when_recorded": 639,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 643,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 648,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 655,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ce70d9f0492921e9",
+      "line_when_recorded": 659,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "54902d031f2af9b5",
+      "line_when_recorded": 795,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 799,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "fbbdcce9fb0250c6",
+      "line_when_recorded": 824,
+      "snippet": ".font(.system(size: 48))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "32c2335d78579ddd",
+      "line_when_recorded": 827,
+      "snippet": ".font(.system(size: 17, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "ac62203b00dcf55a",
+      "line_when_recorded": 833,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactProfileSheet.swift",
+      "fingerprint": "e1b808e60f9836c7",
+      "line_when_recorded": 839,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "080a73e06068bc5d",
+      "line_when_recorded": 377,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9649d8f289bb5ae0",
+      "line_when_recorded": 384,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "e103ea14dc12259d",
+      "line_when_recorded": 405,
+      "snippet": ".font(.system(size: 17, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "0f4b97b9c9241003",
+      "line_when_recorded": 410,
+      "snippet": ".font(.system(size: 12.5))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "15f562ab39e631b7",
+      "line_when_recorded": 417,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "a6ee2efe281b9cce",
+      "line_when_recorded": 533,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d5a1550a1a6dad07",
+      "line_when_recorded": 547,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "15f562ab39e631b7",
+      "line_when_recorded": 564,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9c9a3b3028571a8d",
+      "line_when_recorded": 582,
+      "snippet": ".font(.system(size: size, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "5d2ecf94017c6456",
+      "line_when_recorded": 607,
+      "snippet": ".font(.system(size: 72, weight: .light))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9b64c7030a55f3a9",
+      "line_when_recorded": 611,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "f464f586bac2f1cf",
+      "line_when_recorded": 614,
+      "snippet": ".font(.system(size: 16))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "15f562ab39e631b7",
+      "line_when_recorded": 624,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "8b69a0b0e21a9403",
+      "line_when_recorded": 680,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "60abecb92956dfd3",
+      "line_when_recorded": 687,
+      "snippet": ".font(.system(size: 22, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "78afd492ec5a699f",
+      "line_when_recorded": 695,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "1b88b7594122e91d",
+      "line_when_recorded": 727,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9649d8f289bb5ae0",
+      "line_when_recorded": 739,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "cc339ac2b6656df6",
+      "line_when_recorded": 758,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d544243993fcb6e2",
+      "line_when_recorded": 764,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "a6ee2efe281b9cce",
+      "line_when_recorded": 767,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "6b1daee1747dce8e",
+      "line_when_recorded": 856,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d544243993fcb6e2",
+      "line_when_recorded": 863,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "8b69a0b0e21a9403",
+      "line_when_recorded": 911,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9b64c7030a55f3a9",
+      "line_when_recorded": 918,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "6b1daee1747dce8e",
+      "line_when_recorded": 925,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9649d8f289bb5ae0",
+      "line_when_recorded": 934,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "847e622e7693b715",
+      "line_when_recorded": 948,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "1812ceaf135d9d10",
+      "line_when_recorded": 982,
+      "snippet": ".font(.system(size: 34))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9b64c7030a55f3a9",
+      "line_when_recorded": 989,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "6b1daee1747dce8e",
+      "line_when_recorded": 996,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d544243993fcb6e2",
+      "line_when_recorded": 1008,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "178e5a7a411d6824",
+      "line_when_recorded": 1021,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "9649d8f289bb5ae0",
+      "line_when_recorded": 1030,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "847e622e7693b715",
+      "line_when_recorded": 1045,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d5a1550a1a6dad07",
+      "line_when_recorded": 1071,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "178e5a7a411d6824",
+      "line_when_recorded": 1076,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "47fba84d3f45c081",
+      "line_when_recorded": 1084,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "d5a1550a1a6dad07",
+      "line_when_recorded": 1117,
+      "snippet": ".font(.system(size: 17, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "178e5a7a411d6824",
+      "line_when_recorded": 1122,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "178e5a7a411d6824",
+      "line_when_recorded": 1132,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/ContactsScreen.swift",
+      "fingerprint": "47fba84d3f45c081",
+      "line_when_recorded": 1134,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "2e3f604750f072a2",
+      "line_when_recorded": 121,
+      "snippet": ".font(.system(size: 44, weight: .light))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "c3f300edf2ec435e",
+      "line_when_recorded": 124,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "4c7ba246e978fe19",
+      "line_when_recorded": 148,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "65e7ddc350eb745a",
+      "line_when_recorded": 183,
+      "snippet": "Image(systemName: \"hourglass\").font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "87b4f7cdbb632539",
+      "line_when_recorded": 185,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "65e7ddc350eb745a",
+      "line_when_recorded": 202,
+      "snippet": "Image(systemName: \"hourglass\").font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "87b4f7cdbb632539",
+      "line_when_recorded": 204,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "d11fc63395ee4249",
+      "line_when_recorded": 217,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "d11fc63395ee4249",
+      "line_when_recorded": 228,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "c3f300edf2ec435e",
+      "line_when_recorded": 249,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Contacts/SwiftUI/NotificationsScreen.swift",
+      "fingerprint": "cfb4c2a4f794587a",
+      "line_when_recorded": 253,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
+      "fingerprint": "68ea53b83a769207",
+      "line_when_recorded": 226,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
+      "fingerprint": "24bf81a8a51a4021",
+      "line_when_recorded": 234,
+      "snippet": ".font(.system(size: 14, design: .monospaced))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Invitations/ClaimInvitationScreen.swift",
+      "fingerprint": "3323fc854ec9bb4c",
+      "line_when_recorded": 305,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "e478b6ecbf1331aa",
+      "line_when_recorded": 221,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "fa0b4fdea47194cb",
+      "line_when_recorded": 297,
+      "snippet": ".font(.system(size: 18))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "8d43d0f579f4ad59",
+      "line_when_recorded": 303,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "bf4b9dcb6cb8d4d4",
+      "line_when_recorded": 313,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "b26483c457254e8e",
+      "line_when_recorded": 645,
+      "snippet": ".font(.system(size: 34))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "1a183cd9c5f0929a",
+      "line_when_recorded": 652,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "209c6279f1284789",
+      "line_when_recorded": 659,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 680,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 688,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 692,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "8d43d0f579f4ad59",
+      "line_when_recorded": 708,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "b0c05be285841cf4",
+      "line_when_recorded": 710,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "8d43d0f579f4ad59",
+      "line_when_recorded": 721,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "b0c05be285841cf4",
+      "line_when_recorded": 723,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "aececc43bd4d247f",
+      "line_when_recorded": 738,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 745,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 751,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "587f4d827726b4a4",
+      "line_when_recorded": 761,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "e478b6ecbf1331aa",
+      "line_when_recorded": 765,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 772,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "156032002835d55a",
+      "line_when_recorded": 787,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "aececc43bd4d247f",
+      "line_when_recorded": 795,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Profile/SDKIdentityProfileSheet.swift",
+      "fingerprint": "bcfabf7425d08697",
+      "line_when_recorded": 812,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "755388e771ef6baa",
+      "line_when_recorded": 176,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "ccad05e4b7dc3661",
+      "line_when_recorded": 466,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "ccad05e4b7dc3661",
+      "line_when_recorded": 497,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "ccad05e4b7dc3661",
+      "line_when_recorded": 606,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "ccad05e4b7dc3661",
+      "line_when_recorded": 655,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/CreateUsernameViewController.swift",
+      "fingerprint": "ccad05e4b7dc3661",
+      "line_when_recorded": 677,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "1c7f7ea6bbc75234",
+      "line_when_recorded": 67,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "24c9bb8dd99a19c3",
+      "line_when_recorded": 86,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "6c7822476f64d8a9",
+      "line_when_recorded": 244,
+      "snippet": ".font(.system(size: 20, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "6046a4740c7c4ad1",
+      "line_when_recorded": 250,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "9205079d05ff6487",
+      "line_when_recorded": 254,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Setup/CreateUsername/JoinDashPayReadinessScreen.swift",
+      "fingerprint": "080948e71a2268bd",
+      "line_when_recorded": 263,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Voting/BulkVoteSheet.swift",
+      "fingerprint": "dc1458ffa24dd205",
+      "line_when_recorded": 378,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Voting/CastVoteSheet.swift",
+      "fingerprint": "c29bdb1de30d25da",
+      "line_when_recorded": 246,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/DashPay/Voting/UsernameVotingScreen.swift",
+      "fingerprint": "1f2a95a6321e9e34",
+      "line_when_recorded": 384,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "6f1620a366e5ff77",
+      "line_when_recorded": 143,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 148,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "b2b67d815b005022",
+      "line_when_recorded": 212,
+      "snippet": ".font(.system(size: 22))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "d61e678894bb557a",
+      "line_when_recorded": 271,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 277,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "d61e678894bb557a",
+      "line_when_recorded": 316,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 322,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "d61e678894bb557a",
+      "line_when_recorded": 333,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 384,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 414,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/Details/Views/POIDetailsView.swift",
+      "fingerprint": "26f388f658636abb",
+      "line_when_recorded": 425,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift",
+      "fingerprint": "51ffca9cf8b647ca",
+      "line_when_recorded": 127,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/AllMerchantLocations/AllMerchantLocationsView.swift",
+      "fingerprint": "91ad4cbb0169cab8",
+      "line_when_recorded": 132,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
+      "fingerprint": "9b84c97dfc9e294e",
+      "line_when_recorded": 230,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/MerchantFiltersView.swift",
+      "fingerprint": "9b84c97dfc9e294e",
+      "line_when_recorded": 237,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Merchants & ATMs/List/Filters/TerritoryPickerView.swift",
+      "fingerprint": "8bc76e94170a5e55",
+      "line_when_recorded": 127,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "e9cd1e0d3e625029",
+      "line_when_recorded": 521,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 616,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "e9cd1e0d3e625029",
+      "line_when_recorded": 626,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 677,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 681,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a4a32498cb62e978",
+      "line_when_recorded": 689,
+      "snippet": ".font(.system(size: 10, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 692,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "7fb2ae8ff24fe9e8",
+      "line_when_recorded": 697,
+      "snippet": ".font(.system(size: 10, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 701,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 761,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 768,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a4a32498cb62e978",
+      "line_when_recorded": 776,
+      "snippet": ".font(.system(size: 10, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 779,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 784,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 818,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 822,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a4a32498cb62e978",
+      "line_when_recorded": 830,
+      "snippet": ".font(.system(size: 10, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 833,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 838,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "97100287959b34b3",
+      "line_when_recorded": 903,
+      "snippet": ".font(.system(size: 20, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 910,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "d523068a185b0211",
+      "line_when_recorded": 915,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 921,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "eb57050f3f263917",
+      "line_when_recorded": 977,
+      "snippet": ".font(.system(size: 26))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 981,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 984,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 989,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1008,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1019,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "736ab3b0660ece46",
+      "line_when_recorded": 1041,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "1c044349c188f0b9",
+      "line_when_recorded": 1119,
+      "snippet": ".font(.system(size: 22, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1146,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 1201,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "e76b9efeadf7433b",
+      "line_when_recorded": 1204,
+      "snippet": ".font(.system(size: 18, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1207,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "d523068a185b0211",
+      "line_when_recorded": 1215,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1226,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1230,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1271,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 1296,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1301,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 1306,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1452,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "fe46c5cd570a7fbc",
+      "line_when_recorded": 1456,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 1461,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1471,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1475,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "637b6d9ae6cc9cb4",
+      "line_when_recorded": 1486,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "6d823c326d86d556",
+      "line_when_recorded": 1499,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c18fad49d81aeea6",
+      "line_when_recorded": 1537,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "5b1131fa195c8c9d",
+      "line_when_recorded": 1544,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "f3a46846ccf1c319",
+      "line_when_recorded": 1557,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1564,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1572,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 1591,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c9f5433ac6d992a9",
+      "line_when_recorded": 1608,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c18fad49d81aeea6",
+      "line_when_recorded": 1647,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "5b1131fa195c8c9d",
+      "line_when_recorded": 1652,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "9fded2ec55ba0230",
+      "line_when_recorded": 1665,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 1672,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 1688,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c9f5433ac6d992a9",
+      "line_when_recorded": 1706,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3d8148d5c6c30ac2",
+      "line_when_recorded": 1801,
+      "snippet": ".font(.system(size: 36))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c18fad49d81aeea6",
+      "line_when_recorded": 1812,
+      "snippet": ".font(.system(size: 20, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "5b1131fa195c8c9d",
+      "line_when_recorded": 1820,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "c9f5433ac6d992a9",
+      "line_when_recorded": 1843,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "5b1131fa195c8c9d",
+      "line_when_recorded": 1875,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "5b1131fa195c8c9d",
+      "line_when_recorded": 1897,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1943,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1949,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 1956,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1960,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 1966,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "3a21eec1805f704b",
+      "line_when_recorded": 1974,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 1996,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 2003,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "d671bd8549c1c66e",
+      "line_when_recorded": 2043,
+      "snippet": ".font(.system(size: 13, weight: emphasized ? .semibold : .regular))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 2049,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 2059,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "69fd6636b0c7aad8",
+      "line_when_recorded": 2063,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "017502583fd9b095",
+      "line_when_recorded": 2086,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "a785d656fb830563",
+      "line_when_recorded": 2090,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/UsernameMarketplaceScreen.swift",
+      "fingerprint": "531fbb8e1cbd2681",
+      "line_when_recorded": 2105,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
+      "fingerprint": "6f391204f4b5c651",
+      "line_when_recorded": 41,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
+      "fingerprint": "730e0942c14020bf",
+      "line_when_recorded": 86,
+      "snippet": ".font(.system(size: 14, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendTermsScreen.swift",
+      "fingerprint": "6140482c89b529b8",
+      "line_when_recorded": 96,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
+      "fingerprint": "6f50b84020dd6612",
+      "line_when_recorded": 85,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
+      "fingerprint": "3a2cde81f0d2a6f4",
+      "line_when_recorded": 93,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
+      "fingerprint": "ea7e709ffd238c7c",
+      "line_when_recorded": 111,
+      "snippet": ".font(.system(size: 24, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Explore Dash/Views/DashSpend/DashSpendUserAuthScreen.swift",
+      "fingerprint": "74599f252ce59c65",
+      "line_when_recorded": 115,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "3f25959907f25967",
+      "line_when_recorded": 231,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "a256feb052596cfa",
+      "line_when_recorded": 279,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "a256feb052596cfa",
+      "line_when_recorded": 285,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "e85c9e5f462216f9",
+      "line_when_recorded": 288,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "bf63ce438b1dda6f",
+      "line_when_recorded": 297,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "3f25959907f25967",
+      "line_when_recorded": 371,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/CoinJoinMoveFundsSheet.swift",
+      "fingerprint": "3f25959907f25967",
+      "line_when_recorded": 398,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift",
+      "fingerprint": "ce1197cdc5e863f8",
+      "line_when_recorded": 62,
+      "snippet": ".font(.system(size: 26, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/BalanceInfoSheet.swift",
+      "fingerprint": "219d4833ef88fe45",
+      "line_when_recorded": 83,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
+      "fingerprint": "3412bd57595cab9a",
+      "line_when_recorded": 238,
+      "snippet": ".font(.system(size: 11, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
+      "fingerprint": "3027a019fe575207",
+      "line_when_recorded": 266,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Home Balance View/HomeBalanceView.swift",
+      "fingerprint": "ec3b61b85d2a17f4",
+      "line_when_recorded": 314,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/HomeView.swift",
+      "fingerprint": "01c63eecf3014b95",
+      "line_when_recorded": 741,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift",
+      "fingerprint": "55cf453394cf8832",
+      "line_when_recorded": 84,
+      "snippet": ".font(.system(size: 24, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/PlatformAddressHistory.swift",
+      "fingerprint": "4016783cd171fd54",
+      "line_when_recorded": 89,
+      "snippet": ".font(.system(size: 11, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift",
+      "fingerprint": "c34f9f9921fe57a8",
+      "line_when_recorded": 329,
+      "snippet": ".font(.system(size: 26, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/ShieldedActivityHistory.swift",
+      "fingerprint": "9c682b3d735256d6",
+      "line_when_recorded": 335,
+      "snippet": ".font(.system(size: 11, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/NodesShortcutIcon.swift",
+      "fingerprint": "58a3591902c332b6",
+      "line_when_recorded": 86,
+      "snippet": ".font(.system(size: 19, weight: .bold, design: .rounded))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/NodesShortcutIcon.swift",
+      "fingerprint": "9e02482ada2734cc",
+      "line_when_recorded": 92,
+      "snippet": ".font(.system(size: 8.5, weight: .heavy, design: .rounded))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/ShortcutCustomizeBannerView.swift",
+      "fingerprint": "008cc823c50cdebf",
+      "line_when_recorded": 43,
+      "snippet": ".font(.system(size: 10, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Home/Views/Shortcuts/WalletSwitchDialog.swift",
+      "fingerprint": "58f88a00fdde9f45",
+      "line_when_recorded": 55,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
+      "fingerprint": "278c057f6580bf1e",
+      "line_when_recorded": 569,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
+      "fingerprint": "bc14db0c86fada64",
+      "line_when_recorded": 573,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
+      "fingerprint": "f21de81f316aa8d6",
+      "line_when_recorded": 580,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/RecoveryPhraseFlow.swift",
+      "fingerprint": "be3828644272788c",
+      "line_when_recorded": 584,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "8388c880a9255221",
+      "line_when_recorded": 121,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "f57aa6cfb415640a",
+      "line_when_recorded": 136,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "f57aa6cfb415640a",
+      "line_when_recorded": 151,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "911a5928f5b444c0",
+      "line_when_recorded": 180,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "17120559b8005208",
+      "line_when_recorded": 206,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "f57aa6cfb415640a",
+      "line_when_recorded": 231,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d2f660dad68c399e",
+      "line_when_recorded": 248,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0f3f3d5e7d0f26a7",
+      "line_when_recorded": 263,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "8388c880a9255221",
+      "line_when_recorded": 426,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "7729fe1170cc468d",
+      "line_when_recorded": 444,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d7a05632edfea3b8",
+      "line_when_recorded": 465,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d2f660dad68c399e",
+      "line_when_recorded": 477,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "377befe798feee21",
+      "line_when_recorded": 485,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d2f660dad68c399e",
+      "line_when_recorded": 496,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "6b58a0a920c7a23c",
+      "line_when_recorded": 523,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "085e67c41be3a9e4",
+      "line_when_recorded": 566,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0f3f3d5e7d0f26a7",
+      "line_when_recorded": 570,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "101c50e0aaa2d77b",
+      "line_when_recorded": 573,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d7a05632edfea3b8",
+      "line_when_recorded": 612,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "67fdf35bfbba02d0",
+      "line_when_recorded": 616,
+      "snippet": ".font(.system(size: 18))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "67fdf35bfbba02d0",
+      "line_when_recorded": 637,
+      "snippet": ".font(.system(size: 18))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "17120559b8005208",
+      "line_when_recorded": 643,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "101c50e0aaa2d77b",
+      "line_when_recorded": 653,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "d7a05632edfea3b8",
+      "line_when_recorded": 682,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "085e67c41be3a9e4",
+      "line_when_recorded": 719,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0f3f3d5e7d0f26a7",
+      "line_when_recorded": 723,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "8388c880a9255221",
+      "line_when_recorded": 815,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "f57aa6cfb415640a",
+      "line_when_recorded": 830,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "085e67c41be3a9e4",
+      "line_when_recorded": 852,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "17120559b8005208",
+      "line_when_recorded": 866,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "6b58a0a920c7a23c",
+      "line_when_recorded": 911,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "085e67c41be3a9e4",
+      "line_when_recorded": 950,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/IdentitiesScreen.swift",
+      "fingerprint": "0f3f3d5e7d0f26a7",
+      "line_when_recorded": 954,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
+      "fingerprint": "d443bc75f57b0f2c",
+      "line_when_recorded": 97,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
+      "fingerprint": "66836a2040815e08",
+      "line_when_recorded": 162,
+      "snippet": ".font(.system(size: 15, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountDetailScreen.swift",
+      "fingerprint": "9e02abea1b52bc80",
+      "line_when_recorded": 293,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
+      "fingerprint": "dbcdc2c75d0a261a",
+      "line_when_recorded": 169,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletAccountsScreen.swift",
+      "fingerprint": "8d899caae8725242",
+      "line_when_recorded": 183,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf45f673aec2a714",
+      "line_when_recorded": 230,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf45f673aec2a714",
+      "line_when_recorded": 238,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "47f065ae0d4cf9ee",
+      "line_when_recorded": 335,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "b62949a6cebfb0e2",
+      "line_when_recorded": 340,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "b62949a6cebfb0e2",
+      "line_when_recorded": 346,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 354,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 391,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "2f77d94e68348492",
+      "line_when_recorded": 397,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "58190b0931f2086c",
+      "line_when_recorded": 442,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 463,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "019d5ba8f88fb0d1",
+      "line_when_recorded": 595,
+      "snippet": ".font(.system(size: 22))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 600,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "b62949a6cebfb0e2",
+      "line_when_recorded": 603,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "2f77d94e68348492",
+      "line_when_recorded": 608,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "8da52739bf05fedd",
+      "line_when_recorded": 652,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 663,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "1542fabd64399bdb",
+      "line_when_recorded": 698,
+      "snippet": ".font(.system(size: 13, design: .monospaced))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "58190b0931f2086c",
+      "line_when_recorded": 702,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "900cf989191b7974",
+      "line_when_recorded": 770,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift",
+      "fingerprint": "bf2f6ca974f687ed",
+      "line_when_recorded": 781,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "961c2d9707c8710d",
+      "line_when_recorded": 148,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 201,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 206,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 212,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 218,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "2ab5dbbada58a3a5",
+      "line_when_recorded": 224,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 237,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 252,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "04156343d109247d",
+      "line_when_recorded": 255,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "fef56d029b85cb59",
+      "line_when_recorded": 273,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "04156343d109247d",
+      "line_when_recorded": 292,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/DashPaySyncInfoScreen.swift",
+      "fingerprint": "efaf6753ca37d662",
+      "line_when_recorded": 296,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "f958529e49f8b9d0",
+      "line_when_recorded": 47,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 102,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 108,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 114,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "ba36857c726693a7",
+      "line_when_recorded": 120,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 154,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d241cce6ddd5e328",
+      "line_when_recorded": 160,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "f5d1960bf7113327",
+      "line_when_recorded": 223,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d241cce6ddd5e328",
+      "line_when_recorded": 227,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d241cce6ddd5e328",
+      "line_when_recorded": 230,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 244,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "ba36857c726693a7",
+      "line_when_recorded": 248,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 266,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "f5d1960bf7113327",
+      "line_when_recorded": 269,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 288,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 304,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "d644d609ea265c74",
+      "line_when_recorded": 317,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "f5d1960bf7113327",
+      "line_when_recorded": 333,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "e400cade6090ac20",
+      "line_when_recorded": 337,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "1959ddbc5273be14",
+      "line_when_recorded": 346,
+      "snippet": ".font(.system(size: 16, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "e36db957a18fe033",
+      "line_when_recorded": 350,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/PlatformSyncStatusScreen.swift",
+      "fingerprint": "699689a3f05643ac",
+      "line_when_recorded": 354,
+      "snippet": ".font(.system(size: 10))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "e8c2820754b61109",
+      "line_when_recorded": 41,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 97,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 102,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 108,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 114,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 120,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "a425634931a4676c",
+      "line_when_recorded": 126,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 153,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "a425634931a4676c",
+      "line_when_recorded": 158,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 201,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "a425634931a4676c",
+      "line_when_recorded": 205,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 222,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "991674adbaa847b2",
+      "line_when_recorded": 225,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 244,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "2e082897e331c5ad",
+      "line_when_recorded": 257,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "991674adbaa847b2",
+      "line_when_recorded": 276,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "07a6ab41f1475a4f",
+      "line_when_recorded": 280,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "991674adbaa847b2",
+      "line_when_recorded": 292,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "0a9de042f9860a93",
+      "line_when_recorded": 299,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "0a9de042f9860a93",
+      "line_when_recorded": 305,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "6dba5368218fd867",
+      "line_when_recorded": 319,
+      "snippet": ".font(.system(size: 16, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/ShieldedSyncInfoScreen.swift",
+      "fingerprint": "b661f0fad60620f0",
+      "line_when_recorded": 323,
+      "snippet": ".font(.system(size: 11, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c5a0f89015cb9e98",
+      "line_when_recorded": 90,
+      "snippet": ".font(.system(size: 18, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "aa0528c87ab928ca",
+      "line_when_recorded": 245,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 258,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 262,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 294,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "f5dcfeab0e3ba1f5",
+      "line_when_recorded": 298,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "f5dcfeab0e3ba1f5",
+      "line_when_recorded": 306,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 321,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 325,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 333,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 339,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "f050e6e33aace722",
+      "line_when_recorded": 356,
+      "snippet": ".font(.system(size: 11, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 385,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 426,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 432,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 441,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 454,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 460,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 474,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 480,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 500,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 514,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "11f2745ef3ec8a06",
+      "line_when_recorded": 520,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 534,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 537,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 553,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c647c06200e94414",
+      "line_when_recorded": 570,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 591,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "f5dcfeab0e3ba1f5",
+      "line_when_recorded": 595,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "c6f5dbed95f97fea",
+      "line_when_recorded": 604,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/SyncInfo/SwiftDashSDKSPVStatusScreen.swift",
+      "fingerprint": "ef347edb5857ac0a",
+      "line_when_recorded": 608,
+      "snippet": ".font(.system(size: 12, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift",
+      "fingerprint": "ca93c49bda34a50b",
+      "line_when_recorded": 42,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/CSVExportSheet.swift",
+      "fingerprint": "94e85104b58b9f77",
+      "line_when_recorded": 48,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Evonode Status/EvonodeStatusScreen.swift",
+      "fingerprint": "ab920a5dc45ed110",
+      "line_when_recorded": 103,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift",
+      "fingerprint": "e132d6afc6832fb9",
+      "line_when_recorded": 101,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ExtendedKeys/ExtendedPublicKeySheet.swift",
+      "fingerprint": "70b53f9218741ead",
+      "line_when_recorded": 116,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Keys/DerivationPathKeys/DerivationPathKeysView.swift",
+      "fingerprint": "6e6311d9ad5145b2",
+      "line_when_recorded": 76,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Keys/Overview/KeysOverviewView.swift",
+      "fingerprint": "d0d17fb3d24847eb",
+      "line_when_recorded": 40,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 137,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 143,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "d6cb6382fdb4553b",
+      "line_when_recorded": 191,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "01086ffda9dbda82",
+      "line_when_recorded": 211,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 219,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 226,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "9102314d2ad9060a",
+      "line_when_recorded": 232,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "387c7e29955d5643",
+      "line_when_recorded": 237,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 253,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "d6cb6382fdb4553b",
+      "line_when_recorded": 272,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "d6cb6382fdb4553b",
+      "line_when_recorded": 278,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 285,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "9102314d2ad9060a",
+      "line_when_recorded": 325,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 328,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 418,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 427,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "9102314d2ad9060a",
+      "line_when_recorded": 465,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 497,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "4caf2fbccf088fa2",
+      "line_when_recorded": 503,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "1b43a799b768bab6",
+      "line_when_recorded": 544,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "01086ffda9dbda82",
+      "line_when_recorded": 552,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "9102314d2ad9060a",
+      "line_when_recorded": 608,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "21caa2de777ff76e",
+      "line_when_recorded": 612,
+      "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/Masternode Withdrawal/EvonodeWithdrawalScreen.swift",
+      "fingerprint": "21caa2de777ff76e",
+      "line_when_recorded": 612,
+      "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/MasternodesScreen.swift",
+      "fingerprint": "34614d6f2f7cfc68",
+      "line_when_recorded": 257,
+      "snippet": ".font(.system(size: 40))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
+      "fingerprint": "37d5823d5aec4b48",
+      "line_when_recorded": 45,
+      "snippet": ".font(.system(size: 28, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
+      "fingerprint": "ef9dbcca73150c14",
+      "line_when_recorded": 51,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Menu/Tools/ZenLedger/ZenLedgerInfoSheet.swift",
+      "fingerprint": "863c270cc1311c9c",
+      "line_when_recorded": 63,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "aaa69f0ca77a1543",
+      "line_when_recorded": 118,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "f0ec5adf85b65344",
+      "line_when_recorded": 327,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "7eb31d497e0d4efb",
+      "line_when_recorded": 334,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "145d09dd36926d90",
+      "line_when_recorded": 359,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "145d09dd36926d90",
+      "line_when_recorded": 365,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "aaa69f0ca77a1543",
+      "line_when_recorded": 368,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "aaa69f0ca77a1543",
+      "line_when_recorded": 610,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "145d09dd36926d90",
+      "line_when_recorded": 701,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "145d09dd36926d90",
+      "line_when_recorded": 707,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "aaa69f0ca77a1543",
+      "line_when_recorded": 712,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "63119344afb5a628",
+      "line_when_recorded": 846,
+      "snippet": ".font(.system(size: 15, weight: state == .active ? .semibold : .regular))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferConfirmSheet.swift",
+      "fingerprint": "d9d7e44836bcc46f",
+      "line_when_recorded": 879,
+      "snippet": ".font(.system(size: 11, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "9aff53ae2e1cd596",
+      "line_when_recorded": 140,
+      "snippet": ".font(.system(size: 24, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "220f45355e7593c5",
+      "line_when_recorded": 406,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "002e01927b833c30",
+      "line_when_recorded": 410,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "2d4ace0ba7c7fdcf",
+      "line_when_recorded": 495,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "2d4ace0ba7c7fdcf",
+      "line_when_recorded": 498,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "5f93ac9c90f5933e",
+      "line_when_recorded": 532,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "27f6cad051445d61",
+      "line_when_recorded": 545,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "17c9ddd4bee56a44",
+      "line_when_recorded": 553,
+      "snippet": ".font(.system(size: 11))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "f6617e3c43b7cc62",
+      "line_when_recorded": 556,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/InternalTransferScreen.swift",
+      "fingerprint": "002e01927b833c30",
+      "line_when_recorded": 568,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
+      "fingerprint": "35b1042b89979923",
+      "line_when_recorded": 21,
+      "snippet": ".font(.system(size: 24, weight: .bold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
+      "fingerprint": "8625ad2b42fc1368",
+      "line_when_recorded": 67,
+      "snippet": ".font(.system(size: 18, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
+      "fingerprint": "f3a10d3c3cee19aa",
+      "line_when_recorded": 73,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/InternalTransfer/TransferTimingSheet.swift",
+      "fingerprint": "77ed87c75fca734a",
+      "line_when_recorded": 77,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "4278181bb7b120dd",
+      "line_when_recorded": 111,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "c02837d854577e0f",
+      "line_when_recorded": 143,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "d7849b4571170958",
+      "line_when_recorded": 145,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Landing/PaymentsLandingScreen.swift",
+      "fingerprint": "f6efb32e79615515",
+      "line_when_recorded": 326,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "f13639e928f93e11",
+      "line_when_recorded": 89,
+      "snippet": ".font(.system(size: 16, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "defb175bcd87b069",
+      "line_when_recorded": 185,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "ebd3f98ef7d86a4b",
+      "line_when_recorded": 199,
+      "snippet": ".font(.system(size: 10, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "d441b14a3c1b5569",
+      "line_when_recorded": 263,
+      "snippet": ".font(.system(size: 14, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "713c2b5de21dae45",
+      "line_when_recorded": 489,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "1a64618a96658ecc",
+      "line_when_recorded": 497,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "defb175bcd87b069",
+      "line_when_recorded": 502,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "2da3d12ad779cdcd",
+      "line_when_recorded": 590,
+      "snippet": ".font(.system(size: 16, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "defb175bcd87b069",
+      "line_when_recorded": 630,
+      "snippet": ".font(.system(size: 13, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "ebd3f98ef7d86a4b",
+      "line_when_recorded": 665,
+      "snippet": ".font(.system(size: 10, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "2dfd1f0e28719bb2",
+      "line_when_recorded": 794,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "1705709bc5d9460f",
+      "line_when_recorded": 872,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "1705709bc5d9460f",
+      "line_when_recorded": 909,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "713c2b5de21dae45",
+      "line_when_recorded": 913,
+      "snippet": ".font(.system(size: 15, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "4e57d77e637e7001",
+      "line_when_recorded": 997,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "4e57d77e637e7001",
+      "line_when_recorded": 1003,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "2dfd1f0e28719bb2",
+      "line_when_recorded": 1006,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Payments/Pay/SendScreen.swift",
+      "fingerprint": "2dfd1f0e28719bb2",
+      "line_when_recorded": 1163,
+      "snippet": ".font(.system(size: 13))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
+      "fingerprint": "c3db04b29f8479b8",
+      "line_when_recorded": 63,
+      "snippet": ".font(.system(size: 13, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
+      "fingerprint": "c09ae9e746f06362",
+      "line_when_recorded": 79,
+      "snippet": ".font(.system(size: 12))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
+      "fingerprint": "a7c2bc997c0285e2",
+      "line_when_recorded": 119,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Setup/SecureWallet/Seed/RecoveryPhraseLength.swift",
+      "fingerprint": "107b2d1240aba61c",
+      "line_when_recorded": 121,
+      "snippet": ".font(.system(size: 11, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
+      "fingerprint": "64cf107eb1994bc2",
+      "line_when_recorded": 55,
+      "snippet": ".font(.system(size: 17))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
+      "fingerprint": "dd16bf2a726147de",
+      "line_when_recorded": 64,
+      "snippet": ".font(.system(size: 20))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/QRScanner/GenericQRScannerView.swift",
+      "fingerprint": "113223743ee6dd6b",
+      "line_when_recorded": 79,
+      "snippet": ".font(.system(size: 15, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
+      "fingerprint": "de937384b0f3a469",
+      "line_when_recorded": 180,
+      "snippet": ".font(.system(size: Layout.errorIconSize))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
+      "fingerprint": "2587f469a611a31b",
+      "line_when_recorded": 184,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Swap/SelectCoin/SelectCoinView.swift",
+      "fingerprint": "6ae38dca76bc0270",
+      "line_when_recorded": 200,
+      "snippet": ".font(.system(size: 14, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
+      "fingerprint": "7fa5f3927cdfa4b5",
+      "line_when_recorded": 60,
+      "snippet": ".font(.system(size: iconSize))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
+      "fingerprint": "7fac7a7750d4c569",
+      "line_when_recorded": 71,
+      "snippet": ".font(.system(size: fontSize))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Button.swift",
+      "fingerprint": "7fa5f3927cdfa4b5",
+      "line_when_recorded": 80,
+      "snippet": ".font(.system(size: iconSize))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Dialogs/ConfirmSpendDialog.swift",
+      "fingerprint": "058bd28f8541a4c4",
+      "line_when_recorded": 43,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "14357cbe2e3055ff",
+      "line_when_recorded": 24,
+      "snippet": "public static let largeTitle: Font = .system(size: 34, weight: .bold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "cd274d8249815587",
+      "line_when_recorded": 27,
+      "snippet": "public static let title1: Font = .system(size: 28, weight: .bold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "ca7b60a94d015c87",
+      "line_when_recorded": 30,
+      "snippet": "public static let title2: Font = .system(size: 22, weight: .bold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "bbcb30070366d2ac",
+      "line_when_recorded": 33,
+      "snippet": "public static let title3: Font = .system(size: 20, weight: .bold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "7bfd2d00c3c09a7f",
+      "line_when_recorded": 36,
+      "snippet": "public static let title3Medium: Font = .system(size: 20, weight: .medium)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "4a52b157b833580d",
+      "line_when_recorded": 41,
+      "snippet": "public static let headline: Font = .system(size: 17, weight: .bold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "ac125a5b3d92d019",
+      "line_when_recorded": 44,
+      "snippet": "public static let body: Font = .system(size: 17, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "260bb09e3fa03a62",
+      "line_when_recorded": 47,
+      "snippet": "public static let callout: Font = .system(size: 16, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "4f637f6662db5365",
+      "line_when_recorded": 50,
+      "snippet": "public static let calloutMedium: Font = .system(size: 16, weight: .semibold)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "5af12a3d74fddb7f",
+      "line_when_recorded": 53,
+      "snippet": "public static let subhead: Font = .system(size: 15, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "88dc400851e7cea5",
+      "line_when_recorded": 56,
+      "snippet": "public static let subheadMedium: Font = .system(size: 15, weight: .medium)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "26dfc40424b0fc32",
+      "line_when_recorded": 59,
+      "snippet": "public static let footnote: Font = .system(size: 13, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "a6f6056029aee936",
+      "line_when_recorded": 62,
+      "snippet": "public static let footnoteMedium: Font = .system(size: 13, weight: .medium)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "2d1dd468941d8ba4",
+      "line_when_recorded": 65,
+      "snippet": "public static let caption1: Font = .system(size: 12, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Font+DWStyle.swift",
+      "fingerprint": "b6d3ddf369d8f379",
+      "line_when_recorded": 68,
+      "snippet": "public static let caption2: Font = .system(size: 11, weight: .regular)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift",
+      "fingerprint": "031eb8c1a8edc249",
+      "line_when_recorded": 61,
+      "snippet": ".font(.system(size: side * 0.4, weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/MerchantLogoPlaceholder.swift",
+      "fingerprint": "5396ff5e123d80d4",
+      "line_when_recorded": 64,
+      "snippet": ".font(.system(size: fittedFontSize(side: side), weight: .semibold))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/NetworkUnavailableStateView.swift",
+      "fingerprint": "a57154fee613d125",
+      "line_when_recorded": 81,
+      "snippet": ".font(.system(size: 17, weight: .medium))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Toast.swift",
+      "fingerprint": "eb5e514029354099",
+      "line_when_recorded": 37,
+      "snippet": ".font(.system(size: 15))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/SwiftUI Components/Toast.swift",
+      "fingerprint": "5409fc0923785110",
+      "line_when_recorded": 43,
+      "snippet": ".font(.system(size: 14))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
+      "fingerprint": "0141b67693808b4d",
+      "line_when_recorded": 90,
+      "snippet": ".font(.system(size: 34))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
+      "fingerprint": "532e966c1eeaa156",
+      "line_when_recorded": 253,
+      "snippet": ".font(.system(size: 11, design: .monospaced))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
+      "fingerprint": "492502273e8725c6",
+      "line_when_recorded": 302,
+      "snippet": ".font(.system(size: 10))"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Tx/Details/RawTransactionView.swift",
+      "fingerprint": "23fd7f1f1d3b17c5",
+      "line_when_recorded": 306,
+      "snippet": ".font(monospaced ? .system(size: 12, design: .monospaced) : .footnote)"
+    },
+    {
+      "rule": "A11Y007",
+      "path": "DashWallet/Sources/UI/Tx/Details/Views/TxDetailContactViews.swift",
+      "fingerprint": "36bdd51d9aabe56d",
+      "line_when_recorded": 92,
+      "snippet": ".font(.system(size: 12, weight: .semibold))"
+    }
+  ]
+}

--- a/scripts/a11y_config.json
+++ b/scripts/a11y_config.json
@@ -1,0 +1,36 @@
+{
+  "_comment": [
+    "Project tuning for scripts/a11y_audit.py. Every field is optional.",
+    "",
+    "disabled_rules      — rules that never run at all",
+    "advisory_rules      — rules that report but never fail CI, whatever their severity",
+    "exclude_paths       — path prefixes skipped entirely",
+    "labeled_wrappers    — our own components that guarantee an accessibility",
+    "                      label themselves; a view built from one counts as",
+    "                      already announced (add yours here rather than",
+    "                      sprinkling a11y-ignore comments)",
+    "speaks_for_itself   — extra tokens meaning 'this view announces its own text'",
+    "allowed_font_shadows — Font token names we knowingly keep even though they",
+    "                      shadow an Apple text style (see A11Y008)",
+    "",
+    "Adding a component to labeled_wrappers is a claim about that component.",
+    "Verify it really does set a label before listing it here."
+  ],
+
+  "disabled_rules": [],
+
+  "advisory_rules": [
+    "A11Y007"
+  ],
+
+  "exclude_paths": [],
+
+  "labeled_wrappers": [
+    "DashStepper",
+    "SegmentedControl"
+  ],
+
+  "speaks_for_itself": [],
+
+  "allowed_font_shadows": []
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Support ticket **32072**: *"Please add support for screenreaders. The tabs at the bottom, as well as buttons, need to be labeled so that screenreaders can read them."*

The tab bar the customer named was fixed in 0227fdf5a. An audit of the rest of the app found the same defect throughout — and, more to the point, found that nothing prevents it from coming back: no lint rule, no CI check, no test asserting labels, and zero `UIAccessibility.*` calls anywhere in the app.

The audit also surfaced two things beyond the report:

- A blind user **cannot complete wallet backup** — `DWCheckbox.m` and `DWSeedWordView.m` expose no state, a wrong word is rejected with a shake, and the only announced control on that screen is *Skip*.
- `Font+DWStyle.swift` declares an `extension Font` whose members shadow Apple's `body`, `headline`, `largeTitle`, `title2`, `title3`, `callout`, `footnote` and `caption2`. It compiles silently and wins inside the app module, so ~135 `.font(.body)`-style calls that look correct do not scale with the user's text size.

This PR does not fix those. It adds the tooling to measure them and to stop the debt growing while they are worked through.

## What was done?

**`scripts/a11y_audit.py`** — a static VoiceOver / Dynamic Type audit. Stdlib-only Python, no Xcode, ~1s over the whole repo.

```bash
scripts/a11y_audit.py                  # full report
scripts/a11y_audit.py --summary        # counts per rule
scripts/a11y_audit.py --list-rules     # what it checks and how to fix each
scripts/a11y_audit.py --path "DashWallet/Sources/UI/Payments"   # one screen
```

Twelve rules, each derived from a defect the audit actually found: unlabeled `UITabBarItem`/`UIBarButtonItem`, icon-only `UIButton` and SwiftUI `Button`, `Toggle` with an empty label, custom back buttons replacing UIKit's automatically labeled one, `.onTapGesture` with no accessibility treatment, image-only controls in xibs, unlocalized labels, labels whose key never reached `en.lproj`, and the two Dynamic Type rules.

Current state of `develop`:

```
657 findings   P0=8  P1=90  P2=559
```

**`.github/workflows/accessibility.yml`** — runs on every PR touching app code, on an Ubuntu runner.

It is a **ratchet, not a gate**. The 657 existing findings are recorded in `scripts/a11y_baseline.json` and never fail the build, so the check can be turned on today without fixing anything first — but a PR cannot add a new unlabeled control. New P2 (Dynamic Type) findings are advisory and do not block. Baseline entries are keyed by a hash of the code snippet rather than a line number, so moving or reindenting code does not produce false failures.

When it fails, the output names the rule, the file, and the fix. A deliberate exception is annotated in place:

```swift
// a11y-ignore: A11Y004 decorative chevron, the row itself carries the label
```

**`scripts/a11y_config.json`** — so the rules bend to the design system rather than the other way round. Components that set their own accessibility label (`DashStepper`, `SegmentedControl`) are declared once instead of annotating every call site; rules can be disabled or made advisory, paths excluded, and font tokens allowlisted.

Worth stating explicitly, since it is the obvious worry: **our own fonts and icons are not what this flags.** There are no bundled font files and no `Font.custom` / `UIFont(name:)` call sites in the repo; the 159 `dw_font` calls are never reported because `dw_font(forTextStyle:)` scales correctly. A11Y008 fires only where a token's *name* collides with one of Apple's — our own tokens (`subhead`, `caption1`, `title3Medium`, …) are untouched — and `allowed_font_shadows` turns it off entirely.

**`ACCESSIBILITY.md`** — how to run the tool, what it deliberately does not check (label wording, focus order, announcements, `.adjustable` traits — all still need a human with VoiceOver on a device), where the debt concentrates, and how to write accessible UI here. Plus a short pointer in `CLAUDE.md`.

## How Has This Been Tested?

No app code changed, so there is nothing to build; the tool was verified directly:

- **35 fixtures** (`scripts/a11y_audit.py --self-test`), covering each rule's positive and negative cases, the suppression comment, the config knobs, and that code inside comments and string literals never triggers a rule. CI runs these *before* the audit, so a regression in the rules cannot pass silently.
- **Validated against a known historical defect**: run over `MainTabbarController.swift` as it stood at `20bd68043` (before 0227fdf5a), A11Y001 reports exactly the five tab items that were broken — lines 180, 199, 210, 221, 242. Against current `develop` it correctly reports none.
- **Ratchet verified both ways**: adding a file with `Button { Image(systemName:) }` fails `--check` with exit 1 and names the fix; adding the `a11y-ignore` comment makes it pass; a new `.system(size:)` is reported as advisory and does not fail.
- **Config verified**: filling `allowed_font_shadows` and disabling A11Y007 takes the run from 657 findings to 90 with P0=0, proving the knobs actually reach the rules.
- **Findings spot-checked by hand** against the source (`POIDetailsView.swift:210`, `IdentitiesScreen.swift:119`, `GiftCardDetailsInfoCard.swift:209`, `BaseNavigationController.swift:177`, `MenuItem.swift:232`) — all real.
- Workflow YAML parsed; script compiles clean under `python3 -W error`; runtime ~1s.

## Breaking Changes

None. No app code is touched — this adds a script, a workflow, a config, a baseline, and documentation. The workflow cannot fail on existing code, only on newly introduced findings.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated accessibility auditing for VoiceOver and Dynamic Type issues.
  - Audits run on pull requests, key branch updates, and manual requests.
  - Added configurable rules, baseline tracking, suppressions, and JSON/GitHub reporting.
  - Accessibility checks compare against the base branch to detect new regressions.
  - Added labeled component tuning and accessibility configuration options.

- **Bug Fixes**
  - Corrected detection of accessibility labels on chained SwiftUI button modifiers.

- **Documentation**
  - Added guidance on accessibility standards, audit usage, configuration, suppressions, and accessible SwiftUI development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->