### PR TITLE
feat(ui): support optional wallet names

### DIFF
--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKHost.swift
@@ -98,6 +98,7 @@ final class SwiftDashSDKHost {
     // MARK: - Singleton
 
     static let shared = SwiftDashSDKHost()
+    nonisolated static let defaultWalletName = "dashwallet"
 
     // MARK: - Logging
 
@@ -497,7 +498,7 @@ final class SwiftDashSDKHost {
     /// manufacture cross-network copies while replaying old key material.
     ///
     /// For adding a wallet ALONGSIDE existing ones without rebinding the
-    /// active wallet, use `addWallet(mnemonic:isImported:)` instead — this path replaces
+    /// active wallet, use `addWallet(mnemonic:isImported:name:)` instead — this path replaces
     /// the running runtime and is not additive.
     @discardableResult
     func createOrImportWallet(
@@ -519,6 +520,7 @@ final class SwiftDashSDKHost {
                 mnemonic: mnemonic,
                 manager: handles.manager,
                 network: handles.network,
+                name: Self.defaultWalletName,
                 // Imported mnemonics may hold history from long before
                 // this device: scan from the network's import floor
                 // (genesis on testnet, block 200,000 on mainnet — see
@@ -551,6 +553,7 @@ final class SwiftDashSDKHost {
                             mnemonic: mnemonic,
                             manager: targetManager,
                             network: targetNetwork,
+                            name: Self.defaultWalletName,
                             birthHeight: isImported
                                 ? Self.importedWalletBirthHeight(for: targetNetwork)
                                 : nil,
@@ -584,15 +587,16 @@ final class SwiftDashSDKHost {
         return createdWallet
     }
 
-    /// Outcome of `addWallet(mnemonic:isImported:)`. `Sendable` because it
+    /// Outcome of `addWallet(mnemonic:isImported:name:)`. `Sendable` because it
     /// crosses the lifecycle queue's awaitable seam
     /// (`SwiftDashSDKWalletRuntime.performAddWallet`).
     enum AddWalletResult: Sendable {
         /// The wallet was created and its mnemonic persisted; the running
         /// runtime is unchanged (the caller switches to it explicitly).
         case added(walletId: Data)
-        /// A wallet deriving this walletId already has a persisted mnemonic on
-        /// this device — nothing was written. The caller offers switching to it.
+        /// A wallet deriving this current-network walletId already has a
+        /// persisted mnemonic. A missing sibling-network representation may
+        /// still have been repaired; the caller offers switching to this one.
         case alreadyExists(walletId: Data)
     }
 
@@ -624,9 +628,11 @@ final class SwiftDashSDKHost {
 
     /// Add a wallet from `mnemonic` ADDITIVELY: create it in the already-running
     /// manager and persist its mnemonic, then materialize the same logical
-    /// wallet for the other supported network. This is explicit provisioning
-    /// at create/import time; reinstall recovery remains network-scoped and
-    /// must never manufacture a mirror from an arbitrary surviving entry.
+    /// wallet for the other supported network. The optional user-facing name
+    /// is written to each newly provisioned network row. This is explicit
+    /// provisioning at create/import time; reinstall recovery remains
+    /// network-scoped and must never manufacture a mirror from an arbitrary
+    /// surviving entry.
     /// Neither operation touches the active-wallet registries or rebinds the
     /// published active wallet. The caller (Wallets screen "Add Wallet")
     /// switches to the current-network wallet afterward via
@@ -634,9 +640,11 @@ final class SwiftDashSDKHost {
     ///
     /// Requires a running host (a bound active wallet already exists — adding
     /// is only reachable from the Wallets screen). Returns `.alreadyExists`
-    /// without writing anything when a mnemonic for the derived walletId is
-    /// already persisted (`manager.createWallet` is idempotent by walletId, so
-    /// re-adding would silently no-op — the caller surfaces this instead).
+    /// without recreating the current-network wallet when its mnemonic is
+    /// already persisted; any missing sibling-network representation is still
+    /// provisioned first. `manager.createWallet` is idempotent by walletId, so
+    /// the caller surfaces the existing-wallet outcome instead of silently
+    /// claiming a new wallet was added.
     ///
     /// Shares the persist-then-create transaction with
     /// `createOrImportWallet` (`createAndPersist`); differs only in that it
@@ -647,7 +655,7 @@ final class SwiftDashSDKHost {
     /// as one link of the serial lifecycle chain so queued refresh/reset
     /// operations cannot interleave with the multi-network provisioning.
     @discardableResult
-    func addWallet(mnemonic: String, isImported: Bool) async throws -> AddWalletResult {
+    func addWallet(mnemonic: String, isImported: Bool, name: String?) async throws -> AddWalletResult {
         let mnemonic = Mnemonic.normalizePhrase(mnemonic)
         guard !mnemonic.isEmpty, Mnemonic.validate(mnemonic) else {
             throw HostError.invalidMnemonic
@@ -690,6 +698,7 @@ final class SwiftDashSDKHost {
                     mnemonic: mnemonic,
                     manager: targetManager,
                     network: targetNetwork,
+                    name: name,
                     // Same semantics as `createOrImportWallet`: imports scan
                     // from each network's import floor, freshly generated
                     // wallets from that network's tip.
@@ -744,6 +753,7 @@ final class SwiftDashSDKHost {
         mnemonic: String,
         manager: PlatformWalletManager,
         network: Network,
+        name: String?,
         birthHeight: UInt32?,
         offMainCreate: Bool
     ) async throws -> ManagedPlatformWallet {
@@ -792,7 +802,7 @@ final class SwiftDashSDKHost {
                         return try await manager.createWallet(
                             mnemonic: mnemonic,
                             network: network,
-                            name: "dashwallet",
+                            name: name,
                             createDefaultAccounts: true,
                             birthHeight: birthHeight)
                     }
@@ -805,7 +815,7 @@ final class SwiftDashSDKHost {
                         try manager.createWallet(
                             mnemonic: mnemonic,
                             network: network,
-                            name: "dashwallet",
+                            name: name,
                             createDefaultAccounts: true,
                             birthHeight: birthHeight)
                     }
@@ -1254,7 +1264,7 @@ final class SwiftDashSDKHost {
                 let created = try handles.manager.createWallet(
                     mnemonic: entry.mnemonic,
                     network: handles.network,
-                    name: "dashwallet",
+                    name: Self.defaultWalletName,
                     createDefaultAccounts: true,
                     // This path registers a keychain mnemonic whose
                     // SwiftData rows are gone (reinstall) or never

--- a/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
+++ b/DashWallet/Sources/Infrastructure/SwiftDashSDK/SwiftDashSDKWalletRuntime.swift
@@ -309,12 +309,13 @@ final class SwiftDashSDKWalletRuntime: NSObject {
     /// `switchWallet` is deliberately a SECOND, sequential chain op (the
     /// caller awaits this method first), never nested inside it.
     @MainActor
-    func performAddWallet(mnemonic: String, isImported: Bool) async throws
+    func performAddWallet(mnemonic: String, isImported: Bool, name: String?) async throws
         -> SwiftDashSDKHost.AddWalletResult {
         try await lifecycleQueue.enqueueAwaitable {
             try await SwiftDashSDKHost.shared.addWallet(
                 mnemonic: mnemonic,
-                isImported: isImported)
+                isImported: isImported,
+                name: name)
         }
     }
 

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsScreen.swift
@@ -497,12 +497,12 @@ private struct RemoveWalletSheet: View {
 
 // MARK: - Add Wallet sheet
 
-/// "Add Wallet" flow: a chooser between creating a brand-new wallet (generate a
-/// 12- or 24-word phrase, show it, require a written-down confirmation) and importing
-/// one from an existing recovery phrase. Both paths add the wallet additively
-/// via `WalletsViewModel.addWallet` and switch to it on success. All SDK work
-/// (generate / validate / add / switch) lives in the ViewModel; this view only
-/// drives the steps and renders (SwiftUI-first guardrail).
+/// "Add Wallet" flow: a chooser between creating a brand-new wallet (optional
+/// name, generated 12- or 24-word phrase, written-down confirmation) and
+/// importing one from an existing recovery phrase with an optional name. Both
+/// paths add the wallet additively via `WalletsViewModel.addWallet` and switch
+/// to it on success. All SDK work (generate / validate / add / switch) lives in
+/// the ViewModel; this view only drives the steps and renders.
 private struct AddWalletSheet: View {
     @ObservedObject var viewModel: WalletsViewModel
     let onFinished: () -> Void
@@ -616,13 +616,14 @@ private struct AddWalletSheet: View {
 
 // MARK: - Create wallet step
 
-/// Generates a 12- or 24-word phrase (user's pick; switching regenerates), shows
-/// it in a grid, and requires an explicit "I've written it down" confirmation
-/// before adding the wallet.
+/// Accepts an optional name, generates a 12- or 24-word phrase (user's pick;
+/// switching regenerates), shows it in a grid, and requires an explicit "I've
+/// written it down" confirmation before adding the wallet.
 private struct CreateWalletView: View {
     @ObservedObject var viewModel: WalletsViewModel
     let onFinished: () -> Void
 
+    @State private var name: String = ""
     @State private var mnemonic: String? = nil
     @State private var confirmedWrittenDown = false
     @State private var phraseLength: RecoveryPhraseLength = .default
@@ -634,6 +635,10 @@ private struct CreateWalletView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
+                WalletNameField(
+                    name: $name,
+                    isDisabled: viewModel.addInProgress || viewModel.switchInProgress)
+
                 RecoveryPhraseLengthPicker(selection: $phraseLength)
                     .disabled(viewModel.addInProgress || viewModel.switchInProgress)
 
@@ -718,7 +723,10 @@ private struct CreateWalletView: View {
     private func create() {
         guard let mnemonic else { return }
         Task {
-            let outcome = await viewModel.addWallet(mnemonic: mnemonic, isImported: false)
+            let outcome = await viewModel.addWallet(
+                mnemonic: mnemonic,
+                isImported: false,
+                name: name)
             if outcome == .switched { onFinished() }
             // A brand-new phrase can't already exist, and on error the sheet
             // stays open (the ViewModel surfaces the message).
@@ -728,14 +736,15 @@ private struct CreateWalletView: View {
 
 // MARK: - Import wallet step
 
-/// Multiline recovery-phrase entry with BIP39 validation. On import, if the
-/// derived wallet is already on this device, offers switching to it instead of
-/// reporting a fabricated success.
+/// Optional wallet name plus multiline recovery-phrase entry with BIP39
+/// validation. On import, if the derived wallet is already on this device,
+/// offers switching to it instead of reporting a fabricated success.
 private struct ImportWalletView: View {
     @ObservedObject var viewModel: WalletsViewModel
     let onFinished: () -> Void
     let onSwitchToExisting: (Data) -> Void
 
+    @State private var name: String = ""
     @State private var phrase: String = ""
     @State private var existingWalletId: Data? = nil
 
@@ -747,6 +756,10 @@ private struct ImportWalletView: View {
                     comment: "Wallets"))
                     .font(.subheadline)
                     .foregroundColor(.dash.secondaryText)
+
+                WalletNameField(
+                    name: $name,
+                    isDisabled: viewModel.addInProgress || viewModel.switchInProgress)
 
                 TextEditor(text: $phrase)
                     .frame(minHeight: 120)
@@ -799,7 +812,10 @@ private struct ImportWalletView: View {
     private func importWallet() {
         existingWalletId = nil
         Task {
-            let outcome = await viewModel.addWallet(mnemonic: phrase, isImported: true)
+            let outcome = await viewModel.addWallet(
+                mnemonic: phrase,
+                isImported: true,
+                name: name)
             switch outcome {
             case .switched:
                 onFinished()
@@ -808,6 +824,39 @@ private struct ImportWalletView: View {
             case .none:
                 break // error surfaced by the ViewModel; sheet stays open
             }
+        }
+    }
+}
+
+// MARK: - Optional wallet name
+
+private struct WalletNameField: View {
+    @Binding var name: String
+    let isDisabled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(NSLocalizedString("Wallet name (optional)", comment: "Wallets"))
+                .font(.subheadline)
+                .foregroundColor(.dash.primaryText)
+
+            TextField(
+                NSLocalizedString("e.g. Spending", comment: "Wallets — optional wallet name placeholder"),
+                text: $name)
+                .textInputAutocapitalization(.words)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 11)
+                .background(Color.dash.secondaryBackground)
+                .cornerRadius(10)
+                .disabled(isDisabled)
+
+            Text(String(
+                format: NSLocalizedString(
+                    "Leave blank to use \"%@\". You can change this later from the wallet menu.",
+                    comment: "Wallets"),
+                SwiftDashSDKHost.defaultWalletName))
+                .font(.footnote)
+                .foregroundColor(.dash.secondaryText)
         }
     }
 }

--- a/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
+++ b/DashWallet/Sources/UI/Menu/Security/Wallets/WalletsViewModel.swift
@@ -108,7 +108,9 @@ final class WalletsViewModel: ObservableObject {
             // Stable ordering: active first, then by display name.
             .sorted { lhs, rhs in
                 if lhs.isActive != rhs.isActive { return lhs.isActive }
-                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+                let nameOrder = lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName)
+                if nameOrder != .orderedSame { return nameOrder == .orderedAscending }
+                return lhs.walletId.lexicographicallyPrecedes(rhs.walletId)
             }
 
         rows = built
@@ -244,23 +246,26 @@ final class WalletsViewModel: ObservableObject {
         Mnemonic.validate(Self.normalize(phrase))
     }
 
-    /// Add a wallet from `mnemonic` and switch to it. `isImported` distinguishes
-    /// the two entry paths and sets the new wallet's `walletNeedsBackup` flag:
-    /// a created wallet still needs a backup (its phrase was only shown, not
-    /// verified — matches onboarding); an imported wallet does not (the user
-    /// already holds the phrase — matches the recover flow).
+    /// Add a wallet from `mnemonic`, persist its optional display `name`, and
+    /// switch to it. `isImported` distinguishes the two entry paths and sets
+    /// the new wallet's `walletNeedsBackup` flag: a created wallet still needs
+    /// a backup (its phrase was only shown, not verified — matches onboarding);
+    /// an imported wallet does not (the user already holds the phrase — matches
+    /// the recover flow).
     ///
     /// Flow: `SwiftDashSDKHost.addWallet` (additive — no rebind) → on `.added`,
     /// `switchWallet(to:)` the new wallet (awaited, progress overlay) → set the
     /// per-wallet backup flag for the now-active new wallet → refresh. On
-    /// `.alreadyExists` nothing is written and `.alreadyOnDevice` is returned so
-    /// the sheet can offer switching instead.
+    /// `.alreadyExists`, an entered name is applied to the existing current-
+    /// network row and `.alreadyOnDevice` lets the sheet offer switching.
     ///
     /// Returns the outcome; returns nil after surfacing an error (the sheet
     /// stays open on failure — never claims a success that didn't happen).
-    func addWallet(mnemonic: String, isImported: Bool) async -> AddOutcome? {
+    func addWallet(mnemonic: String, isImported: Bool, name: String? = nil) async -> AddOutcome? {
         guard !addInProgress, !switchInProgress, !removeInProgress else { return nil }
         let normalized = Self.normalize(mnemonic)
+        let enteredName = Self.normalizedWalletName(name)
+        let creationName = enteredName ?? SwiftDashSDKHost.defaultWalletName
 
         addInProgress = true
         defer { addInProgress = false }
@@ -293,7 +298,8 @@ final class WalletsViewModel: ObservableObject {
             // would self-await-deadlock the queue).
             result = try await SwiftDashSDKWalletRuntime.shared.performAddWallet(
                 mnemonic: normalized,
-                isImported: isImported)
+                isImported: isImported,
+                name: creationName)
         } catch {
             // The ONE exit where a forgotten finish() would strand the
             // blocking overlay with no owner.
@@ -310,6 +316,13 @@ final class WalletsViewModel: ObservableObject {
         switch result {
         case .alreadyExists(let walletId):
             state.finish()
+            // The phrase may already exist on the current network while the
+            // host has just repaired its missing sibling-network copy. Honor
+            // the name the user entered instead of silently discarding it.
+            if enteredName != nil,
+               !persistWalletName(enteredName, walletId: walletId) {
+                return nil
+            }
             return .alreadyOnDevice(walletId: walletId)
         case .added(let walletId):
             switchInProgress = true
@@ -350,23 +363,31 @@ final class WalletsViewModel: ObservableObject {
 
     // MARK: - Rename
 
-    /// Write `name` to `PersistentWallet.name` for `walletId` (empty string
-    /// clears it to nil). Persists via the host's `modelContainer` mainContext.
+    /// Write `name` to `PersistentWallet.name` for `walletId` (empty input
+    /// restores the default name). Persists through the host's model context.
     func rename(walletId: Data, to name: String) {
+        let effectiveName = Self.normalizedWalletName(name)
+            ?? SwiftDashSDKHost.defaultWalletName
+        _ = persistWalletName(effectiveName, walletId: walletId)
+    }
+
+    @discardableResult
+    private func persistWalletName(_ name: String?, walletId: Data) -> Bool {
         guard let context = SwiftDashSDKHost.shared.modelContainer?.mainContext,
               let persisted = Self.fetchPersistentWallet(walletId: walletId, in: context) else {
             Self.logger.error("rename: no PersistentWallet row for target")
             errorMessage = NSLocalizedString("Could not rename this wallet.", comment: "Wallets")
-            return
+            return false
         }
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        persisted.name = trimmed.isEmpty ? nil : trimmed
+        persisted.name = Self.normalizedWalletName(name)
         do {
             try context.save()
             reload()
+            return true
         } catch {
             Self.logger.error("rename save failed: \(String(describing: error), privacy: .public)")
             errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -514,6 +535,14 @@ final class WalletsViewModel: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(whereSeparator: { $0.isWhitespace })
             .joined(separator: " ")
+    }
+
+    /// Trim an optional user-entered wallet name. Blank input becomes nil so
+    /// callers can distinguish "use the default name" from an explicit name.
+    nonisolated static func normalizedWalletName(_ name: String?) -> String? {
+        guard let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
     }
 
     private static func fetchPersistentWallet(walletId: Data, in context: ModelContext) -> PersistentWallet? {

--- a/DashWalletTests/WalletWipeSerialExecutorTests.swift
+++ b/DashWalletTests/WalletWipeSerialExecutorTests.swift
@@ -250,6 +250,24 @@ final class StoredWalletInventoryTests: XCTestCase {
     }
 }
 
+final class WalletNameNormalizationTests: XCTestCase {
+    func testBlankWalletNamesHaveNoExplicitUserValue() {
+        XCTAssertNil(WalletsViewModel.normalizedWalletName(nil))
+        XCTAssertNil(WalletsViewModel.normalizedWalletName(""))
+        XCTAssertNil(WalletsViewModel.normalizedWalletName("  \n\t  "))
+    }
+
+    func testDefaultWalletNameRemainsDashwallet() {
+        XCTAssertEqual(SwiftDashSDKHost.defaultWalletName, "dashwallet")
+    }
+
+    func testWalletNameTrimsOuterWhitespace() {
+        XCTAssertEqual(
+            WalletsViewModel.normalizedWalletName("  Holiday Fund \n"),
+            "Holiday Fund")
+    }
+}
+
 final class LegacyMnemonicSelectionTests: XCTestCase {
     func testTargetedCleanupSelectsOnlyMatchingNormalizedSeed() {
         let target = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Wallets created or imported from the Wallets screen could not be given a name, so every wallet was persisted as `dashwallet`. Equal display names also left the list without a deterministic secondary sort key.

## What was done?

- Add an optional wallet-name field to both Create Wallet and Import Wallet.
- Trim custom names and use `dashwallet` when the field is blank.
- Thread the selected name through the wallet runtime and persist it for both network representations.
- Preserve an existing custom name when importing an already-present wallet with a blank field.
- Reset an emptied rename to `dashwallet` and add wallet-ID sorting as a deterministic tie-breaker.
- Add unit coverage for wallet-name normalization and the default value.

## How Has This Been Tested?

- Parsed all five changed Swift files with `xcrun swiftc -frontend -parse`.
- Ran `scripts/a11y_audit.py --check` successfully (no new blocking findings).
- Ran `git diff --check` successfully.
- A full Xcode build/test run could not be completed because this checkout does not contain the gitignored `DashSDKFFI.xcframework` binary required by the local SwiftDashSDK package.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional wallet naming when creating or importing wallets.
  * Added a wallet-name field to creation and import screens.
  * Blank names use the default “dashwallet” name, while entered names are trimmed and preserved.
  * Duplicate wallet recovery now completes missing network setup and can save a provided name.
  * Wallets are sorted alphabetically by name, with wallet ID used to break ties.
* **Bug Fixes**
  * Improved wallet provisioning across networks when a wallet already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->