### PR TITLE
fix(ui): label the shared controls VoiceOver could not announce

### DIFF
--- a/DashWallet/Sources/UI/SwiftUI Components/DashAmount.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/DashAmount.swift
@@ -49,6 +49,11 @@ struct DashAmount: View {
                 DashSymbol()
                     .padding(.leading, 2)
             }
+            // The currency symbol is an image, so the stack is collapsed into a
+            // single element with a spoken label; child-by-child, VoiceOver
+            // reads the digits and then the image asset name, never "Dash".
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(spokenAmount(cleanedAbsAmount)))
         }
     }
     
@@ -70,6 +75,32 @@ struct DashAmount: View {
         }
     }
     
+    /// The VoiceOver utterance for the rendered row: the same formatted number
+    /// that is displayed, followed by the currency name. The "+"/"-" glyphs
+    /// become spoken words only when `showDirection` renders them, so the
+    /// utterance always matches what is visible.
+    private func spokenAmount(_ cleanedAbsAmount: String) -> String {
+        // "Dash" is the currency's proper name and is deliberately left
+        // unlocalized, matching the wordmark label in HomeBalanceView.
+        let unsignedAmount = "\(cleanedAbsAmount.trimmingCharacters(in: .whitespaces)) Dash"
+
+        guard showDirection else {
+            return unsignedAmount
+        }
+
+        if amount > 0 {
+            return String(
+                format: NSLocalizedString("Plus %@", comment: "VoiceOver-only label for an incoming amount; %@ is the amount with its currency, e.g. 'Plus 0.05 Dash'"),
+                unsignedAmount)
+        } else if amount < 0 {
+            return String(
+                format: NSLocalizedString("Minus %@", comment: "VoiceOver-only label for an outgoing amount; %@ is the amount with its currency, e.g. 'Minus 0.05 Dash'"),
+                unsignedAmount)
+        } else {
+            return unsignedAmount
+        }
+    }
+
     private func cleanAmount(_ amount: String) -> String {
         var result = amount
         

--- a/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
@@ -233,8 +233,11 @@ struct MenuItem: View {
                         .tint(Color.dash.blue)
                         .scaleEffect(0.75)
                         .frame(maxWidth: 60)
-                        // VoiceOver reads the row title on the switch, tying it to what it controls
-                        .accessibilityLabel(title)
+                        // The row Button already carries the switch semantics
+                        // (see `toggleRowAccessibility`), so this stays out of
+                        // the accessibility tree rather than appearing as a
+                        // second, nested control.
+                        .accessibilityHidden(true)
                 }
                 
                 if showChevron {
@@ -275,6 +278,7 @@ struct MenuItem: View {
         }
         .padding(10)
         .frame(maxWidth: .infinity)
+        .toggleRowAccessibility(isToggleRow: showToggle, title: title, isOn: isToggled)
         .onChange(of: isToggled) { newValue in
             action?()
         }
@@ -287,6 +291,33 @@ struct MenuItem: View {
         Text(text)
             .font(.caption)
             .foregroundColor(.dash.secondaryText)
+    }
+}
+
+extension View {
+    /// Presents a `MenuItem` that carries a switch as one accessibility element
+    /// with switch semantics.
+    ///
+    /// The row is a `Button` whose label contains the `Toggle`, so without this
+    /// the two nest: VoiceOver is handed two overlapping controls and has to
+    /// guess which one an activation belongs to. Collapsing the row to a single
+    /// element with `.isToggle` and a spoken on/off value leaves exactly one
+    /// target, while the `Button` keeps driving the state as before.
+    ///
+    /// Rows without a switch are untouched — `Button` already merges its label
+    /// content into one element with the correct trait.
+    @ViewBuilder
+    func toggleRowAccessibility(isToggleRow: Bool, title: String, isOn: Bool) -> some View {
+        if isToggleRow {
+            accessibilityElement(children: .ignore)
+                .accessibilityLabel(title)
+                .accessibilityValue(isOn
+                    ? NSLocalizedString("On", comment: "Accessibility value for a settings switch that is enabled")
+                    : NSLocalizedString("Off", comment: "Accessibility value for a settings switch that is disabled"))
+                .accessibilityAddTraits(.isToggle)
+        } else {
+            self
+        }
     }
 }
 

--- a/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift
@@ -233,6 +233,8 @@ struct MenuItem: View {
                         .tint(Color.dash.blue)
                         .scaleEffect(0.75)
                         .frame(maxWidth: 60)
+                        // VoiceOver reads the row title on the switch, tying it to what it controls
+                        .accessibilityLabel(title)
                 }
                 
                 if showChevron {

--- a/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
+++ b/DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift
@@ -113,6 +113,20 @@ enum NavigationBarElement: String {
             .contentShape(Rectangle())
         }
         .buttonStyle(NavigationBarButtonStyle())
+        .accessibilityLabel(Text(accessibilityLabelText))
+    }
+
+    var accessibilityLabelText: String {
+        switch self {
+        case .back:
+            return NSLocalizedString("Back", comment: "Accessibility label for the navigation bar back button")
+        case .close:
+            return NSLocalizedString("Close", comment: "Accessibility label for the navigation bar close button")
+        case .plus:
+            return NSLocalizedString("Add", comment: "Accessibility label for the navigation bar add button")
+        case .info:
+            return NSLocalizedString("Info", comment: "Accessibility label for the navigation bar info button")
+        }
     }
 }
 
@@ -169,6 +183,7 @@ struct NavBarBack: View {
                        .foregroundColor(.dash.primaryText)
                }
            }
+           .accessibilityLabel(Text(NavigationBarElement.back.accessibilityLabelText))
            .padding(.leading, 20)
 
            Spacer()
@@ -225,6 +240,7 @@ struct NavBarBackPlus: View {
                        .foregroundColor(.dash.primaryText)
                }
            }
+           .accessibilityLabel(Text(NavigationBarElement.back.accessibilityLabelText))
            .padding(.leading, 20)
 
            Spacer()
@@ -246,6 +262,7 @@ struct NavBarBackPlus: View {
                        .foregroundColor(.dash.primaryText)
                }
            }
+           .accessibilityLabel(Text(NavigationBarElement.plus.accessibilityLabelText))
            .padding(.trailing, 20)
        }
        .frame(height: 64)
@@ -300,6 +317,7 @@ struct NavBarClose: View {
                        .foregroundColor(.dash.primaryText)
                }
            }
+           .accessibilityLabel(Text(NavigationBarElement.close.accessibilityLabelText))
            .padding(.trailing, 20)
        }
        .frame(height: 64)

--- a/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
+++ b/DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift
@@ -178,8 +178,10 @@ extension BaseNavigationController: UINavigationControllerDelegate {
             backButton.frame = .init(x: 0, y: 0, width: 30, height: 30)
             backButton.setImage(UIImage(systemName: "arrow.backward"), for: .normal)
             backButton.tintColor = backButtonTintColor
+            backButton.accessibilityLabel = NSLocalizedString("Back", comment: "Accessibility label for the navigation bar back button")
             backButton.addTarget(self, action: #selector(backButtonAction), for: .touchUpInside)
             let item = UIBarButtonItem(customView: backButton)
+            item.accessibilityLabel = backButton.accessibilityLabel
 
             viewController.navigationItem.leftBarButtonItem = item
             viewController.navigationItem.leftItemsSupplementBackButton = false

--- a/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboardButton.swift
+++ b/DashWallet/Sources/UI/Views/SharedViews/Keyboard/NumberKeyboardButton.swift
@@ -120,6 +120,9 @@ class NumberKeyboardButton: UIView {
     private func reloadTitle() {
         #if SNAPSHOT
         if value == .separator {
+            // The button view is the exposed accessibility element, so the XCUITest
+            // id lives on it as well as on the label
+            accessibilityIdentifier = "amount_button_separator"
             titleLabel.accessibilityIdentifier = "amount_button_separator"
         }
         #endif // SNAPSHOT
@@ -152,6 +155,37 @@ class NumberKeyboardButton: UIView {
             attributedText.append(NSAttributedString(string: " "))
 
             titleLabel.attributedText = attributedText
+        }
+
+        updateAccessibility()
+    }
+
+    private func updateAccessibility() {
+        switch value {
+        case .empty:
+            // A spacer key: hidden from VoiceOver entirely
+            isAccessibilityElement = false
+            accessibilityElementsHidden = true
+            accessibilityLabel = nil
+            accessibilityTraits = []
+        case .digit, .custom:
+            isAccessibilityElement = true
+            accessibilityElementsHidden = false
+            accessibilityLabel = value.stringValue
+            accessibilityTraits = .button
+        case .separator:
+            isAccessibilityElement = true
+            accessibilityElementsHidden = false
+            accessibilityLabel = NSLocalizedString("Decimal separator",
+                                                   comment: "VoiceOver label for the decimal separator key on the number keyboard")
+            accessibilityTraits = .button
+        case .delete:
+            // The visible title is an SF Symbol attachment, so the spoken label is set explicitly
+            isAccessibilityElement = true
+            accessibilityElementsHidden = false
+            accessibilityLabel = NSLocalizedString("Delete",
+                                                   comment: "VoiceOver label for the delete key on the number keyboard")
+            accessibilityTraits = .button
         }
     }
 

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -474,6 +474,9 @@
 /* DashPay Contacts */
 "Available: %@ DASH" = "Available: %@ DASH";
 
+/* Accessibility label for the navigation bar back button */
+"Back" = "Back";
+
 /* Dash DEX */
 "Back home" = "Back home";
 
@@ -746,6 +749,9 @@
 /* DashPay: title of the enable success sheet */
 "DashPay enabled" = "DashPay enabled";
 
+/* Accessibility label for the decimal separator key on the number keypad */
+"Decimal separator" = "Decimal separator";
+
 /* Identity top-up sheet — custom amount below the floor */
 "Discard" = "Discard";
 "Enter at least %@ DASH" = "Enter at least %@ DASH";
@@ -793,6 +799,9 @@
 /* Usernames */
 "In the meantime you are reachable at “%1$@”, which is yours to keep. If the vote awards you “%2$@”, you will be reachable at both usernames." = "In the meantime you are reachable at “%1$@”, which is yours to keep. If the vote awards you “%2$@”, you will be reachable at both usernames.";
 
+/* Accessibility label for the navigation bar info button */
+"Info" = "Info";
+
 /* Username marketplace: search row for a label a past vote locked */
 "Inputs" = "Inputs";
 "Locked by a network vote — nobody can register it" = "Locked by a network vote — nobody can register it";
@@ -811,6 +820,9 @@
 
 /* Username marketplace: set price fee note */
 "Listing is a network transaction with a small fee, paid from your identity balance." = "Listing is a network transaction with a small fee, paid from your identity balance.";
+
+/* VoiceOver-only label for an outgoing amount; %@ is the amount with its currency, e.g. 'Minus 0.05 Dash' */
+"Minus %@" = "Minus %@";
 
 /* DashPay: banner fallback when the identity has no name yet */
 "Move %@ from shielded balance" = "Move %@ from shielded balance";
@@ -834,6 +846,9 @@
 "Operator payout address" = "Operator payout address";
 "Operator signature (BLS)" = "Operator signature (BLS)";
 "Platform P2P port" = "Platform P2P port";
+/* VoiceOver-only label for an incoming amount; %@ is the amount with its currency, e.g. 'Plus 0.05 Dash' */
+"Plus %@" = "Plus %@";
+
 "Provider update payload" = "Provider update payload";
 "Receive some DASH to this wallet, or fund its shielded balance, then return here." = "Receive some DASH to this wallet, or fund its shielded balance, then return here.";
 "Register username" = "Register username";

--- a/DashWallet/en.lproj/Localizable.strings
+++ b/DashWallet/en.lproj/Localizable.strings
@@ -843,6 +843,12 @@
 
 /* Usernames */
 "Non-standard output" = "Non-standard output";
+/* Accessibility value for a settings switch that is enabled */
+"On" = "On";
+
+/* Accessibility value for a settings switch that is disabled */
+"Off" = "Off";
+
 "Operator payout address" = "Operator payout address";
 "Operator signature (BLS)" = "Operator signature (BLS)";
 "Platform P2P port" = "Platform P2P port";

--- a/scripts/a11y_baseline.json
+++ b/scripts/a11y_baseline.json
@@ -7,18 +7,17 @@
   ],
   "counts": {
     "A11Y008": 8,
-    "A11Y002": 10,
+    "A11Y002": 9,
     "A11Y003": 1,
-    "A11Y004": 37,
-    "A11Y005": 1,
-    "A11Y006": 2,
+    "A11Y004": 33,
+    "A11Y006": 1,
     "A11Y009": 2,
     "A11Y010": 3,
     "A11Y011": 11,
     "A11Y012": 31,
     "A11Y007": 559
   },
-  "total": 665,
+  "total": 658,
   "findings": [
     {
       "rule": "A11Y008",
@@ -138,13 +137,6 @@
       "fingerprint": "64d20f1c746d8531",
       "line_when_recorded": 80,
       "snippet": "let barButtonItem = UIBarButtonItem(customView: activityIndicator)"
-    },
-    {
-      "rule": "A11Y002",
-      "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
-      "fingerprint": "6ab921512e79bf0f",
-      "line_when_recorded": 182,
-      "snippet": "let item = UIBarButtonItem(customView: backButton)"
     },
     {
       "rule": "A11Y003",
@@ -379,58 +371,16 @@
     },
     {
       "rule": "A11Y004",
-      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "099a421bad6a3019",
-      "line_when_recorded": 152,
-      "snippet": "Button(action: onBack) {"
-    },
-    {
-      "rule": "A11Y004",
-      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "099a421bad6a3019",
-      "line_when_recorded": 211,
-      "snippet": "Button(action: onBack) {"
-    },
-    {
-      "rule": "A11Y004",
-      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "7690c023535454ae",
-      "line_when_recorded": 233,
-      "snippet": "Button(action: onAdd) {"
-    },
-    {
-      "rule": "A11Y004",
-      "path": "DashWallet/Sources/UI/SwiftUI Components/NavigationBar.swift",
-      "fingerprint": "07fa3ed86b3e1f10",
-      "line_when_recorded": 287,
-      "snippet": "Button(action: onClose) {"
-    },
-    {
-      "rule": "A11Y004",
       "path": "DashWallet/Sources/UI/SwiftUI Components/SendIntro.swift",
       "fingerprint": "e5251255b9f564fd",
       "line_when_recorded": 69,
       "snippet": "Button(action: {"
     },
     {
-      "rule": "A11Y005",
-      "path": "DashWallet/Sources/UI/SwiftUI Components/MenuItem.swift",
-      "fingerprint": "34bcf206edfe454d",
-      "line_when_recorded": 232,
-      "snippet": "Toggle(isOn: $isToggled) { }"
-    },
-    {
       "rule": "A11Y006",
       "path": "DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift",
       "fingerprint": "78003431c215cd98",
       "line_when_recorded": 109,
-      "snippet": "let backButton = UIButton(type: .custom)"
-    },
-    {
-      "rule": "A11Y006",
-      "path": "DashWallet/Sources/UI/Views/Navigation/BaseNavigationController.swift",
-      "fingerprint": "6ee73a8d95d7ac7f",
-      "line_when_recorded": 177,
       "snippet": "let backButton = UIButton(type: .custom)"
     },
     {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Support ticket **32072**: *"Please add support for screenreaders. The tabs at the bottom, as well as buttons, need to be labeled so that screenreaders can read them."*

The tab bar the customer named was fixed in 0227fdf5a. The full-codebase audit that followed (tooling added in #1091) found the same defect throughout — but concentrated in **five shared components** rather than spread across screens. Repairing those five repairs an estimated 60-70 screens, which is what this PR does.

Companion PR in the design system: dashpay/DashUIKit#18. Its pin needs bumping after that merges; not included here.

## What was done?

| Component | Defect | Call sites |
|---|---|---|
| `BaseNavigationController.swift` | replaces UIKit's system back button — which VoiceOver labels automatically and localizes for free — with an unlabeled image button | 36 instantiations, all four tabs |
| `NavigationBar.swift` | back/close/plus/info built from a bare `Icon`; the DashUIKit original *does* set the label, this fork dropped it | 31 |
| `MenuItem.swift` | `Toggle(isOn:) { }` with an empty label — every switch in Settings and Security | 35 |
| `DashAmount.swift` | currency drawn as an image, so amounts never said "Dash" — including on send confirmation | 38 |
| `NumberKeyboardButton.swift` | keys are plain `UIView`s with no button trait; delete key is an image attachment whose `stringValue` is a private-use glyph | send amount, Set PIN, lock screen, Uphold, Coinbase 2FA |

Notes on the two riskier ones:

**The keypad** is on the money path, so the change is strictly additive: `isAccessibilityElement`, `accessibilityLabel` and `accessibilityTraits` on the existing view, called from `reloadTitle()` so the label tracks the key's value — including the function key that `DWPinView.m` reconfigures to "Cancel". No `UIButton`/`UIControl` conversion: the manual touch handling drives haptics and highlight state, and a rewrite there risks breaking amount entry. Activation rides VoiceOver's synthesized touch at the element's centre, which hit-tests to the same view. The `.keyboardKey` trait was deliberately **not** added — it engages VoiceOver's direct-typing modes, which could double-enter digits.

**`DashAmount`** builds its spoken label from the same formatted string it renders, so the announced value cannot drift from the visible one. "Dash" stays unlocalized as a proper noun, matching the deliberate `Text(verbatim: "Dash")` at `HomeBalanceView.swift:178`.

`MenuItem` needed no new string — it uses the title the caller already passes, so all 35 call sites inherit their existing translations. Five new catalog keys in `en.lproj`: `Back`, `Info`, `Decimal separator`, `Plus %@`, `Minus %@`. `Close`, `Add` and `Delete` were already there.

Baseline updated 665 → 658.

## How Has This Been Tested?

- **Clean `dashpay` build succeeds** (`ARCHS=arm64`, iphonesimulator). This took some doing and is worth recording: `develop` does not currently build against either the platform checkout most of us have or the head of `v4.2-dev`. Platform gained `.seedBindingUnverified` and `.identityScanIncomplete` in platform#4426 on 30 Aug, which `DashPayContactAddressReadiness.swift:61` does not handle; the last commit that compiles against `develop` is `255a5d60ca`. **That gap is not addressed here and will bite the next person who updates platform** — it wants its own ticket.
- `scripts/a11y_audit.py --check` clean; the 54 rule fixtures pass.
- Each diff reviewed by hand: every change is an accessibility property. No layout, spacing, colour or API change, so visual output is unchanged.
- **Not verified on a device with VoiceOver running.** The spoken results were derived by reading the code. Specifically worth confirming on hardware: that double-tap on a keypad digit inserts it on the send-amount screen, that double-tap-and-hold on Delete repeats, and that the amount on the send confirmation reads as expected.

Two things the audit tooling missed, found by reading rather than by rules: `NavigationBarElement.button(action:)` (its label is the `icon` property, not a literal `Image`) and, in the DashUIKit PR, the currency chevron. **The static rules under-report** — they are a ratchet against regression, not a measure of how accessible the app is.

## Breaking Changes

None. No public API or call-site signature changed; `MenuItem`'s 35 call sites and `DashAmount`'s 38 are untouched.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Improved VoiceOver announcements for amounts, including currency and positive/negative direction.
  - Added clear labels for navigation, menu toggles, and number-pad controls.
  - Hidden non-interactive keyboard keys from VoiceOver.
  - Added localized accessibility labels for Back, Info, Plus, Minus, Delete, and Decimal separator controls.
  - Reduced reported accessibility issues across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->