### PR TITLE
fix(coinjoin): make the sweep's input chunking actually bound the transaction

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -251,9 +251,12 @@ final class SwiftDashSDKTransactionSender: NSObject {
             let utxos = manager.accountUtxos(for: walletId, balance: cjBalance)
             guard !utxos.isEmpty else { return [] }
 
-            // Drain each balanced ≤500-input chunk to `address`. `SelectionStrategy.all`
-            // makes core compute output = Σinputs − fee with no change (the addOutput
-            // amount is ignored); `finalizeAtomic` resolves dual-chain `/0/`+`/1/` signing.
+            // Drain each balanced ≤500-input chunk to `address`. `useOnlyAddedInputs`
+            // is what makes the chunk the transaction's input set — the finalizer
+            // otherwise funds from the whole account regardless of what was seeded.
+            // `SelectionStrategy.all` makes core compute output = Σinputs − fee with
+            // no change (the addOutput amount is ignored); `finalizeAtomic` resolves
+            // dual-chain `/0/`+`/1/` signing.
             // Partial-failure tolerant: keep the txs that broadcast, log the rest, and
             // throw only if nothing broadcast at all (a re-run sweeps the remainder).
             var txids: [Data] = []
@@ -264,6 +267,11 @@ final class SwiftDashSDKTransactionSender: NSObject {
                     try builder.addInputs(
                         wallet: wallet, accountType: .coinJoin,
                         accountIndex: Self.coinJoinAccountIndex, utxos: chunk)
+                    // Without this the finalizer adds every unreserved UTXO of
+                    // the account on top of the chunk and `.all` takes the lot,
+                    // so the chunking below has no effect and an account over
+                    // the input cap fails on every chunk and every retry.
+                    try builder.useOnlyAddedInputs()
                     try builder.setSelectionStrategy(.all)
                     try builder.setFeeRate(satPerKb: Self.feeRateSatPerKb)
                     // No setCurrentHeight: the finalizer sets the height from the

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKTransactionSender.swift
@@ -205,6 +205,30 @@ final class SwiftDashSDKTransactionSender: NSObject {
 
     // MARK: - CoinJoin Sweep
 
+    /// Outcome of a chunked CoinJoin sweep.
+    ///
+    /// Each chunk is an independent transaction, so a sweep can end up partly
+    /// done: some chunks broadcast while another fails to build, sign or
+    /// broadcast. The txids alone cannot express that — a caller that only sees
+    /// a non-empty array reports "your mixed coins were moved" while the failed
+    /// chunks are still sitting in the CoinJoin account. So the failure travels
+    /// with them, and the caller records the accepted transactions *and* still
+    /// surfaces the partial state.
+    struct CoinJoinSweepOutcome {
+        /// Wire-order txids of the chunks that broadcast, in chunk order —
+        /// ready to record in `CoinJoinWithdrawalStore` (matches
+        /// `Transaction.txHashData`).
+        let txids: [Data]
+        /// How many chunks did not broadcast.
+        let failedChunkCount: Int
+        /// The first failed chunk's error; nil when every chunk broadcast.
+        let firstFailure: Error?
+
+        /// Some chunks broadcast and some did not: coins remain in the CoinJoin
+        /// account, and a re-run sweeps the remainder.
+        var isPartial: Bool { !txids.isEmpty && failedChunkCount > 0 }
+    }
+
     /// Sweep the entire CoinJoin-account balance to `address` (the user's own
     /// BIP44 receive address), fully emptying the CoinJoin account across one or
     /// more transactions.
@@ -222,13 +246,12 @@ final class SwiftDashSDKTransactionSender: NSObject {
     ///
     /// - Parameter address: Destination Dash address (the user's own BIP44
     ///   receive address, resolved via `SwiftDashSDKReceiveAddressReader`).
-    /// - Returns: The **wire-order** txids of the broadcast sweep transactions
-    ///   (one per chunk) — ready to record in `CoinJoinWithdrawalStore`
-    ///   (matches `Transaction.txHashData`).
-    static func sweepCoinJoin(to address: String) throws -> [Data] {
+    /// - Returns: A `CoinJoinSweepOutcome` carrying the broadcast chunks' txids
+    ///   and any chunk failure. Throws only when nothing broadcast at all.
+    static func sweepCoinJoin(to address: String) throws -> CoinJoinSweepOutcome {
         logger.info("💸 TXSEND :: sweeping CoinJoin account → spendable balance")
 
-        let sweep = { @MainActor () throws -> [Data] in
+        let sweep = { @MainActor () throws -> CoinJoinSweepOutcome in
             let host = SwiftDashSDKHost.shared
             guard let wallet = host.wallet, let manager = host.manager,
                   let network = host.runningNetwork else {
@@ -243,13 +266,15 @@ final class SwiftDashSDKTransactionSender: NSObject {
             guard let cjBalance = manager.accountBalances(for: walletId).first(where: {
                 $0.typeTag == Self.coinJoinTypeTag && $0.index == Self.coinJoinAccountIndex
             }) else {
-                return []
+                return CoinJoinSweepOutcome(txids: [], failedChunkCount: 0, firstFailure: nil)
             }
 
             // Snapshot the account's spendable UTXOs (after the recovery scan has
             // materialized deep `/0/` + `/1/` addresses).
             let utxos = manager.accountUtxos(for: walletId, balance: cjBalance)
-            guard !utxos.isEmpty else { return [] }
+            guard !utxos.isEmpty else {
+                return CoinJoinSweepOutcome(txids: [], failedChunkCount: 0, firstFailure: nil)
+            }
 
             // Drain each balanced ≤500-input chunk to `address`. `useOnlyAddedInputs`
             // is what makes the chunk the transaction's input set — the finalizer
@@ -259,7 +284,9 @@ final class SwiftDashSDKTransactionSender: NSObject {
             // dual-chain `/0/`+`/1/` signing.
             // Partial-failure tolerant: keep the txs that broadcast, log the rest, and
             // throw only if nothing broadcast at all (a re-run sweeps the remainder).
+            // A mixed outcome is reported through `CoinJoinSweepOutcome`, not swallowed.
             var txids: [Data] = []
+            var failedChunkCount = 0
             var firstError: Error?
             for (index, chunk) in Self.balancedChunks(utxos).enumerated() {
                 do {
@@ -289,32 +316,34 @@ final class SwiftDashSDKTransactionSender: NSObject {
                     // so reverse it back to wire order.
                     txids.append(Data(Self.computeTxHash(from: txData).reversed()))
                 } catch {
+                    failedChunkCount += 1
                     firstError = firstError ?? error
                     Self.logger.error(
                         "💸 TXSEND :: coinjoin sweep chunk \(index + 1, privacy: .public) failed to broadcast, continuing: \(String(describing: error), privacy: .public)")
                 }
             }
             if txids.isEmpty, let error = firstError { throw error }
-            return txids
+            return CoinJoinSweepOutcome(
+                txids: txids, failedChunkCount: failedChunkCount, firstFailure: firstError)
         }
 
-        let txids: [Data]
+        let outcome: CoinJoinSweepOutcome
         if Thread.isMainThread {
-            txids = try MainActor.assumeIsolated { try sweep() }
+            outcome = try MainActor.assumeIsolated { try sweep() }
         } else {
-            var captured: Result<[Data], Error> = .failure(SendError.walletNotReady("uninitialized result"))
+            var captured: Result<CoinJoinSweepOutcome, Error> = .failure(SendError.walletNotReady("uninitialized result"))
             DispatchQueue.main.sync {
                 captured = Result { try MainActor.assumeIsolated { try sweep() } }
             }
-            txids = try captured.get()
+            outcome = try captured.get()
         }
 
         // Log display-order hex (byte-reversed wire order) to match explorers.
-        let hexes = txids.map { txid -> String in
+        let hexes = outcome.txids.map { txid -> String in
             Data(txid.reversed()).map { String(format: "%02x", $0) }.joined()
         }
-        logger.info("💸 TXSEND :: coinjoin sweep broadcast — \(txids.count, privacy: .public) tx(s): \(hexes.joined(separator: ","), privacy: .public)")
-        return txids
+        logger.info("💸 TXSEND :: coinjoin sweep broadcast — \(outcome.txids.count, privacy: .public) tx(s), \(outcome.failedChunkCount, privacy: .public) chunk(s) failed: \(hexes.joined(separator: ","), privacy: .public)")
+        return outcome
     }
 
     // MARK: - Selected-input send (CrowdNode signal txs)

--- a/DashWallet/Sources/Models/Transactions/WalletSendService.swift
+++ b/DashWallet/Sources/Models/Transactions/WalletSendService.swift
@@ -357,6 +357,12 @@ final class WalletSendService: NSObject {
     /// CoinJoin-balance re-tally so both surfaces self-clear without waiting
     /// for the next SPV balance event.
     ///
+    /// A heavy mixer's account is swept across several independent chunk
+    /// transactions, so the sweep can end up partly done. In that case the
+    /// accepted chunks are recorded and the balance re-tallied exactly as on a
+    /// full sweep, and only then does this throw `.coinJoinSweepPartial` — the
+    /// caller must not show "moved" over coins that are still in the account.
+    ///
     /// - Returns: the CoinJoin balance (duffs) that was swept, for the success
     ///   message; the on-chain amount delivered is this minus the network fee.
     @discardableResult
@@ -380,7 +386,8 @@ final class WalletSendService: NSObject {
         }
 
         Self.logger.info("💸 TXSEND :: CoinJoin sweep destination resolved \(destination, privacy: .public)")
-        let txids = try SwiftDashSDKTransactionSender.sweepCoinJoin(to: destination)
+        let outcome = try SwiftDashSDKTransactionSender.sweepCoinJoin(to: destination)
+        let txids = outcome.txids
         guard !txids.isEmpty else {
             // A reported-success sweep that produced no transaction is treated
             // as a failure, so the caller surfaces an error (the sweep alert)
@@ -414,6 +421,20 @@ final class WalletSendService: NSObject {
             // sweep may be partial across chunks and does NOT imply the wide scan
             // completed, so it must not mark recovered here — doing so would suppress
             // a legitimate re-widen after an interrupted scan.
+        }
+
+        // Everything above ran for the accepted chunks — the txids are in the
+        // withdrawal store and the balance is re-tallied — so it is safe to fail
+        // here. Reported as a failure because the coins the failed chunks hold
+        // are still in the CoinJoin account: a re-run sweeps the remainder, and
+        // a success screen would tell the user there is nothing left to move.
+        if outcome.isPartial {
+            Self.logger.error(
+                "💸 TXSEND :: CoinJoin sweep partial — \(txids.count, privacy: .public) chunk(s) broadcast, \(outcome.failedChunkCount, privacy: .public) failed: \(String(describing: outcome.firstFailure), privacy: .public)")
+            throw Self.makeError(
+                code: .coinJoinSweepPartial,
+                description: "CoinJoin sweep moved \(txids.count) of \(txids.count + outcome.failedChunkCount) transactions"
+            )
         }
         return amount
     }
@@ -528,8 +549,18 @@ final class WalletSendService: NSObject {
     /// User-facing message for a CoinJoin sweep failure, or nil if the user
     /// simply cancelled authentication (callers stay silent). Centralizes the
     /// cancel predicate + copy so every sweep entry point behaves identically.
+    ///
+    /// A partial sweep gets its own copy: "try again" is still the right
+    /// action, but telling the user nothing moved would contradict the
+    /// transactions already in their history.
     static func coinJoinSweepUserMessage(for error: Error) -> String? {
-        guard !isAuthenticationCancelledError(error as NSError) else { return nil }
+        let nsError = error as NSError
+        guard !isAuthenticationCancelledError(nsError) else { return nil }
+        if nsError.domain == errorDomain, nsError.code == ErrorCode.coinJoinSweepPartial.rawValue {
+            return NSLocalizedString(
+                "Some of your CoinJoin funds were moved. Please try again to move the rest.",
+                comment: "CoinJoin")
+        }
         return NSLocalizedString(
             "Couldn't move your CoinJoin funds. Please try again.", comment: "CoinJoin")
     }
@@ -662,6 +693,7 @@ private extension WalletSendService {
         case broadcastRejected = 9
         case broadcastUnknown = 10
         case invalidSwapMemo = 11
+        case coinJoinSweepPartial = 12
     }
 
     static let errorDomain = "org.dashfoundation.dash.wallet-send-service"


### PR DESCRIPTION
## Issue being fixed or feature implemented

`sweepCoinJoin` splits the CoinJoin account into batches of at most 500 inputs and seeds one per
build, but the seeding never bound anything: `finalizeAtomic` adds every unreserved UTXO of the
funding account on top of the seeded chunk, and `SelectionStrategy.all` then takes the lot. The
chunking has therefore always been a no-op, and an account above the standard-transaction input cap
could not be swept at all — every chunk, and every retry, failed identically.

Reported from a mainnet wallet holding 589 mixed UTXOs (support ticket 32081):

```
sweep failed: Transaction building failed: Too many inputs for a standard transaction: 589 (max 500)
```

~101 DASH that no route in the app can move: the ordinary send pool excludes CoinJoin by design, the
shielded asset lock funds from BIP44 only, and the sweep that exists to bridge the two cannot build.
The failure is at build time, so nothing broadcasts — the "Please try again" in the alert can never
succeed.

Depends on dashpay/platform#4548 (and dashpay/rust-dashcore#994 beneath it), which add the call.

## What was done?

One call — `useOnlyAddedInputs()` — which makes the seeded chunk the transaction's input set, i.e.
what the surrounding code already assumed.

Also corrects the comment above the loop. Its claim that the chunking worked is what hid this: the
code reads as if it handles large accounts, and it never did.

## How Has This Been Tested?

End to end on the simulator, on a purpose-built testnet wallet whose CoinJoin account holds more than
500 UTXOs. Same wallet, same state, both builds:

| Build | Result |
|---|---|
| `develop` | `sweep failed: … Too many inputs for a standard transaction: 700 (max 500)` |
| this branch | no failure; "CoinJoin Withdrawals" appears with **2 transactions**, CoinJoin account empties, fee 0.00088888 tDash |

Two transactions is the expected shape: above the cap the account is drained across `ceil(N/500)`
builds.

The mechanism is also covered upstream in key-wallet — a 589-UTXO account fails with `TooManyInputs`
when funded ordinarily and builds its 500-input chunk when funded reservation-only
(dashpay/rust-dashcore#994). That test is the regression guard.

**Note for QA:** the CoinJoin address window advances about 100 addresses per sync pass, so a freshly
restored wallet shows only part of its mixed balance and it grows on each relaunch. A full rescan
surfaces all of it at once. Budget for that before concluding funds are missing.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CoinJoin sweeps now support partial completion, preserving successful transactions while reporting failed portions.
  * Empty-account sweeps return a successful empty result.
  * Mixed results provide clearer failure details and a dedicated partial-sweep status message.

* **Bug Fixes**
  * Fully failed CoinJoin sweeps continue to report an error instead of being treated as successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->